### PR TITLE
Fix bugs reported by mercury in batch #3

### DIFF
--- a/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -20,18 +20,19 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string TillRegex = @"(?<till>to|till|until|thru|through|--|-|—|——)";
 		public const string RangeConnectorRegex = @"(?<and>and|through|to|--|-|—|——)";
 		public const string RelativeRegex = @"(?<order>next|upcoming|this|last|past|previous|current|over the)";
-		public const string DayRegex = @"(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)";
+		public const string NextPrefixRegex = @"(next|upcoming)\b";
+		public const string PastPrefixRegex = @"(last|past|previous)\b";
+		public const string ThisPrefixRegex = @"(this|current|over the)\b";
+		public const string DayRegex = @"(the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)";
 		public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)";
 		public const string PeriodYearRegex = @"\b(?<year>19\d{2}|20\d{2})\b";
 		public const string WeekDayRegex = @"(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)";
 		public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+month)";
 		public const string EngMonthRegex = @"(?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sept|Sep)";
 		public static readonly string MonthSuffixRegex = $@"(?<msuf>(in\s+|of\s+|on\s+)?({RelativeMonthRegex}|{EngMonthRegex}))";
-		public const string UnitRegex = @"(?<unit>years|year|months|month|weeks|week|days|day)\b";
-		public const string PastRegex = @"(?<past>\b(past|last|previous)\b)";
-		public const string FutureRegex = @"(?<past>\b(next|in)\b)";
-		public static readonly string SimpleCasesRegex = $@"\b(from\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){PeriodYearRegex})?\b";
-		public static readonly string MonthFrontSimpleCasesRegex = $@"\b{MonthSuffixRegex}\s+(from\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b";
+		public const string DateUnitRegex = @"(?<unit>years|year|months|month|weeks|week|days|day)\b";
+		public static readonly string SimpleCasesRegex = $@"\b((from|between)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){PeriodYearRegex})?\b";
+		public static readonly string MonthFrontSimpleCasesRegex = $@"\b((from|between)\s+)?{MonthSuffixRegex}\s+((from|between)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b";
 		public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b";
 		public static readonly string BetweenRegex = $@"\b(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){PeriodYearRegex})?\b";
 		public static readonly string MonthWithYear = $@"\b((?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sep|Sept),?(\s+of)?\s+({PeriodYearRegex}|(?<order>next|last|this)\s+year))";
@@ -39,8 +40,8 @@ namespace Microsoft.Recognizers.Definitions.English
 		public static readonly string MonthNumWithYear = $@"({PeriodYearRegex}[/\-\.]{MonthNumRegex})|({MonthNumRegex}[/\-]{PeriodYearRegex})";
 		public static readonly string WeekOfMonthRegex = $@"(?<wom>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week\s+{MonthSuffixRegex})";
 		public static readonly string WeekOfYearRegex = $@"(?<woy>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week(\s+of)?\s+({PeriodYearRegex}|{RelativeRegex}\s+year))";
-		public static readonly string FollowedUnit = $@"^\s*{UnitRegex}";
-		public static readonly string NumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){UnitRegex}";
+		public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
+		public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
 		public static readonly string QuarterRegex = $@"(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)\s+quarter(\s+of|\s*,\s*)?\s+({PeriodYearRegex}|{RelativeRegex}\s+year)";
 		public static readonly string QuarterRegexYearFront = $@"({PeriodYearRegex}|{RelativeRegex}\s+year)\s+(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)\s+quarter";
 		public static readonly string SeasonRegex = $@"\b(?<season>({RelativeRegex}\s+)?(?<seas>spring|summer|fall|autumn|winter)((\s+of|\s*,\s*)?\s+({PeriodYearRegex}|{RelativeRegex}\s+year))?)\b";
@@ -52,8 +53,8 @@ namespace Microsoft.Recognizers.Definitions.English
 		public static readonly string OnRegex = $@"(?<=\bon\s+)({DayRegex}s?)\b";
 		public const string RelaxedOnRegex = @"(?<=\b(on|at|in)\s+)((?<day>10th|11th|11st|12nd|12th|13rd|13th|14th|15th|16th|17th|18th|19th|1st|20th|21st|22nd|23rd|24th|25th|26th|27th|28th|29th|2nd|30th|31st|3rd|4th|5th|6th|7th|8th|9th)s?)\b";
 		public static readonly string ThisRegex = $@"\b((this(\s*week)?\s+){WeekDayRegex})|({WeekDayRegex}(\s+this\s*week))\b";
-		public static readonly string LastRegex = $@"\b(last(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b";
-		public static readonly string NextRegex = $@"\b(next(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}(\s+next\s*week))\b";
+		public static readonly string LastDateRegex = $@"\b({PastPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b";
+		public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}(\s+next\s*week))\b";
 		public const string SpecialDayRegex = @"\b((the\s+)?day before yesterday|(the\s+)?day after (tomorrow|tmr)|(the\s)?next day|(the\s+)?last day|the day|yesterday|tomorrow|tmr|today)\b";
 		public const string StrictWeekDay = @"\b(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Fri|Sat)s?\b";
 		public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
@@ -70,8 +71,8 @@ namespace Microsoft.Recognizers.Definitions.English
 		public static readonly string DateExtractorA = $@"\b{DateYearRegex}\s*[/\\\-]\s*{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}";
 		public static readonly string OfMonth = $@"^\s*of\s*{MonthRegex}";
 		public static readonly string MonthEnd = $@"{MonthRegex}\s*(the)?\s*$";
-		public const string NonDateUnitRegex = @"(?<unit>hours|hour|hrs|seconds|second|secs|sec|minutes|minute|mins)\b'";
-		public const string DescRegex = @"(?<desc>ampm|am\b|a\.m\.|a m\b|a\. m\.\b|a\.m\b|a\. m\b|pm\b|p\.m\.|p m\b|p\. m\.\b|p\.m\b|p\. m\b|p\b)";
+		public const string RangeUnitRegex = @"\b(?<unit>years|year|months|month|weeks|week)\b";
+		public const string DescRegex = @"(?<desc>ampm|am\b|a\.m\.|a m\b|a\. m\.|a\.m\b|a\. m\b|pm\b|p\.m\.|p m\b|p\. m\.|p\.m\b|p\. m\b|p\b)";
 		public const string HourNumRegex = @"\b(?<hournum>zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b";
 		public const string MinuteNumRegex = @"(?<minnum>one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty)";
 		public const string DeltaMinuteNumRegex = @"(?<deltaminnum>one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty)";
@@ -105,7 +106,7 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string PeriodDescRegex = @"(?<desc>pm|am|p\.m\.|a\.m\.|p)";
 		public const string PeriodPmRegex = @"(?<pm>afternoon|evening|in the afternoon|in the evening|in the night)s?";
 		public const string PeriodAmRegex = @"(?<am>morning|in the morning)s?";
-		public static readonly string PureNumFromTo = $@"(from\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?";
+		public static readonly string PureNumFromTo = $@"((from|between)\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?";
 		public static readonly string PureNumBetweenAnd = $@"(between\s+)({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{RangeConnectorRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?";
 		public const string PrepositionRegex = @"(?<prep>^(at|on|of)(\s+the)?$)";
 		public const string TimeOfDayRegex = @"\b(?<timeOfDay>((((in\s+(the)?\s+)?((?<early>early(\s+|-))|(?<late>late(\s+|-)))?(morning|afternoon|night|evening)))|(((in\s+(the)?\s+)?)(daytime)))s?)\b";
@@ -147,23 +148,22 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string TokenBeforeTime = "at ";
 		public const string AMTimeRegex = @"(?<am>morning)";
 		public const string PMTimeRegex = @"\b(?<pm>afternoon|evening|night)\b";
-		public const string BeforeRegex = @"\b(before)$";
-		public const string AfterRegex = @"\b(after|since)$";
+		public const string BeforeRegex = @"\b(before)\b";
+		public const string AfterRegex = @"\b(after|since)\b";
 		public const string AgoRegex = @"\b(ago)\b";
 		public const string LaterRegex = @"\b(later|from now)\b";
 		public const string InConnectorRegex = @"\b(in)\b";
-		public const string AmDescRegex = @"(am\b|a\.m\.|a m\b|a\. m\.\b|a\.m\b|a\. m\b)";
-		public const string PmDescRegex = @"(pm\b|p\.m\.|p\b|p m\b|p\. m\.\b|p\.m\b|p\. m\b)";
+		public const string AmDescRegex = @"(am\b|a\.m\.|a m\b|a\. m\.|a\.m\b|a\. m\b)";
+		public const string PmDescRegex = @"(pm\b|p\.m\.|p\b|p m\b|p\. m\.|p\.m\b|p\. m\b)";
 		public const string AmPmDescRegex = @"(ampm)";
-		public const string NextPrefixRegex = @"(next|upcoming)\b";
-		public const string PastPrefixRegex = @"(last|past|previous)\b";
-		public const string ThisPrefixRegex = @"(this|current|over the)\b";
 		public const string MorningStartEndRegex = @"(^(morning))|((morning)$)";
 		public const string AfternoonStartEndRegex = @"(^(afternoon))|((afternoon)$)";
 		public const string EveningStartEndRegex = @"(^(evening))|((evening)$)";
 		public const string NightStartEndRegex = @"(^(overnight|tonight|night))|((overnight|tonight|night)$)";
 		public const string InExactNumberRegex = @"\b(a few|few|some|several)\b";
 		public static readonly string InExactNumberUnitRegex = $@"({InExactNumberRegex})\s+({DurationUnitRegex})";
+		public static readonly string RelativeTimeUnitRegex = $@"({RelativeRegex})\s+({TimeUnitRegex})";
+		public const string ConnectorRegex = @"^(,|for|t|around)$";
 		public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
 		{
 			{ "years", "Y" },

--- a/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -162,6 +162,8 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string AfternoonStartEndRegex = @"(^(afternoon))|((afternoon)$)";
 		public const string EveningStartEndRegex = @"(^(evening))|((evening)$)";
 		public const string NightStartEndRegex = @"(^(overnight|tonight|night))|((overnight|tonight|night)$)";
+		public const string InExactNumberRegex = @"\b(a few|few|some|several)\b";
+		public static readonly string InExactNumberUnitRegex = $@"({InExactNumberRegex})\s+({DurationUnitRegex})";
 		public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
 		{
 			{ "years", "Y" },

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateExtractor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back the last day", 13, 12);
             BasicTest("I'll go back the day", 13, 7);
             BasicTest("I'll go back this week Friday", 13, 16);
-            BasicTest("I'll go back nextweek Sunday", 13, 15);
+            BasicTest("I'll go back next week Sunday", 13, 16);
             BasicTest("I'll go back last week Sunday", 13, 16);
             BasicTest("I'll go back 15 June 2016", 13, 12);
             BasicTest("a baseball on may the eleventh", 14, 16);
@@ -79,14 +79,20 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back the first friday of july", 13, 24);
             BasicTest("I'll go back the first friday in this month", 13, 30);
 
-            BasicTest("I went back two months ago", 12, 14);
-            BasicTest("I'll go back two days later", 13, 14);
-
-            BasicTest("I'll go back in two weeks", 13, 12);
             BasicTest("I'll go back two weeks from now", 13, 18);
 
             BasicTest("I'll go back next week on Friday", 13, 19);
             BasicTest("I'll go back on Friday next week", 13, 19);
+
+            BasicTest("past Monday", 0, 11);
+        }
+
+        [TestMethod]
+        public void TestDateExtractAgoLater()
+        {
+            BasicTest("I went back two months ago", 12, 14);
+            BasicTest("I'll go back two days later", 13, 14);
+            BasicTest("who did i email a month ago", 16, 11);
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateParser.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back next Sunday", new DateObject(2016, 11, 20));
             BasicTest("I'll go back last Sunday", new DateObject(2016, 11, 6));
             BasicTest("I'll go back this week Friday", new DateObject(2016, 11, 11));
-            BasicTest("I'll go back nextweek Sunday", new DateObject(2016, 11, 20));
+            BasicTest("I'll go back next week Sunday", new DateObject(2016, 11, 20));
             BasicTest("I'll go back last week Sunday", new DateObject(2016, 11, 6));
             BasicTest("I'll go back last day", new DateObject(2016, 11, 6));
             BasicTest("I'll go back the last day", new DateObject(2016, 11, 6));
@@ -110,11 +110,17 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back the first friday of july", new DateObject(2017, 7, 7), new DateObject(2016, 7, 1));
             BasicTest("I'll go back the first friday in this month", new DateObject(2016, 11, 4));
 
-            BasicTest("I'll go back in two weeks", new DateObject(2016, 11, 21));
-            BasicTest("I'll go back two weeks from now", new DateObject(2016, 11, 21));
-
             BasicTest("I'll go back next week on Friday", new DateObject(2016, 11, 18));
             BasicTest("I'll go back on Friday next week", new DateObject(2016, 11, 18));
+        }
+
+        [TestMethod]
+        public void TestDateParseAgoLater()
+        {
+            BasicTest("I'll go back two weeks from now", new DateObject(2016, 11, 21));
+            BasicTest("who did I email a month ago", new DateObject(2016, 10, 7));
+            BasicTest("who did I email few month ago", new DateObject(2016, 8, 7));
+            BasicTest("who did I email a few day ago", new DateObject(2016, 11, 4));
         }
 
         [TestMethod]
@@ -161,7 +167,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I went back two days ago", "2016-11-05");
             BasicTest("I went back two years ago", "2014-11-07");
 
-            BasicTest("I'll go back in two weeks", "2016-11-21");
             BasicTest("I'll go back two weeks from now", "2016-11-21");
 
             BasicTest("I'll go back next week on Friday", "2016-11-18");

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodExtractor.cs
@@ -68,6 +68,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests.English
             BasicTest("I'll be out between 4 and 22 this month", 12, 27);
             BasicTest("I'll be out between 3 and 12 of Sept hahaha", 12, 24);
             BasicTest("I'll be out between september 4th through september 8th", 12, 43);
+            BasicTest("I'll be out between November 15th through 19th", 12, 34);
+            BasicTest("I'll be out between November 15th through the 19th", 12, 38);
+            BasicTest("I'll be out between November the 15th through 19th", 12, 38);
             BasicTest("I'll be out between 4 and 22 this month", 12, 27);
             BasicTest("I'll be out from 4 to 22 January, 2017", 12, 26);
             BasicTest("I'll be out between 4-22 January, 2017", 12, 26);
@@ -82,13 +85,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests.English
             BasicTest("I'll be out this weekend", 12, 12);
             BasicTest("I'll be out the third week of this month", 12, 28);
             BasicTest("I'll be out the last week of july", 12, 21);
+        }
 
+        [TestMethod]
+        public void TestDatePeriodExtractDuration()
+        {
             BasicTest("I'll be out next 3 days", 12, 11);
             BasicTest("I'll be out next 3 months", 12, 13);
             BasicTest("I'll be out in 3 year", 12, 9);
+            BasicTest("I'll be out in 3 years", 12, 10);
+            BasicTest("I'll be out in 3 weeks", 12, 10);
+            BasicTest("I'll be out in 3 months", 12, 11);
             BasicTest("I'll be out past 3 weeks", 12, 12);
             BasicTest("I'll be out last 3year", 12, 10);
+            BasicTest("I'll be out last year", 12, 9);
+            BasicTest("I'll be out past month", 12, 10);
             BasicTest("I'll be out previous 3 weeks", 12, 16);
+
+            BasicTest("past few weeks", 0, 14);
+            BasicTest("past several days", 0, 17);
         }
 
         [TestMethod]

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDatePeriodParser.cs
@@ -72,12 +72,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll be out between 3 and 12 of Sept hahaha", 3, 12, 9, year + 1);
             BasicTestFuture("I'll be out from 4 to 22 January, 1995", 4, 22, 1, 1995);
             BasicTestFuture("I'll be out between 4-22 January, 1995", 4, 22, 1, 1995);
-
             BasicTestFuture("I'll be out between september 4th through september 8th", 4, 8, 9, year+1);
 
             if (inclusiveEnd)
             {
-                BasicTestFuture("scheduel a meeting in two weeks", 15, 21, month, year);
                 BasicTestFuture("I'll be out on this week", 7, 13, month, year);
                 BasicTestFuture("I'll be out on current week", 7, 13, month, year);
                 BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 2, 28);
@@ -91,7 +89,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             }
             else
             {
-                BasicTestFuture("scheduel a meeting in two weeks", 15, 22, month, year);
                 BasicTestFuture("I'll be out on this week", 7, 14, month, year);
                 BasicTestFuture("I'll be out on current week", 7, 14, month, year);
                 BasicTestFuture("I'll be out February", year + 1, 2, 1, year + 1, 3, 1);
@@ -103,19 +100,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
                 BasicTestFuture("week of september.16th", 11, 18, 9, year + 1);
                 BasicTestFuture("month of september.16th", year + 1, 9, 1, year + 1, 10, 1);
             }
-
-            // test merging two time points
-            BasicTestFuture("I'll be out Oct. 2 to October 22", 2, 22, 10, year + 1);
-            BasicTestFuture("I'll be out January 12, 2016 - 01/22/2016", 12, 22, 1, year);
-            BasicTestFuture("I'll be out 1st Jan until Wed, 22 of Jan", 1, 22, 1, year + 1);
-            BasicTestFuture("I'll be out today till tomorrow", 7, 8, month, year);
-
-            BasicTestFuture("I'll be out from Oct. 2 to October 22", 2, 22, 10, year + 1);
-            BasicTestFuture("I'll be out between Oct. 2 and October 22", 2, 22, 10, year + 1);
-
-            BasicTestFuture("I'll be out November 19-20", 19, 20, 11, year);
-            BasicTestFuture("I'll be out November 19 to 20", 19, 20, 11, year);
-            BasicTestFuture("I'll be out November between 19 and 20", 19, 20, 11, year);
 
             if (inclusiveEnd)
             {
@@ -132,6 +116,45 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
                 BasicTestFuture("I'll be out 3/2015", 2015, 3, 1, 2015, 4, 1);
             }
 
+        }
+
+        [TestMethod]
+        public void TestDatePeriodParseDuration()
+        {
+            int year = 2016, month = 11;
+            bool inclusiveEnd = parser.GetInclusiveEndPeriodFlag();
+
+            if (inclusiveEnd)
+            {
+                BasicTestFuture("scheduel a meeting in two weeks", 15, 21, month, year);
+                BasicTestFuture("next 2 days", 8, 9, month, year);
+                BasicTestFuture("past few days", 4, 6, month, year);
+            }
+            else
+            {
+                BasicTestFuture("scheduel a meeting in two weeks", 15, 22, month, year);
+                BasicTestFuture("next 2 days", 8, 10, month, year);
+                BasicTestFuture("past few days", 4, 7, month, year);
+            }
+        }
+
+        [TestMethod]
+        public void TestDatePeriodMergeTwoTimepoints()
+        {
+            int year = 2016, month = 11;
+
+            // test merging two time points
+            BasicTestFuture("I'll be out Oct. 2 to October 22", 2, 22, 10, year + 1);
+            BasicTestFuture("I'll be out January 12, 2016 - 01/22/2016", 12, 22, 1, year);
+            BasicTestFuture("I'll be out 1st Jan until Wed, 22 of Jan", 1, 22, 1, year + 1);
+            BasicTestFuture("I'll be out today till tomorrow", 7, 8, month, year);
+
+            BasicTestFuture("I'll be out from Oct. 2 to October 22", 2, 22, 10, year + 1);
+            BasicTestFuture("I'll be out between Oct. 2 and October 22", 2, 22, 10, year + 1);
+
+            BasicTestFuture("I'll be out November 19-20", 19, 20, 11, year);
+            BasicTestFuture("I'll be out November 19 to 20", 19, 20, 11, year);
+            BasicTestFuture("I'll be out November between 19 and 20", 19, 20, 11, year);
         }
 
         [TestMethod]
@@ -157,7 +180,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
 
             BasicTest("I'll be out next 3 days", "(2016-11-08,2016-11-11,P3D)");
             BasicTest("I'll be out next 3 months", "(2016-11-08,2017-02-08,P3M)");
-            BasicTest("I'll be out in 3 year", "(2016-11-08,2019-11-08,P3Y)");
+            BasicTest("I'll be out in 3 year", "(2018-11-08,2019-11-08,P1Y)");
             BasicTest("I'll be out past 3 weeks", "(2016-10-17,2016-11-07,P3W)");
             BasicTest("I'll be out last 3year", "(2013-11-07,2016-11-07,P3Y)");
             BasicTest("I'll be out previous 3 weeks", "(2016-10-17,2016-11-07,P3W)");

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateTimePeriodExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateTimePeriodExtractor.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll be out from 5 to 6 next sunday", 12, 23);
             BasicTest("I'll be out from 5 to 6pm next sunday", 12, 25);
 
-            // merge to time points 49);
-
             BasicTest("I'll be out from 4pm to 5pm today", 12, 21);
             BasicTest("I'll be out from 4pm today to 5pm tomorrow", 12, 30);
             BasicTest("I'll be out from 4pm to 5pm of tomorrow", 12, 27);
@@ -58,6 +56,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back next 5 hrs", 13, 10);
             BasicTest("I'll go back last minute", 13, 11);
             BasicTest("I'll go back next hour", 13, 9);
+            BasicTest("I'll go back last few minutes", 13, 16);
+            BasicTest("I'll go back past several minutes", 13, 20);
 
             BasicTest("I'll go back tuesday in the morning", 13, 22);
             BasicTest("I'll go back tuesday in the afternoon", 13, 24);

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDateTimePeriodParser.cs
@@ -135,12 +135,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll go back previous 3mins",
                 new DateObject(year, month, day, 16, 9, second),
                 new DateObject(year, month, day, 16, 12, second));
-            BasicTestFuture("I'll go back in 3 hours",
-                new DateObject(year, month, day, 16, 12, second),
-                new DateObject(year, month, day, 19, 12, second));
-            BasicTestFuture("I'll go back in 5 hrs",
-                new DateObject(year, month, day, 16, 12, second),
-                new DateObject(year, month, day, 21, 12, second));
             BasicTestFuture("I'll go back next 5 hrs",
                 new DateObject(year, month, day, 16, 12, second),
                 new DateObject(year, month, day, 21, 12, second));
@@ -150,6 +144,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTestFuture("I'll go back next hour",
                 new DateObject(year, month, day, 16, 12, second),
                 new DateObject(year, month, day, 17, 12, second));
+            BasicTestFuture("I'll go back next few hours",
+                new DateObject(year, month, day, 16, 12, second),
+                new DateObject(year, month, day, 19, 12, second));
 
             BasicTestFuture("I'll go back tuesday in the morning",
                 new DateObject(year, month, day + 1, 8, 0, 0),
@@ -259,8 +256,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("I'll go back past 3 minute", "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)");
             BasicTest("I'll go back previous 3 minute", "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)");
             BasicTest("I'll go back previous 3mins", "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)");
-            BasicTest("I'll go back in 3 hours", "(2016-11-07T16:12:00,2016-11-07T19:12:00,PT3H)");
-            BasicTest("I'll go back in 5 hrs", "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)");
             BasicTest("I'll go back next 5 hrs", "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)");
             BasicTest("I'll go back last minute", "(2016-11-07T16:11:00,2016-11-07T16:12:00,PT1M)");
             BasicTest("I'll go back next hour", "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)");

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDurationExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestDurationExtractor.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("In a day", 3, 5);
             BasicTest("for an hour", 4, 7);
             BasicTest("for a month", 4, 7);
+
+            BasicTest("I'll leave for few hours", 15, 9);
+            BasicTest("I'll leave for a few minutes", 15, 13);
+            BasicTest("I'll leave for some days", 15, 9);
+            BasicTest("I'll leave for several days", 15, 12);
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestEnglishModel.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestEnglishModel.cs
@@ -231,6 +231,22 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest(model, reference,
                 "I'll leave for an hour",
                 Constants.SYS_DATETIME_DURATION, "an hour", "PT1H");
+
+            BasicTest(model, reference,
+                "I'll leave for few hours",
+                Constants.SYS_DATETIME_DURATION, "few hours", "PT3H");
+
+            BasicTest(model, reference,
+                "I'll leave for a few minutes",
+                Constants.SYS_DATETIME_DURATION, "a few minutes", "PT3M");
+
+            BasicTest(model, reference,
+                "I'll leave for some days",
+                Constants.SYS_DATETIME_DURATION, "some days", "P3D");
+
+            BasicTest(model, reference,
+                "I'll leave for several weeks",
+                Constants.SYS_DATETIME_DURATION, "several weeks", "P3W");
         }
 
         [TestMethod]

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedExtractor.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
         [TestMethod]
         public void TestMergedExtract()
         {
-            BasicTest("after 7/2 ", 0, 9);
-            BasicTest("since 7/2 ", 0, 9);
-
             BasicTest("this is 2 days", 8, 6);
 
             BasicTest("this is before 4pm", 8, 10);
@@ -37,6 +34,23 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
             BasicTest("this is after 4pm tomorrow", 8, 18);
             BasicTest("this is after tomorrow 4pm ", 8, 18);
 
+            BasicTest("I'll be back in 5 minutes", 13, 12);
+            BasicTest("past week", 0, 9);
+            BasicTest("past Monday", 0, 11);
+            BasicTest("schedule a meeting in 10 hours", 19, 11);
+        }
+
+        [TestMethod]
+        public void TestAfterBefore()
+        {
+            BasicTest("after 7/2 ", 0, 9);
+            BasicTest("since 7/2 ", 0, 9);
+            BasicTest("before 7/2 ", 0, 10);
+        }
+
+        [TestMethod]
+        public void TestNegativeExtract()
+        {
             //Unit tests for text should not extract datetime
             BasicTestNone("which email have gotten a reply");
             BasicTestNone("He is often alone");

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests.English
         [TestMethod]
         public void TestMergedParseIn()
         {
+            BasicTest("schedule a meeting in 8 minutes", Constants.SYS_DATETIME_DATETIME);
             BasicTest("schedule a meeting in 10 hours", Constants.SYS_DATETIME_DATETIME);
             BasicTest("schedule a meeting in 10 days", Constants.SYS_DATETIME_DATE);
             BasicTest("schedule a meeting in 3 weeks", Constants.SYS_DATETIME_DATEPERIOD);

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Recognizers.Text.DateTime.English;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DateTime.Tests.English
+{
+    [TestClass]
+    public class TestMergedParser
+    {
+        private readonly IExtractor extractor = new BaseMergedExtractor(new EnglishMergedExtractorConfiguration());
+        private readonly IDateTimeParser parser = new BaseMergedParser(new EnglishMergedParserConfiguration());
+
+        readonly DateObject refrenceDate;
+
+        public TestMergedParser()
+        {
+            refrenceDate = new DateObject(2016, 11, 7);
+        }
+
+        public void BasicTest(string text, string type)
+        {
+            var er = extractor.Extract(text);
+            Assert.AreEqual(1, er.Count);
+            var pr = parser.Parse(er[0], refrenceDate);
+            Assert.AreEqual(type, pr.Type.Replace("datetimeV2.",""));
+        }
+
+        public void BasicTestWithTwoResults(string text, string type1, string type2)
+        {
+            var er = extractor.Extract(text);
+            Assert.AreEqual(2, er.Count);
+            var pr = parser.Parse(er[0], refrenceDate);
+            Assert.AreEqual(type1, pr.Type.Replace("datetimeV2.", ""));
+            pr = parser.Parse(er[1], refrenceDate);
+            Assert.AreEqual(type2, pr.Type.Replace("datetimeV2.", ""));
+        }
+
+        [TestMethod]
+        public void TestMergedParse()
+        {
+            BasicTest("on Friday in the afternoon", Constants.SYS_DATETIME_DATETIMEPERIOD);
+            BasicTest("on Friday for 3 in the afternoon", Constants.SYS_DATETIME_DATETIME);
+        }
+
+        [TestMethod]
+        public void TestMergedParseIn()
+        {
+            BasicTest("schedule a meeting in 10 hours", Constants.SYS_DATETIME_DATETIME);
+            BasicTest("schedule a meeting in 10 days", Constants.SYS_DATETIME_DATE);
+            BasicTest("schedule a meeting in 3 weeks", Constants.SYS_DATETIME_DATEPERIOD);
+            BasicTest("schedule a meeting in 3 months", Constants.SYS_DATETIME_DATEPERIOD);
+            BasicTest("I'll be out in 3 year", Constants.SYS_DATETIME_DATEPERIOD);
+        }
+
+        [TestMethod]
+        public void TestMergedParseAfterBefore()
+        {
+            BasicTest("after 8pm", Constants.SYS_DATETIME_TIMEPERIOD);
+            BasicTest("before 8pm", Constants.SYS_DATETIME_TIMEPERIOD);
+            BasicTest("since 8pm", Constants.SYS_DATETIME_TIMEPERIOD);
+        }
+
+        [TestMethod]
+        public void TestMergedParseWithTwoResults()
+        {
+            BasicTestWithTwoResults("on Friday for 3 in Bellevue in the afternoon", Constants.SYS_DATETIME_DATE,
+                Constants.SYS_DATETIME_TIMEPERIOD);
+        }
+    }
+}

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestTimeExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestTimeExtractor.cs
@@ -99,6 +99,32 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Tests
         }
 
         [TestMethod]
+        public void TestTimeDescExtract()
+        {
+            BasicTest("I'll be back 7pm", 13, 3);
+            BasicTest("I'll be back 7 p m", 13, 5);
+            BasicTest("I'll be back 7 p. m", 13, 6);
+            BasicTest("I'll be back 7 p. m.", 13, 7);
+            BasicTest("I'll be back 7p.m.", 13, 5);
+            BasicTest("I'll be back 7 p.m.", 13, 6);
+            BasicTest("I'll be back 7:56 a m", 13, 8);
+            BasicTest("I'll be back 7:56:35 a. m", 13, 12);
+            BasicTest("I'll be back 7:56:35 am", 13, 10);
+            BasicTest("I'll be back 7:56:35 a. m.", 13, 13);
+
+            BasicTest("I'll go back seven thirty pm", 13, 15);
+            BasicTest("I'll go back seven thirty p.m.", 13, 17);
+            BasicTest("I'll go back seven thirty p m", 13, 16);
+            BasicTest("I'll go back seven thirty p. m", 13, 17);
+            BasicTest("I'll go back seven thirty p. m.", 13, 18);
+
+            BasicTest("I'll be back 340pm", 13, 5);
+            BasicTest("I'll be back 340 pm", 13, 6);
+            BasicTest("I'll be back 1140 a.m.", 13, 9);
+            BasicTest("I'll be back 1140 a m", 13, 8);
+        }
+
+        [TestMethod]
         public void TestDatePeriodExtractNegativeCase()
         {
 

--- a/Microsoft.Recognizers.Text.DateTime.Tests/Microsoft.Recognizers.Text.DateTime.Tests.csproj
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/Microsoft.Recognizers.Text.DateTime.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="English\TestHolidayExtractor.cs" />
     <Compile Include="English\TestHolidayParser.cs" />
     <Compile Include="English\TestMergedExtractor.cs" />
+    <Compile Include="English\TestMergedParser.cs" />
     <Compile Include="English\TestSetExtractor.cs" />
     <Compile Include="English\TestSetParser.cs" />
     <Compile Include="English\TestTimeExtractor.cs" />

--- a/Microsoft.Recognizers.Text.DateTime.Tests/Spanish/TestDateTimePeriodExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/Spanish/TestDateTimePeriodExtractor.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Tests
             BasicTest("Estaré fuera desde las 5 hasta las 6pm el próximo domingo", 13, 44);
             BasicTest("Estaré fuera desde las 5 hasta las 6pm del próximo domingo", 13, 45);
 
-            // merge to time points 49);
             BasicTest("Estaré afuera de 4pm a 5pm hoy", 14, 16);
             BasicTest("Estaré afuera de 4pm a 5pm de hoy", 14, 19);
             BasicTest("Estaré afuera de 4pm de hoy a 5pm de mañana", 14, 29);

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -44,13 +44,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.ThisRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.LastRegex,
+        public static readonly Regex LastDateRegex = new Regex(DateTimeDefinitions.LastDateRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.NextRegex,
+        public static readonly Regex NextDateRegex = new Regex(DateTimeDefinitions.NextDateRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex,
+        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex SpecialDayRegex =
@@ -117,7 +117,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public static readonly Regex[] ImplicitDateList =
         {
-            OnRegex, RelaxedOnRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
+            OnRegex, RelaxedOnRegex, SpecialDayRegex, ThisRegex, LastDateRegex, NextDateRegex,
             StrictWeekDay, WeekDayOfMonthRegex, SpecialDate
         };
 
@@ -125,9 +125,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex MonthEnd = new Regex(DateTimeDefinitions.MonthEnd,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        public static readonly Regex NonDateUnitRegex = new Regex(DateTimeDefinitions.NonDateUnitRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public EnglishDateExtractorConfiguration()
@@ -157,6 +154,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;
 
-        Regex IDateExtractorConfiguration.NonDateUnitRegex => NonDateUnitRegex;
+        Regex IDateExtractorConfiguration.DateUnitRegex => DateUnitRegex;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -44,13 +44,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             new Regex(DateTimeDefinitions.MonthSuffixRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex,
+        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex,
+        public static readonly Regex PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex,
+        public static readonly Regex NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         // composite regexes
@@ -97,11 +97,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             new Regex(
                 DateTimeDefinitions.WeekOfYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.FollowedUnit,
+        public static readonly Regex FollowedDateUnit = new Regex(DateTimeDefinitions.FollowedDateUnit,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex NumberCombinedWithDateUnit =
+            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex QuarterRegex =
             new Regex(
@@ -133,6 +133,16 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 DateTimeDefinitions.MonthOfRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeUnitRegex =
+            new Regex(
+                DateTimeDefinitions.RangeUnitRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex InConnectorRegex =
+            new Regex(
+                DateTimeDefinitions.InConnectorRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
 
         private static readonly Regex[] SimpleCasesRegexes =
         {
@@ -156,27 +166,36 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             DatePointExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
             CardinalExtractor = new CardinalExtractor();
+            DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
         }
 
         public IExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         IEnumerable<Regex> IDatePeriodExtractorConfiguration.SimpleCasesRegexes => SimpleCasesRegexes;
 
         Regex IDatePeriodExtractorConfiguration.TillRegex => TillRegex;
 
-        Regex IDatePeriodExtractorConfiguration.FollowedUnit => FollowedUnit;
+        Regex IDatePeriodExtractorConfiguration.FollowedDateUnit => FollowedDateUnit;
 
-        Regex IDatePeriodExtractorConfiguration.NumberCombinedWithUnit => NumberCombinedWithUnit;
+        Regex IDatePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
 
-        Regex IDatePeriodExtractorConfiguration.PastRegex => PastRegex;
+        Regex IDatePeriodExtractorConfiguration.NumberCombinedWithDateUnit => NumberCombinedWithDateUnit;
 
-        Regex IDatePeriodExtractorConfiguration.FutureRegex => FutureRegex;
+        Regex IDatePeriodExtractorConfiguration.PastRegex => PastPrefixRegex;
+
+        Regex IDatePeriodExtractorConfiguration.FutureRegex => NextPrefixRegex;
 
         Regex IDatePeriodExtractorConfiguration.WeekOfRegex => WeekOfRegex;
 
         Regex IDatePeriodExtractorConfiguration.MonthOfRegex => MonthOfRegex;
+
+        Regex IDatePeriodExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDatePeriodExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex ConnectorRegex = new Regex(DateTimeDefinitions.ConnectorRegex,
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public EnglishDateTimeExtractorConfiguration()
         {
             DatePointExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
@@ -80,9 +83,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public bool IsConnector(string text)
         {
-            return (string.IsNullOrEmpty(text) || text.Equals(",") ||
-                        PrepositionRegex.IsMatch(text) || text.Equals("t") || text.Equals("for") ||
-                        text.Equals("around"));
+            text = text.Trim();
+            return (string.IsNullOrEmpty(text) 
+                    || PrepositionRegex.IsMatch(text)
+                    || ConnectorRegex.IsMatch(text));
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             SingleDateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
             SingleTimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());
+            DurationExtractor=new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
         }
         
         private static readonly Regex[] SimpleCases = new Regex[]
@@ -38,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public Regex SpecificTimeOfDayRegex => PeriodSpecificTimeOfDayRegex;
 
-        private static readonly Regex TimeUnitRegex =
+        private static readonly Regex TimeTimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -48,23 +49,28 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex TimeNumberCombinedWithUnit = new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex TimePeriodTimeOfDayWithDateRegex = new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex,
+        public static readonly Regex PeriodTimeOfDayWithDateRegex = new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex,
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RelativeTimeUnitRegex = new Regex(DateTimeDefinitions.RelativeTimeUnitRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public Regex FollowedUnit => TimeFollowedUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => TimeNumberCombinedWithUnit;
         
-        public Regex UnitRegex => TimeUnitRegex;
+        Regex IDateTimePeriodExtractorConfiguration.TimeUnitRegex => TimeTimeUnitRegex;
 
-        public Regex PastRegex => EnglishDatePeriodExtractorConfiguration.PastRegex;
+        Regex IDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex => RelativeTimeUnitRegex;
 
-        public Regex FutureRegex => EnglishDatePeriodExtractorConfiguration.FutureRegex;
+        public Regex PastPrefixRegex => EnglishDatePeriodExtractorConfiguration.PastPrefixRegex;
+
+        public Regex NextPrefixRegex => EnglishDatePeriodExtractorConfiguration.NextPrefixRegex;
 
         public Regex WeekDayRegex => new Regex(DateTimeDefinitions.WeekDayRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        Regex IDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex => TimePeriodTimeOfDayWithDateRegex;
+        Regex IDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex => PeriodTimeOfDayWithDateRegex;
 
         public IExtractor CardinalExtractor { get; }
 
@@ -73,6 +79,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IExtractor SingleTimeExtractor { get; }
 
         public IExtractor SingleDateTimeExtractor { get; }
+
+        public IExtractor DurationExtractor { get; }
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
@@ -32,6 +32,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex ConjunctionRegex = new Regex(DateTimeDefinitions.ConjunctionRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex InExactNumberRegex = new Regex(DateTimeDefinitions.InExactNumberRegex,
+           RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex InExactNumberUnitRegex = new Regex(DateTimeDefinitions.InExactNumberUnitRegex,
+           RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public EnglishDurationExtractorConfiguration()
         {
             CardinalExtractor = new CardinalExtractor();
@@ -52,5 +58,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         Regex IDurationExtractorConfiguration.SuffixAndRegex => SuffixAndRegex;
 
         Regex IDurationExtractorConfiguration.ConjunctionRegex => ConjunctionRegex;
+
+        Regex IDurationExtractorConfiguration.InExactNumberRegex => InExactNumberRegex;
+
+        Regex IDurationExtractorConfiguration.InExactNumberUnitRegex => InExactNumberUnitRegex;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -62,12 +62,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex TimeNumberCombinedWithUnit =
             new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
         public EnglishTimePeriodExtractorConfiguration()
         {
             SingleTimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DatePeriodExtractor=new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration());
             TimePeriodExtractor = new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
             DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new EnglishDateTimePeriodExtractorConfiguration());
+            DurationParser = new BaseDurationParser(new EnglishDurationParserConfiguration(this));
             DateParser = new BaseDateParser(new EnglishDateParserConfiguration(this));
             TimeParser = new TimeParser(new EnglishTimeParserConfiguration(this));
             DateTimeParser = new BaseDateTimeParser(new EnglishDateTimeParserConfiguration(this));
-            DurationParser = new BaseDurationParser(new EnglishDurationParserConfiguration(this));
             DatePeriodParser = new BaseDatePeriodParser(new EnglishDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new EnglishTimePeriodParserConfiguration(this));
             DateTimePeriodParser = new BaseDateTimePeriodParser(new EnglishDateTimePeriodParserConfiguration(this));

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -66,10 +66,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DateRegexes = EnglishDateExtractorConfiguration.DateRegexList;
             OnRegex = EnglishDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
-            NextRegex = EnglishDateExtractorConfiguration.NextRegex;
+            NextRegex = EnglishDateExtractorConfiguration.NextDateRegex;
             ThisRegex = EnglishDateExtractorConfiguration.ThisRegex;
-            LastRegex = EnglishDateExtractorConfiguration.LastRegex;
-            UnitRegex = EnglishDateExtractorConfiguration.UnitRegex;
+            LastRegex = EnglishDateExtractorConfiguration.LastDateRegex;
+            UnitRegex = EnglishDateExtractorConfiguration.DateUnitRegex;
             StrictWeekDay = EnglishDateExtractorConfiguration.StrictWeekDay;
             MonthRegex = EnglishDateExtractorConfiguration.MonthRegex;
             WeekDayOfMonthRegex = EnglishDateExtractorConfiguration.WeekDayOfMonthRegex;

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -14,9 +14,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         public IParser NumberParser { get; }
 
         public IDateTimeParser DateParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
 
         #endregion
 
@@ -81,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;
             DateExtractor = config.DateExtractor;
+            DurationExtractor = config.DurationExtractor;
+            DurationParser = config.DurationParser;
             DateParser = config.DateParser;
             MonthFrontBetweenRegex = EnglishDatePeriodExtractorConfiguration.MonthFrontBetweenRegex;
             BetweenRegex = EnglishDatePeriodExtractorConfiguration.BetweenRegex;
@@ -90,8 +96,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             MonthWithYear = EnglishDatePeriodExtractorConfiguration.MonthWithYear;
             MonthNumWithYear = EnglishDatePeriodExtractorConfiguration.MonthNumWithYear;
             YearRegex = EnglishDatePeriodExtractorConfiguration.YearRegex;
-            PastRegex = EnglishDatePeriodExtractorConfiguration.PastRegex;
-            FutureRegex = EnglishDatePeriodExtractorConfiguration.FutureRegex;
+            PastRegex = EnglishDatePeriodExtractorConfiguration.PastPrefixRegex;
+            FutureRegex = EnglishDatePeriodExtractorConfiguration.NextPrefixRegex;
             NumberCombinedWithUnit = EnglishDurationExtractorConfiguration.NumberCombinedWithDurationUnit;
             WeekOfMonthRegex = EnglishDatePeriodExtractorConfiguration.WeekOfMonthRegex;
             WeekOfYearRegex = EnglishDatePeriodExtractorConfiguration.WeekOfYearRegex;

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         public IParser NumberParser { get; }
 
         public IDateTimeParser DateParser { get; }
@@ -21,6 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IDateTimeParser TimeParser { get; }
 
         public IDateTimeParser DateTimeParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 
@@ -40,6 +44,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public Regex PeriodTimeOfDayWithDateRegex { get; }
 
+        public Regex RelativeTimeUnitRegex { get; }
+
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public IImmutableDictionary<string, int> Numbers { get; }
@@ -50,19 +56,22 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             TimeExtractor = config.TimeExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
             CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
             NumberParser = config.NumberParser;
             DateParser = config.DateParser;
             TimeParser = config.TimeParser;
+            DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
             PureNumberFromToRegex = EnglishTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = EnglishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
             SpecificTimeOfDayRegex = EnglishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
             TimeOfDayRegex = EnglishDateTimeExtractorConfiguration.TimeOfDayRegex;
-            PastRegex = EnglishDatePeriodExtractorConfiguration.PastRegex;
-            FutureRegex = EnglishDatePeriodExtractorConfiguration.FutureRegex;
+            PastRegex = EnglishDatePeriodExtractorConfiguration.PastPrefixRegex;
+            FutureRegex = EnglishDatePeriodExtractorConfiguration.NextPrefixRegex;
             NumberCombinedWithUnitRegex = EnglishDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
             UnitRegex = EnglishTimePeriodExtractorConfiguration.TimeUnitRegex;
-            PeriodTimeOfDayWithDateRegex = EnglishDateTimePeriodExtractorConfiguration.TimePeriodTimeOfDayWithDateRegex;
+            PeriodTimeOfDayWithDateRegex = EnglishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = EnglishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
             UnitMap = config.UnitMap;
             Numbers = config.Numbers;
         }

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public Regex ConjunctionRegex { get; }
 
+        public Regex InExactNumberRegex { get; }
+
+        public Regex InExactNumberUnitRegex { get; }
+
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public IImmutableDictionary<string, long> UnitValueMap { get; }
@@ -40,6 +44,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             SuffixAndRegex = EnglishDurationExtractorConfiguration.SuffixAndRegex;
             FollowedUnit = EnglishDurationExtractorConfiguration.DurationFollowedUnit;
             ConjunctionRegex = EnglishDurationExtractorConfiguration.ConjunctionRegex;
+            InExactNumberRegex = EnglishDurationExtractorConfiguration.InExactNumberRegex;
+            InExactNumberUnitRegex = EnglishDurationExtractorConfiguration.InExactNumberUnitRegex;
             UnitMap = config.UnitMap;
             UnitValueMap = config.UnitValueMap;
             DoubleNumbers = config.DoubleNumbers;

--- a/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnlighDatetimeUtilityConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnlighDatetimeUtilityConfiguration.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Utilities
         public static readonly Regex AmPmDescRegex = new Regex(DateTimeDefinitions.AmPmDescRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeUnitRegex = new Regex(DateTimeDefinitions.RangeUnitRegex,
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         Regex IDateTimeUtilityConfiguration.LaterRegex => LaterRegex;
 
         Regex IDateTimeUtilityConfiguration.AgoRegex => AgoRegex;
@@ -35,5 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Utilities
         Regex IDateTimeUtilityConfiguration.PmDescRegex => PmDescRegex;
 
         Regex IDateTimeUtilityConfiguration.AmPmDescRegex => AmPmDescRegex;
+
+        Regex IDateTimeUtilityConfiguration.RangeUnitRegex => RangeUnitRegex;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -107,16 +107,14 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             foreach (var er in durationEr)
             {
-                var match = config.NonDateUnitRegex.Match(er.Text);
+                var match = config.DateUnitRegex.Match(er.Text);
                 if (match.Success)
                 {
-                    continue;
+                    ret = AgoLaterUtil.ExtractorDurationWithBeforeAndAfter(text,
+                        er,
+                        ret,
+                        config.UtilityConfiguration);
                 }
-
-                ret = AgoLaterUtil.ExtractorDurationWithBeforeAndAfter(text,
-                    er,
-                    ret,
-                    config.UtilityConfiguration);
             }
 
             return ret;

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDurationExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDurationExtractor.cs
@@ -57,18 +57,13 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // handle "3hrs"
-            var matches = this.config.NumberCombinedWithUnit.Matches(text);
-            foreach (Match match in matches)
-            {
-                ret.Add(new Token(match.Index, match.Index + match.Length));
-            }
+            ret.AddRange(GetTokenFromRegex(config.NumberCombinedWithUnit, text));
 
             // handle "an hour"
-            matches = this.config.AnUnitRegex.Matches(text);
-            foreach (Match match in matches)
-            {
-                ret.Add(new Token(match.Index, match.Index + match.Length));
-            }
+            ret.AddRange(GetTokenFromRegex(config.AnUnitRegex, text));
+
+            // handle "few" related cases
+            ret.AddRange(GetTokenFromRegex(config.InExactNumberUnitRegex, text));
 
             return ret;
         }

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
@@ -99,11 +99,12 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             index = -1;
             var match = regex.Match(text);
-            if (match.Success)
+            if (match.Success && string.IsNullOrWhiteSpace(text.Substring(match.Index+match.Length)))
             {
                 index = match.Index;
+                return true;
             }
-            return match.Success;
+            return false;
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var beforeStr = text.Substring(0, er.Start ?? 0);
                 var match = this.config.EachPrefixRegex.Match(beforeStr);
-                if (match.Success)
+                if (match.Success && string.IsNullOrWhiteSpace(beforeStr.Substring(match.Index + match.Length)))
                 {
                     ret.Add(new Token(match.Index, match.Index + match.Length + (er.Length ?? 0)));
                 }

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex MonthEnd { get; }
 
-        Regex NonDateUnitRegex { get; }
+        Regex DateUnitRegex { get; }
 
         IExtractor IntegerExtractor { get; }
 

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -9,9 +9,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex TillRegex { get; }
 
-        Regex FollowedUnit { get; }
+        Regex DateUnitRegex { get; }
 
-        Regex NumberCombinedWithUnit { get; }
+        Regex FollowedDateUnit { get; }
+
+        Regex NumberCombinedWithDateUnit { get; }
 
         Regex PastRegex { get; }
 
@@ -21,9 +23,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex MonthOfRegex { get; }
 
+        Regex RangeUnitRegex { get; }
+
+        Regex InConnectorRegex { get; }
+
         IExtractor DatePointExtractor { get; }
 
         IExtractor CardinalExtractor { get; }
+
+        IExtractor DurationExtractor { get; }
 
         bool GetFromTokenIndex(string text, out int index);
 

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
@@ -19,15 +19,17 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex NumberCombinedWithUnit { get; }
 
-        Regex UnitRegex { get; }
+        Regex TimeUnitRegex { get; }
 
-        Regex PastRegex { get; }
+        Regex PastPrefixRegex { get; }
 
-        Regex FutureRegex { get; }
+        Regex NextPrefixRegex { get; }
 
         Regex WeekDayRegex { get; }
 
         Regex PeriodTimeOfDayWithDateRegex { get; }
+
+        Regex RelativeTimeUnitRegex { get; }
 
         IExtractor CardinalExtractor { get; }
 
@@ -36,7 +38,9 @@ namespace Microsoft.Recognizers.Text.DateTime
         IExtractor SingleTimeExtractor { get; }
 
         IExtractor SingleDateTimeExtractor { get; }
-        
+
+        IExtractor DurationExtractor { get; }
+
         bool GetFromTokenIndex(string text, out int index);
 
         bool HasConnectorToken(string text);

--- a/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex ConjunctionRegex { get; }
 
+        Regex InExactNumberRegex { get; }
+
+        Regex InExactNumberUnitRegex { get; }
+
         IExtractor CardinalExtractor { get; }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 if (!innerResult.Success)
                 {
-                    innerResult = ParserDurationWithAgoAndLater(er.Text, referenceDate);
+                    innerResult = ParseDurationWithAgoAndLater(er.Text, referenceDate);
                 }
 
                 if (innerResult.Success)
@@ -305,14 +305,13 @@ namespace Microsoft.Recognizers.Text.DateTime
         }
 
         // handle like "two days ago" 
-        private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceDate)
+        private DateTimeResolutionResult ParseDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
-            return AgoLaterUtil.ParserDurationWithAgoAndLater(
+            return AgoLaterUtil.ParseDurationWithAgoAndLater(
                 text,
                 referenceDate,
                 config.DurationExtractor,
-                config.CardinalExtractor,
-                config.NumberParser,
+                config.DurationParser,
                 config.UnitMap,
                 config.UnitRegex,
                 config.UtilityConfiguration,

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -312,12 +312,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         // handle like "two hours ago" 
         private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceTime)
         {
-            return AgoLaterUtil.ParserDurationWithAgoAndLater(
+            return AgoLaterUtil.ParseDurationWithAgoAndLater(
                 text,
                 referenceTime,
                 config.DurationExtractor,
-                config.CardinalExtractor,
-                config.NumberParser,
+                config.DurationParser,
                 config.UnitMap,
                 config.UnitRegex,
                 config.UtilityConfiguration,

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -40,7 +40,12 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 if (!innerResult.Success)
                 {
-                    innerResult = ParseNumberWithUnit(er.Text, referenceTime);
+                    innerResult = ParseDuration(er.Text, referenceTime);
+                }
+
+                if (!innerResult.Success)
+                {
+                    innerResult = ParseRelativeUnit(er.Text, referenceTime);
                 }
 
                 if (innerResult.Success)
@@ -457,230 +462,108 @@ namespace Microsoft.Recognizers.Text.DateTime
             return ret;
         }
 
+        //TODO: this can be abstracted with the similar method in BaseDatePeriodParser
         // parse "in 20 minutes"
-        private DateTimeResolutionResult ParseNumberWithUnit(string text, DateObject referenceTime)
+        private DateTimeResolutionResult ParseDuration(string text, DateObject referenceTime)
         {
             var ret = new DateTimeResolutionResult();
-            string numStr, unitStr;
 
-            // if there are spaces between nubmer and unit
-            var ers = this.Config.CardinalExtractor.Extract(text);
+            var ers = Config.DurationExtractor.Extract(text);
             if (ers.Count == 1)
             {
-                var pr = this.Config.NumberParser.Parse(ers[0]);
-                var srcUnit = text.Substring(ers[0].Start + ers[0].Length ?? 0).Trim().ToLower();
-                var beforeStr = text.Substring(0, ers[0].Start ?? 0).Trim().ToLowerInvariant();
-
-                if (this.Config.UnitMap.ContainsKey(srcUnit))
+                var pr = Config.DurationParser.Parse(ers[0]);
+                var beforeStr = text.Substring(0, pr.Start ?? 0).Trim().ToLowerInvariant();
+                if (pr.Value != null)
                 {
-                    numStr = pr.ResolutionStr;
-                    unitStr = this.Config.UnitMap[srcUnit];
-                    var prefixMatch = this.Config.PastRegex.Match(beforeStr);
-                    if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
+                    var swiftSeconds = 0;
+                    var durationResult = (DateTimeResolutionResult)pr.Value;
+                    if (durationResult.PastValue is double && durationResult.FutureValue is double)
                     {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime.AddHours(-(double) pr.Value);
-                                endDate = referenceTime;
-                                break;
-                            case "M":
-                                beginDate = referenceTime.AddMinutes(-(double) pr.Value);
-                                endDate = referenceTime;
-                                break;
-                            case "S":
-                                beginDate = referenceTime.AddSeconds(-(double) pr.Value);
-                                endDate = referenceTime;
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT{numStr}{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-                        return ret;
+                        swiftSeconds = (int)((double)durationResult.FutureValue);
                     }
 
-                    prefixMatch = this.Config.FutureRegex.Match(beforeStr);
+                    DateObject beginTime;
+                    var  endTime = beginTime = referenceTime;
+
+                    var prefixMatch = Config.PastRegex.Match(beforeStr);
                     if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
                     {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddHours((double) pr.Value);
-                                break;
-                            case "M":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddMinutes((double) pr.Value);
-                                break;
-                            case "S":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddSeconds((double) pr.Value);
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT{numStr}{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-
-                        return ret;
+                        beginTime = referenceTime.AddSeconds(-swiftSeconds);
                     }
-                }
-            }
 
-            // if there are NO spaces between number and unit
-            var match = this.Config.NumberCombinedWithUnitRegex.Match(text);
-            if (match.Success)
-            {
-                var srcUnit = match.Groups["unit"].Value.ToLower();
-                var beforeStr = text.Substring(0, match.Index).Trim().ToLowerInvariant();
-                if (this.Config.UnitMap.ContainsKey(srcUnit))
-                {
-                    unitStr = this.Config.UnitMap[srcUnit];
-                    numStr = match.Groups["num"].Value;
-
-                    var prefixMatch = this.Config.PastRegex.Match(beforeStr);
+                    prefixMatch = Config.FutureRegex.Match(beforeStr);
                     if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
                     {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime.AddHours(-double.Parse(numStr));
-                                endDate = referenceTime;
-                                break;
-                            case "M":
-                                beginDate = referenceTime.AddMinutes(-double.Parse(numStr));
-                                endDate = referenceTime;
-                                break;
-                            case "S":
-                                beginDate = referenceTime.AddSeconds(-double.Parse(numStr));
-                                endDate = referenceTime;
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT{numStr}{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-
-                        return ret;
+                        endTime = beginTime.AddSeconds(swiftSeconds);
                     }
 
-                    prefixMatch = this.Config.FutureRegex.Match(beforeStr);
-                    if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
-                    {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddHours(double.Parse(numStr));
-                                break;
-                            case "M":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddMinutes(double.Parse(numStr));
-                                break;
-                            case "S":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddSeconds(double.Parse(numStr));
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT{numStr}{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-
-                        return ret;
-                    }
-                }
-            }
-
-            // handle "last hour"
-            match = this.Config.UnitRegex.Match(text);
-            if (match.Success)
-            {
-                var srcUnit = match.Groups["unit"].Value.ToLower();
-                var beforeStr = text.Substring(0, match.Index).Trim().ToLowerInvariant();
-                if (this.Config.UnitMap.ContainsKey(srcUnit))
-                {
-                    unitStr = this.Config.UnitMap[srcUnit];
-                    var prefixMatch = this.Config.PastRegex.Match(beforeStr);
-                    if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
-                    {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime.AddHours(-1);
-                                endDate = referenceTime;
-                                break;
-                            case "M":
-                                beginDate = referenceTime.AddMinutes(-1);
-                                endDate = referenceTime;
-                                break;
-                            case "S":
-                                beginDate = referenceTime.AddSeconds(-1);
-                                endDate = referenceTime;
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT1{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-
-                        return ret;
-                    }
-
-                    prefixMatch = this.Config.FutureRegex.Match(beforeStr);
-                    if (prefixMatch.Success && prefixMatch.Length == beforeStr.Length)
-                    {
-                        DateObject beginDate, endDate;
-                        switch (unitStr)
-                        {
-                            case "H":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddHours(1);
-                                break;
-                            case "M":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddMinutes(1);
-                                break;
-                            case "S":
-                                beginDate = referenceTime;
-                                endDate = referenceTime.AddSeconds(1);
-                                break;
-                            default:
-                                return ret;
-                        }
-
-                        ret.Timex =
-                            $"({FormatUtil.LuisDate(beginDate)}T{FormatUtil.LuisTime(beginDate)},{FormatUtil.LuisDate(endDate)}T{FormatUtil.LuisTime(endDate)},PT1{unitStr[0]})";
-                        ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
-                        ret.Success = true;
-
-                        return ret;
-                    }
+                    ret.Timex =
+                        $"({FormatUtil.LuisDate(beginTime)}T{FormatUtil.LuisTime(beginTime)}," +
+                        $"{FormatUtil.LuisDate(endTime)}T{FormatUtil.LuisTime(endTime)}," +
+                        $"{durationResult.Timex})";
+                    ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginTime, endTime);
+                    ret.Success = true;
+                    return ret;
                 }
             }
 
             return ret;
         }
+
+        // parse "last minute", "next hour"
+        private DateTimeResolutionResult ParseRelativeUnit(string text, DateObject referenceTime)
+        {
+            var ret = new DateTimeResolutionResult();
+
+            var match = Config.RelativeTimeUnitRegex.Match(text);
+            if (match.Success)
+            {
+                var srcUnit = match.Groups["unit"].Value.ToLower();
+
+                var unitStr = Config.UnitMap[srcUnit];
+
+                int swiftValue = 1;
+                var prefixMatch = Config.PastRegex.Match(text);
+                if (prefixMatch.Success)
+                {
+                    swiftValue = -1;
+                }
+
+                DateObject beginTime;
+                var endTime = beginTime = referenceTime;
+
+                if (Config.UnitMap.ContainsKey(srcUnit))
+                {
+                    switch (unitStr)
+                    {
+                        case "H":
+                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddHours(swiftValue);
+                            endTime = swiftValue > 0 ? referenceTime.AddHours(swiftValue) : endTime;
+                            break;
+                        case "M":
+                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddMinutes(swiftValue);
+                            endTime = swiftValue > 0 ? referenceTime.AddMinutes(swiftValue) : endTime;
+                            break;
+                        case "S":
+                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddSeconds(swiftValue);
+                            endTime = swiftValue > 0 ? referenceTime.AddSeconds(swiftValue) : endTime;
+                            break;
+                        default:
+                            return ret;
+                    }
+
+                    ret.Timex =
+                            $"({FormatUtil.LuisDate(beginTime)}T{FormatUtil.LuisTime(beginTime)},{FormatUtil.LuisDate(endTime)}T{FormatUtil.LuisTime(endTime)},PT1{unitStr[0]})";
+                    ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginTime, endTime);
+                    ret.Success = true;
+
+                    return ret;
+                }
+            }
+
+            return ret;
+        }
+
+
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IParser NumberParser { get; }
 
+        IExtractor DurationExtractor { get; }
+
+        IDateTimeParser DurationParser { get; }
+
         IDateTimeParser DateParser { get; }
 
         Regex MonthFrontBetweenRegex { get; }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IExtractor DateTimeExtractor { get; }
 
+        IExtractor DurationExtractor { get; }
+
         IExtractor CardinalExtractor { get; }
 
         IParser NumberParser { get; }
@@ -20,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         IDateTimeParser TimeParser { get; }
 
         IDateTimeParser DateTimeParser { get; }
+
+        IDateTimeParser DurationParser { get; }
 
         Regex PureNumberFromToRegex { get; }
 
@@ -38,6 +42,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         Regex UnitRegex { get; }
 
         Regex PeriodTimeOfDayWithDateRegex { get; }
+
+        Regex RelativeTimeUnitRegex { get; }
 
         IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex ConjunctionRegex { get; }
 
+        Regex InExactNumberRegex { get; }
+
+        Regex InExactNumberUnitRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, long> UnitValueMap { get; }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex ThisRegex = new Regex($@"\b((este\s*){WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex LastRegex = new Regex($@"\b(([uú]ltimo)\s*{WeekDayRegex})|({WeekDayRegex}(\s+((de\s+)?(esta|la)\s+([uú]ltima\s+)?semana)))\b",
+        public static readonly Regex LastDateRegex = new Regex($@"\b(([uú]ltimo)\s*{WeekDayRegex})|({WeekDayRegex}(\s+((de\s+)?(esta|la)\s+([uú]ltima\s+)?semana)))\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         //TODO: modify it according to the coresponding English regex
-        public static readonly Regex NextRegex = new Regex($@"\b(((pr[oó]ximo|siguiente)\s*){WeekDayRegex})|({WeekDayRegex}(\s+(de\s+)?(la\s+)?(pr[oó]xima|siguiente)(\s*semana)))\b",
+        public static readonly Regex NextDateRegex = new Regex($@"\b(((pr[oó]ximo|siguiente)\s*){WeekDayRegex})|({WeekDayRegex}(\s+(de\s+)?(la\s+)?(pr[oó]xima|siguiente)(\s*semana)))\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex SpecialDayRegex =
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 @"\b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a siguiente|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo d[ií]a|(d)?el d[ií]a|ayer|mañana|hoy)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex UnitRegex =
+        public static readonly Regex DateUnitRegex =
             new Regex(
                 @"(?<unit>anos|ano|meses|mes|semanas|semana|d[íi]as|d[íi]a)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -122,7 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex[] ImplicitDateList =
         {
-            OnRegex, RelaxedOnRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
+            OnRegex, RelaxedOnRegex, SpecialDayRegex, ThisRegex, LastDateRegex, NextDateRegex,
             StrictWeekDay, WeekDayOfMonthRegex, SpecialDate
         };
 
@@ -130,9 +130,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex MonthEnd = new Regex(MonthRegex + @"\s*(el)?\s*$",
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-        public static readonly Regex NonDateUnitRegex = new Regex(@"(?<unit>horas|hora|hrs|segundos|segundo|secs|sec|minutos|minuto|mins)\b'",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public SpanishDateExtractorConfiguration()
@@ -162,6 +159,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;
 
-        Regex IDateExtractorConfiguration.NonDateUnitRegex => NonDateUnitRegex;
+        Regex IDateExtractorConfiguration.DateUnitRegex => DateUnitRegex;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             new Regex($@"(?<msuf>(en\s+|del\s+|de\s+)?({RelativeMonthRegex}|{EngMonthRegex}))",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex UnitRegex = new Regex(@"(?<unit>años|año|meses|mes|semanas|semana|d[ií]a(s)?)\b",
+        public static readonly Regex DateUnitRegex = new Regex(@"(?<unit>años|año|meses|mes|semanas|semana|d[ií]a(s)?)\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex PastRegex = new Regex(@"(?<past>\b(pasad(a|o)(s)?|[uú]ltim[oa](s)?|anterior(es)?|previo(s)?)\b)",
@@ -95,11 +95,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 $@"(?<woy>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima?)\s+semana(\s+del?)?\s+({
                     YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex FollowedUnit = new Regex($@"^\s*{UnitRegex}",
+        public static readonly Regex FollowedDateUnit = new Regex($@"^\s*{DateUnitRegex}",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex NumberCombinedWithUnit =
-            new Regex($@"\b(?<num>\d+(\.\d*)?){UnitRegex}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex NumberCombinedWithDateUnit =
+            new Regex($@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex QuarterRegex =
             new Regex(
@@ -134,6 +134,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 $@"(mes)(\s*)((do|da|de))",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        //TODO: add this two regex
+        public static readonly Regex RangeUnitRegex =
+            new Regex(
+                @"\b(?<unit>años|año|meses|mes|semanas|semana)\b",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex InConnectorRegex =
+            new Regex(
+                @"\b(in)\b",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         private static readonly Regex FromRegex = new Regex(@"((desde|de)(\s*la(s)?)?)$", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         private static readonly Regex ConnectorAndRegex = new Regex(@"(y\s*(la(s)?)?)$", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         private static readonly Regex BeforeRegex = new Regex(@"(entre\s*(la(s)?)?)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -159,19 +170,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             DatePointExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration());
             CardinalExtractor = new CardinalExtractor();
+            DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
         }
 
         public IExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         IEnumerable<Regex> IDatePeriodExtractorConfiguration.SimpleCasesRegexes => SimpleCasesRegexes;
 
         Regex IDatePeriodExtractorConfiguration.TillRegex => TillRegex;
 
-        Regex IDatePeriodExtractorConfiguration.FollowedUnit => FollowedUnit;
+        Regex IDatePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
 
-        Regex IDatePeriodExtractorConfiguration.NumberCombinedWithUnit => NumberCombinedWithUnit;
+        Regex IDatePeriodExtractorConfiguration.FollowedDateUnit => FollowedDateUnit;
+
+        Regex IDatePeriodExtractorConfiguration.NumberCombinedWithDateUnit => NumberCombinedWithDateUnit;
 
         Regex IDatePeriodExtractorConfiguration.PastRegex => PastRegex;
 
@@ -180,6 +196,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IDatePeriodExtractorConfiguration.WeekOfRegex => WeekOfRegex;
 
         Regex IDatePeriodExtractorConfiguration.MonthOfRegex => MonthOfRegex;
+
+        Regex IDatePeriodExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDatePeriodExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             SingleDateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration());
             SingleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
+            DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
         }
 
         public IExtractor CardinalExtractor { get; }
@@ -28,6 +29,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IExtractor SingleTimeExtractor { get; }
 
         public IExtractor SingleDateTimeExtractor { get; }
+
+        public IExtractor DurationExtractor { get; }
 
         public IEnumerable<Regex> SimpleCasesRegex => new Regex[] 
             {
@@ -45,19 +48,34 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public Regex FollowedUnit => SpanishTimePeriodExtractorConfiguration.FollowedUnit;
 
-        public Regex UnitRegex => SpanishTimePeriodExtractorConfiguration.UnitRegex;
+        public Regex TimeUnitRegex => SpanishTimePeriodExtractorConfiguration.UnitRegex;
 
-        public Regex PastRegex => SpanishDatePeriodExtractorConfiguration.PastRegex;
+        public Regex PastPrefixRegex => SpanishDatePeriodExtractorConfiguration.PastRegex;
 
-        public Regex FutureRegex => SpanishDatePeriodExtractorConfiguration.FutureRegex;
-
-        //TODO: add this
-        public Regex WeekDayRegex => new Regex(@"^[\.]", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public Regex NextPrefixRegex => SpanishDatePeriodExtractorConfiguration.FutureRegex;
 
         //TODO: add this
-        public Regex PeriodTimeOfDayWithDateRegex => new Regex(@"\b(?<timeOfDay>mañana|madrugada|(pasado\s+(el\s+)?)?medio\s?d[ií]a|tarde|noche|anoche)\b", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex WeekDayRegex = new Regex(@"^[\.]", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        //TODO: add this
+        public static readonly Regex PeriodTimeOfDayWithDateRegex = new Regex(@"\b(((y|a|en|por)\s+la|al)\s+)?(?<timeOfDay>mañana|madrugada|(pasado\s+(el\s+)?)?medio\s?d[ií]a|tarde|noche|anoche)\b", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        //TODO: add this according to English
+        public static readonly Regex RelativeTimeUnitRegex =
+            new Regex(
+                $@"({SpanishDatePeriodExtractorConfiguration.PastRegex}|{
+                    SpanishDatePeriodExtractorConfiguration.FutureRegex})\s+{
+                    SpanishTimePeriodExtractorConfiguration.UnitRegex
+                    }",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => NumberCombinedWithUnit;
+
+        Regex IDateTimePeriodExtractorConfiguration.WeekDayRegex => WeekDayRegex;
+
+        Regex IDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex => PeriodTimeOfDayWithDateRegex;
+
+        Regex IDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex => RelativeTimeUnitRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
@@ -34,6 +34,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex ConjunctionRegex = new Regex(@"^[\.]",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        //TODO: change to Spanish according to corresponding Regex
+        public static readonly Regex InExactNumberRegex = new Regex(@"\b(a few|few|some|several)\b",
+           RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex InExactNumberUnitRegex = new Regex($@"\b(a few|few|some|several)\s+{UnitRegex}",
+           RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public SpanishDurationExtractorConfiguration()
         {
             CardinalExtractor = new CardinalExtractor();
@@ -54,5 +61,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IDurationExtractorConfiguration.SuffixAndRegex => SuffixAndRegex;
 
         Regex IDurationExtractorConfiguration.ConjunctionRegex => ConjunctionRegex;
+
+        Regex IDurationExtractorConfiguration.InExactNumberRegex => InExactNumberRegex;
+
+        Regex IDurationExtractorConfiguration.InExactNumberUnitRegex => InExactNumberUnitRegex;
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IExtractor DateTimePeriodExtractor { get; }
 
-        Regex ISetExtractorConfiguration.LastRegex => SpanishDateExtractorConfiguration.LastRegex;
+        Regex ISetExtractorConfiguration.LastRegex => SpanishDateExtractorConfiguration.LastDateRegex;
 
         Regex ISetExtractorConfiguration.EachPrefixRegex => EachPrefixRegex;
 

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DateRegexes = SpanishDateExtractorConfiguration.DateRegexList;
             OnRegex = SpanishDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
-            NextRegex = SpanishDateExtractorConfiguration.NextRegex;
+            NextRegex = SpanishDateExtractorConfiguration.NextDateRegex;
             ThisRegex = SpanishDateExtractorConfiguration.ThisRegex;
-            LastRegex = SpanishDateExtractorConfiguration.LastRegex;
-            UnitRegex = SpanishDateExtractorConfiguration.UnitRegex;
+            LastRegex = SpanishDateExtractorConfiguration.LastDateRegex;
+            UnitRegex = SpanishDateExtractorConfiguration.DateUnitRegex;
             StrictWeekDay = SpanishDateExtractorConfiguration.StrictWeekDay;
             MonthRegex = SpanishDateExtractorConfiguration.MonthRegex;
             WeekDayOfMonthRegex = SpanishDateExtractorConfiguration.WeekDayOfMonthRegex;

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -14,9 +14,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         public IParser NumberParser { get; }
 
         public IDateTimeParser DateParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
 
         #endregion
 
@@ -83,7 +87,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             TokenBeforeDate = "en ";
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
+            DurationParser = config.DurationParser;
             DateParser = config.DateParser;
             MonthFrontBetweenRegex = SpanishDatePeriodExtractorConfiguration.MonthFrontBetweenRegex;
             BetweenRegex = SpanishDatePeriodExtractorConfiguration.BetweenRegex;

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IExtractor CardinalExtractor { get; }
 
+        public IExtractor DurationExtractor { get; }
+
         public IParser NumberParser { get; }
 
         public IDateTimeParser DateParser { get; }
@@ -20,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeParser TimeParser { get; }
 
         public IDateTimeParser DateTimeParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 
@@ -39,6 +43,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public Regex PeriodTimeOfDayWithDateRegex { get; }
 
+        public Regex RelativeTimeUnitRegex { get; }
+
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public IImmutableDictionary<string, int> Numbers { get; }
@@ -49,10 +55,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             TimeExtractor = config.TimeExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
             CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
             NumberParser = config.NumberParser;
             DateParser = config.DateParser;
             TimeParser = config.TimeParser;
             DateTimeParser = config.DateTimeParser;
+            DurationParser = config.DurationParser;
             PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
             SpecificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
@@ -61,6 +69,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             FutureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
             NumberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
             UnitRegex = SpanishTimePeriodExtractorConfiguration.UnitRegex;
+            PeriodTimeOfDayWithDateRegex = SpanishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = SpanishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
             UnitMap = config.UnitMap;
             Numbers = config.Numbers;
         }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public Regex ConjunctionRegex { get; }
 
+        public Regex InExactNumberRegex { get; }
+
+        public Regex InExactNumberUnitRegex { get; }
+
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public IImmutableDictionary<string, long> UnitValueMap { get; }
@@ -43,6 +47,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DoubleNumbers = config.DoubleNumbers;
             FollowedUnit = SpanishDurationExtractorConfiguration.FollowedUnit;
             ConjunctionRegex = SpanishDurationExtractorConfiguration.ConjunctionRegex;
+            InExactNumberRegex = SpanishDurationExtractorConfiguration.InExactNumberRegex;
+            InExactNumberUnitRegex = SpanishDurationExtractorConfiguration.InExactNumberUnitRegex;
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Utilities
 
         public static readonly Regex AmPmDescRegex = new Regex(@"(ampm)", RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeUnitRegex = new Regex(@"\b(?<unit>años|año|meses|mes|semanas|semana)\b", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         Regex IDateTimeUtilityConfiguration.LaterRegex => LaterRegex;
 
         Regex IDateTimeUtilityConfiguration.AgoRegex => AgoRegex;
@@ -30,6 +32,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Utilities
         Regex IDateTimeUtilityConfiguration.PmDescRegex => PmDescRegex;
 
         Regex IDateTimeUtilityConfiguration.AmPmDescRegex => AmPmDescRegex;
+
+        Regex IDateTimeUtilityConfiguration.RangeUnitRegex => RangeUnitRegex;
 
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Utilities/IDateTimeUtilityConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Utilities/IDateTimeUtilityConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
 
         Regex InConnectorRegex { get; }
 
+        Regex RangeUnitRegex { get; }
+
         Regex AmDescRegex { get; }
 
         Regex PmDescRegex { get; }

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -5,8 +5,14 @@ RangeConnectorRegex : !simpleRegex
   def: (?<and>and|through|to|--|-|—|——)
 RelativeRegex: !simpleRegex
   def: (?<order>next|upcoming|this|last|past|previous|current|over the)
+NextPrefixRegex: !simpleRegex
+  def: (next|upcoming)\b
+PastPrefixRegex: !simpleRegex
+  def: (last|past|previous)\b
+ThisPrefixRegex: !simpleRegex
+  def: (this|current|over the)\b
 DayRegex: !simpleRegex
-  def: (?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)
+  def: (the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)
 MonthNumRegex: !simpleRegex
   def: (?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)
 PeriodYearRegex: !simpleRegex
@@ -21,17 +27,13 @@ EngMonthRegex: !simpleRegex
 MonthSuffixRegex: !nestedRegex
   def: (?<msuf>(in\s+|of\s+|on\s+)?({RelativeMonthRegex}|{EngMonthRegex}))
   references: [ RelativeMonthRegex, EngMonthRegex ]
-UnitRegex: !simpleRegex
+DateUnitRegex: !simpleRegex
   def: (?<unit>years|year|months|month|weeks|week|days|day)\b
-PastRegex: !simpleRegex
-  def: (?<past>\b(past|last|previous)\b)
-FutureRegex: !simpleRegex
-  def: (?<past>\b(next|in)\b)
 SimpleCasesRegex: !nestedRegex
-  def: \b(from\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){PeriodYearRegex})?\b
+  def: \b((from|between)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){PeriodYearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, PeriodYearRegex ]
 MonthFrontSimpleCasesRegex: !nestedRegex
-  def: \b{MonthSuffixRegex}\s+(from\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b
+  def: \b((from|between)\s+)?{MonthSuffixRegex}\s+((from|between)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b
   references: [ MonthSuffixRegex, DayRegex, TillRegex, PeriodYearRegex ]
 MonthFrontBetweenRegex: !nestedRegex
   def: \b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){PeriodYearRegex})?\b
@@ -54,12 +56,12 @@ WeekOfMonthRegex: !nestedRegex
 WeekOfYearRegex: !nestedRegex
   def: (?<woy>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week(\s+of)?\s+({PeriodYearRegex}|{RelativeRegex}\s+year))
   references: [ PeriodYearRegex, RelativeRegex ]
-FollowedUnit: !nestedRegex
-  def: ^\s*{UnitRegex}
-  references: [ UnitRegex ]
-NumberCombinedWithUnit: !nestedRegex
-  def: \b(?<num>\d+(\.\d*)?){UnitRegex}
-  references: [ UnitRegex ]
+FollowedDateUnit: !nestedRegex
+  def: ^\s*{DateUnitRegex}
+  references: [ DateUnitRegex ]
+NumberCombinedWithDateUnit: !nestedRegex
+  def: \b(?<num>\d+(\.\d*)?){DateUnitRegex}
+  references: [ DateUnitRegex ]
 QuarterRegex: !nestedRegex
   def: (the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)\s+quarter(\s+of|\s*,\s*)?\s+({PeriodYearRegex}|{RelativeRegex}\s+year)
   references: [ PeriodYearRegex, RelativeRegex ]
@@ -87,12 +89,12 @@ RelaxedOnRegex: !simpleRegex
 ThisRegex: !nestedRegex
   def: \b((this(\s*week)?\s+){WeekDayRegex})|({WeekDayRegex}(\s+this\s*week))\b
   references: [ WeekDayRegex ]
-LastRegex: !nestedRegex
-  def: \b(last(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b
-  references: [ WeekDayRegex ]
-NextRegex: !nestedRegex
-  def: \b(next(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}(\s+next\s*week))\b
-  references: [ WeekDayRegex ]
+LastDateRegex: !nestedRegex
+  def: \b({PastPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b
+  references: [ PastPrefixRegex, WeekDayRegex ]
+NextDateRegex: !nestedRegex
+  def: \b({NextPrefixRegex}(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}(\s+next\s*week))\b
+  references: [ NextPrefixRegex, WeekDayRegex ]
 SpecialDayRegex: !simpleRegex
   def: \b((the\s+)?day before yesterday|(the\s+)?day after (tomorrow|tmr)|(the\s)?next day|(the\s+)?last day|the day|yesterday|tomorrow|tmr|today)\b
 StrictWeekDay: !simpleRegex
@@ -139,10 +141,10 @@ OfMonth: !nestedRegex
 MonthEnd: !nestedRegex
   def: '{MonthRegex}\s*(the)?\s*$'
   references: [ MonthRegex ]
-NonDateUnitRegex: !simpleRegex
-  def: (?<unit>hours|hour|hrs|seconds|second|secs|sec|minutes|minute|mins)\b'
+RangeUnitRegex: !simpleRegex
+  def: \b(?<unit>years|year|months|month|weeks|week)\b
 DescRegex: !simpleRegex
-  def: (?<desc>ampm|am\b|a\.m\.|a m\b|a\. m\.\b|a\.m\b|a\. m\b|pm\b|p\.m\.|p m\b|p\. m\.\b|p\.m\b|p\. m\b|p\b)
+  def: (?<desc>ampm|am\b|a\.m\.|a m\b|a\. m\.|a\.m\b|a\. m\b|pm\b|p\.m\.|p m\b|p\. m\.|p\.m\b|p\. m\b|p\b)
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b
 MinuteNumRegex: !simpleRegex
@@ -227,7 +229,7 @@ PeriodPmRegex: !simpleRegex
 PeriodAmRegex: !simpleRegex
   def: (?<am>morning|in the morning)s?
 PureNumFromTo: !nestedRegex
-  def: (from\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?
+  def: ((from|between)\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?
   references: [ HourRegex, PeriodHourNumRegex, PeriodDescRegex, TillRegex, PmRegex, AmRegex ]
 PureNumBetweenAnd: !nestedRegex
   def: (between\s+)({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{PeriodDescRegex}))?\s*{RangeConnectorRegex}\s*({HourRegex}|{PeriodHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{PeriodDescRegex})?
@@ -326,9 +328,9 @@ AMTimeRegex: !simpleRegex
 PMTimeRegex: !simpleRegex
   def: \b(?<pm>afternoon|evening|night)\b
 BeforeRegex: !simpleRegex
-  def: \b(before)$
+  def: \b(before)\b
 AfterRegex: !simpleRegex
-  def: \b(after|since)$
+  def: \b(after|since)\b
 AgoRegex: !simpleRegex
   def: \b(ago)\b
 LaterRegex: !simpleRegex
@@ -336,17 +338,11 @@ LaterRegex: !simpleRegex
 InConnectorRegex: !simpleRegex
   def: \b(in)\b
 AmDescRegex: !simpleRegex
-  def: (am\b|a\.m\.|a m\b|a\. m\.\b|a\.m\b|a\. m\b)
+  def: (am\b|a\.m\.|a m\b|a\. m\.|a\.m\b|a\. m\b)
 PmDescRegex: !simpleRegex
-  def: (pm\b|p\.m\.|p\b|p m\b|p\. m\.\b|p\.m\b|p\. m\b)
+  def: (pm\b|p\.m\.|p\b|p m\b|p\. m\.|p\.m\b|p\. m\b)
 AmPmDescRegex: !simpleRegex
   def: (ampm)
-NextPrefixRegex: !simpleRegex
-  def: (next|upcoming)\b
-PastPrefixRegex: !simpleRegex
-  def: (last|past|previous)\b
-ThisPrefixRegex: !simpleRegex
-  def: (this|current|over the)\b
 MorningStartEndRegex: !simpleRegex
   def: (^(morning))|((morning)$)
 AfternoonStartEndRegex: !simpleRegex
@@ -360,6 +356,11 @@ InExactNumberRegex: !simpleRegex
 InExactNumberUnitRegex: !nestedRegex
   def: ({InExactNumberRegex})\s+({DurationUnitRegex})
   references: [InExactNumberRegex, DurationUnitRegex]
+RelativeTimeUnitRegex: !nestedRegex
+  def: ({RelativeRegex})\s+({TimeUnitRegex})
+  references: [RelativeRegex, TimeUnitRegex]
+ConnectorRegex: !simpleRegex
+  def: ^(,|for|t|around)$
 UnitMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -355,6 +355,11 @@ EveningStartEndRegex: !simpleRegex
   def: (^(evening))|((evening)$)
 NightStartEndRegex: !simpleRegex
   def: (^(overnight|tonight|night))|((overnight|tonight|night)$)
+InExactNumberRegex: !simpleRegex
+  def: \b(a few|few|some|several)\b
+InExactNumberUnitRegex: !nestedRegex
+  def: ({InExactNumberRegex})\s+({DurationUnitRegex})
+  references: [InExactNumberRegex, DurationUnitRegex]
 UnitMap: !dictionary
   types: [ string, string ]
   entries:


### PR DESCRIPTION
Bugs fixed:

- [x] support for few, next few days
- [x] past week, past Monday
- [x] the is not ignored, "Between November 15th through the 19th"
- [x] spacing problem, a m/a. m.
- [x] a regression bug caused by regex typo for after/before
- [x] bugs for parsing duration with next/past as date or range
- [x] resolution for a month ago
- [x] in+duration (resolution <= day will be absolute datetime while resolution > day will be range)