### PR TITLE
Change the end of date period to inclusive

### DIFF
--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
         {
             referenceDay = new DateObject(2016, 11, 7);
             extractor = new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration());
-            parser = new BaseDatePeriodParser(new EnglishDatePeriodParserConfiguration( new EnglishCommonDateTimeParserConfiguration()));
+            parser = new BaseDatePeriodParser(new EnglishDatePeriodParserConfiguration(new EnglishCommonDateTimeParserConfiguration()));
         }
 
         public void BasicTestFuture(string text, int beginDay, int endDay, int month, int year)
@@ -26,10 +26,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             Assert.AreEqual(Constants.SYS_DATETIME_DATEPERIOD, pr.Type);
             var beginDate = new DateObject(year, month, beginDay);
             Assert.AreEqual(beginDate,
-                ((Tuple<DateObject, DateObject>) ((DTParseResult) pr.Value).FutureValue).Item1);
+                ((Tuple<DateObject, DateObject>)((DTParseResult)pr.Value).FutureValue).Item1);
             var endDate = new DateObject(year, month, endDay);
             Assert.AreEqual(endDate,
-                ((Tuple<DateObject, DateObject>) ((DTParseResult) pr.Value).FutureValue).Item2);
+                ((Tuple<DateObject, DateObject>)((DTParseResult)pr.Value).FutureValue).Item2);
         }
 
         public void BasicTestFuture(string text, int beginYear, int beginMonth, int beginDay, int endYear, int endMonth,
@@ -41,10 +41,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             Assert.AreEqual(Constants.SYS_DATETIME_DATEPERIOD, pr.Type);
             var beginDate = new DateObject(beginYear, beginMonth, beginDay);
             Assert.AreEqual(beginDate,
-                ((Tuple<DateObject, DateObject>) ((DTParseResult) pr.Value).FutureValue).Item1);
+                ((Tuple<DateObject, DateObject>)((DTParseResult)pr.Value).FutureValue).Item1);
             var endDate = new DateObject(endYear, endMonth, endDay);
             Assert.AreEqual(endDate,
-                ((Tuple<DateObject, DateObject>) ((DTParseResult) pr.Value).FutureValue).Item2);
+                ((Tuple<DateObject, DateObject>)((DTParseResult)pr.Value).FutureValue).Item2);
         }
 
         public void BasicTest(string text, string luisValueStr)
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             Assert.AreEqual(1, er.Count);
             var pr = parser.Parse(er[0], referenceDay);
             Assert.AreEqual(Constants.SYS_DATETIME_DATEPERIOD, pr.Type);
-            Assert.AreEqual(luisValueStr, ((DTParseResult) pr.Value).Timex);
+            Assert.AreEqual(luisValueStr, ((DTParseResult)pr.Value).Timex);
         }
 
         [TestMethod]
@@ -72,13 +72,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll be out from 4 to 22 January, 1995", 4, 22, 1, 1995);
             BasicTestFuture("I'll be out between 4-22 January, 1995", 4, 22, 1, 1995);
 
-            BasicTestFuture("I'll be out on this week", 7, 14, month, year);
-            BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 3, 1);
-            BasicTestFuture("I'll be out this September", year, 9, 1, year, 10, 1);
-            BasicTestFuture("I'll be out last sept", year - 1, 9, 1, year - 1, 10, 1);
-            BasicTestFuture("I'll be out next june", year + 1, 6, 1, year + 1, 7, 1);
-            BasicTestFuture("I'll be out the third week of this month", 21, 28, month, year);
-            BasicTestFuture("I'll be out the last week of july", year + 1, 7, 24, year + 1, 7, 31);
+            BasicTestFuture("I'll be out on this week", 7, 13, month, year);
+            BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 2, 28);
+            BasicTestFuture("I'll be out this September", year, 9, 1, year, 9, 30);
+            BasicTestFuture("I'll be out last sept", year - 1, 9, 1, year - 1, 9, 30);
+            BasicTestFuture("I'll be out next june", year + 1, 6, 1, year + 1, 6, 30);
+            BasicTestFuture("I'll be out the third week of this month", 21, 27, month, year);
+            BasicTestFuture("I'll be out the last week of july", year + 1, 7, 24, year + 1, 7, 30);
 
             // test merging two time points
             BasicTestFuture("I'll be out Oct. 2 to October 22", 2, 22, 10, year + 1);
@@ -93,10 +93,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll be out November 19 to 20", 19, 20, 11, year);
             BasicTestFuture("I'll be out November between 19 and 20", 19, 20, 11, year);
 
-            BasicTestFuture("I'll be out 2015.3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("I'll be out 2015-3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("I'll be out 2015/3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 4, 1);
+            BasicTestFuture("I'll be out 2015.3", 2015, 3, 1, 2015, 3, 31);
+            BasicTestFuture("I'll be out 2015-3", 2015, 3, 1, 2015, 3, 31);
+            BasicTestFuture("I'll be out 2015/3", 2015, 3, 1, 2015, 3, 31);
+            BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 3, 31);
 
             //BasicTestFuture("I'll leave this summer", 2016, 6, 1, 2016, 9, 1);
             //BasicTestFuture("I'll leave in summer", 2017, 6, 1, 2017, 9, 1);

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
     [TestClass]
     public class TestDatePeriodParser
     {
-        readonly IDateTimeParser parser;
+        readonly BaseDatePeriodParser parser;
         readonly BaseDatePeriodExtractor extractor;
         readonly DateObject referenceDay;
 
@@ -60,7 +60,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
         public void TestDatePeriodParse()
         {
             int year = 2016, month = 11;
+            bool inclusiveEnd = parser.GetInclusiveEndPeriodFlag();
 
+            BasicTestFuture("scheduel a meeting in two weeks", 4, 22, month, year);
             // test basic cases
             BasicTestFuture("I'll be out from 4 to 22 this month", 4, 22, month, year);
             BasicTestFuture("I'll be out from 4-23 in next month", 4, 23, 12, year);
@@ -72,13 +74,26 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll be out from 4 to 22 January, 1995", 4, 22, 1, 1995);
             BasicTestFuture("I'll be out between 4-22 January, 1995", 4, 22, 1, 1995);
 
-            BasicTestFuture("I'll be out on this week", 7, 13, month, year);
-            BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 2, 28);
-            BasicTestFuture("I'll be out this September", year, 9, 1, year, 9, 30);
-            BasicTestFuture("I'll be out last sept", year - 1, 9, 1, year - 1, 9, 30);
-            BasicTestFuture("I'll be out next june", year + 1, 6, 1, year + 1, 6, 30);
-            BasicTestFuture("I'll be out the third week of this month", 21, 27, month, year);
-            BasicTestFuture("I'll be out the last week of july", year + 1, 7, 24, year + 1, 7, 30);
+            if (inclusiveEnd)
+            {
+                BasicTestFuture("I'll be out on this week", 7, 13, month, year);
+                BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 2, 28);
+                BasicTestFuture("I'll be out this September", year, 9, 1, year, 9, 30);
+                BasicTestFuture("I'll be out last sept", year - 1, 9, 1, year - 1, 9, 30);
+                BasicTestFuture("I'll be out next june", year + 1, 6, 1, year + 1, 6, 30);
+                BasicTestFuture("I'll be out the third week of this month", 21, 27, month, year);
+                BasicTestFuture("I'll be out the last week of july", year + 1, 7, 24, year + 1, 7, 30);
+            }
+            else
+            {
+                BasicTestFuture("I'll be out on this week", 7, 14, month, year);
+                BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 3, 1);
+                BasicTestFuture("I'll be out this September", year, 9, 1, year, 10, 1);
+                BasicTestFuture("I'll be out last sept", year - 1, 9, 1, year - 1, 10, 1);
+                BasicTestFuture("I'll be out next june", year + 1, 6, 1, year + 1, 7, 1);
+                BasicTestFuture("I'll be out the third week of this month", 21, 28, month, year);
+                BasicTestFuture("I'll be out the last week of july", year + 1, 7, 24, year + 1, 7, 31);
+            }
 
             // test merging two time points
             BasicTestFuture("I'll be out Oct. 2 to October 22", 2, 22, 10, year + 1);
@@ -93,10 +108,20 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll be out November 19 to 20", 19, 20, 11, year);
             BasicTestFuture("I'll be out November between 19 and 20", 19, 20, 11, year);
 
-            BasicTestFuture("I'll be out 2015.3", 2015, 3, 1, 2015, 3, 31);
-            BasicTestFuture("I'll be out 2015-3", 2015, 3, 1, 2015, 3, 31);
-            BasicTestFuture("I'll be out 2015/3", 2015, 3, 1, 2015, 3, 31);
-            BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 3, 31);
+            if (inclusiveEnd)
+            {
+                BasicTestFuture("I'll be out 2015.3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("I'll be out 2015-3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("I'll be out 2015/3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 3, 31);
+            }
+            else
+            {
+                BasicTestFuture("I'll be out 2015.3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("I'll be out 2015-3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("I'll be out 2015/3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 4, 1);
+            }
 
             //BasicTestFuture("I'll leave this summer", 2016, 6, 1, 2016, 9, 1);
             //BasicTestFuture("I'll leave in summer", 2017, 6, 1, 2017, 9, 1);

--- a/Microsoft.Recognizers.Text.DateTime.Tests/Spanish/TestDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/Spanish/TestDatePeriodParser.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Tests
     [TestClass]
     public class TestDatePeriodParser
     {
-        readonly IDateTimeParser parser;
+        readonly BaseDatePeriodParser parser;
         readonly BaseDatePeriodExtractor extractor;
         readonly DateObject referenceDay;
 
@@ -61,6 +61,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Tests
         {
             int year = 2016, month = 11;
 
+            bool inclusiveEnd=parser.GetInclusiveEndPeriodFlag();
+
             // test basic cases
             BasicTestFuture("Estare afuera desde el 4 hasta el 22 de este mes", 4, 22, month, year);
             BasicTestFuture("Estare afuera desde 4-23 del proximo mes", 4, 23, 12, year);
@@ -72,13 +74,27 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Tests
             BasicTestFuture("Estare afuera del 4 al 22 de enero, 1995", 4, 22, 1, 1995);
             BasicTestFuture("Estare afuera entre 4-22 enero,  1995", 4, 22, 1, 1995);
 
-            BasicTestFuture("Estare afuera esta semana", 7, 14, month, year);
-            BasicTestFuture("Estare afuera en Febrero", year + 1, 2, 1, year + 1, 3, 1);
-            BasicTestFuture("Estare afuera este Septiembre", year, 9, 1, year, 10, 1);
-            BasicTestFuture("Estare afuera el ultimo sept", year - 1, 9, 1, year - 1, 10, 1);
-            BasicTestFuture("Estare afuera el proximo junio", year + 1, 6, 1, year + 1, 7, 1);
-            BasicTestFuture("Estare afuera la tercera semana de este mes", 21, 28, month, year);
-            BasicTestFuture("Estare afuera la ultima semana de julio", year + 1, 7, 24, year + 1, 7, 31);
+            if (inclusiveEnd)
+            {
+                BasicTestFuture("Estare afuera esta semana", 7, 13, month, year);
+                BasicTestFuture("Estare afuera en Febrero", year + 1, 2, 1, year + 1, 2, 28);
+                BasicTestFuture("Estare afuera este Septiembre", year, 9, 1, year, 9, 30);
+                BasicTestFuture("Estare afuera el ultimo sept", year - 1, 9, 1, year - 1, 9, 30);
+                BasicTestFuture("Estare afuera el proximo junio", year + 1, 6, 1, year + 1, 6, 30);
+                BasicTestFuture("Estare afuera la tercera semana de este mes", 21, 28, month, year);
+                BasicTestFuture("Estare afuera la ultima semana de julio", year + 1, 7, 24, year + 1, 7, 31);
+            }
+            else
+            {
+                BasicTestFuture("Estare afuera esta semana", 7, 14, month, year);
+                BasicTestFuture("Estare afuera en Febrero", year + 1, 2, 1, year + 1, 3, 1);
+                BasicTestFuture("Estare afuera este Septiembre", year, 9, 1, year, 10, 1);
+                BasicTestFuture("Estare afuera el ultimo sept", year - 1, 9, 1, year - 1, 10, 1);
+                BasicTestFuture("Estare afuera el proximo junio", year + 1, 6, 1, year + 1, 7, 1);
+                BasicTestFuture("Estare afuera la tercera semana de este mes", 21, 28, month, year);
+                BasicTestFuture("Estare afuera la ultima semana de julio", year + 1, 7, 24, year + 1, 7, 31);
+            }
+            
 
             // test merging two time points
             BasicTestFuture("Estare afuera el 2 de Oct hasta 22 de Octubre", 2, 22, 10, year + 1);
@@ -93,10 +109,21 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Tests
             BasicTestFuture("Estare afuera 19 hasta 20 de Noviembre", 19, 20, 11, year);
             BasicTestFuture("Estare afuera entre 19 y 20 de Noviembre", 19, 20, 11, year);
 
-            BasicTestFuture("Estare afuera 2015.3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("Estare afuera 2015-3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("Estare afuera 2015/3", 2015, 3, 1, 2015, 4, 1);
-            BasicTestFuture("Estare afuera 3/2015", 2015, 3, 1, 2015, 4, 1);
+            if (inclusiveEnd)
+            {
+                BasicTestFuture("Estare afuera 2015.3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("Estare afuera 2015-3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("Estare afuera 2015/3", 2015, 3, 1, 2015, 3, 31);
+                BasicTestFuture("Estare afuera 3/2015", 2015, 3, 1, 2015, 3, 31);
+            }
+            else
+            {
+                BasicTestFuture("Estare afuera 2015.3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("Estare afuera 2015-3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("Estare afuera 2015/3", 2015, 3, 1, 2015, 4, 1);
+                BasicTestFuture("Estare afuera 3/2015", 2015, 3, 1, 2015, 4, 1);
+            }
+            
 
             //BasicTestFuture("I'll leave this summer", 2016, 6, 1, 2016, 9, 1);
             //BasicTestFuture("I'll leave in summer", 2017, 6, 1, 2017, 9, 1);

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -8,10 +8,12 @@ namespace Microsoft.Recognizers.Text.DateTime
     public class BaseDatePeriodParser : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATEPERIOD; //"DatePeriod";
-        
+
         private static readonly Calendar _cal = DateTimeFormatInfo.InvariantInfo.Calendar;
 
         private readonly IDatePeriodParserConfiguration config;
+
+        private static bool InclusiveEndPeriod = true;
 
         public BaseDatePeriodParser(IDatePeriodParserConfiguration configuration)
         {
@@ -114,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Type = er.Type,
                 Data = er.Data,
                 Value = value,
-                TimexStr = value == null ? "" : ((DTParseResult) value).Timex,
+                TimexStr = value == null ? "" : ((DTParseResult)value).Timex,
                 ResolutionStr = ""
             };
             return ret;
@@ -294,29 +296,32 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     if (this.config.IsWeekOnly(trimedText))
                     {
-                        var monday = referenceDate.This(DayOfWeek.Monday).AddDays(7*swift);
+                        var monday = referenceDate.This(DayOfWeek.Monday).AddDays(7 * swift);
                         ret.Timex = monday.Year.ToString("D4") + "-W" +
                                     _cal.GetWeekOfYear(monday, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
                                         .ToString("D2");
                         ret.FutureValue =
                             ret.PastValue =
                                 new Tuple<DateObject, DateObject>(
-                                    referenceDate.This(DayOfWeek.Monday).AddDays(7*swift),
-                                    referenceDate.This(DayOfWeek.Sunday).AddDays(7*swift).AddDays(1));
+                                    referenceDate.This(DayOfWeek.Monday).AddDays(7 * swift),
+                                    InclusiveEndPeriod
+                                        ? referenceDate.This(DayOfWeek.Sunday).AddDays(7 * swift)
+                                        : referenceDate.This(DayOfWeek.Sunday).AddDays(7 * swift).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
                     if (this.config.IsWeekend(trimedText))
                     {
                         DateObject beginDate, endDate;
-                        beginDate = referenceDate.This(DayOfWeek.Saturday).AddDays(7*swift);
-                        endDate = referenceDate.This(DayOfWeek.Sunday).AddDays(7*swift);
+                        beginDate = referenceDate.This(DayOfWeek.Saturday).AddDays(7 * swift);
+                        endDate = referenceDate.This(DayOfWeek.Sunday).AddDays(7 * swift);
 
                         ret.Timex = beginDate.Year.ToString("D4") + "-W" +
                                     _cal.GetWeekOfYear(beginDate, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
                                         .ToString("D2") + "-WE";
+                        endDate = InclusiveEndPeriod ? endDate : endDate.AddDays(1);
                         ret.FutureValue =
-                            ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate.AddDays(1));
+                            ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
                         ret.Success = true;
                         return ret;
                     }
@@ -334,7 +339,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                         ret.FutureValue =
                             ret.PastValue =
                                 new Tuple<DateObject, DateObject>(new DateObject(year, 1, 1),
-                                    new DateObject(year, 12, 31).AddDays(1));
+                                    InclusiveEndPeriod
+                                    ? new DateObject(year, 12, 31)
+                                    : new DateObject(year, 12, 31).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
@@ -348,15 +355,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             // only "month" will come to here
             ret.FutureValue = new Tuple<DateObject, DateObject>(
                 new DateObject(futureYear, month, 1),
-                new DateObject(futureYear, month, 1).AddMonths(1));
+                InclusiveEndPeriod
+                ? new DateObject(futureYear, month, 1).AddMonths(1).AddDays(-1)
+                : new DateObject(futureYear, month, 1).AddMonths(1));
             ret.PastValue = new Tuple<DateObject, DateObject>(
                 new DateObject(pastYear, month, 1),
-                new DateObject(pastYear, month, 1).AddMonths(1));
+                InclusiveEndPeriod
+                ? new DateObject(pastYear, month, 1).AddMonths(1).AddDays(-1)
+                : new DateObject(pastYear, month, 1).AddMonths(1));
             ret.Success = true;
             return ret;
         }
 
-        private  DTParseResult ParseMonthWithYear(string text, DateObject referenceDate)
+        private DTParseResult ParseMonthWithYear(string text, DateObject referenceDate)
         {
             var ret = new DTParseResult();
             var match = this.config.MonthWithYear.Match(text);
@@ -387,7 +398,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
                     new DateObject(year, month, 1),
-                    new DateObject(year, month, 1).AddMonths(1));
+                    InclusiveEndPeriod
+                        ? new DateObject(year, month, 1).AddMonths(1).AddDays(-1)
+                        : new DateObject(year, month, 1).AddMonths(1));
                 ret.Timex = year.ToString("D4") + "-" + month.ToString("D2");
                 ret.Success = true;
             }
@@ -402,7 +415,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var year = int.Parse(match.Value);
                 var beginDay = new DateObject(year, 1, 1);
-                var endDay = new DateObject(year + 1, 1, 1);
+                var endDay = InclusiveEndPeriod
+                        ? new DateObject(year + 1, 1, 1).AddDays(-1)
+                        : new DateObject(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
@@ -435,10 +450,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 return ret;
             }
 
-            DateObject futureBegin = (DateObject) ((DTParseResult) pr1.Value).FutureValue,
-                futureEnd = (DateObject) ((DTParseResult) pr2.Value).FutureValue;
-            DateObject pastBegin = (DateObject) ((DTParseResult) pr1.Value).PastValue,
-                pastEnd = (DateObject) ((DTParseResult) pr2.Value).PastValue;
+            DateObject futureBegin = (DateObject)((DTParseResult)pr1.Value).FutureValue,
+                futureEnd = (DateObject)((DTParseResult)pr2.Value).FutureValue;
+            DateObject pastBegin = (DateObject)((DTParseResult)pr1.Value).PastValue,
+                pastEnd = (DateObject)((DTParseResult)pr2.Value).PastValue;
             if (futureBegin > futureEnd)
             {
                 futureBegin = pastBegin;
@@ -482,19 +497,19 @@ namespace Microsoft.Recognizers.Text.DateTime
                         switch (unitStr)
                         {
                             case "D":
-                                beginDate = referenceDate.AddDays(-(double) pr.Value);
+                                beginDate = referenceDate.AddDays(-(double)pr.Value);
                                 endDate = referenceDate;
                                 break;
                             case "W":
-                                beginDate = referenceDate.AddDays(-7*(double) pr.Value);
+                                beginDate = referenceDate.AddDays(-7 * (double)pr.Value);
                                 endDate = referenceDate;
                                 break;
                             case "MON":
-                                beginDate = referenceDate.AddMonths(-Convert.ToInt32((double) pr.Value));
+                                beginDate = referenceDate.AddMonths(-Convert.ToInt32((double)pr.Value));
                                 endDate = referenceDate;
                                 break;
                             case "Y":
-                                beginDate = referenceDate.AddYears(-Convert.ToInt32((double) pr.Value));
+                                beginDate = referenceDate.AddYears(-Convert.ToInt32((double)pr.Value));
                                 endDate = referenceDate;
                                 break;
                             default:
@@ -514,19 +529,19 @@ namespace Microsoft.Recognizers.Text.DateTime
                         {
                             case "D":
                                 beginDate = referenceDate;
-                                endDate = referenceDate.AddDays((double) pr.Value);
+                                endDate = referenceDate.AddDays((double)pr.Value);
                                 break;
                             case "W":
                                 beginDate = referenceDate;
-                                endDate = referenceDate.AddDays(7*(double) pr.Value);
+                                endDate = referenceDate.AddDays(7 * (double)pr.Value);
                                 break;
                             case "MON":
                                 beginDate = referenceDate;
-                                endDate = referenceDate.AddMonths(Convert.ToInt32((double) pr.Value));
+                                endDate = referenceDate.AddMonths(Convert.ToInt32((double)pr.Value));
                                 break;
                             case "Y":
                                 beginDate = referenceDate;
-                                endDate = referenceDate.AddYears(Convert.ToInt32((double) pr.Value));
+                                endDate = referenceDate.AddYears(Convert.ToInt32((double)pr.Value));
                                 break;
                             default:
                                 return ret;
@@ -563,7 +578,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 endDate = referenceDate;
                                 break;
                             case "W":
-                                beginDate = referenceDate.AddDays(-7*double.Parse(numStr));
+                                beginDate = referenceDate.AddDays(-7 * double.Parse(numStr));
                                 endDate = referenceDate;
                                 break;
                             case "MON":
@@ -594,7 +609,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 break;
                             case "W":
                                 beginDate = referenceDate;
-                                endDate = referenceDate.AddDays(7*double.Parse(numStr));
+                                endDate = referenceDate.AddDays(7 * double.Parse(numStr));
                                 break;
                             case "MON":
                                 beginDate = referenceDate;
@@ -739,8 +754,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 year = referenceDate.Year + swift;
             }
             var quarterNum = this.config.CardinalMap[cardinalStr];
-            var beginDate = new DateObject(year, quarterNum*3 - 2, 1);
-            var endDate = new DateObject(year, quarterNum*3 + 1, 1);
+            var beginDate = new DateObject(year, quarterNum * 3 - 2, 1);
+            var endDate = new DateObject(year, quarterNum * 3 + 1, 1);
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
             ret.Timex = $"({Util.LuisDate(beginDate)},{Util.LuisDate(endDate)},P3M)";
             ret.Success = true;
@@ -819,8 +834,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             ret.Timex += "-W" + cardinal.ToString("D2");
-            ret.FutureValue = new Tuple<DateObject, DateObject>(futureDate, futureDate.AddDays(7));
-            ret.PastValue = new Tuple<DateObject, DateObject>(pastDate, pastDate.AddDays(7));
+            ret.FutureValue = InclusiveEndPeriod
+                ? new Tuple<DateObject, DateObject>(futureDate, futureDate.AddDays(6))
+                : new Tuple<DateObject, DateObject>(futureDate, futureDate.AddDays(7));
+            ret.PastValue = InclusiveEndPeriod
+                ? new Tuple<DateObject, DateObject>(pastDate, pastDate.AddDays(6))
+                : new Tuple<DateObject, DateObject>(pastDate, pastDate.AddDays(7));
             ret.Success = true;
 
             return ret;
@@ -829,17 +848,17 @@ namespace Microsoft.Recognizers.Text.DateTime
         private static DateObject ComputeDate(int cadinal, int weekday, int month, int year)
         {
             var firstDay = new DateObject(year, month, 1);
-            var firstWeekday = firstDay.This((DayOfWeek) weekday);
+            var firstWeekday = firstDay.This((DayOfWeek)weekday);
             if (weekday == 0)
             {
                 weekday = 7;
             }
-            var firstDayOfWeek = firstDay.DayOfWeek != 0 ? (int) firstDay.DayOfWeek : 7;
+            var firstDayOfWeek = firstDay.DayOfWeek != 0 ? (int)firstDay.DayOfWeek : 7;
             if (weekday < firstDayOfWeek)
             {
-                firstWeekday = firstDay.Next((DayOfWeek) weekday);
+                firstWeekday = firstDay.Next((DayOfWeek)weekday);
             }
-            return firstWeekday.AddDays(7*(cadinal - 1));
+            return firstWeekday.AddDays(7 * (cadinal - 1));
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private readonly IDatePeriodParserConfiguration config;
 
-        private static bool InclusiveEndPeriod = true;
+        private static bool InclusiveEndPeriod = false;
 
         public BaseDatePeriodParser(IDatePeriodParserConfiguration configuration)
         {
@@ -845,7 +845,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return ret;
         }
 
-        private static DateObject ComputeDate(int cadinal, int weekday, int month, int year)
+        private static DateObject ComputeDate(int cardinal, int weekday, int month, int year)
         {
             var firstDay = new DateObject(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
@@ -858,7 +858,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 firstWeekday = firstDay.Next((DayOfWeek)weekday);
             }
-            return firstWeekday.AddDays(7 * (cadinal - 1));
+            return firstWeekday.AddDays(7 * (cardinal - 1));
+        }
+
+        public bool GetInclusiveEndPeriodFlag()
+        {
+            return InclusiveEndPeriod;
         }
     }
 }


### PR DESCRIPTION
As discussed with Borje, we should inform the user for the change before we actually make the change. Before that we should set the bool "InclusiveEndPeriod" in BaseDatePeriodParser to false.