### PR TITLE
More currency extractor changes for Portuguese + small fixes and cleanup in Spanish and Chinese recognizers

### DIFF
--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestHolidayParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestHolidayParser.cs
@@ -72,9 +72,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back on Yuandan of next year",
                 new DateObject(2017, 1, 1), 
                 new DateObject(2017, 1, 1));
+
             BasicTest("I'll go back on thanks giving day 2010", 
                 new DateObject(2010, 11, 25),
                 new DateObject(2010, 11, 25));
+
             BasicTest("I'll go back on father's day of 2015",
                 new DateObject(2015, 6, 21),
                 new DateObject(2015, 6, 21));

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/BaseDateTimeExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/BaseDateTimeExtractor.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public abstract class BaseDateTimeExtractor<T> : IExtractor
     {
         internal abstract ImmutableDictionary<Regex, T> Regexes { get; }
+
         protected virtual string ExtractType { get; } = "";
 
         public virtual List<ExtractResult> Extract(string source)
@@ -16,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 return new List<ExtractResult>();
             }
+
             var result = new List<ExtractResult>();
             var matchSource = new Dictionary<Match, T>();
             var matched = new bool[source.Length];
@@ -23,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 matched[i] = false;
             }
+
             foreach (var collection in Regexes.ToDictionary(o => o.Key.Matches(source), p => p.Value))
             {
                 foreach (Match m in collection.Key)
@@ -35,6 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     matchSource.Add(m, collection.Value);
                 }
             }
+
             var last = -1;
             for (var i = 0; i < source.Length; i++)
             {
@@ -45,6 +49,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         var start = last + 1;
                         var length = i - last;
                         var substr = source.Substring(start, length);
+
                         if (matchSource.Keys.Any(o => o.Index == start && o.Length == length))
                         {
                             var srcMatch = matchSource.Keys.First(o => o.Index == start && o.Length == length);
@@ -54,8 +59,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                                 Length = length,
                                 Text = substr,
                                 Type = ExtractType,
-                                Data = matchSource.ContainsKey(srcMatch)
-                                    ? new DateTimeExtra<T>
+                                Data = matchSource.ContainsKey(srcMatch) ?
+                                    new DateTimeExtra<T>
                                     {
                                         NamedEntity = srcMatch.Groups,
                                         Type = matchSource[srcMatch]
@@ -78,6 +83,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class DateTimeExtra<T>
     {
         public GroupCollection NamedEntity { get; set; }
+
         public T Type { get; set; }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateExtractorChs.cs
@@ -138,13 +138,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex AfterRegex = new Regex(@"之后|后",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly IntegerExtractor _integerExtractor = new IntegerExtractor();
-
-        private static readonly IParser _integerParser =
-            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Integer,
-                new ChineseNumberParserConfiguration());
-
-        private static readonly DurationExtractorChs _durationExtractor = new DurationExtractorChs();
+        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
 
         public List<ExtractResult> Extract(string text)
         {
@@ -199,8 +193,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private List<Token> DurationWithBeforeAndAfter(string text)
         {
             var ret = new List<Token>();
-            var duration_er = _durationExtractor.Extract(text);
-            foreach (var er in duration_er)
+            var durationEr = DurationExtractor.Extract(text);
+            foreach (var er in durationEr)
             {
                 var pos = (int)er.Start + (int)er.Length;
                 if (pos < text.Length)

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DatePeriodExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DatePeriodExtractorChs.cs
@@ -126,8 +126,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 YearInChineseRegex),
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly DateExtractorChs _datePointExtractor = new DateExtractorChs();
-        private static readonly IntegerExtractor _integerExtractor = new IntegerExtractor();
+        private static readonly DateExtractorChs DatePointExtractor = new DateExtractorChs();
+        private static readonly IntegerExtractor IntegerExtractor = new IntegerExtractor();
 
         private static readonly Regex[] SimpleCasesRegexes =
         {
@@ -172,7 +172,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private List<Token> MergeTwoTimePoints(string text)
         {
             var ret = new List<Token>();
-            var er = _datePointExtractor.Extract(text);
+            var er = DatePointExtractor.Extract(text);
             if (er.Count <= 1)
             {
                 return ret;
@@ -220,7 +220,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var ret = new List<Token>();
 
             var durations = new List<Token>();
-            var ers = _integerExtractor.Extract(text);
+            var ers = IntegerExtractor.Extract(text);
             foreach (var er in ers)
             {
                 var afterStr = text.Substring(er.Start + er.Length ?? 0);
@@ -246,6 +246,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     continue;
                 }
+
                 var match = PastRegex.Match(beforeStr);
                 if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {
@@ -253,6 +254,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     continue;
                 }
                 match = FutureRegex.Match(beforeStr);
+
                 if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {
                     ret.Add(new Token(match.Index, duration.End));

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtractorChs.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex TimeOfTodayRegex = new Regex(@"(今晚|今早|今晨|明晚|明早|明晨|昨晚)(的|在)?",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly DateExtractorChs _datePointExtractor = new DateExtractorChs();
-        private static readonly TimeExtractorChs _timePointExtractor = new TimeExtractorChs();
+        private static readonly DateExtractorChs DatePointExtractor = new DateExtractorChs();
+        private static readonly TimeExtractorChs TimePointExtractor = new TimeExtractorChs();
 
         public List<ExtractResult> Extract(string text)
         {
@@ -53,13 +53,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public List<Token> MergeDateAndTime(string text)
         {
             var ret = new List<Token>();
-            var ers = _datePointExtractor.Extract(text);
+            var ers = DatePointExtractor.Extract(text);
             if (ers.Count == 0)
             {
                 return ret;
             }
 
-            ers.AddRange(_timePointExtractor.Extract(text));
+            ers.AddRange(TimePointExtractor.Extract(text));
             if (ers.Count < 2)
             {
                 return ret;
@@ -74,6 +74,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     return -1;
                 }
+
                 if (start1 == start2)
                 {
                     return 0;
@@ -89,6 +90,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     j++;
                 }
+
                 if (j >= ers.Count)
                 {
                     break;
@@ -102,14 +104,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         break;
                     }
+
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim().ToLower();
-                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",") ||
-                        PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",") || PrepositionRegex.IsMatch(middleStr))
                     {
                         var begin = ers[i].Start ?? 0;
                         var end = (ers[j].Start ?? 0) + (ers[j].Length ?? 0);
                         ret.Add(new Token(begin, end));
                     }
+
                     i = j + 1;
                     continue;
                 }
@@ -123,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public List<Token> TimeOfToday(string text)
         {
             var ret = new List<Token>();
-            var ers = _timePointExtractor.Extract(text);
+            var ers = TimePointExtractor.Extract(text);
             foreach (var er in ers)
             {
                 var beforeStr = text.Substring(0, er.Start ?? 0);
@@ -135,11 +138,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     beforeStr = text.Substring(0, (er.Start ?? 0) + innerMatch.Length);
                 }
 
-
                 if (string.IsNullOrEmpty(beforeStr))
                 {
                     continue;
                 }
+
                 var match = TimeOfTodayRegex.Match(beforeStr);
                 if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
@@ -62,12 +62,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex FutureRegex = new Regex(@"(?<past>(后|下|之后))",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly TimeExtractorChs _singleTimeExtractor = new TimeExtractorChs();
-        private static readonly DateTimeExtractorChs _timeWithDateExtractor = new DateTimeExtractorChs();
-        private static readonly DateExtractorChs _singleDateExtractor = new DateExtractorChs();
-        private static readonly CardinalExtractor _cardinalExtractor = new CardinalExtractor();
-        private static readonly TimePeriodExtractorChs _timePeriodExtractor = new TimePeriodExtractorChs();
-
+        private static readonly TimeExtractorChs SingleTimeExtractor = new TimeExtractorChs();
+        private static readonly DateTimeExtractorChs TimeWithDateExtractor = new DateTimeExtractorChs();
+        private static readonly DateExtractorChs SingleDateExtractor = new DateExtractorChs();
+        private static readonly CardinalExtractor CardinalExtractor = new CardinalExtractor();
+        private static readonly TimePeriodExtractorChs TimePeriodExtractor = new TimePeriodExtractorChs();
 
         public List<ExtractResult> Extract(string text)
         {
@@ -84,9 +83,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private List<Token> MergeDateAndTimePeriod(string text)
         {
             var ret = new List<Token>();
-            var er1 = _singleDateExtractor.Extract(text);
-            var er2 = _timePeriodExtractor.Extract(text);
+            var er1 = SingleDateExtractor.Extract(text);
+            var er2 = TimePeriodExtractor.Extract(text);
             var timePoints = new List<ExtractResult>();
+            
             // handle the overlap problem
             var j = 0;
             for (var i = 0; i < er1.Count; i++)
@@ -97,15 +97,18 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     timePoints.Add(er2[j]);
                     j++;
                 }
+
                 while (j < er2.Count && er2[j].IsOverlap(er1[i]))
                 {
                     j++;
                 }
             }
+
             for (; j < er2.Count; j++)
             {
                 timePoints.Add(er2[j]);
             }
+
             timePoints.Sort(delegate(ExtractResult er_1, ExtractResult er_2)
             {
                 var start1 = er_1.Start ?? 0;
@@ -114,6 +117,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     return -1;
                 }
+
                 if (start1 == start2)
                 {
                     return 0;
@@ -151,9 +155,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private List<Token> MergeTwoTimePoints(string text)
         {
             var ret = new List<Token>();
-            var er1 = _timeWithDateExtractor.Extract(text);
-            var er2 = _singleTimeExtractor.Extract(text);
+            var er1 = TimeWithDateExtractor.Extract(text);
+            var er2 = SingleTimeExtractor.Extract(text);
             var timePoints = new List<ExtractResult>();
+
             // handle the overlap problem
             var j = 0;
             for (var i = 0; i < er1.Count; i++)
@@ -164,15 +169,18 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     timePoints.Add(er2[j]);
                     j++;
                 }
+
                 while (j < er2.Count && er2[j].IsOverlap(er1[i]))
                 {
                     j++;
                 }
             }
+
             for (; j < er2.Count; j++)
             {
                 timePoints.Add(er2[j]);
             }
+
             timePoints.Sort(delegate(ExtractResult er_1, ExtractResult er_2)
             {
                 var start1 = er_1.Start ?? 0;
@@ -181,13 +189,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     return -1;
                 }
+
                 if (start1 == start2)
                 {
                     return 0;
                 }
                 return 1;
             });
-
 
             // merge "{TimePoint} to {TimePoint}", "between {TimePoint} and {TimePoint}"
             var idx = 0;
@@ -223,6 +231,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     idx += 2;
                     continue;
                 }
+               
                 // handle "between {TimePoint} and {TimePoint}"
                 if (middleStr.Equals("和") || middleStr.Equals("与") || middleStr.Equals("到"))
                 {
@@ -256,11 +265,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // Date followed by morning, afternoon
-            var ers = _singleDateExtractor.Extract(text);
+            var ers = SingleDateExtractor.Extract(text);
             if (ers.Count == 0)
             {
                 return ret;
             }
+
             foreach (var er in ers)
             {
                 var afterStr = text.Substring(er.Start + er.Length ?? 0);
@@ -283,7 +293,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var ret = new List<Token>();
 
             var durations = new List<Token>();
-            var ers = _cardinalExtractor.Extract(text);
+            var ers = CardinalExtractor.Extract(text);
+
             foreach (var er in ers)
             {
                 var afterStr = text.Substring(er.Start + er.Length ?? 0);
@@ -307,12 +318,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     continue;
                 }
+
                 var match = PastRegex.Match(beforeStr);
                 if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {
                     ret.Add(new Token(match.Index, duration.End));
                     continue;
                 }
+
                 match = FutureRegex.Match(beforeStr);
                 if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DurationExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DurationExtractorChs.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class DurationExtractorChs : BaseDateTimeExtractor<DurationType>
     {
         internal override ImmutableDictionary<Regex, DurationType> Regexes { get; }
+
         protected sealed override string ExtractType { get; } = Constants.SYS_DATETIME_DURATION; // "Duration";
 
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 
-        private static readonly Regex YearRegex = new Regex(@"((19\d{2}|20\d{2})|两千)年",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        private static readonly Regex YearRegex = new Regex(@"((19\d{2}|20\d{2})|两千)年", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         // extract by number with unit
         public override List<ExtractResult> Extract(string source)
@@ -57,6 +57,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }.ToImmutableDictionary();
 
             public override ImmutableList<string> AmbiguousUnitList => AmbiguousUnits;
+
             public static readonly ImmutableList<string> AmbiguousUnits = new List<string>()
             {
                 "分钟",

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/MergedDateTimeExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/MergedDateTimeExtractor.cs
@@ -5,30 +5,29 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class MergedExtractorChs : IExtractor
     {
-        private static readonly DateExtractorChs _dateExtractor = new DateExtractorChs();
-        private static readonly TimeExtractorChs _timeExtractor = new TimeExtractorChs();
-        private static readonly DateTimeExtractorChs _dateTimeExtractor = new DateTimeExtractorChs();
-        private static readonly DatePeriodExtractorChs _datePeriodExtractor = new DatePeriodExtractorChs();
-        private static readonly TimePeriodExtractorChs _timePeriodExtractor = new TimePeriodExtractorChs();
-        private static readonly DateTimePeriodExtractorChs _dateTimePeriodExtractor = new DateTimePeriodExtractorChs();
-        private static readonly DurationExtractorChs _durationExtractor = new DurationExtractorChs();
-        private static readonly SetExtractorChs _setExtractor = new SetExtractorChs();
-        private static readonly BaseHolidayExtractor _holidayExtractor = new BaseHolidayExtractor(new ChineseHolidayExtractorConfiguration());
-
+        private static readonly DateExtractorChs DateExtractor = new DateExtractorChs();
+        private static readonly TimeExtractorChs TimeExtractor = new TimeExtractorChs();
+        private static readonly DateTimeExtractorChs DateTimeExtractor = new DateTimeExtractorChs();
+        private static readonly DatePeriodExtractorChs DatePeriodExtractor = new DatePeriodExtractorChs();
+        private static readonly TimePeriodExtractorChs TimePeriodExtractor = new TimePeriodExtractorChs();
+        private static readonly DateTimePeriodExtractorChs DateTimePeriodExtractor = new DateTimePeriodExtractorChs();
+        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
+        private static readonly SetExtractorChs SetExtractor = new SetExtractorChs();
+        private static readonly BaseHolidayExtractor HolidayExtractor = new BaseHolidayExtractor(new ChineseHolidayExtractorConfiguration());
 
         public List<ExtractResult> Extract(string text)
         {
-            var ret = new List<ExtractResult>();
+            var ret = DateExtractor.Extract(text);
+
             // the order is important, since there is a problem in merging
-            ret = _dateExtractor.Extract(text);
-            AddTo(ret, _timeExtractor.Extract(text));
-            AddTo(ret, _durationExtractor.Extract(text));
-            AddTo(ret, _datePeriodExtractor.Extract(text));
-            AddTo(ret, _dateTimeExtractor.Extract(text));
-            AddTo(ret, _timePeriodExtractor.Extract(text));
-            AddTo(ret, _dateTimePeriodExtractor.Extract(text));
-            AddTo(ret, _setExtractor.Extract(text));
-            AddTo(ret, _holidayExtractor.Extract(text));
+            AddTo(ret, TimeExtractor.Extract(text));
+            AddTo(ret, DurationExtractor.Extract(text));
+            AddTo(ret, DatePeriodExtractor.Extract(text));
+            AddTo(ret, DateTimeExtractor.Extract(text));
+            AddTo(ret, TimePeriodExtractor.Extract(text));
+            AddTo(ret, DateTimePeriodExtractor.Extract(text));
+            AddTo(ret, SetExtractor.Extract(text));
+            AddTo(ret, HolidayExtractor.Extract(text));
 
             CheckBlackList(ret, text);
             return ret;
@@ -41,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var regex = new Regex(@"^\d{1,2}号", RegexOptions.IgnoreCase);
             foreach (var d in dst)
             {
-                var tmp = (int) d.Start + (int) d.Length;
+                var tmp = (int)d.Start + (int)d.Length;
                 if (tmp != text.Length)
                 {
                     var tmpchar = text.Substring(tmp, 1);
@@ -50,6 +49,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         continue;
                     }
                 }
+
                 if (regex.Match(d.Text).Success)
                 {
                     continue;
@@ -70,6 +70,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     duplicate.Add(i);
                 }
             }
+
             foreach (var dup in duplicate)
             {
                 dst.RemoveAt(dup);
@@ -100,6 +101,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         break;
                     }
                 }
+
                 if (!isFound)
                 {
                     dst.Add(result);

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/SetExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/SetExtractorChs.cs
@@ -8,10 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
         public static readonly Regex UnitRegex =
-            new Regex(
-                @"(?<unit>年|月|周|星期|日|天|小时|时|分钟|分|秒钟|秒)",
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
+            new Regex(@"(?<unit>年|月|周|星期|日|天|小时|时|分钟|分|秒钟|秒)",
+                      RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex EachUnitRegex = new Regex(
             $@"(?<each>(每个|每一|每)\s*{UnitRegex})", RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -25,10 +23,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex EachDayRegex = new Regex(@"(每|每一)(天|日)\s*$",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly DurationExtractorChs _durationExtractor = new DurationExtractorChs();
-        private static readonly TimeExtractorChs _timeExtractor = new TimeExtractorChs();
-        private static readonly DateExtractorChs _dateExtractor = new DateExtractorChs();
-        private static readonly DateTimeExtractorChs _dateTimeExtractor = new DateTimeExtractorChs();
+        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
+        private static readonly TimeExtractorChs TimeExtractor = new TimeExtractorChs();
+        private static readonly DateExtractorChs DateExtractor = new DateExtractorChs();
+        private static readonly DateTimeExtractorChs DateTimeExtractor = new DateTimeExtractorChs();
 
         public List<ExtractResult> Extract(string text)
         {
@@ -46,7 +44,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var ret = new List<Token>();
 
-            var ers = _durationExtractor.Extract(text);
+            var ers = DurationExtractor.Extract(text);
             foreach (var er in ers)
             {
                 // "each last summer" doesn't make sense
@@ -77,14 +75,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Add(new Token(match.Index, match.Index + match.Length));
             }
 
-
             return ret;
         }
 
         public List<Token> TimeEveryday(string text)
         {
             var ret = new List<Token>();
-            var ers = _timeExtractor.Extract(text);
+            var ers = TimeExtractor.Extract(text);
             foreach (var er in ers)
             {
                 var beforeStr = text.Substring(0, er.Start ?? 0);
@@ -100,7 +97,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public List<Token> MatchEachDate(string text)
         {
             var ret = new List<Token>();
-            var ers = _dateExtractor.Extract(text);
+            var ers = DateExtractor.Extract(text);
             foreach (var er in ers)
             {
                 var beforeStr = text.Substring(0, er.Start ?? 0);
@@ -116,7 +113,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public List<Token> MatchEachDateTime(string text)
         {
             var ret = new List<Token>();
-            var ers = _dateTimeExtractor.Extract(text);
+            var ers = DateTimeExtractor.Extract(text);
             foreach (var er in ers)
             {
                 var beforeStr = text.Substring(0, er.Start ?? 0);

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimeExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimeExtractorChs.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class TimeExtractorChs : BaseDateTimeExtractor<TimeType>
     {
         internal sealed override ImmutableDictionary<Regex, TimeType> Regexes { get; }
+
         protected sealed override string ExtractType { get; } = Constants.SYS_DATETIME_TIME; // "Fraction";
 
         public static readonly string HourNumRegex =
@@ -67,7 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public TimeExtractorChs()
         {
-            var _regexes = new Dictionary<Regex, TimeType>
+            var regexes = new Dictionary<Regex, TimeType>
             {
                 {
                     new Regex(
@@ -86,7 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     TimeType.LessTime
                 }
             };
-            Regexes = _regexes.ToImmutableDictionary();
+            Regexes = regexes.ToImmutableDictionary();
         }
     }
 

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimePeriodExtractorChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimePeriodExtractorChs.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class TimePeriodExtractorChs : BaseDateTimeExtractor<PeriodType>
     {
         internal sealed override ImmutableDictionary<Regex, PeriodType> Regexes { get; }
+
         protected sealed override string ExtractType { get; } = Constants.SYS_DATETIME_TIMEPERIOD;
 
         public const string TimePeriodConnectWords = "(起|至|到|–|-|—|~|～)";
@@ -38,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public TimePeriodExtractorChs()
         {
-            var _regexes = new Dictionary<Regex, PeriodType>
+            var regexes = new Dictionary<Regex, PeriodType>
             {
                 {
                     new Regex($@"({LeftDigitTimeRegex}{RightDigitTimeRegex}|{LeftChsTimeRegex}{RightChsTimeRegex})",
@@ -52,7 +53,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     PeriodType.ShortTime
                 }
             };
-            Regexes = _regexes.ToImmutableDictionary();
+
+            Regexes = regexes.ToImmutableDictionary();
         }
     }
 

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -38,8 +38,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public string After => @"(后|之后)$";
 
         public string LastWeekDayToken => "最后一个";
+
         public string NextMonthToken => "下一个";
+
         public string LastMonthToken => "上一个";
+
         public string DatePrefix => " ";
 
         #region internalParsers
@@ -480,6 +483,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {"大年", 13}
             }.ToImmutableDictionary();
         }
+
         private static ImmutableDictionary<string, int> InitNumbers()
         {
             return new Dictionary<string, int>

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
@@ -10,15 +10,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATEPERIOD; //"DatePeriod";
 
-        private static readonly IExtractor _singleDateExtractor = new DateExtractorChs();
+        private static readonly IExtractor SingleDateExtractor = new DateExtractorChs();
 
-        private static readonly IExtractor _integerExtractor = new IntegerExtractor();
+        private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser _integerParser = new ChineseNumberParser(new ChineseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new ChineseNumberParser(new ChineseNumberParserConfiguration());
 
-        private static readonly IExtractor durationextractor = new DurationExtractorChs();
+        private static readonly IExtractor Durationextractor = new DurationExtractorChs();
 
-        private static readonly Calendar _cal = DateTimeFormatInfo.InvariantInfo.Calendar;
+        private static readonly Calendar Cal = DateTimeFormatInfo.InvariantInfo.Calendar;
 
         private readonly IFullDateTimeParserConfiguration config;
 
@@ -46,39 +46,46 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     innerResult = ParseOneWordPeriod(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = MergeTwoTimePoints(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseNumberWithUnit(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseYearAndMonth(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseYearToYear(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseYear(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseWeekOfMonth(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseSeason(er.Text, referenceDate);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseQuarter(er.Text, referenceDate);
                 }
-
 
                 if (innerResult.Success)
                 {
@@ -127,6 +134,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 TimexStr = value == null ? "" : ((DateTimeResolutionResult) value).Timex,
                 ResolutionStr = ""
             };
+
             return ret;
         }
 
@@ -158,6 +166,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     noYear = true;
                 }
+
                 if (!string.IsNullOrEmpty(monthStr))
                 {
                     month = this.config.MonthOfYear[monthStr.ToLower()];
@@ -222,6 +231,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 futureYear++;
             }
+
             if (noYear && startDate >= referenceDate)
             {
                 pastYear--;
@@ -281,6 +291,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         EndYear = int.Parse(yearTo);
                     }
                 }
+
                 if (BeginYear < 100 && BeginYear >= 90)
                 {
                     BeginYear += 1900;
@@ -289,6 +300,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     BeginYear += 2000;
                 }
+
                 if (EndYear < 100 && EndYear >= 90)
                 {
                     EndYear += 1900;
@@ -300,9 +312,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 var beginDay = new DateObject(BeginYear, 1, 1);
                 var endDay = new DateObject(EndYear, 12, 31);
-                var BeginTimex = BeginYear.ToString("D4");
-                var EndTimex = EndYear.ToString("D4");
-                ret.Timex = $"({BeginTimex},{EndTimex},P{EndYear - BeginYear}Y)";
+                var beginTimex = BeginYear.ToString("D4");
+                var endTimex = EndYear.ToString("D4");
+                ret.Timex = $"({beginTimex},{endTimex},P{EndYear - BeginYear}Y)";
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
                 return ret;
@@ -319,6 +331,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 match = DatePeriodExtractorChs.PureNumYearAndMonth.Match(text);
             }
+
             if (!(match.Success && match.Length == text.Length))
             {
                 return ret;
@@ -405,6 +418,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ret.Success = true;
                     return ret;
                 }
+
                 var thismatch = DatePeriodExtractorChs.ThisRegex.Match(trimedText);
                 var nextmatch = DatePeriodExtractorChs.NextRegex.Match(trimedText);
                 var lastmatch = DatePeriodExtractorChs.LastRegex.Match(trimedText);
@@ -439,6 +453,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         {
                             futureYear++;
                         }
+
                         if (month >= referenceDate.Month)
                         {
                             pastYear--;
@@ -461,7 +476,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         var monday = referenceDate.This(DayOfWeek.Monday).AddDays(7*swift);
                         ret.Timex = monday.Year.ToString("D4") + "-W" +
-                                    _cal.GetWeekOfYear(monday, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
+                                    Cal.GetWeekOfYear(monday, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
                                         .ToString("D2");
                         ret.FutureValue =
                             ret.PastValue =
@@ -471,6 +486,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         ret.Success = true;
                         return ret;
                     }
+
                     if (trimedText.EndsWith("周末"))
                     {
                         DateObject beginDate, endDate;
@@ -478,13 +494,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         endDate = referenceDate.This(DayOfWeek.Sunday).AddDays(7*swift);
 
                         ret.Timex = beginDate.Year.ToString("D4") + "-W" +
-                                    _cal.GetWeekOfYear(beginDate, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
+                                    Cal.GetWeekOfYear(beginDate, CalendarWeekRule.FirstDay, DayOfWeek.Monday)
                                         .ToString("D2") + "-WE";
                         ret.FutureValue =
                             ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate.AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
+
                     if (trimedText.EndsWith("月"))
                     {
                         month = referenceDate.AddMonths(swift).Month;
@@ -541,12 +558,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private static int ConvertChineseToNum(string numStr)
         {
             var num = -1;
-            var er = _integerExtractor.Extract(numStr);
+            var er = IntegerExtractor.Extract(numStr);
             if (er.Count != 0)
             {
                 if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                 {
-                    num = Convert.ToInt32((double) (_integerParser.Parse(er[0]).Value ?? 0));
+                    num = Convert.ToInt32((double) (IntegerParser.Parse(er[0]).Value ?? 0));
                 }
             }
             return num;
@@ -558,26 +575,27 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var year = 0;
             var num = 0;
 
-            var er = _integerExtractor.Extract(yearChsStr);
+            var er = IntegerExtractor.Extract(yearChsStr);
             if (er.Count != 0)
             {
                 if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                 {
-                    num = Convert.ToInt32((double) (_integerParser.Parse(er[0]).Value ?? 0));
+                    num = Convert.ToInt32((double) (IntegerParser.Parse(er[0]).Value ?? 0));
                 }
             }
+
             if (num < 10)
             {
                 num = 0;
                 foreach (var ch in yearChsStr)
                 {
                     num *= 10;
-                    er = _integerExtractor.Extract(ch.ToString());
+                    er = IntegerExtractor.Extract(ch.ToString());
                     if (er.Count != 0)
                     {
                         if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                         {
-                            num += Convert.ToInt32((double) (_integerParser.Parse(er[0]).Value ?? 0));
+                            num += Convert.ToInt32((double) (IntegerParser.Parse(er[0]).Value ?? 0));
                         }
                     }
                 }
@@ -602,6 +620,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     tmp = tmp.Substring(0, tmp.Length - 1);
                 }
+
                 var num = 0;
                 var year = 0;
                 if (tmp.Length == 2)
@@ -621,6 +640,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     year = int.Parse(tmp);
                 }
+
                 var beginDay = new DateObject(year, 1, 1);
                 var endDay = new DateObject(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
@@ -628,6 +648,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Success = true;
                 return ret;
             }
+
             match = DatePeriodExtractorChs.YearInChineseRegex.Match(text);
             if (match.Success && match.Length == text.Length)
             {
@@ -636,10 +657,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     tmp = tmp.Substring(0, tmp.Length - 1);
                 }
+
                 if (tmp.Length == 1)
                 {
                     return ret;
                 }
+
                 var re = ConvertChineseToInteger(tmp);
                 var year = re;
 
@@ -651,6 +674,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     year += 2000;
                 }
+
                 var beginDay = new DateObject(year, 1, 1);
                 var endDay = new DateObject(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
@@ -666,10 +690,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult MergeTwoTimePoints(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var er = _singleDateExtractor.Extract(text);
+            var er = SingleDateExtractor.Extract(text);
             if (er.Count < 2)
             {
-                er = _singleDateExtractor.Extract("on " + text);
+                er = SingleDateExtractor.Extract("on " + text);
                 if (er.Count < 2)
                 {
                     return ret;
@@ -689,15 +713,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 futureEnd = (DateObject) ((DateTimeResolutionResult) pr2.Value).FutureValue;
             DateObject pastBegin = (DateObject) ((DateTimeResolutionResult) pr1.Value).PastValue,
                 pastEnd = (DateObject) ((DateTimeResolutionResult) pr2.Value).PastValue;
+
             if (futureBegin > futureEnd)
             {
                 futureBegin = pastBegin;
             }
+
             if (pastEnd < pastBegin)
             {
                 pastEnd = futureEnd;
             }
-
 
             ret.Timex = $"({pr1.TimexStr},{pr2.TimexStr},P{(futureEnd - futureBegin).TotalDays}D)";
             ret.FutureValue = new Tuple<DateObject, DateObject>(futureBegin, futureEnd);
@@ -725,6 +750,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     unitStr = this.config.UnitMap[srcUnit];
                     numStr = match.Groups["num"].Value;
+
                     var prefixMatch = DatePeriodExtractorChs.PastRegex.Match(beforeStr);
                     if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
                     {
@@ -750,11 +776,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             default:
                                 return ret;
                         }
+
                         ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P{numStr}{unitStr[0]})";
                         ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
                         ret.Success = true;
                         return ret;
                     }
+
                     prefixMatch = DatePeriodExtractorChs.FutureRegex.Match(beforeStr);
                     if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
                     {
@@ -780,6 +808,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             default:
                                 return ret;
                         }
+
                         ret.Timex =
                             $"({FormatUtil.LuisDate(beginDate.AddDays(1))},{FormatUtil.LuisDate(endDate.AddDays(1))},P{numStr}{unitStr[0]})";
                         ret.FutureValue =
@@ -791,15 +820,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // for case "前两年" "后三年"
-            var duration_res = durationextractor.Extract(text);
-            if (duration_res.Count > 0)
+            var durationRes = Durationextractor.Extract(text);
+            if (durationRes.Count > 0)
             {
-                var beforeStr = text.Substring(0, (int) duration_res[0].Start).Trim().ToLowerInvariant();
-                match = DatePeriodExtractorChs.UnitRegex.Match(duration_res[0].Text);
+                var beforeStr = text.Substring(0, (int)durationRes[0].Start).Trim().ToLowerInvariant();
+                match = DatePeriodExtractorChs.UnitRegex.Match(durationRes[0].Text);
                 if (match.Success)
                 {
                     var srcUnit = match.Groups["unit"].Value.ToLowerInvariant();
-                    var numberStr = duration_res[0].Text.Substring(0, match.Index).Trim().ToLowerInvariant();
+                    var numberStr = durationRes[0].Text.Substring(0, match.Index).Trim().ToLowerInvariant();
                     var number = ConvertChineseToNum(numberStr);
                     if (this.config.UnitMap.ContainsKey(srcUnit))
                     {
@@ -830,11 +859,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                                 default:
                                     return ret;
                             }
+
                             ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P{numStr}{unitStr[0]})";
                             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
                             ret.Success = true;
                             return ret;
                         }
+
                         prefixMatch = DatePeriodExtractorChs.FutureRegex.Match(beforeStr);
                         if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
                         {
@@ -860,6 +891,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                                 default:
                                     return ret;
                             }
+
                             ret.Timex =
                                 $"({FormatUtil.LuisDate(beginDate.AddDays(1))},{FormatUtil.LuisDate(endDate.AddDays(1))},P{numStr}{unitStr[0]})";
                             ret.FutureValue =
@@ -899,6 +931,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 cardinal = this.config.CardinalMap[cardinalStr];
             }
+
             int month;
             if (string.IsNullOrEmpty(monthStr))
             {
@@ -935,6 +968,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     futureDate = futureDate.AddDays(-7);
                 }
             }
+
             if (noYear && pastDate >= referenceDate)
             {
                 pastDate = ComputeDate(cardinal, 1, month, year - 1);
@@ -959,12 +993,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var match = DatePeriodExtractorChs.SeasonWithYear.Match(text);
             if (match.Success && match.Length == text.Length)
             {
-                // pare year 
+                // parse year 
                 var year = referenceDate.Year;
                 var hasYear = false;
                 var yearNum = match.Groups["year"].Value;
                 var yearChs = match.Groups["yearchs"].Value;
                 var yearRel = match.Groups["yearrel"].Value;
+
                 if (!string.IsNullOrEmpty(yearNum))
                 {
                     hasYear = true;
@@ -1090,10 +1125,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 weekday = 7;
             }
+
             if (weekday < (int) firstDay.DayOfWeek)
             {
                 firstWeekday = firstDay.Next((DayOfWeek) weekday);
             }
+
             return firstWeekday.AddDays(7*(cadinal - 1));
         }
     }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
@@ -8,14 +8,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIME;
 
-        public static readonly Regex SimpleAmRegex = new Regex(@"(?<am>早|晨)",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex SimpleAmRegex = new Regex(@"(?<am>早|晨)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex SimplePmRegex = new Regex(@"(?<pm>晚)",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex SimplePmRegex = new Regex(@"(?<pm>晚)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly IExtractor _singleDateExtractor = new DateExtractorChs();
-        private static readonly IExtractor _singleTimeExtractor = new TimeExtractorChs();
+        private static readonly IExtractor SingleDateExtractor = new DateExtractorChs();
+        private static readonly IExtractor SingleTimeExtractor = new TimeExtractorChs();
 
         private readonly IFullDateTimeParserConfiguration config;
 
@@ -41,6 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     innerResult = ParseBasicRegex(er.Text, referenceTime);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseTimeOfToday(er.Text, referenceTime);
@@ -52,10 +51,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         {TimeTypeConstants.DATETIME, FormatUtil.FormatDateTime((DateObject) innerResult.FutureValue)}
                     };
+
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
                         {TimeTypeConstants.DATETIME, FormatUtil.FormatDateTime((DateObject) innerResult.PastValue)}
                     };
+
                     innerResult.IsLunar = IsLunarCalendar(er.Text);
 
                     value = innerResult;
@@ -109,6 +110,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     ret.Timex = "FUTURE_REF";
                 }
+
                 ret.FutureValue = ret.PastValue = referenceTime;
                 ret.Success = true;
                 return ret;
@@ -122,18 +124,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var ret = new DateTimeResolutionResult();
 
-            var er1 = _singleDateExtractor.Extract(text);
+            var er1 = SingleDateExtractor.Extract(text);
             if (er1.Count == 0)
             {
                 return ret;
             }
 
-            var er2 = _singleTimeExtractor.Extract(text);
+            var er2 = SingleTimeExtractor.Extract(text);
             if (er2.Count == 0)
             {
                 return ret;
             }
-
 
             var pr1 = this.config.DateParser.Parse(er1[0], referenceTime.Date);
             // TODO: Add reference time
@@ -168,13 +169,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
             timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
             ret.Timex = pr1.TimexStr + timeStr;
-            var Val = (DateTimeResolutionResult) pr2.Value;
+
+            var val = (DateTimeResolutionResult) pr2.Value;
+
             if (hour <= 12 && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
-                !string.IsNullOrEmpty(Val.Comment))
+                !string.IsNullOrEmpty(val.Comment))
             {
                 //ret.Timex += "ampm";
                 ret.Comment = "ampm";
             }
+
             ret.FutureValue = new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
             ret.PastValue = new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
             ret.Success = true;
@@ -185,7 +189,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseTimeOfToday(string text, DateObject referenceTime)
         {
             var ret = new DateTimeResolutionResult();
-            var ers = _singleTimeExtractor.Extract(text);
+            var ers = SingleTimeExtractor.Extract(text);
             if (ers.Count != 1)
             {
                 return ret;

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DurationParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DurationParserChs.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var dtParseResult = new DateTimeResolutionResult();
             var unitStr = unitResult.Unit;
             var numStr = unitResult.Number;
+
             dtParseResult.Timex = "P" + (BaseDurationParser.IsLessThanDay(unitStr) ? "T" : "") + numStr + unitStr[0];
             dtParseResult.FutureValue = dtParseResult.PastValue = double.Parse(numStr)*UnitValueMap[unitStr];
             dtParseResult.Success = true;
@@ -60,11 +61,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     {TimeTypeConstants.DURATION, dtParseResult.FutureValue.ToString()}
                 };
+
                 dtParseResult.PastResolution = new Dictionary<string, string>
                 {
                     {TimeTypeConstants.DURATION, dtParseResult.PastValue.ToString()}
                 };
             }
+
             var ret = new DateTimeParseResult
             {
                 Text = er.Text,
@@ -76,6 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 TimexStr = dtParseResult.Timex,
                 ResolutionStr = ""
             };
+
             return ret;
         }
     }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
@@ -11,14 +11,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATE; //"Date";
 
-        private static readonly IExtractor _integerExtractor = new IntegerExtractor();
+        private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser _integerParser = new ChineseNumberParser(new ChineseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new ChineseNumberParser(new ChineseNumberParserConfiguration());
 
         public static readonly Dictionary<string, DateObject> FixedHolidaysDict = new Dictionary<string, DateObject>
         {
-            //fixed holidays
-            #region fix holidays
+            
+            #region Fixed Date Holidays
+
             {"元旦", TimexConstants.yuandan},
             {"元旦节", TimexConstants.yuandan},
             {"教师节", TimexConstants.teacherday},
@@ -48,28 +49,37 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {"光棍节", TimexConstants.singlesday},
             {"双十一", TimexConstants.singlesday},
             {"重阳节", TimexConstants.chongyangday}
+
             #endregion
+
         };
 
         public static readonly Dictionary<string, Func<int, DateObject>> HolidayFuncDict = new Dictionary
             <string, Func<int, DateObject>>
         {
-            #region holiday func
+            
+            #region Holiday Functions
+
             {"父亲节", GetFathersDayOfYear},
             {"母亲节", GetMothersDayOfYear},
             {"感恩节", GetThanksgivingDayOfYear}
+            
             #endregion
+
         };
 
         public static readonly Dictionary<string, string> NoFixedTimex = new Dictionary<string, string>
         {
-            #region holiday TimeX
+            
+            #region Holiday Timexes
+
             {"父亲节", @"-06-WXX-6-3"},
             {"母亲节", @"-05-WXX-7-2"},
             {"感恩节", @"-11-WXX-4-4"}
-            #endregion
-        };
 
+            #endregion
+
+        };
 
         private readonly IFullDateTimeParserConfiguration config;
 
@@ -77,6 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             config = configuration;
         }
+
         public ParseResult Parse(ExtractResult extResult)
         {
             return this.Parse(extResult, DateObject.Now);
@@ -97,10 +108,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         {TimeTypeConstants.DATE, FormatUtil.FormatDate((DateObject) innerResult.FutureValue)}
                     };
+
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
                         {TimeTypeConstants.DATE, FormatUtil.FormatDate((DateObject) innerResult.PastValue)}
                     };
+
                     innerResult.IsLunar = IsLunarCalendar(er.Text);
                     value = innerResult;
                 }
@@ -125,11 +138,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var trimedText = text.Trim();
             var match = ChineseHolidayExtractorConfiguration.LunarHolidayRegex.Match(trimedText);
-            if (match.Success)
-            {
-                return true;
-            }
-            return false;
+            return match.Success;
         }
 
         private static DateTimeResolutionResult ParseHolidayRegexMatch(string text, DateObject referenceDate)
@@ -229,12 +238,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ret.Success = true;
                     return ret;
                 }
+
                 ret.Timex = "XXXX" + timexStr;
                 ret.FutureValue = GetFutureValue(value, referenceDate, holidayStr);
                 ret.PastValue = GetPastValue(value, referenceDate, holidayStr);
                 ret.Success = true;
                 return ret;
             }
+
             return ret;
         }
 
@@ -246,6 +257,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     return value.AddYears(1);
                 }
+
                 if (HolidayFuncDict.ContainsKey(holiday))
                 {
                     value = HolidayFuncDict[holiday](referenceDate.Year + 1);
@@ -262,6 +274,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     return value.AddYears(-1);
                 }
+
                 if (HolidayFuncDict.ContainsKey(holiday))
                 {
                     value = HolidayFuncDict[holiday](referenceDate.Year - 1);
@@ -338,26 +351,27 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var year = 0;
             var num = 0;
 
-            var er = _integerExtractor.Extract(yearChsStr);
+            var er = IntegerExtractor.Extract(yearChsStr);
             if (er.Count != 0)
             {
                 if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                 {
-                    num = Convert.ToInt32((double) (_integerParser.Parse(er[0]).Value ?? 0));
+                    num = Convert.ToInt32((double) (IntegerParser.Parse(er[0]).Value ?? 0));
                 }
             }
+
             if (num < 10)
             {
                 num = 0;
                 foreach (var ch in yearChsStr)
                 {
                     num *= 10;
-                    er = _integerExtractor.Extract(ch.ToString());
+                    er = IntegerExtractor.Extract(ch.ToString());
                     if (er.Count != 0)
                     {
                         if (er[0].Type.Equals(Number.Constants.SYS_NUM_INTEGER))
                         {
-                            num += Convert.ToInt32((double) (_integerParser.Parse(er[0]).Value ?? 0));
+                            num += Convert.ToInt32((double) (IntegerParser.Parse(er[0]).Value ?? 0));
                         }
                     }
                 }
@@ -371,7 +385,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
     }
 
-    #region holiday timexconstants
+    #region Holiday Timex Constants
 
     internal static class TimexConstants
     {
@@ -404,4 +418,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     }
 
     #endregion
+
 }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/MergedParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/MergedParserChs.cs
@@ -10,9 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static readonly Regex AfterRegex = new Regex(@"(后|之后)$", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public MergedParserChs(IMergedParserConfiguration configuration) : base(configuration)
-        {
-        }
+        public MergedParserChs(IMergedParserConfiguration configuration) : base(configuration) { }
 
         public new ParseResult Parse(ExtractResult er)
         {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/SetParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/SetParserChs.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_SET;
 
-        private static readonly IExtractor _durationExtractor = new DurationExtractorChs();
-        private static readonly IExtractor _timeExtractor = new TimeExtractorChs();
-        private static readonly IExtractor _dateExtractor = new DateExtractorChs();
-        private static readonly IExtractor _dateTimeExtractor = new DateTimeExtractorChs();
+        private static readonly IExtractor DurationExtractor = new DurationExtractorChs();
+        private static readonly IExtractor TimeExtractor = new TimeExtractorChs();
+        private static readonly IExtractor DateExtractor = new DateExtractorChs();
+        private static readonly IExtractor DateTimeExtractor = new DateTimeExtractorChs();
 
         private readonly IFullDateTimeParserConfiguration config;
 
@@ -35,6 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     innerResult = ParseEachDuration(er.Text);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParserTimeEveryday(er.Text);
@@ -46,6 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     innerResult = ParseEachDateTime(er.Text);
                 }
+
                 if (!innerResult.Success)
                 {
                     innerResult = ParseEachDate(er.Text);
@@ -57,10 +59,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         {TimeTypeConstants.SET, (string) innerResult.FutureValue}
                     };
+
                     innerResult.PastResolution = new Dictionary<string, string>
                     {
                         {TimeTypeConstants.SET, (string) innerResult.PastValue}
                     };
+
                     value = innerResult;
                 }
             }
@@ -82,7 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseEachDuration(string text)
         {
             var ret = new DateTimeResolutionResult();
-            var ers = _durationExtractor.Extract(text);
+            var ers = DurationExtractor.Extract(text);
             if (ers.Count != 1 || !string.IsNullOrWhiteSpace(text.Substring(ers[0].Start + ers[0].Length ?? 0)))
             {
                 return ret;
@@ -131,6 +135,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         return ret;
                     }
+
                     ret.FutureValue = ret.PastValue = "Set: " + ret.Timex;
                     ret.Success = true;
                     return ret;
@@ -143,7 +148,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParserTimeEveryday(string text)
         {
             var ret = new DateTimeResolutionResult();
-            var ers = _timeExtractor.Extract(text);
+            var ers = TimeExtractor.Extract(text);
             if (ers.Count != 1)
             {
                 return ret;
@@ -166,7 +171,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseEachDate(string text)
         {
             var ret = new DateTimeResolutionResult();
-            var ers = _dateExtractor.Extract(text);
+            var ers = DateExtractor.Extract(text);
             if (ers.Count != 1)
             {
                 return ret;
@@ -188,7 +193,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseEachDateTime(string text)
         {
             var ret = new DateTimeResolutionResult();
-            var ers = _dateTimeExtractor.Extract(text);
+            var ers = DateTimeExtractor.Extract(text);
             if (ers.Count != 1)
             {
                 return ret;
@@ -207,14 +212,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             return ret;
         }
 
-
         private static bool IsLessThanDay(string unit)
         {
-            if (unit.Equals("S") || unit.Equals("M") || unit.Equals("H"))
-            {
-                return true;
-            }
-            return false;
+            return (unit.Equals("S") || unit.Equals("M") || unit.Equals("H"));
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {TimeType.LessTime, TimeFunctions.HandleLess}
             };
 
-
         private readonly IFullDateTimeParserConfiguration config;
 
         public TimeParserChs(IFullDateTimeParserConfiguration configuration)
@@ -42,6 +41,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 var result = TimeExtractor.Extract(er.Text);
                 extra = result[0]?.Data as DateTimeExtra<TimeType>;
             }
+
             if (extra != null)
             {
                 var timeResult = FunctionMap[extra.Type](extra);
@@ -52,11 +52,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         {TimeTypeConstants.TIME, FormatUtil.FormatTime((DateObject) parseResult.FutureValue)}
                     };
+
                     parseResult.PastResolution = new Dictionary<string, string>
                     {
                         {TimeTypeConstants.TIME, FormatUtil.FormatTime((DateObject) parseResult.PastValue)}
                     };
                 }
+
                 var ret = new DateTimeParseResult
                 {
                     Start = er.Start,
@@ -68,8 +70,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ResolutionStr = "",
                     TimexStr = parseResult.Timex
                 };
+
                 return ret;
             }
+
             return null;
         }
     }
@@ -111,18 +115,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var hour = MatchToValue(extra.NamedEntity["hour"].Value);
             var quarter = MatchToValue(extra.NamedEntity["quarter"].Value);
-            var minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter*15 : 0;
+            var minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter * 15 : 0;
             var second = MatchToValue(extra.NamedEntity["sec"].Value);
             var less = MatchToValue(extra.NamedEntity["min"].Value);
-            var all = hour*60 + minute - less;
+
+            var all = hour * 60 + minute - less;
             if (all < 0)
             {
                 all += 1440;
             }
+
             return new TimeResult
             {
-                Hour = all/60,
-                Minute = all%60,
+                Hour = all / 60,
+                Minute = all % 60,
                 Second = second
             };
         }
@@ -133,7 +139,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var quarter = MatchToValue(extra.NamedEntity["quarter"].Value);
             var minute = MatchToValue(extra.NamedEntity["min"].Value);
             var second = MatchToValue(extra.NamedEntity["sec"].Value);
-            minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter*15 : minute;
+            minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter * 15 : minute;
+
             return new TimeResult
             {
                 Hour = hour,
@@ -153,8 +160,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             return timeResult;
         }
 
-        public static DateTimeResolutionResult PackTimeResult(DateTimeExtra<TimeType> extra, TimeResult timeResult,
-            DateObject referenceTime)
+        public static DateTimeResolutionResult PackTimeResult(DateTimeExtra<TimeType> extra, TimeResult timeResult, DateObject referenceTime)
         {
             //Find if there is a description
             var noDesc = true;
@@ -174,30 +180,34 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             var dtResult = new DateTimeResolutionResult();
 
-
             var build = new StringBuilder("T");
             if (timeResult.Hour >= 0)
             {
                 build.Append(timeResult.Hour.ToString("D2"));
             }
+
             if (timeResult.Minute >= 0)
             {
                 build.Append(":" + timeResult.Minute.ToString("D2"));
             }
+
             if (timeResult.Second >= 0)
             {
                 build.Append(":" + timeResult.Second.ToString("D2"));
             }
+
             if (noDesc)
             {
                 //build.Append("ampm");
                 dtResult.Comment = "ampm";
             }
+
             dtResult.Timex = build.ToString();
             if (hour == 24)
             {
                 hour = 0;
             }
+
             dtResult.FutureValue = dtResult.PastValue = new DateObject(year, month, day, hour, min, second);
             dtResult.Success = true;
             return dtResult;
@@ -209,14 +219,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 return -1;
             }
+
             if (Regex.IsMatch(text, @"\d+"))
             {
                 return Int32.Parse(text);
             }
+
             if (text.Length == 1)
             {
                 return NumberDictionary[text[0]];
             }
+            
             //五十九,十一,二
             var tempValue = 1;
             foreach (var c in text)
@@ -243,6 +256,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 return;
             }
+
             if (LowBoundDesc.ContainsKey(dayDesc) && result.Hour < LowBoundDesc[dayDesc])
             {
                 result.Hour += 12;
@@ -261,6 +275,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 des = text.Substring(0, text.Length - 1);
             }
+
             var hour = MatchToValue(text.Substring(text.Length - 1, 1));
             var timeResult = new TimeResult
             {
@@ -269,6 +284,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 Second = -1
             };
             AddDesc(timeResult, des);
+
             return timeResult;
         }
     }
@@ -280,4 +296,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public int Second { get; set; }
         public int LowBound { get; set; } = -1;
     }
+
 }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 var result = new TimeExtractorChs().Extract(er.Text);
                 extra = result[0]?.Data as DateTimeExtra<PeriodType>;
             }
+
             if (extra != null)
             {
                 var parseResult = TimePeriodFunctions.Handle(this.config.TimeParser, extra, referenceTime);
@@ -44,6 +45,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             FormatUtil.FormatTime(((Tuple<DateObject, DateObject>) parseResult.FutureValue).Item2)
                         }
                     };
+
                     parseResult.PastResolution = new Dictionary<string, string>
                     {
                         {
@@ -56,6 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         }
                     };
                 }
+
                 var ret = new DateTimeParseResult
                 {
                     Start = er.Start,
@@ -66,8 +69,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ResolutionStr = "",
                     TimexStr = parseResult.Timex
                 };
+
                 return ret;
             }
+
             return null;
         }
     }
@@ -79,6 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             //Left is a time
             var left = extra.NamedEntity["left"];
             TimeResult leftResult, rightResult = null;
+            
             // 下午四点十分到五点十分
             if (extra.Type == PeriodType.FullTime)
             {
@@ -91,11 +97,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 };
                 leftResult = timeParser.Parse(leftExtract, refTime).Data as TimeResult;
             }
-            // 下午四到五点
             else
             {
+                // 下午四到五点
                 leftResult = TimeFunctions.GetShortLeft(left.Value);
             }
+
             //Right is a time
             var right = extra.NamedEntity["right"];
             var rightExtract = new ExtractResult
@@ -105,6 +112,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 Text = right.Value,
                 Type = Constants.SYS_DATETIME_TIME
             };
+
             rightResult = timeParser.Parse(rightExtract, refTime).Data as TimeResult;
 
             var ret = new DateTimeResolutionResult()
@@ -117,9 +125,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 rightResult.Hour += 12;
             }
+
             int day = refTime.Day,
                 month = refTime.Month,
                 year = refTime.Year;
+            
             //判断右侧是否比小测的小,如果比左侧的小,则增加一天
             int hour = leftResult.Hour > 0 ? leftResult.Hour : 0,
                 min = leftResult.Minute > 0 ? leftResult.Minute : 0,
@@ -153,14 +163,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 build.Append(timeResult.Hour.ToString("D2"));
             }
+
             if (timeResult.Minute >= 0)
             {
                 build.Append(":" + timeResult.Minute.ToString("D2"));
             }
+
             if (timeResult.Second >= 0)
             {
                 build.Append(":" + timeResult.Second.ToString("D2"));
             }
+
             return build.ToString();
         }
 
@@ -170,14 +183,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 right.Minute = 0;
             }
+
             if (right.Second == -1)
             {
                 right.Second = 0;
             }
+
             if (left.Minute == -1)
             {
                 left.Minute = 0;
             }
+
             if (left.Second == -1)
             {
                 left.Second = 0;
@@ -191,17 +207,21 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 spanSecond += 60;
                 spanMinute -= 1;
             }
+
             if (spanMinute < 0)
             {
                 spanMinute += 60;
                 spanHour -= 1;
             }
+
             if (spanHour < 0)
             {
                 spanHour += 24;
             }
+
             var spanTimex = new StringBuilder();
             spanTimex.Append($"PT{spanHour}H");
+
             if (spanMinute != 0 && spanSecond == 0)
             {
                 spanTimex.Append($"{spanMinute}M");
@@ -210,6 +230,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 spanTimex.Append($"{spanMinute}M{spanSecond}S");
             }
+
             return spanTimex.ToString();
         }
     }

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     {
         // part 1: smallest component
         // --------------------------------------
-
         public static readonly Regex DescRegex = new Regex(@"(?<desc>pm\b|am\b|p\.m\.|a\.m\.|p\b|a\b)",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -51,7 +50,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                     MinuteNumRegex),
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-
         public static readonly Regex TimePrefix =
             new Regex(string.Format(@"(?<prefix>({0} past|{0} to))", LessThanOneHour),
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -63,7 +61,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             new Regex(
                 string.Format(@"(?<basictime>{4}|{0}|{1}:{2}(:{3})?|{1})", HourNumRegex, BaseTimeExtractor.HourRegex, BaseTimeExtractor.MinuteRegex,
                     BaseTimeExtractor.SecondRegex, EngTimeRegex), RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
 
         // part 3: regex for time
         // --------------------------------------

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
@@ -4,9 +4,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class TimeParser : BaseTimeParser
     {
-        public TimeParser(ITimeParserConfiguration configuration) : 
-            base(configuration)
-        { }
+        public TimeParser(ITimeParserConfiguration configuration) : base(configuration) { }
 
         protected override DateTimeResolutionResult InternalParse(string text, DateObject referenceTime)
         {
@@ -23,6 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             var ret = new DateTimeResolutionResult();
             var trimedText = text.ToLowerInvariant().Trim();
+
             var match = EnglishTimeExtractorConfiguration.IshRegex.Match(trimedText);
             if (match.Success && match.Length == trimedText.Length)
             {
@@ -32,6 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 {
                     hour = int.Parse(hourStr);
                 }
+
                 ret.Timex = "T" + hour.ToString("D2");
                 ret.FutureValue =
                     ret.PastValue =
@@ -39,6 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 ret.Success = true;
                 return ret;
             }
+
             return ret;
         }
     }

--- a/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnlighDatetimeUtilityConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnlighDatetimeUtilityConfiguration.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Utilities
         };
 
         List<string> IDateTimeUtilityConfiguration.AgoStringList => AgoStringList;
+
         List<string> IDateTimeUtilityConfiguration.LaterStringList => LaterStringList;
+
         List<string> IDateTimeUtilityConfiguration.InStringList => InStringList;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Utilities
         };
 
         List<string> IDateTimeUtilityConfiguration.AgoStringList => AgoStringList;
+
         List<string> IDateTimeUtilityConfiguration.LaterStringList => LaterStringList;
+
         List<string> IDateTimeUtilityConfiguration.InStringList => InStringList;
     }
 }

--- a/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Recognizers.Text.Number.Chinese;
 using Microsoft.Recognizers.Text.Number.English;
 using Microsoft.Recognizers.Text.Number.French;
+using Microsoft.Recognizers.Text.Number.Portuguese;
 using Microsoft.Recognizers.Text.Number.Spanish;
 
 namespace Microsoft.Recognizers.Text.Number
@@ -59,13 +60,13 @@ namespace Microsoft.Recognizers.Text.Number
                     Culture.Portuguese, new Dictionary<Type, IModel>
                     {
                         [typeof(NumberModel)] = new NumberModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration()),
                             new Portuguese.NumberExtractor(NumberMode.PureNumber)),
                         [typeof(OrdinalModel)] = new OrdinalModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new PortugueseNumberParserConfiguration()),
                             new Portuguese.OrdinalExtractor()),
                         [typeof(PercentModel)] = new PercentModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new PortugueseNumberParserConfiguration()),
                             new Portuguese.PercentageExtractor())
                     }
                 },

--- a/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -56,19 +56,30 @@ namespace Microsoft.Recognizers.Text.Number
                     }
                 },
                 {
+                    Culture.Portuguese, new Dictionary<Type, IModel>
+                    {
+                        [typeof(NumberModel)] = new NumberModel(
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration()),
+                            new Portuguese.NumberExtractor(NumberMode.PureNumber)),
+                        [typeof(OrdinalModel)] = new OrdinalModel(
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new FrenchNumberParserConfiguration()),
+                            new Portuguese.OrdinalExtractor()),
+                        [typeof(PercentModel)] = new PercentModel(
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration()),
+                            new Portuguese.PercentageExtractor())
+                    }
+                },
+                {
                     Culture.French, new Dictionary<Type, IModel>
                     {
                         [typeof(NumberModel)] = new NumberModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number,
-                                new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration()),
                             new French.NumberExtractor(NumberMode.PureNumber)),
                         [typeof(OrdinalModel)] = new OrdinalModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal,
-                                new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new FrenchNumberParserConfiguration()),
                             new French.OrdinalExtractor()),
                         [typeof(PercentModel)] = new PercentModel(
-                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage,
-                                new FrenchNumberParserConfiguration()),
+                            AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration()),
                             new French.PercentageExtractor())
                     }
                 }

--- a/Microsoft.Recognizers.Text.NumberWithUnit.Tests/TestNumberWithUnitPortuguese.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit.Tests/TestNumberWithUnitPortuguese.cs
@@ -33,34 +33,34 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
         [TestMethod]
         public void TestCurrency()
         {
-            var model = NumberWithUnitRecognizer.GetCurrencyModel(Culture.Spanish);
+            var model = NumberWithUnitRecognizer.GetCurrencyModel(Culture.Portuguese);
 
             BasicTest(model,
-            "Condado de Montgomery, md. - - $ 75 millones de obligaciones generales, Serie b , bonos consolidados de mejoramiento público de 1989 , A través de un Manufacturers Hanover Trust co. group.",
+            "Condado de Montgomery, md. - - $ 75 milhões de obligaciones generales, Serie b , bonos consolidados de mejoramiento público de 1989 , A través de un Manufacturers Hanover Trust co. group.",
             "75000000 Dólar");
 
             BasicTest(model,
-            "Conglomerado finlandés nokia ( oy ab ) dijo que llegó a un acuerdo para comprar la compañía de cable holandés NKF kabel b.v. por 420 millones de marcos finlandeses",
-            "420000000 Marco finlandés");
+            "Conglomerado finlandés nokia ( oy ab ) dijo que llegó a un acuerdo para comprar la compañía de cable holandés NKF kabel b.v. por 420 milhoes de marcos finlandeses",
+            "420000000 Marco finlandês");
 
             BasicTest(model,
             "Nacional pagó a Siegel y Shuster $ 94.000 para cancelar todas las reclamaciones.",
             "94000 Dólar");
 
             BasicTest(model,
-            "Servicios de dinámica general co., una unidad de Dinámica General corp., ganó un contrato del ejército de $ 48,2 millones para establecer facilidades del mantenimiento para los vehículos con seguimiento en Paquistán.",
+            "Servicios de dinámica general co., una unidad de Dinámica General corp., ganó un contrato del ejército de $ 48,2 milhoes para establecer facilidades del mantenimiento para los vehículos con seguimiento en Paquistán.",
             "48200000 Dólar");
 
             BasicTest(model,
-            "El precio del segundo simulador oscila entre C$ 16,4 millones",
-            "16400000 Dólar canadiense");
+            "El precio del segundo simulador oscila entre C$ 16,4 milhoes",
+            "16400000 Dólar canadense");
 
             BasicTest(model,
-            "Golar Gas Holding co., una subsidiaria de Gotaas-Larsen Shipping corp., ofreciendo $ 280 millones por las notas preferidas de la hipoteca de buques, vía los mercados de capitales de Merrill Linch.",
+            "Golar Gas Holding co., una subsidiaria de Gotaas-Larsen Shipping corp., ofreciendo $ 280 milhoes por las notas preferidas de la hipoteca de buques, vía los mercados de capitales de Merrill Linch.",
             "280000000 Dólar");
 
             BasicTest(model,
-            "Bard/Ems tenía 1988 ventas de cerca de $ 14 millones, según Birtcher.",
+            "Bard/Ems tenía 1988 ventas de cerca de $ 14 milhões, según Birtcher.",
             "14000000 Dólar");
 
             BasicTest(model,
@@ -68,23 +68,23 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "12345 Dólar");
 
             BasicTest(model,
-            "solamente Batman ha acumulado mas de $247 millones en taquilla hasta la fecha, convirtiendola en la película con mejor recaudación de Warner Bros.",
+            "solamente Batman ha acumulado mas de $247 milhoes en taquilla hasta la fecha, convirtiendola en la película con mejor recaudación de Warner Bros.",
             "247000000 Dólar");
 
             BasicTest(model,
-            "El patrimonio neto de Coyle fue estimado en £ 8,10 millones en Octuble del 2014.",
+            "El patrimonio neto de Coyle fue estimado en £ 8,10 milhões en Octuble del 2014.",
             "8100000 Libra");
 
             BasicTest(model,
-            "Los ingresos netos por intereses cayeron un 27% en el trimestre a $ 254 millones",
+            "Los ingresos netos por intereses cayeron un 27% en el trimestre a $ 254 milhões",
             "254000000 Dólar");
 
             BasicTest(model,
-            "Un tribunal de apelaciones federal anuló una regulación de gas natural que había impedido que las compañías de gasoductos pasaran a los clientes un gasto de $ un mil millones en costos de contratos controversiales",
+            "Un tribunal de apelaciones federal anuló una regulación de gas natural que había impedido que las compañías de gasoductos pasaran a los clientes un gasto de $ um bilhão en costos de contratos controversiales",
             "1000000000 Dólar");
 
             BasicTest(model,
-            "El trimestre de 1988 también incluyó ganancias únicas por un total de aproximadamente $ 35 millones.",
+            "El trimestre de 1988 también incluyó ganancias únicas por un total de aproximadamente $ 35 milhões.",
             "35000000 Dólar");
 
             BasicTest(model,
@@ -104,7 +104,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "800 Dólar");
 
             BasicTest(model,
-            "(El almacenista también tomó $ 125 millones de bonos Junior SCI TV como pago parcial para los activos de TV).",
+            "(El almacenista también tomó $ 125 milhões de bonos Junior SCI TV como pago parcial para los activos de TV).",
             "125000000 Dólar");
 
             BasicTest(model,
@@ -112,15 +112,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "2,75 Dólar");
 
             BasicTest(model,
-            "Al mismo tiempo, los inversionistas estiman que la reestructuración reduciría la factura anual de intereses en efectivo de la compañía en aproximadamente U$D 90 millones.",
-            "90000000 Dólar estadounidense");
+            "Al mismo tiempo, los inversionistas estiman que la reestructuración reduciría la factura anual de intereses en efectivo de la compañía en aproximadamente U$D 90 milhões.",
+            "90000000 Dólar estadunidense");
 
             BasicTest(model,
-            "Los gastos de capital en 1990 aumentarán ligeramente, dijo Mr.Marous, de un estimado de $ 470 millones este año",
+            "Los gastos de capital en 1990 aumentarán ligeramente, dijo Mr.Marous, de un estimado de $ 470 milhões este año",
             "470000000 Dólar");
 
             BasicTest(model,
-            "Shearson \"realmente solo tiene $ 300 millones de capital\", dice el sr. Bowman de S&P.",
+            "Shearson \"realmente solo tiene $ 300 milhões de capital\", dice el sr. Bowman de S&P.",
             "300000000 Dólar");
 
             BasicTest(model,
@@ -136,15 +136,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "70 Dólar");
 
             BasicTest(model,
-            "Las ventas netas para el tercer trimestre de este año fueron de $ 14 millones más que el año pasado.",
+            "Las ventas netas para el tercer trimestre de este año fueron de $ 14 milhões más que el año pasado.",
             "14000000 Dólar");
 
             BasicTest(model,
-            "La compañía matriz del primer banco nacional de Chicago, con 48.000 millones de dólares en activos, dijo que se reservó de absorber pérdidas en préstamos e inversiones en países con dificultades financieras.",
+            "La compañía matriz del primer banco nacional de Chicago, con 48.000 milhões de dólares en activos, dijo que se reservó de absorber pérdidas en préstamos e inversiones en países con dificultades financieras.",
             "48000000000 Dólar");
 
             BasicTest(model,
-            "Fluor Corp. dijo que se le adjudicó un contrato de $ 300 millones para prestar servicios de ingeniería y gestión de la construcción en una mina de cobre en Irian Jaya, Indonesia, para una unidad de Freeport-McMoran Copper co.",
+            "Fluor Corp. dijo que se le adjudicó un contrato de $ 300 milhões para prestar servicios de ingeniería y gestión de la construcción en una mina de cobre en Irian Jaya, Indonesia, para una unidad de Freeport-McMoran Copper co.",
             "300000000 Dólar");
 
             BasicTest(model,
@@ -152,19 +152,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "5000 Dólar");
 
             BasicTest(model,
-            "Warner Communications Inc., que está siendo adquirida por Time Warner, ha presentado una demanda por violación de contrato de un mil millones de dólares contra Sony y dos productores.",
+            "Warner Communications Inc., que está siendo adquirida por Time Warner, ha presentado una demanda por violación de contrato de um bilhão de dólares contra Sony y dos productores.",
             "1000000000 Dólar");
 
             BasicTest(model,
-            "En agosto, Asarco, a través de su subsidiaria Lac d'amiante Du Québec, vendió el interés restante de un tercio en una sociedad limitada minera de amianto en Canadá por $ 11,7 millones.",
+            "En agosto, Asarco, a través de su subsidiaria Lac d'amiante Du Québec, vendió el interés restante de un tercio en una sociedad limitada minera de amianto en Canadá por $ 11,7 milhões.",
             "11700000 Dólar");
 
             BasicTest(model,
-            "En 1988, las exportaciones de juguetes y juegos de producción nacional cayeron un 19% desde 1987 hasta alcanzar los 10050 millones de dólares de Hong Kong.",
+            "En 1988, las exportaciones de juguetes y juegos de producción nacional cayeron un 19% desde 1987 hasta alcanzar los 10050 milhões de dólares de Hong Kong.",
             "10050000000 Dólar de Hong Kong");
 
             BasicTest(model,
-            "Las ventas del cuarto trimestre fiscal crecieron cerca de 18% a $ 1,17 mil millones en comparacion al año anterior.",
+            "Las ventas del cuarto trimestre fiscal crecieron cerca de 18% a $ 1,17 bilhões en comparacion al año anterior.",
             "1170000000 Dólar");
 
             BasicTest(model,
@@ -176,11 +176,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "300000 Dólar");
 
             BasicTest(model,
-            "Las ventas subieron 6,2% a $ 1,45 mil millones",
+            "Las ventas subieron 6,2% a $ 1,45 bilhões",
             "1450000000 Dólar");
 
             BasicTest(model,
-            "A partir de ayer por la tarde, los reembolsos representaron menos del 15% de la posición total de efectivo de alrededor de $ 2 mil millones de los fondos de acciones de fidelidad.",
+            "A partir de ayer por la tarde, los reembolsos representaron menos del 15% de la posición total de efectivo de alrededor de $ 2 bilhões de los fondos de acciones de fidelidad.",
             "2000000000 Dólar");
 
             BasicTest(model,
@@ -188,11 +188,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "34 Centavo");
 
             BasicTest(model,
-            "El nuevo folleto dice que si la adquisición hubiera sido completada antes, las ganancias antes de impuestos \"habrían sido insuficientes para cubrir sus cargos fijos, incluyendo intereses sobre títulos de deuda\", por aproximadamente $ 62,7 millones en el primer semestre de 1989.",
+            "El nuevo folleto dice que si la adquisición hubiera sido completada antes, las ganancias antes de impuestos \"habrían sido insuficientes para cubrir sus cargos fijos, incluyendo intereses sobre títulos de deuda\", por aproximadamente $ 62,7 milhões en el primer semestre de 1989.",
             "62700000 Dólar");
 
             BasicTest(model,
-            "Filenet señaló que tenía efectivo y valores negociables por un total de $ 22,5 millones en septiembre.",
+            "Filenet señaló que tenía efectivo y valores negociables por un total de $ 22,5 milhões en septiembre.",
             "22500000 Dólar");
 
             BasicTest(model,
@@ -200,7 +200,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "63,45 Dólar");
 
             BasicTest(model,
-            "Trans Mundo Airlines Inc., ofreciendo billetes senior de 150 millones de dólares, a través de Drexel Burnham.",
+            "Trans Mundo Airlines Inc., ofreciendo billetes senior de 150 milhões de dólares, a través de Drexel Burnham.",
             "150000000 Dólar");
 
             BasicTest(model,
@@ -212,31 +212,31 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "14,27 Centavo");
 
             BasicTest(model,
-            "En el tercer trimestre de 1988 fue de $ 75,3 millones",
+            "En el tercer trimestre de 1988 fue de $ 75,3 milhões",
             "75300000 Dólar");
 
             BasicTest(model,
-            "La confianza de los demandantes del protector del dalkon $ 2,38 mil millones fue establecida",
+            "La confianza de los demandantes del protector del dalkon $ 2,38 bilhões fue establecida",
             "2380000000 Dólar");
 
             BasicTest(model,
-            "Los términos de la oferta pusieron un valor de 528 millones de francos por 32,99% de participación",
+            "Los términos de la oferta pusieron un valor de 528 milhões de francos por 32,99% de participación",
             "528000000 Franco");
 
             BasicTest(model,
-            "Rusia aceptó un préstamo del Banco Mundial de US$ 150 millones para combatir la propagación del sida y la tuberculosis, poniendo fin a un proceso de negociación que duró cuatro años, dijeron el viernes funcionarios del Banco Mundial.",
-            "150000000 Dólar estadounidense");
+            "Rusia aceptó un préstamo del Banco Mundial de US$ 150 milhões para combatir la propagación del sida y la tuberculosis, poniendo fin a un proceso de negociación que duró cuatro años, dijeron el viernes funcionarios del Banco Mundial.",
+            "150000000 Dólar estadunidense");
 
             BasicTest(model,
             "El pacto de la campana anterior estaba valorado en alrededor de $ 98 por acción",
             "98 Dólar");
 
             BasicTest(model,
-            "Un distribuidor dijo que la conversación fue que la firma vendió cerca de 500 millones de dólares de bonos de 30 años",
+            "Un distribuidor dijo que la conversación fue que la firma vendió cerca de 500 milhões de dólares de bonos de 30 años",
             "500000000 Dólar");
 
             BasicTest(model,
-            "Para el tercer trimestre, Sears dijo que sus ingresos totales aumentaron 4. 8% a $ 13180 millones a un año antes.",
+            "Para el tercer trimestre, Sears dijo que sus ingresos totales aumentaron 4. 8% a $ 13180 milhões a un año antes.",
             "13180000000 Dólar");
 
             BasicTest(model,
@@ -244,15 +244,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "1,4 Dólar");
 
             BasicTest(model,
-            "Las expectativas de los analistas sugieren un déficit en cuenta corriente de septiembre de 1. 6 mil millones ($ 2,54 mil millones), comparado con los 2MM de agosto en déficit.",
+            "Las expectativas de los analistas sugieren un déficit en cuenta corriente de septiembre de 1. 6 bilhões ($ 2,54 bilhões), comparado con los 2MM de agosto en déficit.",
             "2540000000 Dólar");
 
             BasicTest(model,
-            "125 millones de dólares australianos de eurobonos de cupón, a un precio de 50,9375 para producir 15,06% menos comisiones a través de Hambros Bank ltd.",
+            "125 milhões de dólares australianos de eurobonos de cupón, a un precio de 50,9375 para producir 15,06% menos comisiones a través de Hambros Bank ltd.",
             "125000000 Dólar australiano");
 
             BasicTest(model,
-            "El viernes, el secretario jefe del gabinete anunció que ocho ministros del gabinete habían recibido cinco millones de yenes de la industria",
+            "El viernes, el secretario jefe del gabinete anunció que ocho ministros del gabinete habían recibido cinco milhões de ienes de la industria",
             "5000000 Yen");
 
             BasicTest(model,
@@ -260,100 +260,100 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "450000 Yen");
 
             BasicTest(model,
-            "Dóllar : 143,80 yenes, arriba de 0,95; 1.8500 puntos, arriba de 0,0085.",
+            "Dóllar : 143,80 yenes, arriba de 0,95; 1.8500 pontos, arriba de 0,0085.",
             "143,8 Yen");
 
             BasicTest(model,
-            "Orkem S.A., un fabricante francés de productos químicos controlados por el Estado, está haciendo una oferta amistosa de 470 peniques por acción para los 59,2% de UK",
-            "470 Penique");
+            "Orkem S.A., un fabricante francés de productos químicos controlados por el Estado, está haciendo una oferta amistosa de 470 penies por acción para los 59,2% de UK",
+            "470 Pêni");
 
             BasicTest(model,
             "Agosto, el gasto ajustado de las familias asalariadas disminuyó 0,6% a 309.381 yenes de un año antes.",
             "309381 Yen");
 
             BasicTest(model,
-            "Sr. Bowder dijo que los C$ 300 millones de ingresos...",
-            "300000000 Dólar canadiense");
+            "Sr. Bowder dijo que los C$ 300 milhões de ingresos...",
+            "300000000 Dólar canadense");
 
             BasicTest(model,
             "Ascendería a alrededor de C$ 1,34 por acción.",
-            "1,34 Dólar canadiense");
+            "1,34 Dólar canadense");
 
             BasicTest(model,
             "Los precios de los huevos promediaron 64,2 centavos la docena.",
             "64,2 Centavo");
 
             BasicTest(model,
-            "Aún así, dijo que espera que las ventas para 1989 sean del orden de los 20.000 millones de francos, lo que refleja la facturación anticipada de dos grandes contratos en la segunda mitad del año.",
+            "Aún así, dijo que espera que las ventas para 1989 sean del orden de los 20.000 milhões de francos, lo que refleja la facturación anticipada de dos grandes contratos en la segunda mitad del año.",
             "20000000000 Franco");
 
             BasicTest(model,
-            "La transacción pidió a Murdoch's News International, una unidad de noticias australia corp., para suscribir una emisión de derechos valorada en 6,65 mil millones de pesetas.",
+            "La transacción pidió a Murdoch's News International, una unidad de noticias australia corp., para suscribir una emisión de derechos valorada en 6,65 bilhões de pesetas.",
             "6650000000 Peseta");
 
             BasicTest(model,
-            "Fujitsu ltd dijo que quiere retirar su polémica oferta de un yen para diseñar un sistema de computadoras de agua para la ciudad de hiroshima.",
+            "Fujitsu ltd dijo que quiere retirar su polémica oferta de um yen para diseñar un sistema de computadoras de agua para la ciudad de hiroshima.",
             "1 Yen");
 
             BasicTest(model,
-            "250 millones de florines neerlandeses de 7 3/4% de bonos debidos nov. 15, 1999, a un precio de 101 1/4 para dar 7. 57% al precio de emisión y 7. 86% menos los honorarios completos, vía el banco del amro.",
-            "250000000 Florín neerlandés");
+            "250 milhões de florins holandeses de 7 3/4% de bonos debidos nov. 15, 1999, a un precio de 101 1/4 para dar 7. 57% al precio de emisión y 7. 86% menos los honorarios completos, vía el banco del amro.",
+            "250000000 Florim holandês");
 
             BasicTest(model,
             "Además, el banco tiene la opción de comprar una participación de 30,84% en BIP societe generale después de enero. 1.1990 a 1.015 francos por acción.",
             "1015 Franco");
 
             BasicTest(model,
-            "Sus acciones se deslizaron en los últimos tratos para cerrar un centavo",
+            "Sus acciones se deslizaron en los últimos tratos para cerrar um centavo",
             "1 Centavo");
 
             BasicTest(model,
-            "Por acción menor a 197 peniques.",
-            "197 Penique");
+            "Por acción menor a 197 penies.",
+            "197 Pêni");
 
             BasicTest(model,
-            "Su beneficio operativo trimestral mejoró a 361 millones de libras",
+            "Su beneficio operativo trimestral mejoró a 361 milhões de libras",
             "361000000 Libra");
 
             BasicTest(model,
-            "El año pasado, el valor bruto de producción de las empresas del municipio de toda la ciudad se rompió por 100 millones de yuanes por primera vez, ocupando el primer lugar en toda la provincia.",
-            "100000000 Yuan chino");
+            "El año pasado, el valor bruto de producción de las empresas del municipio de toda la ciudad se rompió por 100 milhões de yuans por primera vez, ocupando el primer lugar en toda la provincia.",
+            "100000000 Yuan chinês");
 
             BasicTest(model,
-            "Los guardabosques consiguieron guardar £ 50 millones ahorrados por el consejo de Baxendale-Walker.",
+            "Los guardabosques consiguieron guardar £ 50 milhões ahorrados por el consejo de Baxendale-Walker.",
             "50000000 Libra");
 
             BasicTest(model,
-            "A su vez, francis leung pak-to ha acordado vender una participación de 8% en PCCW a telefónica por 323 millones de euros.",
+            "A su vez, francis leung pak-to ha acordado vender una participación de 8% en PCCW a telefónica por 323 milhões de euros.",
             "323000000 Euro");
 
             BasicTest(model,
-            "La UEFA acusó a ferguson de desacreditar el juego con sus comentarios, y el 1 de mayo de ese año fue multado con 10.000 francos suizos.",
-            "10000 Franco suizo");
+            "La UEFA acusó a ferguson de desacreditar el juego con sus comentarios, y el 1 de mayo de ese año fue multado con 10.000 francos suicos.",
+            "10000 Franco suíço");
 
             BasicTest(model,
-            "El IPL firmó a las líneas aéreas de martín pescador como el socio oficial del árbitro para la serie en un reparto (aproximadamente £ 15 millones).",
+            "El IPL firmó a las líneas aéreas de martín pescador como el socio oficial del árbitro para la serie en un reparto (aproximadamente £ 15 milhões).",
             "15000000 Libra");
 
             BasicTest(model,
-            "Los ingresos de la industria electrónica de adelaide ha crecido en alrededor del 15% anual desde 1990, y en 2011 supera los $ 4 mil millones.",
+            "Los ingresos de la industria electrónica de adelaide ha crecido en alrededor del 15% anual desde 1990, y en 2011 supera os $ 4 bilhões.",
             "4000000000 Dólar");
 
             BasicTest(model,
-            "Abel y sus asociados ofrecen 4 millones de dólares por hacer los efectos de la película.",
+            "Abel y sus asociados ofrecen 4 milhoes de dólares por hacer los efectos de la película.",
             "4000000 Dólar");
 
             BasicTest(model,
-            "Malone demandó a 20th century-fox por $ 1,6 millones por incumplimiento de contrato.",
+            "Malone demandó a 20th century-fox por $ 1,6 milhões por incumplimiento de contrato.",
             "1600000 Dólar");
 
             BasicTest(model,
-            "En 2003, Bayern Munich prestó € 2 millones a Dortmund por un par de meses para pagar su nómina.",
+            "En 2003, Bayern Munich prestó € 2 milhões a Dortmund por un par de meses para pagar su nómina.",
             "2000000 Euro");
 
             BasicTest(model,
-            "Lockheed Martin y el gobierno de los Estados Unidos intensamente presionaron para el contrato de US$ 10 mil millones de la India para 126 aviones de combate.",
-            "10000000000 Dólar estadounidense");
+            "Lockheed Martin y el gobierno de los Estados Unidos intensamente presionaron para el contrato de US$ 10 bilhões de la India para 126 aviones de combate.",
+            "10000000000 Dólar estadunidense");
 
             BasicTest(model,
             "Según la firma de investigación NPD, el precio de venta promedio de todas las PC portátiles de las ventanas ha caído de $ 659 en octubre de 2008 a",
@@ -372,15 +372,15 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "100 Libra");
 
             BasicTest(model,
-            "Para los nueve meses, la red de AMR subió 15% a $ 415,9 millones",
+            "Para los nueve meses, la red de AMR subió 15% a $ 415,9 milhões",
             "415900000 Dólar");
 
             BasicTest(model,
-            "El precio de la acción de la aerolínea ya está muy por debajo del nivel de 210 peniques visto después de que la compañía anunció la emisión de derechos a fines de septiembre.",
-            "210 Penique");
+            "El precio de la acción de la aerolínea ya está muy por debajo del nivel de 210 penies visto después de que la compañía anunció la emisión de derechos a fines de septiembre.",
+            "210 Pêni");
 
             BasicTest(model,
-            "Rolling Stone observó, \"Harpercollins adquirió el proyecto de libro por $ 3 millones en 2008.",
+            "Rolling Stone observó, \"Harpercollins adquirió el proyecto de libro por $ 3 milhoes en 2008.",
             "3000000 Dólar");
 
             BasicTest(model,
@@ -388,11 +388,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "48 Dólar");
 
             BasicTest(model,
-            "2013, la edición de la revista forbes presenta a Keith en la portada con el título música country's $ 500 millones.",
+            "2013, la edición de la revista forbes presenta a Keith en la portada con el título música country's $ 500 milhoes.",
             "500000000 Dólar");
 
             BasicTest(model,
-            "Harry Ferguson nos demandó por el uso ilegal de sus patentes pidiendo una indemnización de £ 90 millones, resuelto fuera de la corte en 1952.",
+            "Harry Ferguson nos demandó por el uso ilegal de sus patentes pidiendo una indemnización de £ 90 milhões, resuelto fuera de la corte en 1952.",
             "90000000 Libra");
 
             BasicTest(model,
@@ -400,28 +400,28 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Tests
             "125000 Dólar");
 
             BasicTest(model,
-            "Fue una de las mayores adquisiciones de Coke desde que compró Odwalla Inc. por $ 186 millones en 2001.",
+            "Fue una de las mayores adquisiciones de Coke desde que compró Odwalla Inc. por $ 186 milhões en 2001.",
             "186000000 Dólar");
 
             BasicTest(model,
-            "Apple y Creative llegaron a un acuerdo, con Apple pagando $ 100 millones a Creative y Creative para unirse al programa de accesorios \"hecho para ipod\".",
+            "Apple y Creative llegaron a un acuerdo, con Apple pagando $ 100 milhões a Creative y Creative para unirse al programa de accesorios \"hecho para ipod\".",
             "100000000 Dólar");
 
             BasicTest(model,
-            "A su vez, francis leung pak-a ha acordado vender una participación de 8% en PCCW a telefónica por 323 millones de euros.",
+            "A su vez, francis leung pak-a ha acordado vender una participación de 8% en PCCW a telefónica por 323 milhões de euros.",
             "323000000 Euro");
 
             BasicTest(model,
-            "Malone demandó a 20th century-fox por 1,6 millones de dólares por incumplimiento de contrato;",
+            "Malone demandó a 20th century-fox por 1,6 milhoes de dólares por incumplimiento de contrato;",
             "1600000 Dólar");
 
             BasicTest(model,
-            "En 2003, Bayern munich prestó € 2 millones a Dortmund por un par de meses para pagar su nómina.",
+            "En 2003, Bayern munich prestó € 2 milhões a Dortmund por un par de meses para pagar su nómina.",
             "2000000 Euro");
 
             BasicTest(model,
-            "Lockheed martin y el gobierno de los estados unidos intensamente presionaron para el contrato de U$D 10 mil millones de la India para 126 aviones de combate.",
-            "10000000000 Dólar estadounidense");
+            "Lockheed martin y el gobierno de los estados unidos intensamente presionaron para el contrato de U$D 10 bilhões de la India para 126 aviones de combate.",
+            "10000000000 Dólar estadunidense");
 
             BasicTest(model,
             "La presentación de hart-scott se revisa y se resuelve cualquier problema antimonopolio. Por lo general, hart-scott se utiliza ahora para dar a los gerentes de las firmas objetivo noticias tempranas de una oferta y la oportunidad de utilizar la revisión regulatoria como una táctica de retraso. El impuesto de 20.000 dólares sería un pequeño costo en un acuerdo de varios billones de dólares, pero un grave obstáculo para miles de pequeños acuerdos amistosos.",

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 
         public static readonly ImmutableDictionary<string, string> CurrencySuffixList = new Dictionary<string, string>
         {
-            // Reference Source: https://pt.wikipedia.org/wiki/Lista_de_moedas
+            // Reference Sources: https://pt.wikipedia.org/wiki/Lista_de_moedas and http://repositorio.ul.pt/bitstream/10451/9948/1/ulfl139260_tm.pdf
 
             // General Units
             { "Dólar", "dólar|dolar|dólares|dolares" },
@@ -213,160 +213,134 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Libra de Guernsey", "libra de Guernsey|libras de Guernsey|ggp" },
             { "Peni de Guernsey", "peni de Guernsey|penies de Guernsey" },
             //Guiné // @HERE
-            { "Franco guineano", "franco guineano|francos guineanos|gnf|fg" },
-            { "Céntimo guineano", "céntimo guineano|céntimos guineanos" },
-            //Guinea-Bisáu -> Franco CFA de África Occidental
-            //Guinea Ecuatorial -> Franco CFA de África Central
-            //Guyana
-            { "Dólar guyanés", "dólar guyanés|dólares guyaneses|gyd|gy" },
-            //Haití
-            { "Gourde haitiano", "gourde haitiano|gourde haitianos|htg" },
-            { "Céntimo haitiano", "céntimo haitiano|céntimos haitianos" },
+            { "Franco da Guiné", "franco da guiné|franco da guine| franco guineense|francos da guiné|francos da guine|francos guineense|gnf|fg" },
+            { "Centavo da Guiné", "cêntimo guineense|centimo guineense|centavo guineense|cêntimos guineenses|centimos guineenses|centavos guineenses" },
+            //Guiana
+            { "Dólar guianense", "dólar guianense|dólares guianense|dolar guianense|dolares guianense|gyd|gy" },
+            //Haiti
+            { "Gurde haitiano", "gurde haitiano|gourde|gurdes haitianos|htg" },
+            { "Centavo haitiano", "cêntimo haitiano|cêntimos haitianos|centavo haitiano|centavos haitianos" },
             //Honduras
-            { "Lempira hondureño", "lempira hondureño|lempira hondureños|hnl" },
-            { "Centavo hondureño", "centavo hondureño|centavos hondureño" },
+            { "Lempira hondurenha", "lempira hondurenha|lempiras hondurenhas|lempira|lempiras|hnl" },
+            { "Centavo hondurenho", "centavo hondurenho|centavos hondurehos|cêntimo hondurenho|cêntimos hondurenhos" },
             //Hong Kong
-            { "Dólar de Hong Kong", "dólar de hong kong|dólares de hong kong|hk$|hkd" },
+            { "Dólar de Hong Kong", "dólar de hong kong|dolar de hong kong|dólares de hong kong|dolares de hong kong|hk$|hkd" },
             //Hungría
-            { "Forinto húngaro", "forinto húngaro|forinto húngaros|huf" },
-            //India
-            { "Rupia india", "rupia india|rupias indias|inr" },
-            { "Paisa india", "paisa india|paise indias" },
-            //Indonesia
-            { "Rupia indonesia", "rupia indonesia|rupias indonesias|idr" },
-            { "Sen indonesia", "sen indonesia|sen indonesias" },
-            //Irán
-            { "Rial iraní", "rial iraní|rial iranies|irr" },
-            //Irak
-            { "Dinar iraquí", "dinar iraquí|dinares iraquies|iqd" },
-            { "Fil iraquí", "fil iraquí|fils iraquies" },
-            //Irlanda -> Euro
-            //Isla Ascensión -> Libra se Santa Elena
-            //Isla de Man
+            { "Florim húngaro", "florim húngaro|florim hungaro|florins húngaros|florins hungaros|forinte|forintes|huf" },
+            { "Filér húngaro", "fillér|filér|filler|filer" },
+            //Índia
+            { "Rupia indiana", "rúpia indiana|rupia indiana|rupias indianas|inr" },
+            { "Paisa indiana", "paisa indiana|paisas indianas" },
+            //Indonésia
+            { "Rupia indonésia", "rupia indonesia|rupia indonésia|rupias indonesias|rupias indonésias|idr" },
+            { "Sen indonésio", "send indonésio|sen indonesio|sen indonésios|sen indonesios" },
+            //Irã
+            { "Rial iraniano", "rial iraniano|riais iranianos|irr" },
+            //Iraque
+            { "Dinar iraquiano", "dinar iraquiano|dinares iraquianos|iqd" },
+            { "Fil iraquiano", "fil iraquiano|fils iraquianos|files iraquianos" },
+            //Ilha de Man
             { "Libra manesa", "libra manesa|libras manesas|imp" },
-            { "Penique manes", "penique manes|peniques maneses" },
-            //Islandia
-            { "Corona islandesa", "corona islandesa|coronas islandesas|isk|íkr" },
-            { "Aurar islandes", "aurar islandes|aurar islandeses" },
-            //Islas Caimán
-            { "Dólar de las Islas Caimán", "dólar de las Islas Caimán|dólares de las Islas Caimán|ci$|kyd" },
-            //Islas Cocos -> Dólar australiano
-            //Islas Cook
-            { "Dólar de las Islas Cook", "dólar de las Islas Cook|dólares de las Islas Cook" },
-            //Islas Feroe
-            { "Corona feroesa", "corona feroesa|coronas feroesas|fkr" },
-            //Islas Georgias del Sur y Sandwich del Sur
-            //Islas Malvinas
-            { "Libra malvinense", "libra malvinense|libras malvinenses|fk£|fkp" },
-            //Islas Marianas del Norte -> Dólar estadounidense
-            //Islas Marshall -> Dólar estadounidense
-            //Islas Pitcairn -> Dólar neozelandés
-            //Islas Salomón
-            { "Dólar de las Islas Salomón", "dólar de las Islas Salomón|dólares de las Islas Salomón|sbd" },
-            //Islas Turcas y Caicos -> Dólar estadounidense
-            //Islas Vírgenes Británicas -> Dólar estadounidense
+            { "Peni manês", "peni manes|peni manês|penies maneses" },
+            //Islândia
+            { "Coroa islandesa", "coroa islandesa|coroas islandesas|isk|íkr" },
+            { "Aurar islandês", "aurar islandês|aurar islandes|aurar islandeses|eyrir" },
+            //Ilhas Cayman
+            { "Dólar das Ilhas Cayman", "dólar das ilhas cayman|dolar das ilhas cayman|dólar das ilhas caimão|dólares das ilhas cayman|dolares das ilhas cayman|dólares das ilhas caimão|ci$|kyd" },
+            //Ilhas Cook
+            { "Dólar das Ilhas Cook", "dólar das ilhas cook|dolar das ilhas cook|dólares das ilhas cook|dolares das ilhas cook" },
+            //Ilhas Féroe/Faroé/Faroés
+            { "Coroa feroesa", "coroa feroesa|coroas feroesas|fkr" },
+            //Ilhas Malvinas
+            { "Libra das Malvinas", "libra das malvinas|libras das malvinas|fk£|fkp" },
+            //Ilhas Salomão
+            { "Dólar das Ilhas Salomão", "dólar das ilhas salomão|dolar das ilhas salomao|dólares das ilhas salomão|dolares das ilhas salomao|sbd" },
             //Israel
-            { "Nuevo shéquel", "nuevo shéquel|nuevos shéquel|ils" },
-            { "Agorot", "agorot" },
-            //Italia -> Europe
+            { "Novo shekel israelense", "novo shekel|novos shekeles|novo shequel|novo siclo|novo xéquel|shekeles novos|novos sheqalim|sheqalim novos|ils" },
+            { "Agora", "agora|agorot" },
             //Jamaica
-            { "Dólar jamaiquino", "dólar jamaiquino|dólares jamaiquinos|j$|ja$|jmd" },
-            //Japón
+            { "Dólar jamaicano", "dólar jamaicano|dolar jamaicano|dólares jamaicanos|dolares jamaicanos|j$|ja$|jmd" },
+            //Japão
             { "Yen", "yen|iene|yenes|ienes|jpy" },
             //Jersey
             { "Libra de Jersey", "libra de Jersey|libras de Jersey|jep" },
-            //Jordania
-            { "Dinar jordano", "dinar jordano|dinares jordanos|jd|jod" },
-            { "Piastra jordano", "piastra jordano|piastras jordanos" },
-            //Kazajistán
-            { "Tenge kazajo", "tenge|tenge kazajo|kzt" },
-            //Kenia
-            { "Chelín keniano", "chelín keniano|chelines kenianos|ksh|kes" },
-            //Kirguistán
-            { "Som kirguís", "som kirguís|kgs" },
-            { "Tyiyn", "tyiyn" },
+            //Jordânia
+            { "Dinar jordaniano", "dinar jordaniano|dinar jordano|dinares jordanianos|dinares jordanos|jd|jod" },
+            { "Piastra jordaniana", "piastra jordaniana|piastra jordano|piastras jordanianas|piastra jordaniano|piastras jordanianos|piastras jordanos" },
+            //Cazaquistão
+            { "Tengue cazaque", "tenge|tengue|tengué|tengue cazaque|kzt" },
+            { "Tiyin", "tiyin|tiyins"},
+            //Quênia
+            { "Xelim queniano", "xelim queniano|xelins quenianos|ksh|kes" },
+            //Quirguistão
+            { "Som quirguiz", "som quirguiz|som quirguizes|soms quirguizes|kgs" },
+            { "Tyiyn", "tyiyn|tyiyns" },
             //Kiribati
-            { "Dólar de Kiribati", "dólar de Kiribati|dólares de Kiribati" },
-            //Kosovo -> Euro
-            //Kuwait
-            { "Dinar kuwaití", "dinar kuwaití|dinares kuwaití" },
-            //Laos
-            { "Kip laosiano", "kip|kip laosiano|kip laosianos|lak" },
-            { "Att laosiano", "att|att laosiano|att laosianos" },
+            { "Dólar de Kiribati", "dólar de kiribati|dolar de kiribati|dólares de kiribati|dolares de kiribati" },
+            //Kuwait/Cuaite
+            { "Dinar kuwaitiano", "dinar kuwaitiano|dinar cuaitiano|dinares kuwaitiano|dinares cuaitianos|kwd" },
+            //Laos/Laus
+            { "Quipe laosiano", "quipe|quipes|kipe|kipes|kip|kip laosiano|kip laociano|kips laosianos|kips laocianos|lak" },
+            { "Att laosiano", "at|att|att laosiano|att laosianos" },
             //Lesoto
-            { "Loti", "loti|maloti|lsl" },
+            { "Loti do Lesoto", "loti|lóti|maloti|lotis|lótis|lsl" },
             { "Sente", "sente|lisente" },
-            //Letonia -> Euro
             //Líbano
             { "Libra libanesa", "libra libanesa|libras libanesas|lbp" },
-            //Liberia
-            { "Dólar liberiano", "dólar liberiano|dólares liberianos|l$|lrd" },
-            //Libia
-            { "Dinar libio", "dinar libio|dinares libios|ld|lyd" },
-            { "Dirham libio", "dirham libio|dirhams libios" },
-            //Liechtenstein -> Franco suizo
-            //Lituania -> Euro
+            //Libéria
+            { "Dólar liberiano", "dólar liberiano|dolar liberiano|dólares liberianos|dolares liberianos|l$|lrd" },
+            //Líbia
+            { "Dinar libio", "dinar libio|dinar líbio|dinares libios|dinares líbios|ld|lyd" },
+            { "Dirham libio", "dirham libio|dirhams libios|dirham líbio|dirhams líbios" },
+            //Lituania -> Euro + old lita
             {"Litas lituana", "litas lituana|litai lituanas|ltl" },
-            //Luxemburgo -> Euro
             //Macao
             { "Pataca macaense", "pataca macaense|patacas macaenses|mop$|mop" },
             { "Avo macaense", "avo macaense|avos macaenses" },
             { "Ho macaense", "ho macaense|ho macaenses" },
-            //Macedonia, República de
-            { "Denar macedonio", "denar macedonio|denare macedonios|den|mkd" },
-            { "Deni macedonio", "deni macedonio|deni macedonios" },
-            //Madagascar
-            { "Ariary malgache", "ariary malgache|ariary malgaches|mga" },
-            { "Iraimbilanja malgache", "iraimbilanja malgache|iraimbilanja malgaches" },
-            //Malasia
-            { "Ringgit malayo", "ringgit malayo|ringgit malayos|rm|myr" },
-            { "Sen malayo", "sen malayo|sen malayos" },
-            //Malaui
-            { "Kwacha malauí", "kwacha malauí|mk|mwk" },
-            { "Támbala malauí", "támbala malauí" },
+            //Macedônia, República de
+            { "Dinar macedônio", "denar macedonio|denare macedonios|denar macedônio|denar macedónio|denare macedônio|denare macedónio|dinar macedonio|dinar macedônio|dinar macedónio|dinares macedonios|dinares macedônios|dinares macedónios|den|mkd" },
+            { "Deni macedônio", "deni macedonio|deni macedônio|deni macedónio|denis macedonios|denis macedônios|denis macedónios" },
+            //Madagáscar
+            { "Ariary malgaxe", "ariai malgaxe|ariary malgaxe|ariary malgaxes|ariaris|mga" },
+            { "Iraimbilanja", "iraimbilanja|iraimbilanjas" },
+            //Malásia
+            { "Ringuite malaio", "ringgit malaio|ringgit malaios|ringgits malaios|ringuite malaio|ringuites malaios|rm|myr" },
+            { "Sen malaio", "sen malaio|sen malaios|centavo malaio|centavos malaios|cêntimo malaio|cêntimos malaios" },
+            //Malawi/Maláui
+            { "Kwacha do Malawi", "kwacha|cuacha|quacha|mk|mwk" },
+            { "Tambala", "tambala|tambalas|tambala malawi" },
             //Maldivas
-            { "Rupia de Maldivas", "rupia de Maldivas|rupias de Maldivas|mvr" },
-            //Malí -> Franco CFA de África Occidental
-            //Malta -> Euro
-            //Marruecos
-            { "Dirham marroquí", "dirham marroquí|dirhams marroquies|mad" },
-            //Mauricio
-            { "Rupia de Mauricio", "rupia de Mauricio|rupias de Mauricio|mur" },
-            //Mauritania
-            { "Uguiya", "uguiya|uguiyas|mro" },
-            { "Jum", "jum|jums" },
+            { "Rupia maldiva", "rupia maldiva|rupias maldivas|rupia das maldivas| rupias das maldivas|mvr" },
+            //Marrocos
+            { "Dirame marroquino", "dirame marroquino|dirham marroquinho|dirhams marroquinos|dirames marroquinos|mad" },
+            //Maurício/Maurícia
+            { "Rupia maurícia", "rupia maurícia|rupia de Maurício|rupia mauricia|rupia de mauricio|rupias de mauricio|rupias de maurício|rupias mauricias|rupias maurícias|mur" },
+            //Mauritânia
+            { "Uguia", "uguia|uguias|oguia|ouguiya|oguias|mro" },
+            { "Kume", "kumes|kume|khoums" },
             //México
             { "Peso mexicano", "peso mexicano|pesos mexicanos|mxn" },
             { "Centavo mexicano", "centavo mexicano|centavos mexicanos" },
-            //Micronesia, Estados Federados de -> Dólar estadounidense
-            //Moldavia
-            { "Leu moldavo", "leu moldavo|lei moldavos|mdl" },
-            { "Ban moldavo", "ban moldavo|bani moldavos" },
-            //Mónaco -> Euro
-            //Mongolia
-            { "Tugrik mongol", "tugrik mongol|tugrik|tugrik mongoles|tug|mnt" },
-            //Montenegro -> Euro
-            //Montserrat -> Dólar del Caribe Oriental
-            //Mozambique
-            { "Metical mozambiqueño", "metical|metical mozambiqueño|meticales|meticales mozambiqueños|mtn|mzn" },
-            //Nagorno Karabaj
-            { "Dram de Nagorno Karabaj", "dram de Nagorno Karabaj|drams de Nagorno Karabaj|" },
-            { "Luma de Nagorno Karabaj", "luma de Nagorno Karabaj" },
-            //Namibia
-            { "Dólar namibio", "dólar namibio|dólares namibios|n$|nad" },
-            { "Centavo namibio", "centavo namibio|centavos namibios" },
-            //Nauru -> Dólar australiano
+            //Moldávia
+            { "Leu moldávio", "leu moldavo|lei moldavos|leu moldávio|leu moldavio|lei moldávios|lei moldavios|leus moldavos|leus moldavios|leus moldávios|mdl" },
+            { "Ban moldávio", "ban moldavo|bani moldavos" },
+            //Mongólia
+            { "Tugrik mongol", "tugrik mongol|tugrik|tugriks mongóis|tugriks mongois|tug|mnt" },
+            //Moçambique
+            { "Metical moçambicao", "metical|metical moçambicano|metical mocambicano|meticais|meticais moçambicanos|meticais mocambicanos|mtn|mzn" },
+            //Namíbia
+            { "Dólar namibiano", "dólar namibiano|dólares namibianos|dolar namibio|dolares namibios|n$|nad" },
+            { "Centavo namibiano", "centavo namibiano|centavos namibianos|centavo namibio|centavos namibianos" },
             //Nepal
-            { "Rupia nepalí", "rupia nepalí|rupias nepalies|npr" },
-            { "Paisa nepalí", "paisa nepalí|paisas nepalies" },
-            //Nicaragua
+            { "Rupia nepalesa", "rupia nepalesa|rupias nepalesas|npr" },
+            { "Paisa nepalesa", "paisa nepalesa|paisas nepalesas" },
+            //Nicarágua //@HERE
             { "Córdoba nicaragüense", "córdoba nicaragüense|córdobas nicaragüenses|c$|nio" },
             { "Centavo nicaragüense", "centavo nicaragüense|centavos nicaragüenses" },
-            //Níger -> Franco CFA de África Occidental
             //Nigeria
             { "Naira", "naira|ngn" },
             { "Kobo", "kobo" },
-            //Niue -> Dólar neozelandés
             //Noruega
             { "Corona noruega", "corona noruega|coronas noruegas|nok" },
             //Nueva Caledonia
@@ -374,17 +348,14 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Nueva Zelanda
             { "Dólar neozelandés", "dólar neozelandés|dólares neozelandeses|dólar de Nueva Zelanda|dólares de Nueva Zelanda|nz$|nzd" },
             { "Centavo neozelandés", "centavo neozelandés|centavo de Nueva Zelanda|centavos de Nueva Zelanda|centavos neozelandeses" },
-            //Omán
+            //Oman
             { "Rial omaní", "rial omaní|riales omanies|omr" },
             { "Baisa omaní", "baisa omaní|baisa omanies" },
-            //Osetia del Sur -> Rublo ruso
-            //Países Bajos -> Euro
+            //Países Baixos/Holanda -> Euro + old florin
             { "Florim holandês", "florim holandês|florim holandes|florins holandeses|nlg" },
-            //Pakistán
+            //Paquistão
             { "Rupia pakistaní", "rupia pakistaní|rupias pakistanies|pkr" },
             { "Paisa pakistaní", "paisa pakistaní|paisas pakistanies" },
-            //Palaos -> Dólar estadounidense
-            //Palestina -> Nuevo shéquel | Dinar jordano
             //Panamá
             { "Balboa panameño", "balboa panameño|balboa panameños|pab" },
             { "Centésimo panameño", "centésimo panameño|centésimos panameños" },

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 
         public static readonly ImmutableDictionary<string, string> CurrencySuffixList = new Dictionary<string, string>
         {
-            //GeneralsUnits
+            // General Units
             { "Dólar", "dólar|dolar|dólares|dolares" },
             { "Peso", "peso|pesos" },
             { "Rublo", "rublo|rublos"},
             { "Libra", "libra|libras" },
-            { "Florín", "florín|florin|floríns|florins" },
+            { "Florín", "florín|florin|floríns|florins|ƒ" },
             { "Dinar", "dinar|dinares" },
             { "Franco", "franco|francos" },
             { "Rúpia", "rúpia|rupia|rúpias|rupias" },
@@ -35,71 +35,69 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Centavo", "centavo|cêntimo|centimo|centavos|cêntimos|centimo" },
             { "Centésimo", "centésimo|centésimos" },
             { "Pêni", "pêni|péni|peni|penies|pennies" },
+            { "Manat", "manat|manate|mánate|man|manats|manates|mánates" },
 
             //Euro
             { "Euro", "euro|euros|€|eur" },
             { "Centavo de Euro", "centavo de euro|cêntimo de euro|centimo de euro|centavos de euro|cêntimos de euro|centimos de euro" },
             //Dólar do Caribe Oriental
-            { "Dólar do Caribe Oriental", "dólar do Caribe Oriental|dolar do Caribe Oriental|dólares do Caribe Oriental|dolares do Caribe Oriental|ec$|xcd" },
-            { "Centavo do Caribe Oriental", "centavo do Caribe Oriental|cêntimo do Caribe Oriental|centavos do Caribe Oriental|cêntimos do Caribe Oriental" },
+            { "Dólar do Caribe Oriental", "dólar do Caribe Oriental|dolar do Caribe Oriental|dólares do Caribe Oriental|dolares do Caribe Oriental|dólar das Caraíbas Orientais|dolar das Caraibas Orientais|dólares das Caraíbas Orientais|dolares das Caraibas Orientais|ec$|xcd" },
+            { "Centavo do Caribe Oriental", "centavo do Caribe Oriental|centavo das Caraíbas Orientais|cêntimo do Caribe Oriental|cêntimo das Caraíbas Orientais|centavos do Caribe Oriental|centavos das Caraíbas Orientais|cêntimos do Caribe Oriental|cêntimos das Caraíbas Orientais" },
             //Franco CFA da África Ocidental
-            { "Franco CFA da África Ocidental", "franco CFA da África Ocidental|franco CFA da Africa Ocidental|francos CFA da África Occidental|francos CFA da Africa Occidental|xof" },
+            { "Franco CFA da África Ocidental", "franco CFA da África Ocidental|franco CFA da Africa Ocidental|francos CFA da África Occidental|francos CFA da Africa Occidental|franco CFA Ocidental|xof" },
             { "Centavo de CFA da África Ocidental", "centavo de CFA da Africa Occidental|centavos de CFA da África Ocidental|cêntimo de CFA da Africa Occidental|cêntimos de CFA da África Ocidental" },
             //Franco CFA da África Central
-            { "Franco CFA da África Central", "franco CFA da África Central|franco CFA da Africa Central|francos CFA da África Central|francos CFA da Africa Central|xaf" },
+            { "Franco CFA da África Central", "franco CFA da África Central|franco CFA da Africa Central|francos CFA da África Central|francos CFA da Africa Central|franco CFA central|xaf" },
             { "Centavo de CFA da África Central", "centavo de CFA de África Central|centavos de CFA da África Central|cêntimo de CFA de África Central|cêntimos de CFA da África Central" },
+
             //Abcásia
-            {"Apsar abcásio", "Apsar abcásio|apsar|apsares"},
-            //Afganistão
-            {"Afegani afegão", "afegani afegão|؋|afn|afegane|afgane|afegâni|afeganis|afeganes|afganes|afegânis"},
+            {"Apsar abcásio", "apsar abcásio|apsar abecásio|apsar abcasio|apsar|apsares"},
+            //Afeganistão
+            {"Afegani afegão", "afegani afegão|afegane afegão|؋|afn|afegane|afgane|afegâni|afeganis|afeganes|afganes|afegânis"},
             {"Pul", "pul|pules|puls"},
-            //Albania
-            {"Lek albanês", "lek|lekë|lekes|lek albanês"},
-            {"Qindarka", "qindarka|qindarkë|qindarkas"},
+            //Albânia
+            {"Lek albanês", "lek|lekë|lekes|lek albanês|leque|leques|all"},
+            {"Qindarke", "qindarka|qindarkë|qindarke|qindarkas"},
             //Angola
-            {"Kwanza angolano", "kwanza angolano|kwanzas angolanos|kwanzas|aoa|kz" },
+            {"Kwanza angolano", "kwanza angolano|kwanzas angolanos|kwanza|kwanzas|aoa|kz" },
             {"Cêntimo angolano", "cêntimo angolano|cêntimo|cêntimos" },
             //Antilhas Neerlandesas or Antilhas Holandesas
             { "Florim das Antilhas Holandesas", "florim das antilhas holandesas|florim das antilhas neerlandesas|ang" },
             //Arabia Saudita
-            { "Riyal saudita", "riyal saudí|riyales saudí|sar" },
-            { "Halalá saudita", "halalá saudí|hallalah" },
-            //Argelia
+            { "Rial saudita", "rial saudita|riais sauditas|riyal saudita|riyals sauditas|riyal|riyals|sar" },
+            { "Halala saudita", "halala saudita|halala|hallalah" },
+            //Argélia
             { "Dinar argelino", "dinar argelino|dinares argelinos|dzd" },
-            { "Céntimo argelino", "centimo argelino|centimos argelinos|" },
+            { "Cêntimo argelino", "centimo argelino|centimos argelinos|cêntimo argelino|cêntimos argelinos|centavo argelino|centavos argelinos" },
             //Argentina
             { "Peso argentino", "peso argentino|pesos argentinos|peso|pesos|ar$|ars" },
             { "Centavo argentino", "centavo argentino|centavos argentinos|centavo|ctvo.|ctvos." },
             //Armenia
-            { "Dram armenio", "dram armenio|dram armenios|dram|դր." },
-            { "Luma armenio", "luma armenio|luma armenios" },
+            { "Dram armênio", "dram armênio|dram armênios|dram arménio|dram arménios|dram armenio|dram armenios|dram|drame|drames|դր." },
+            { "Luma armênio", "luma armênio|lumas armênios|luma arménio|lumas arménios|luma armenio|lumas armenios|luma|lumas" },
             //Aruba
-            { "Florín arubeño", "florín arubeño|florines arubeños|ƒ arubeños|aƒ|awg" },
-            { "Yotin arubeño", "yotin arubeño|yotines arubeños" },
+            { "Florim arubano", "florín arubeño|florines arubeños|ƒ arubeños|aƒ|awg" },
             //Australia
-            { "Dólar australiano", "dólar australiano|dólares australianos|a$|aud" },
+            { "Dólar australiano", "dólar australiano|dólares australianos|dolar australiano|dolares australianos|a$|aud" },
             { "Centavo australiano", "centavo australiano|centavos australianos" },
-            //Austria -> Euro
-            //Azerbaiyán
-            {"Manat azerí", "manat azerí|man|azn" },
-            {"Qəpik azerí", "qəpik azerí|qəpik" },
+            //Azerbaijão
+            {"Manat azeri", "manat azeri|manats azeris|azn|manat azerbaijanês|manat azerbaijano|manats azerbaijaneses|manats azerbaijanos" },
+            {"Qəpik azeri", "qəpik azeri|qəpik|qəpiks" },
             //Bahamas
-            { "Dólar bahameño", "dólar bahameño|dólares bahameños|b$|bsd" },
-            { "Centavo bahameño", "centavo bahameño|centavos bahameños" },
-            //Baréin
-            { "Dinar bahreiní", "dinar bahreiní|dinares bahreinies|bhd" },
-            { "Fil bahreiní", "fil bahreiní|fils bahreinies" },
-            //Bangladés
-            { "Taka bangladeshí", "taka bangladeshí|takas bangladeshí|bdt" },
-            { "Poisha bangladeshí", "poisha bangladeshí|poishas bangladeshí" },
+            { "Dólar bahamense", "dólar bahamense|dólares bahamense|dolar bahamense|dolares bahamense|dólar baamiano|dólares baamiano|dolar baamiano|dolares baamiano|b$|bsd" },
+            { "Centavo bahamense", "centavo bahamense|centavos bahamense" },
+            //Barein
+            { "Dinar bareinita", "dinar bareinita|dinar baremita|dinares bareinitas|dinares baremitas|bhd" },
+            { "Fil bareinita", "fil bareinita|fil baremita|fils bareinitas|fils baremitas" },
+            //Bangladesh
+            { "Taka bengali", "taka bengali|takas bengalis|taca|tacas|taka|takas|bdt" },
+            { "Poisha bengali", "poisha bengali|poishas bengalis" },
             //Barbados
-            { "Dólar de Barbados", "dólar de barbados|dólares de barbados|bbd" },
-            { "Centavo de Barbados", "centavo de barbados|centavos de barbados" },
-            //Bélgica -> Euro
-            //Belice
+            { "Dólar de Barbados", "dólar de barbados|dólares de barbados|dolar de barbados|dolares de barbados|dólar dos barbados|dólares dos barbados|bbd" },
+            { "Centavo de Barbados", "centavo de barbados|centavos de barbados|centavo dos barbados|centavos dos barbados" },
+            //Belize //@HERE
             { "Dólar beliceño", "dólar beliceño|dólares beliceños|bz$|bzd" },
             { "Centavo beliceño", "centavo beliceño|centavos beliceños" },
-            //Benín -> Franco CFA de África Occidental
             //Bermudas
             { "Dólar bermudeño", "dólar bermudeño|dólares bermudeños|bd$|bmd" },
             { "Centavo bermudeño", "centavo bermudeño|centavos bermudeños" },
@@ -191,7 +189,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //España -> Euro
             { "Peseta", "peseta|pesetas|pts.|ptas.|esp" },
             //Estados Unidos
-            { "Dólar estadunidense", "dólar estadunidense|dólar americano|dólares estadunidenses|dólares americanos|dolar estadunidense|dolar americano|dolares estadunidenses|dolares americanos|usd|u$d|us$" },
+            { "Dólar estadunidense", "dólar dos estados unidos|dolar dos estados unidos|dólar estadunidense|dólar americano|dólares dos estados unidos|dolares dos estados unidos|dólares estadunidenses|dólares americanos|dolar estadunidense|dolar americano|dolares estadunidenses|dolares americanos|usd|u$d|us$" },
             //Estonia
             { "Corona estonia", "corona estonia|coronas estonias|eek" },
             { "Senti estonia", "senti estonia|senti estonias" },
@@ -435,8 +433,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Leu rumano", "leu rumano|lei rumanos|ron" },
             { "Ban rumano", "ban rumano|bani rumanos" },
             //Rusia
-            { "Rublo ruso", "rublo ruso|rublos rusos|rub" },
-            { "Kopek ruso", "kopek ruso|kopeks rusos" },
+            { "Rublo russo", "rublo russo|rublos russos|rub|р." },
+            { "Copeque ruso", "copeque russo|copeques russos|kopek ruso|kopeks rusos|copeque|copeques|kopek|kopeks" },
             //Sahara Occidental -> Dirham marroquí | Dinar argelino
             //Samoa
             { "Tala", "tala|tālā|ws$|sat|wst" },

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Florín", "florín|florin|floríns|florins|ƒ" },
             { "Dinar", "dinar|dinares" },
             { "Franco", "franco|francos" },
-            { "Rúpia", "rúpia|rupia|rúpias|rupias" },
+            { "Rupia", "rúpia|rupia|rúpias|rupias" },
             { "Escudo", "escudo|escudos" },
             { "Xelim", "xelim|xelins|xelims" },
             { "Lira", "lira|liras" },
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Franco CFA da África Central
             { "Franco CFA da África Central", "franco CFA da África Central|franco CFA da Africa Central|francos CFA da África Central|francos CFA da Africa Central|franco CFA central|xaf" },
             { "Centavo de CFA da África Central", "centavo de CFA de África Central|centavos de CFA da África Central|cêntimo de CFA de África Central|cêntimos de CFA da África Central" },
-
+            
             //Abcásia
             {"Apsar abcásio", "apsar abcásio|apsar abecásio|apsar abcasio|apsar|apsares"},
             //Afeganistão
@@ -105,8 +105,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Dólar bermudense", "dólar bermudense|dólares bermudenses|bd$|bmd" },
             { "Centavo bermudense", "centavo bermudense|centavos bermudenses|cêntimo bermudense| cêntimos bermudenses" },
             //Bielorrúsia / Belarus
-            { "Rublo bielorruso", "rublo bielorruso|rublos bielorrusos|br|byr" },
-            { "Copeque ruso", "copeque bielorruso|copeques bielorrusos|kopek bielorruso|kopeks bielorrusos|kap" },
+            { "Rublo bielorrusso", "rublo bielorrusso|rublos bielorrussos|br|byr" },
+            { "Copeque bielorusso", "copeque bielorrusso|copeques bielorrussos|kopek bielorrusso|kopeks bielorrussos|kap" },
             //Mianmar/Birmânia
             { "Quiate mianmarense", "quiate mianmarense|quiates mianmarenses|kyat mianmarense|kyates mianmarenses|quiate myanmarense|quiates myanmarenses|kyat myanmarense|kyates myanmarenses|quiate birmanês|quite birmanes|quiates birmaneses|kyat birmanês|kyat birmanes|kyates birmaneses|mmk" },
             { "Pya mianmarense", "pya mianmarense|pyas mianmarenses|pya myanmarense|pyas myanmarenses|pya birmanês|pya birmanes|pyas birmaneses" },
@@ -440,7 +440,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Sudão do Sur
             { "Libra sursudanesa", "libra sursudanesa|libras sursudanesa|ssp" },
             { "Piastra sursudanesa", "piastra sursudanesa|piastras sursudanesas" },
-            //Suéciama
+            //Suécia
             { "Coroa sueca", "coroa sueca|coroas suecas|sek" },
             //Suíça
             { "Franco suíço", "franco suíço|franco suico|francos suíços|francos suicos|sfr|chf" },
@@ -517,7 +517,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Zambia
             { "Kwacha zambiano", "kwacha zambiano|kwacha zambianos|zmw" },
             { "Ngwee zambiano", "ngwee zambiano|ngwee zambianos" },
-            //Zimbabue -> Dólar Estadounidense
         }.ToImmutableDictionary();
 
         public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Lira", "lira|liras" },
             { "Centavo", "centavo|cêntimo|centimo|centavos|cêntimos|centimo" },
             { "Centésimo", "centésimo|centésimos" },
-            { "Pêni", "pêni|péni|peni|pennies" },
+            { "Pêni", "pêni|péni|peni|penies|pennies" },
 
             //Euro
             { "Euro", "euro|euros|€|eur" },
@@ -59,12 +59,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Angola
             {"Kwanza angolano", "kwanza angolano|kwanzas angolanos|kwanzas|aoa|kz" },
             {"Cêntimo angolano", "cêntimo angolano|cêntimo|cêntimos" },
-            //Antillas Neerlandesas
-            { "Florín antillano neerlandés", "florín antillano neerlandés|florínes antillano neerlandés|ƒ antillano neerlandés|ang|naƒ" },
-            { "Cent antillano neerlandés", "cent|centen" },
+            //Antilhas Neerlandesas or Antilhas Holandesas
+            { "Florim das Antilhas Holandesas", "florim das antilhas holandesas|florim das antilhas neerlandesas|ang" },
             //Arabia Saudita
-            { "Riyal saudí", "riyal saudí|riyales saudí|sar" },
-            { "Halalá saudí", "halalá saudí|hallalah" },
+            { "Riyal saudita", "riyal saudí|riyales saudí|sar" },
+            { "Halalá saudita", "halalá saudí|hallalah" },
             //Argelia
             { "Dinar argelino", "dinar argelino|dinares argelinos|dzd" },
             { "Céntimo argelino", "centimo argelino|centimos argelinos|" },
@@ -121,7 +120,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Thebe", "thebe" },
             //Brasil
             { "Real brasileiro", "real brasileiro|real do Brasil|real|reais brasileiros|reais do brasil|reais|r$|brl" },
-            { "Centavo brasileiro", "centavo de real|centavo brasileiro|centavos de real|centavos brasileiros|centavo|centavos" },
+            { "Centavo brasileiro", "centavo de real|centavo brasileiro|centavos de real|centavos brasileiros" },
             //Brunéi
             { "Dólar de Brunéi", "dólar de brunei|dólares de brunéi|bnd" },
             { "Sen de Brunéi", "sen|sen de brunéi" },
@@ -130,24 +129,24 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Stotinki búlgaro", "stotinka búlgaro|stotinki búlgaros" },
             //Burkina Faso -> Franco CFA de África Occidental
             //Burundi
-            { "Franco de Burundi", "franco de burundi|francos de burundi|fbu|fib" },
-            { "Céntimo Burundi", "céntimo burundi|céntimos burundies" },
+            { "Franco do Burundi", "franco do burundi|francos do burundi|fbu|fib" },
+            { "Centavo Burundi", "centavo burundi|cêntimo burundi|centimo burundi|centavos burundi|cêntimo burundi|centimo burundi" },
             //Bután
             { "Ngultrum butanés", "ngultrum butanés|ngultrum butaneses|btn" },
             { "Chetrum  butanés", "chetrum butanés|chetrum butaneses" },
             //Cabo Verde
             { "Escudo caboverdiano", "escudo caboverdiano|escudos caboverdianos|cve" },
-            //Camboya
-            { "Riel camboyano", "riel camboyano|rieles camboyanos|khr" },
+            //Camboja
+            { "Riel cambojano", "riel cambojano|riels cambojanos|khr" },
             //Camerún -> Franco CFA de África Central
             //Canadá
-            { "Dólar canadiense", "dólar canadiense|dólares canadienses|c$|cad" },
-            { "Centavo canadiense", "centavo canadiense|centavos canadienses" },
+            { "Dólar canadense", "dólar canadense|dolar canadense|dólares canadenses|dolares canadenses|c$|cad" },
+            { "Centavo canadense", "centavo canadense|centavos canadenses" },
             //Chad -> Franco CFA de África Central
             //Chile
             { "Peso chileno", "peso chileno|pesos chilenos|cpl" },
             //China
-            { "Yuan chino", "yuan chino|yuanes chinos|yuan|yuanes|renminbi|rmb|cny|¥" },
+            { "Yuan chinês", "yuan chinês|yuans chineses|yuan|yuans|renminbi|rmb|cny|¥" },
             //Chipre -> Euro
             //Colombia
             { "Peso colombiano", "peso colombiano|pesos colombianos|cop|col$" },
@@ -202,7 +201,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Filipinas
             { "Peso filipino", "peso filipino|pesos filipinos|php" },
             //Finlandia -> Euro
-            { "Marco finlandés", "marco finlandés|marcos finlandeses" },
+            { "Marco finlandês", "marco finlandês|marco finlandes|marcos finlandeses" },
             //Fiyi
             { "Dólar fiyiano", "dólar fiyiano|dólares fiyianos|fj$|fjd" },
             { "Centavo fiyiano", "centavo fiyiano|centavos fiyianos" },
@@ -284,11 +283,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Israel
             { "Nuevo shéquel", "nuevo shéquel|nuevos shéquel|ils" },
             { "Agorot", "agorot" },
-            //Italia -> Euro
+            //Italia -> Europe
             //Jamaica
             { "Dólar jamaiquino", "dólar jamaiquino|dólares jamaiquinos|j$|ja$|jmd" },
             //Japón
-            { "Yen", "yen|yenes|jpy" },
+            { "Yen", "yen|iene|yenes|ienes|jpy" },
             //Jersey
             { "Libra de Jersey", "libra de Jersey|libras de Jersey|jep" },
             //Jordania
@@ -395,7 +394,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Baisa omaní", "baisa omaní|baisa omanies" },
             //Osetia del Sur -> Rublo ruso
             //Países Bajos -> Euro
-            { "Florín neerlandés", "florín neerlandés|florines neerlandeses|nlg" },
+            { "Florim holandês", "florim holandês|florim holandes|florins holandeses|nlg" },
             //Pakistán
             { "Rupia pakistaní", "rupia pakistaní|rupias pakistanies|pkr" },
             { "Paisa pakistaní", "paisa pakistaní|paisas pakistanies" },
@@ -477,31 +476,31 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             { "Céntimo de Sri Lanka", "céntimo de Sri Lanka|céntimos de Sri Lanka" },
             //Suazilandia
             { "Lilangeni", "lilangeni|emalangeni|szl" },
-            //Sudáfrica
-            { "Rand sudafricano", "rand|rand sudafricano|zar" },
-            //Sudán
+            //África do Sul
+            { "Rand sulafricano", "rand|rand sulafricano|zar" },
+            //Sudão
             { "Libra sudanesa", "libra sudanesa|libras sudanesas|sdg" },
             { "Piastra sudanesa", "piastra sudanesa|piastras sudanesas" },
-            //Sudán del Sur
+            //Sudão do Sur
             { "Libra sursudanesa", "libra sursudanesa|libras sursudanesa|ssp" },
             { "Piastra sursudanesa", "piastra sursudanesa|piastras sursudanesas" },
-            //Suecia
-            { "Corona sueca", "corona sueca|coronas suecas|sek" },
-            //Suiza
-            { "Franco suizo", "franco suizo|francos suizos|sfr|chf" },
-            { "Rappen suizo", "rappen suizo|rappens suizos" },
-            //Surinam
-            { "Dólar surinamés", "óolar surinamés|dólares surinameses|srd" },
-            { "Centavo surinamés", "centavo surinamés|centavos surinamés" },
-            //Tailandia
-            { "Baht tailandés", "baht tailandés|baht tailandeses|thb" },
-            { "Satang tailandés", "satang tailandés|satang tailandeses" },
-            //Taiwán
-            { "Nuevo dólar taiwanés", "nuevo dólar taiwanés|dólar taiwanés|dólares taiwaneses|twd" },
-            { "Centavo taiwanés", "centavo taiwanés|centavos taiwaneses" },
-            //Tanzania
-            { "Chelín tanzano", "chelín tanzano|chelines tanzanos|tzs" },
-            { "Centavo tanzano", "centavo tanzano|centavos tanzanos" },
+            //Suéciama
+            { "Coroa sueca", "coroa sueca|coroas suecas|sek" },
+            //Suíça
+            { "Franco suíço", "franco suíço|franco suico|francos suíços|francos suicos|sfr|chf" },
+            { "Rappen suíço", "rappen suíço|rappen suico|rappens suíços|rappens suicos" },
+            //Suriname
+            { "Dólar surinamês", "dólar surinamês|dolar surinames|dólar do Suriname|dolar do Suriname|dólares surinameses|dolares surinameses|dólares do Suriname|dolares do Suriname|srd" },
+            { "Centavo surinamês", "centavo surinamês|centavo surinames|centavos surinameses" },
+            //Tailândia
+            { "Baht tailandês", "baht tailandês|bath tailandes|baht tailandeses|thb" },
+            { "Satang tailandês", "satang tailandês|satang tailandes|satang tailandeses" },
+            //Taiwan
+            { "Novo dólar taiwanês", "novo dólar taiwanês|novo dolar taiwanes|dólar taiwanês|dolar taiwanes|dólares taiwaneses|dolares taiwaneses|twd" },
+            { "Centavo taiwanês", "centavo taiwanês|centavo taiwanes|centavos taiwaneses" },
+            //Tanzânia
+            { "Xelim tanzaniano", "xelim tanzano|xelins tanzanos|tzs" },
+            { "Centavo tanzaniano", "centavo tanzano|centavos tanzanos" },
             //Tayikistán
             { "Somoni tayiko", "somoni tayiko|somoni|tjs" },
             { "Diram", "diram|dirams" },
@@ -577,7 +576,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             {"Dólar bermudeño", "bd$|bmd"},
             {"Dólar de Brunéi", "brunéi $|bnd"},
             {"Dólar de Singapur", "s$|sgd"},
-            {"Dólar canadienser", "c$|can$|cad"},
+            {"Dólar canadense", "c$|can$|cad"},
             {"Dólar de las Islas Caimán", "ci$|kyd"},
             {"Dólar neozelandés", "nz$|nzd"},
             {"Dólar fiyiano", "fj$|fjd"},

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/CurrencyExtractorConfiguration.cs
@@ -20,9 +20,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 
         public static readonly ImmutableDictionary<string, string> CurrencySuffixList = new Dictionary<string, string>
         {
+            // Reference Source: https://pt.wikipedia.org/wiki/Lista_de_moedas
+
             // General Units
             { "Dólar", "dólar|dolar|dólares|dolares" },
             { "Peso", "peso|pesos" },
+            { "Coroa", "coroa|coroas" },
             { "Rublo", "rublo|rublos"},
             { "Libra", "libra|libras" },
             { "Florín", "florín|florin|floríns|florins|ƒ" },
@@ -72,12 +75,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Argentina
             { "Peso argentino", "peso argentino|pesos argentinos|peso|pesos|ar$|ars" },
             { "Centavo argentino", "centavo argentino|centavos argentinos|centavo|ctvo.|ctvos." },
-            //Armenia
+            //Armênia
             { "Dram armênio", "dram armênio|dram armênios|dram arménio|dram arménios|dram armenio|dram armenios|dram|drame|drames|դր." },
             { "Luma armênio", "luma armênio|lumas armênios|luma arménio|lumas arménios|luma armenio|lumas armenios|luma|lumas" },
             //Aruba
             { "Florim arubano", "florín arubeño|florines arubeños|ƒ arubeños|aƒ|awg" },
-            //Australia
+            //Austrália
             { "Dólar australiano", "dólar australiano|dólares australianos|dolar australiano|dolares australianos|a$|aud" },
             { "Centavo australiano", "centavo australiano|centavos australianos" },
             //Azerbaijão
@@ -95,137 +98,121 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             //Barbados
             { "Dólar de Barbados", "dólar de barbados|dólares de barbados|dolar de barbados|dolares de barbados|dólar dos barbados|dólares dos barbados|bbd" },
             { "Centavo de Barbados", "centavo de barbados|centavos de barbados|centavo dos barbados|centavos dos barbados" },
-            //Belize //@HERE
-            { "Dólar beliceño", "dólar beliceño|dólares beliceños|bz$|bzd" },
-            { "Centavo beliceño", "centavo beliceño|centavos beliceños" },
+            //Belize
+            { "Dólar de Belize", "dólar de belize|dólares de belize|dolar de belize|dolares de belize|dólar do belize|dólares do belize|dolar do belize|dolares do belize|bz$|bzd" },
+            { "Centavo de Belize", "centavo de belize|centavos de belize|cêntimo do belize|cêntimos do belize" },
             //Bermudas
-            { "Dólar bermudeño", "dólar bermudeño|dólares bermudeños|bd$|bmd" },
-            { "Centavo bermudeño", "centavo bermudeño|centavos bermudeños" },
-            //Bielorrusia
+            { "Dólar bermudense", "dólar bermudense|dólares bermudenses|bd$|bmd" },
+            { "Centavo bermudense", "centavo bermudense|centavos bermudenses|cêntimo bermudense| cêntimos bermudenses" },
+            //Bielorrúsia / Belarus
             { "Rublo bielorruso", "rublo bielorruso|rublos bielorrusos|br|byr" },
-            { "Kópek bielorruso", "kópek bielorruso|kópeks bielorrusos|kap" },
-            //Birmania
-            { "Kyat birmano", "kyat birmano|kyats birmanos|mmk" },
-            { "Pya birmano", "pya birmano|pyas birmanos" },
-            //Bolivia
+            { "Copeque ruso", "copeque bielorruso|copeques bielorrusos|kopek bielorruso|kopeks bielorrusos|kap" },
+            //Mianmar/Birmânia
+            { "Quiate mianmarense", "quiate mianmarense|quiates mianmarenses|kyat mianmarense|kyates mianmarenses|quiate myanmarense|quiates myanmarenses|kyat myanmarense|kyates myanmarenses|quiate birmanês|quite birmanes|quiates birmaneses|kyat birmanês|kyat birmanes|kyates birmaneses|mmk" },
+            { "Pya mianmarense", "pya mianmarense|pyas mianmarenses|pya myanmarense|pyas myanmarenses|pya birmanês|pya birmanes|pyas birmaneses" },
+            //Bolívia
             { "Boliviano", "boliviano|bolivianos|bob|bs" },
-            { "Centésimo Boliviano", "centésimo boliviano|centésimos bolivianos" },
-            //Bosnia y Herzegovina
-            { "Marco bosnioherzegovino", "marco convertible|marco bosnioherzegovino|marcos convertibles|marcos bosnioherzegovinos|bam" },
-            { "Feningas bosnioherzegovino", "feninga convertible|feninga bosnioherzegovina|feningas convertibles" },
+            { "Centavo Boliviano", "centavo boliviano|centavos bolivianos" },
+            //Bósnia e Herzegovina
+            { "Marco da Bósnia e Herzegovina", "marco conversível|marco conversivel|marco convertível|marco convertivel|marcos conversíveis|marcos conversiveis|marcos convertíveis|marcos convertivies|bam" },
+            { "Fening da Bósnia e Herzegovina", "fening conversível|fening conversivel|fening convertível|fening convertivel|fenings conversíveis|fenings conversiveis|fenings convertíveis|fenings convertiveis" },
             //Botsuana
-            { "Pula", "pula|bwp" },
-            { "Thebe", "thebe" },
+            { "Pula", "pula|pulas|bwp" },
+            { "Thebe", "thebe|thebes" },
             //Brasil
-            { "Real brasileiro", "real brasileiro|real do Brasil|real|reais brasileiros|reais do brasil|reais|r$|brl" },
+            { "Real brasileiro", "real brasileiro|real do brasil|real|reais brasileiros|reais do brasil|reais|r$|brl" },
             { "Centavo brasileiro", "centavo de real|centavo brasileiro|centavos de real|centavos brasileiros" },
-            //Brunéi
-            { "Dólar de Brunéi", "dólar de brunei|dólares de brunéi|bnd" },
-            { "Sen de Brunéi", "sen|sen de brunéi" },
-            //Bulgaria
-            { "Lev búlgaro", "lev búlgaro|leva búlgaros|lv|bgn" },
-            { "Stotinki búlgaro", "stotinka búlgaro|stotinki búlgaros" },
-            //Burkina Faso -> Franco CFA de África Occidental
+            //Brunei
+            { "Dólar de Brunéi", "dólar de brunei|dolar de brunei|dólar do brunei|dolar do brunei|dólares de brunéi|dolares de brunei|dólares do brunei|dolares do brunei|bnd" },
+            { "Sen de Brunéi", "sen de brunei|sen do brunei|sens de brunei|sens do brunei" },
+            //Bulgária
+            { "Lev búlgaro", "lev búlgaro|leve búlgaro|leves búlgaros|lev bulgaro|leve bulgaro|leves bulgaros|lv|bgn" },
+            { "Stotinka búlgaro", "stotinka búlgaro|stotinki búlgaros|stotinka bulgaro|stotinki bulgaros" },
             //Burundi
             { "Franco do Burundi", "franco do burundi|francos do burundi|fbu|fib" },
             { "Centavo Burundi", "centavo burundi|cêntimo burundi|centimo burundi|centavos burundi|cêntimo burundi|centimo burundi" },
-            //Bután
-            { "Ngultrum butanés", "ngultrum butanés|ngultrum butaneses|btn" },
-            { "Chetrum  butanés", "chetrum butanés|chetrum butaneses" },
+            //Butão
+            { "Ngultrum butanês", "ngultrum butanês|ngultrum butanes|ngúltrume butanês|ngultrume butanes|ngultrum butaneses|ngúltrumes butaneses|ngultrumes butaneses|btn" },
+            { "Chetrum  butanês", "chetrum butanês|chetrum butanes|chetrum butaneses" },
             //Cabo Verde
-            { "Escudo caboverdiano", "escudo caboverdiano|escudos caboverdianos|cve" },
+            { "Escudo cabo-verdiano", "escudo cabo-verdiano|escudos cabo-verdianos|cve" },
             //Camboja
-            { "Riel cambojano", "riel cambojano|riels cambojanos|khr" },
-            //Camerún -> Franco CFA de África Central
+            { "Riel cambojano", "riel cambojano|riéis cambojanos|rieis cambojanos|khr" },
             //Canadá
             { "Dólar canadense", "dólar canadense|dolar canadense|dólares canadenses|dolares canadenses|c$|cad" },
             { "Centavo canadense", "centavo canadense|centavos canadenses" },
-            //Chad -> Franco CFA de África Central
             //Chile
             { "Peso chileno", "peso chileno|pesos chilenos|cpl" },
             //China
-            { "Yuan chinês", "yuan chinês|yuans chineses|yuan|yuans|renminbi|rmb|cny|¥" },
-            //Chipre -> Euro
-            //Colombia
+            { "Yuan chinês", "yuan chinês|yuan chines|yuans chineses|yuan|yuans|renminbi|rmb|cny|¥" },
+            //Colômbia
             { "Peso colombiano", "peso colombiano|pesos colombianos|cop|col$" },
             { "Centavo colombiano", "centavo colombiano|centavos colombianos" },
-            //Comoras
-            { "Franco comorano", "franco comorano|francos comoranos|kmf|₣" },
-            //Congo, República del -> Franco CFA de África Central
-            //Congo, República Democrática del
-            { "Franco congoleño", "franco congoleño|francos congoleños|cdf" },
-            { "Céntimo congoleño", "céntimo congoleño|céntimos congoleños" },
-            //Corea del Norte
-            { "Won norcoreano", "won norcoreano|wŏn norcoreano|wŏn norcoreanos|kpw" },
-            { "Chon norcoreano", "chon norcoreano|chŏn norcoreano|chŏn norcoreanos|chon norcoreanos" },
-            //Corea del Sur
-            { "Won surcoreano", "wŏn surcoreano|won surcoreano|wŏnes surcoreanos|wones surcoreanos|krw" },
-            { "Chon surcoreano", "chon surcoreano|chŏn surcoreano|chŏn surcoreanos|chon surcoreanos" },
-            //Costa de Marfil -> Franco CFA de África Occidental
+            //Comores
+            { "Franco comorense", "franco comorense|francos comorenses|kmf|₣" },
+            //Congo, República Democrática do
+            { "Franco congolês", "franco congolês|franco congoles|francos congoleses|cdf" },
+            { "Centavo congolês", "centavo congolês|centavo congoles|centavos congoleses|cêntimo congolês|centimo congoles|cêntimos congoleses|cêntimos congoleses" },
+            //Coréia do Norte
+            { "Won norte-coreano", "won norte-coreano|wŏn norte-coreano|won norte-coreanos|wŏn norte-coreanos|kpw" },
+            { "Chon norte-coreano", "chon norte-coreano|chŏn norte-coreano|chŏn norte-coreanos|chon norte-coreanos" },
+            //Coréia do Sur
+            { "Won sul-coreano", "wŏn sul-coreano|won sul-coreano|wŏnes sul-coreanos|wones sul-coreanos|krw" },
+            { "Jeon sul-coreano", "jeons sul-coreano|jeons sul-coreanos" },
             //Costa Rica
-            { "Colón costarricense", "colón costarricense|colones costarricenses|crc" },
-            //Croacia
-            { "Kuna croata", "kuna croata|kuna croatas|hrk" },
-            { "Lipa croata", "lipa croata|lipa croatas" },
+            { "Colón costarriquenho", "colón costarriquenho|colon costarriquenho|colons costarriquenho|colones costarriquenhos|crc" },
+            //Croácia
+            { "Kuna croata", "kuna croata|kunas croatas|hrk" },
+            { "Lipa croata", "lipa croata|lipas croatas" },
             //Cuba
             { "Peso cubano", "peso cubano|pesos cubanos|cup" },
-            { "Peso cubano convertible", "peso cubano convertible|pesos cubanos convertible|cuc" },
+            { "Peso cubano convertível", "peso cubano conversível|pesos cubanos conversíveis|peso cubano conversivel|pesos cubanos conversiveis|peso cubano convertível|pesos cubanos convertíveis|peso cubano convertivel|pesos cubanos convertiveis|cuc" },
             //Dinamarca
-            { "Corona danesa", "corona danesa|coronas danesas|dkk" },
-            //Dominica -> Dólar del Caribe Oriental
-            //Ecuador -> Dólar estadounidense
-            //Egipto
-            { "Libra egipcia", "libra egipcia|libras egipcias|egp|le" },
-            { "Piastra egipcia", "piastra egipcia|piastras egipcias" },
-            //El Salvador
-            { "Colón salvadoreño", "colón salvadoreño|colones salvadoreños|svc" },
-            //Emiratos Árabes Unidos
-            { "Dirham de los Emiratos Árabes Unidos", "dirham|dirhams|dirham de los Emiratos Árabes Unidos|aed|dhs" },
-            //Eritrea
+            { "Coroa dinamarquesa", "coroa dinamarquesa|coroas dinamarquesas|dkk" },
+            //Egito
+            { "Libra egípcia", "libra egípcia|libra egipcia|libras egípcias|libras egipcias|egp|le" },
+            { "Piastra egípcia", "piastra egípcia|piastra egipcia|pisastras egípcias|piastras egipcias" },
+            //Emirados Árabes Unidos
+            { "Dirham dos Emirados Árabes Unidos", "dirham|dirhams|dirham dos emirados arabes unidos|aed|dhs" },
+            //Eritréia
             { "Nakfa", "nakfa|nfk|ern" },
-            { "Céntimo de Nakfa", "céntimo de nakfa|céntimos de nakfa" },
-            //Eslovaquia -> Euro
-            //Eslovenia -> Euro
-            //España -> Euro
+            { "Centavo de Nakfa", "cêntimo de nakfa|cêntimos de nakfa|centavo de nafka|centavos de nafka" },
+            //Espanha -> Euro + old peseta
             { "Peseta", "peseta|pesetas|pts.|ptas.|esp" },
             //Estados Unidos
             { "Dólar estadunidense", "dólar dos estados unidos|dolar dos estados unidos|dólar estadunidense|dólar americano|dólares dos estados unidos|dolares dos estados unidos|dólares estadunidenses|dólares americanos|dolar estadunidense|dolar americano|dolares estadunidenses|dolares americanos|usd|u$d|us$" },
-            //Estonia
-            { "Corona estonia", "corona estonia|coronas estonias|eek" },
-            { "Senti estonia", "senti estonia|senti estonias" },
-            //Etiopía
-            { "Birr etíope", "birr etíope|birr etíopes|br|etb" },
-            { "Santim etíope", "santim etíope|santim etíopes" },
+            //Estônia -> Euro + old crown
+            { "Coroa estoniana", "coroa estoniana|coroas estonianas|eek" },
+            { "Senti estoniano", "senti estoniano|senti estonianos" },
+            //Etiópia
+            { "Birr etíope", "birr etíope|birr etiope|birr etíopes|birr etiopes|br|etb" },
+            { "Santim etíope", "santim etíope|santim etiope|santim etíopes|santim etiopes" },
             //Filipinas
             { "Peso filipino", "peso filipino|pesos filipinos|php" },
-            //Finlandia -> Euro
+            //Finlandia -> Euro + old mark
             { "Marco finlandês", "marco finlandês|marco finlandes|marcos finlandeses" },
-            //Fiyi
-            { "Dólar fiyiano", "dólar fiyiano|dólares fiyianos|fj$|fjd" },
-            { "Centavo fiyiano", "centavo fiyiano|centavos fiyianos" },
-            //Francia -> Euro
-            //Gabón -> Franco CFA de África Central
-            //Gambia
-            { "Dalasi", "dalasi|gmd" },
+            //Fiji
+            { "Dólar fijiano", "dólar fijiano|dolar fijiano|dólares fijianos|dolares fijianos|fj$|fjd" },
+            { "Centavo fijiano", "centavo fijiano|centavos fijianos" },
+            //Gâmbia
+            { "Dalasi gambiano", "dalasi|gmd" },
             { "Bututs", "butut|bututs" },
-            //Georgia
+            //Geórgia
             { "Lari georgiano", "lari georgiano|lari georgianos|gel" },
             { "Tetri georgiano", "tetri georgiano|tetri georgianos" },
-            //Ghana
+            //Gana
             { "Cedi", "cedi|ghs|gh₵" },
             { "Pesewa", "pesewa" },
             //Gibraltar
-            { "Libra gibraltareña", "libra gibraltareña|libras gibraltareñas|gip" },
-            { "Penique gibraltareña", "penique gibraltareña|peniques gibraltareñas" },
-            //Granada -> Dólar del Caribe Oriental
-            //Grecia -> Euro
+            { "Libra de Gibraltar", "libra de gibraltar|libras de gibraltar|gip" },
+            { "Peni de Gibraltar", "peni de gibraltar|penies de gibraltar" },
             //Guatemala
             { "Quetzal guatemalteco", "quetzal guatemalteco|quetzales guatemaltecos|quetzal|quetzales|gtq" },
             { "Centavo guatemalteco", "centavo guatemalteco|centavos guatemaltecos" },
             //Guernsey
             { "Libra de Guernsey", "libra de Guernsey|libras de Guernsey|ggp" },
-            { "Penique de Guernsey", "penique de Guernsey|peniques de Guernsey" },
-            //Guinea
+            { "Peni de Guernsey", "peni de Guernsey|penies de Guernsey" },
+            //Guiné // @HERE
             { "Franco guineano", "franco guineano|francos guineanos|gnf|fg" },
             { "Céntimo guineano", "céntimo guineano|céntimos guineanos" },
             //Guinea-Bisáu -> Franco CFA de África Occidental

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public static readonly ImmutableDictionary<string, string> CurrencySuffixList = new Dictionary<string, string>
         {
             //Reference Source: https://es.wikipedia.org/wiki/Anexo:Monedas_circulantes
-            //GeneralsUnits
+
+            // General Units
             { "Dólar", "dólar|dólares" },
             { "Peso", "peso|pesos" },
             { "Rublo", "rublo|rublos"},

--- a/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
@@ -584,7 +584,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
             {"Dólar bermudeño", "bd$|bmd"},
             {"Dólar de Brunéi", "brunéi $|bnd"},
             {"Dólar de Singapur", "s$|sgd"},
-            {"Dólar canadienser", "c$|can$|cad"},
+            {"Dólar canadiense", "c$|can$|cad"},
             {"Dólar de las Islas Caimán", "ci$|kyd"},
             {"Dólar neozelandés", "nz$|nzd"},
             {"Dólar fiyiano", "fj$|fjd"},


### PR DESCRIPTION
- Currency extractor almost fully translated;
- Unit tests for currency in Portuguese passing, but utterances not fully in PT, only numbers and units;
- Small currency fixes in Spanish;
- Cleanup in Chinese.

Next PR will finish currencies. 