### PR TITLE
Extract BaseTimeExtractor regex definitions

### DIFF
--- a/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Resources;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
@@ -7,20 +8,11 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         private static readonly string ExtractorName = Constants.SYS_DATETIME_TIME; // "Time";
 
-        public static readonly Regex HourRegex =
-            new Regex(
-                @"(?<hour>00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)",
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex HourRegex = new Regex(BaseDateTime.HourRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex MinuteRegex =
-            new Regex(
-                @"(?<min>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)",
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex MinuteRegex = new Regex(BaseDateTime.MinuteRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex SecondRegex =
-            new Regex(
-                @"(?<sec>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)",
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex SecondRegex = new Regex(BaseDateTime.SecondRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         private readonly ITimeExtractorConfiguration config;
 


### PR DESCRIPTION
Replace 3 missing regex definitions for BaseTimeExtractor.
They were already being generated from YAML.