### PR TITLE
Fix bugs reported by mercury#4

### DIFF
--- a/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string NextPrefixRegex = @"(next|upcoming)\b";
 		public const string PastPrefixRegex = @"(last|past|previous)\b";
 		public const string ThisPrefixRegex = @"(this|current|over the)\b";
-		public const string DayRegex = @"(the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)";
-		public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)";
+		public const string DayRegex = @"(the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)(?=\b|t)";
+		public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b";
 		public const string PeriodYearRegex = @"\b(?<year>19\d{2}|20\d{2})\b";
-		public const string WeekDayRegex = @"(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)";
-		public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+month)";
+		public const string WeekDayRegex = @"(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)\b";
+		public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+month)\b";
 		public const string EngMonthRegex = @"(?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sept|Sep)";
 		public static readonly string MonthSuffixRegex = $@"(?<msuf>(in\s+|of\s+|on\s+)?({RelativeMonthRegex}|{EngMonthRegex}))";
 		public const string DateUnitRegex = @"(?<unit>years|year|months|month|weeks|week|days|day)\b";

--- a/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime.Tests/English/TestMergedParser.cs
@@ -67,8 +67,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests.English
         }
 
         [TestMethod]
+        public void TestMergedParseInvalidDatetime()
+        {
+            BasicTest("2016-2-30", Constants.SYS_DATETIME_DATE);
+            //only 2015-1 is extracted
+            BasicTest("2015-1-32", Constants.SYS_DATETIME_DATEPERIOD);
+            //only 2017 is extracted
+            BasicTest("2017-13-12", Constants.SYS_DATETIME_DATEPERIOD);
+        }
+
+        [TestMethod]
         public void TestMergedParseWithTwoResults()
         {
+            BasicTestWithTwoResults("Change July 22nd meeting in Bellevue to August 22nd", Constants.SYS_DATETIME_DATE,
+                Constants.SYS_DATETIME_DATE);
             BasicTestWithTwoResults("on Friday for 3 in Bellevue in the afternoon", Constants.SYS_DATETIME_DATE,
                 Constants.SYS_DATETIME_TIMEPERIOD);
         }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateParser.cs
@@ -183,13 +183,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 if (day > containsDay[month - 1])
                 {
-                    futureDate = new DateObject(year, month + 1, day);
-                    pastDate = new DateObject(year, month - 1, day);
+                    futureDate = DateObject.MinValue.SetValue(year, month + 1, day);
+                    pastDate = DateObject.MinValue.SetValue(year, month - 1, day);
                 }
                 else
                 {
-                    futureDate = new DateObject(year, month, day);
-                    pastDate = new DateObject(year, month, day);
+                    futureDate = DateObject.MinValue.SetValue(year, month, day);
+                    pastDate = DateObject.MinValue.SetValue(year, month, day);
                     if (!hasMonth)
                     {
                         if (futureDate < referenceDate)
@@ -464,7 +464,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private DateObject ComputeDate(int cadinal, int weekday, int month, int year)
         {
-            var firstDay = new DateObject(year, month, 1);
+            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
             if (weekday == 0)
             {
@@ -608,8 +608,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = new DateObject(year, month, day);
-            var pastDate = new DateObject(year, month, day);
+            var futureDate = DateObject.MinValue.SetValue(year, month, day);
+            var pastDate = DateObject.MinValue.SetValue(year, month, day);
             if (noYear && futureDate < referenceDate)
             {
                 futureDate = futureDate.AddYears(+1);

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateParser.cs
@@ -183,13 +183,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 if (day > containsDay[month - 1])
                 {
-                    futureDate = DateObject.MinValue.SetValue(year, month + 1, day);
-                    pastDate = DateObject.MinValue.SetValue(year, month - 1, day);
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year, month + 1, day);
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year, month - 1, day);
                 }
                 else
                 {
-                    futureDate = DateObject.MinValue.SetValue(year, month, day);
-                    pastDate = DateObject.MinValue.SetValue(year, month, day);
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
                     if (!hasMonth)
                     {
                         if (futureDate < referenceDate)
@@ -464,7 +464,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private DateObject ComputeDate(int cadinal, int weekday, int month, int year)
         {
-            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
+            var firstDay = DateObject.MinValue.SafeCreateFromValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
             if (weekday == 0)
             {
@@ -608,8 +608,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SetValue(year, month, day);
-            var pastDate = DateObject.MinValue.SetValue(year, month, day);
+            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
             if (noYear && futureDate < referenceDate)
             {
                 futureDate = futureDate.AddYears(+1);

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             int futureYear = year, pastYear = year;
-            var startDate = new DateObject(year, month, beginDay);
+            var startDate = DateObject.MinValue.SetValue(year, month, beginDay);
             if (noYear && startDate < referenceDate)
             {
                 futureYear++;
@@ -239,12 +239,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             ret.Timex = $"({beginLuisStr},{endLuisStr},P{endDay - beginDay}D)";
 
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                new DateObject(futureYear, month, beginDay),
-                new DateObject(futureYear, month, endDay));
+                DateObject.MinValue.SetValue(futureYear, month, beginDay),
+                DateObject.MinValue.SetValue(futureYear, month, endDay));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                new DateObject(pastYear, month, beginDay),
-                new DateObject(pastYear, month, endDay));
+                DateObject.MinValue.SetValue(pastYear, month, beginDay),
+                DateObject.MinValue.SetValue(pastYear, month, endDay));
 
             ret.Success = true;
 
@@ -312,8 +312,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     endYear += 2000;
                 }
 
-                var beginDay = new DateObject(beginYear, 1, 1);
-                var endDay = new DateObject(endYear, 12, 31);
+                var beginDay = DateObject.MinValue.SetValue(beginYear, 1, 1);
+                var endDay = DateObject.MinValue.SetValue(endYear, 12, 31);
                 var beginTimex = beginYear.ToString("D4");
                 var endTimex = endYear.ToString("D4");
                 ret.Timex = $"({beginTimex},{endTimex},P{endYear - beginYear}Y)";
@@ -383,16 +383,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             var monthStr = match.Groups["month"].Value;
             var month = this.config.MonthOfYear[monthStr] > 12 ? this.config.MonthOfYear[monthStr]%12 : this.config.MonthOfYear[monthStr];
-            var beginDay = new DateObject(year, month, 1);
+            var beginDay = DateObject.MinValue.SetValue(year, month, 1);
             DateObject endDay;
 
             if (month == 12)
             {
-                endDay = new DateObject(year + 1, 1, 1);
+                endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
             }
             else
             {
-                endDay = new DateObject(year, month + 1, 1);
+                endDay = DateObject.MinValue.SetValue(year, month + 1, 1);
             }
 
             ret.Timex = year.ToString("D4") + "-" + month.ToString("D2");
@@ -418,7 +418,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ret.Timex = referenceDate.Year.ToString("D4");
                     ret.FutureValue =
                         ret.PastValue =
-                            new Tuple<DateObject, DateObject>(new DateObject(referenceDate.Year, 1, 1), referenceDate);
+                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(referenceDate.Year, 1, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -540,8 +540,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         ret.Timex = year.ToString("D4");
                         ret.FutureValue =
                             ret.PastValue =
-                                new Tuple<DateObject, DateObject>(new DateObject(year, 1, 1),
-                                    new DateObject(year, 12, 31).AddDays(1));
+                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, 1, 1),
+                                    DateObject.MinValue.SetValue(year, 12, 31).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
@@ -554,12 +554,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             // only "month" will come to here
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                new DateObject(futureYear, month, 1),
-                new DateObject(futureYear, month, 1).AddMonths(1));
+                DateObject.MinValue.SetValue(futureYear, month, 1),
+                DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                new DateObject(pastYear, month, 1),
-                new DateObject(pastYear, month, 1).AddMonths(1));
+                DateObject.MinValue.SetValue(pastYear, month, 1),
+                DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1));
 
             ret.Success = true;
 
@@ -653,8 +653,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     year = int.Parse(tmp);
                 }
 
-                var beginDay = new DateObject(year, 1, 1);
-                var endDay = new DateObject(year + 1, 1, 1);
+                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
+                var endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
@@ -687,8 +687,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     year += 2000;
                 }
 
-                var beginDay = new DateObject(year, 1, 1);
-                var endDay = new DateObject(year + 1, 1, 1);
+                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
+                var endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
@@ -1119,8 +1119,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var cardinalStr = match.Groups["cardinal"].Value;
             var quarterNum = this.config.CardinalMap[cardinalStr];
 
-            var beginDate = new DateObject(year, quarterNum*3 - 2, 1);
-            var endDate = new DateObject(year, quarterNum*3 + 1, 1);
+            var beginDate = DateObject.MinValue.SetValue(year, quarterNum*3 - 2, 1);
+            var endDate = DateObject.MinValue.SetValue(year, quarterNum*3 + 1, 1);
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
             ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P3M)";
             ret.Success = true;
@@ -1130,7 +1130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static DateObject ComputeDate(int cadinal, int weekday, int month, int year)
         {
-            var firstDay = new DateObject(year, month, 1);
+            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek) weekday);
             if (weekday == 0)
             {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DatePeriodParserChs.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             int futureYear = year, pastYear = year;
-            var startDate = DateObject.MinValue.SetValue(year, month, beginDay);
+            var startDate = DateObject.MinValue.SafeCreateFromValue(year, month, beginDay);
             if (noYear && startDate < referenceDate)
             {
                 futureYear++;
@@ -239,12 +239,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             ret.Timex = $"({beginLuisStr},{endLuisStr},P{endDay - beginDay}D)";
 
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(futureYear, month, beginDay),
-                DateObject.MinValue.SetValue(futureYear, month, endDay));
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, beginDay),
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, endDay));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(pastYear, month, beginDay),
-                DateObject.MinValue.SetValue(pastYear, month, endDay));
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, beginDay),
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, endDay));
 
             ret.Success = true;
 
@@ -312,8 +312,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     endYear += 2000;
                 }
 
-                var beginDay = DateObject.MinValue.SetValue(beginYear, 1, 1);
-                var endDay = DateObject.MinValue.SetValue(endYear, 12, 31);
+                var beginDay = DateObject.MinValue.SafeCreateFromValue(beginYear, 1, 1);
+                var endDay = DateObject.MinValue.SafeCreateFromValue(endYear, 12, 31);
                 var beginTimex = beginYear.ToString("D4");
                 var endTimex = endYear.ToString("D4");
                 ret.Timex = $"({beginTimex},{endTimex},P{endYear - beginYear}Y)";
@@ -383,16 +383,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             var monthStr = match.Groups["month"].Value;
             var month = this.config.MonthOfYear[monthStr] > 12 ? this.config.MonthOfYear[monthStr]%12 : this.config.MonthOfYear[monthStr];
-            var beginDay = DateObject.MinValue.SetValue(year, month, 1);
+            var beginDay = DateObject.MinValue.SafeCreateFromValue(year, month, 1);
             DateObject endDay;
 
             if (month == 12)
             {
-                endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
+                endDay = DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1);
             }
             else
             {
-                endDay = DateObject.MinValue.SetValue(year, month + 1, 1);
+                endDay = DateObject.MinValue.SafeCreateFromValue(year, month + 1, 1);
             }
 
             ret.Timex = year.ToString("D4") + "-" + month.ToString("D2");
@@ -418,7 +418,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     ret.Timex = referenceDate.Year.ToString("D4");
                     ret.FutureValue =
                         ret.PastValue =
-                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(referenceDate.Year, 1, 1), referenceDate);
+                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(referenceDate.Year, 1, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -540,8 +540,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         ret.Timex = year.ToString("D4");
                         ret.FutureValue =
                             ret.PastValue =
-                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, 1, 1),
-                                    DateObject.MinValue.SetValue(year, 12, 31).AddDays(1));
+                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, 1, 1),
+                                    DateObject.MinValue.SafeCreateFromValue(year, 12, 31).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
@@ -554,12 +554,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             // only "month" will come to here
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(futureYear, month, 1),
-                DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1));
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, 1),
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, 1).AddMonths(1));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(pastYear, month, 1),
-                DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1));
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, 1),
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, 1).AddMonths(1));
 
             ret.Success = true;
 
@@ -653,8 +653,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     year = int.Parse(tmp);
                 }
 
-                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
-                var endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
+                var beginDay = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
+                var endDay = DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
@@ -687,8 +687,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     year += 2000;
                 }
 
-                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
-                var endDay = DateObject.MinValue.SetValue(year + 1, 1, 1);
+                var beginDay = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
+                var endDay = DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1);
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                 ret.Success = true;
@@ -1119,8 +1119,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var cardinalStr = match.Groups["cardinal"].Value;
             var quarterNum = this.config.CardinalMap[cardinalStr];
 
-            var beginDate = DateObject.MinValue.SetValue(year, quarterNum*3 - 2, 1);
-            var endDate = DateObject.MinValue.SetValue(year, quarterNum*3 + 1, 1);
+            var beginDate = DateObject.MinValue.SafeCreateFromValue(year, quarterNum*3 - 2, 1);
+            var endDate = DateObject.MinValue.SafeCreateFromValue(year, quarterNum*3 + 1, 1);
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
             ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P3M)";
             ret.Success = true;
@@ -1130,7 +1130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static DateObject ComputeDate(int cadinal, int weekday, int month, int year)
         {
-            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
+            var firstDay = DateObject.MinValue.SafeCreateFromValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek) weekday);
             if (weekday == 0)
             {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
@@ -179,8 +179,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Comment = "ampm";
             }
 
-            ret.FutureValue = new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
-            ret.PastValue = new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
+            ret.FutureValue = DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
+            ret.PastValue = DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
             ret.Success = true;
 
             return ret;
@@ -268,7 +268,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
-                ret.FutureValue = ret.PastValue = new DateObject(date.Year, date.Month, date.Day, hour, min, sec);
+                ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(date.Year, date.Month, date.Day, hour, min, sec);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
@@ -179,8 +179,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Comment = "ampm";
             }
 
-            ret.FutureValue = DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
-            ret.PastValue = DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
+            ret.FutureValue = DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
+            ret.PastValue = DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
             ret.Success = true;
 
             return ret;
@@ -268,7 +268,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
-                ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(date.Year, date.Month, date.Day, hour, min, sec);
+                ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(date.Year, date.Month, date.Day, hour, min, sec);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
@@ -132,16 +132,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             ret.FutureValue =
                 new Tuple<DateObject, DateObject>(
-                    new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, beginTime.Hour, beginTime.Minute,
+                    DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginTime.Hour, beginTime.Minute,
                         beginTime.Second),
-                    new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, endTime.Hour, endTime.Minute,
+                    DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endTime.Hour, endTime.Minute,
                         endTime.Second));
 
             ret.PastValue =
                 new Tuple<DateObject, DateObject>(
-                    new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, beginTime.Hour, beginTime.Minute,
+                    DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginTime.Hour, beginTime.Minute,
                         beginTime.Second),
-                    new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, endTime.Hour, endTime.Minute,
+                    DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endTime.Hour, endTime.Minute,
                         endTime.Second));
 
             var splited = pr2.TimexStr.Split('T');
@@ -166,8 +166,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var er1 = SingleTimeExtractor.Extract(text);
             var er2 = TimeWithDateExtractor.Extract(text);
 
-            var rightTime = new DateObject(referenceTime.Year, referenceTime.Month, referenceTime.Day);
-            var leftTime = new DateObject(referenceTime.Year, referenceTime.Month, referenceTime.Day);
+            var rightTime = DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
+            var leftTime = DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
 
             if (er2.Count == 2)
             {
@@ -238,28 +238,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             if (bothHasDate)
             {
-                rightTime = new DateObject(futureEnd.Year, futureEnd.Month, futureEnd.Day);
-                leftTime = new DateObject(futureBegin.Year, futureBegin.Month, futureBegin.Day);
+                rightTime = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
+                leftTime = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
             }
             else if (beginHasDate)
             {
                 // TODO: Handle "明天下午两点到五点"
-                futureEnd = new DateObject(futureBegin.Year, futureBegin.Month, futureBegin.Day,
+                futureEnd = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
                     futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
-                pastEnd = new DateObject(pastBegin.Year, pastBegin.Month, pastBegin.Day,
+                pastEnd = DateObject.MinValue.SetValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
                     pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
 
-                leftTime = new DateObject(futureBegin.Year, futureBegin.Month, futureBegin.Day);
+                leftTime = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
             }
             else if (endHasDate)
             {
                 // TODO: Handle "明天下午两点到五点"
-                futureBegin = new DateObject(futureEnd.Year, futureEnd.Month, futureEnd.Day,
+                futureBegin = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
                     futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
-                pastBegin = new DateObject(pastEnd.Year, pastEnd.Month, pastEnd.Day,
+                pastBegin = DateObject.MinValue.SetValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
                     pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
 
-                rightTime = new DateObject(futureEnd.Year, futureEnd.Month, futureEnd.Day);
+                rightTime = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
             }
 
             var leftResult = (DateTimeResolutionResult) pr1.Value;
@@ -279,7 +279,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             leftTime = leftTime.AddHours(hour);
             leftTime = leftTime.AddMinutes(min);
             leftTime = leftTime.AddSeconds(second);
-            new DateObject(year, month, day, hour, min, second);
+            DateObject.MinValue.SetValue(year, month, day, hour, min, second);
 
             hour = rightResultTime.Hour > 0 ? rightResultTime.Hour : 0;
             min = rightResultTime.Minute > 0 ? rightResultTime.Minute : 0;
@@ -381,8 +381,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(new DateObject(year, month, day, beginHour, 0, 0),
-                            new DateObject(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -437,8 +437,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(new DateObject(year, month, day, beginHour, 0, 0),
-                            new DateObject(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -463,13 +463,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
@@ -132,16 +132,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             ret.FutureValue =
                 new Tuple<DateObject, DateObject>(
-                    DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginTime.Hour, beginTime.Minute,
+                    DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginTime.Hour, beginTime.Minute,
                         beginTime.Second),
-                    DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endTime.Hour, endTime.Minute,
+                    DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endTime.Hour, endTime.Minute,
                         endTime.Second));
 
             ret.PastValue =
                 new Tuple<DateObject, DateObject>(
-                    DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginTime.Hour, beginTime.Minute,
+                    DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginTime.Hour, beginTime.Minute,
                         beginTime.Second),
-                    DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endTime.Hour, endTime.Minute,
+                    DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endTime.Hour, endTime.Minute,
                         endTime.Second));
 
             var splited = pr2.TimexStr.Split('T');
@@ -166,8 +166,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var er1 = SingleTimeExtractor.Extract(text);
             var er2 = TimeWithDateExtractor.Extract(text);
 
-            var rightTime = DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
-            var leftTime = DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
+            var rightTime = DateObject.MinValue.SafeCreateFromValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
+            var leftTime = DateObject.MinValue.SafeCreateFromValue(referenceTime.Year, referenceTime.Month, referenceTime.Day);
 
             if (er2.Count == 2)
             {
@@ -238,28 +238,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             if (bothHasDate)
             {
-                rightTime = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
-                leftTime = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
+                rightTime = DateObject.MinValue.SafeCreateFromValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
+                leftTime = DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
             }
             else if (beginHasDate)
             {
                 // TODO: Handle "明天下午两点到五点"
-                futureEnd = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
+                futureEnd = DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
                     futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
-                pastEnd = DateObject.MinValue.SetValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
+                pastEnd = DateObject.MinValue.SafeCreateFromValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
                     pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
 
-                leftTime = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
+                leftTime = DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, futureBegin.Month, futureBegin.Day);
             }
             else if (endHasDate)
             {
                 // TODO: Handle "明天下午两点到五点"
-                futureBegin = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
+                futureBegin = DateObject.MinValue.SafeCreateFromValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
                     futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
-                pastBegin = DateObject.MinValue.SetValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
+                pastBegin = DateObject.MinValue.SafeCreateFromValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
                     pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
 
-                rightTime = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
+                rightTime = DateObject.MinValue.SafeCreateFromValue(futureEnd.Year, futureEnd.Month, futureEnd.Day);
             }
 
             var leftResult = (DateTimeResolutionResult) pr1.Value;
@@ -279,7 +279,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             leftTime = leftTime.AddHours(hour);
             leftTime = leftTime.AddMinutes(min);
             leftTime = leftTime.AddSeconds(second);
-            DateObject.MinValue.SetValue(year, month, day, hour, min, second);
+            DateObject.MinValue.SafeCreateFromValue(year, month, day, hour, min, second);
 
             hour = rightResultTime.Hour > 0 ? rightResultTime.Hour : 0;
             min = rightResultTime.Minute > 0 ? rightResultTime.Minute : 0;
@@ -381,8 +381,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -437,8 +437,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -463,13 +463,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 if (hasYear)
                 {
                     ret.Timex = year.ToString("D4") + timexStr;
-                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, value.Month, value.Day);
+                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(year, value.Month, value.Day);
                     ret.Success = true;
                     return ret;
                 }
@@ -286,64 +286,64 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static DateObject GetMothersDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 5, (from day in Enumerable.Range(1, 31)
-                where DateObject.MinValue.SetValue(year, 5, day).DayOfWeek == DayOfWeek.Sunday
+            return DateObject.MinValue.SafeCreateFromValue(year, 5, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SafeCreateFromValue(year, 5, day).DayOfWeek == DayOfWeek.Sunday
                 select day).ElementAt(1));
         }
 
         private static DateObject GetFathersDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 6, (from day in Enumerable.Range(1, 30)
-                where DateObject.MinValue.SetValue(year, 6, day).DayOfWeek == DayOfWeek.Sunday
+            return DateObject.MinValue.SafeCreateFromValue(year, 6, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SafeCreateFromValue(year, 6, day).DayOfWeek == DayOfWeek.Sunday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetMartinLutherKingDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 1, (from day in Enumerable.Range(1, 31)
-                where DateObject.MinValue.SetValue(year, 1, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 1, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SafeCreateFromValue(year, 1, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetWashingtonsBirthdayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 2, (from day in Enumerable.Range(1, 29)
-                where DateObject.MinValue.SetValue(year, 2, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 2, (from day in Enumerable.Range(1, 29)
+                where DateObject.MinValue.SafeCreateFromValue(year, 2, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetCanberraDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 3, (from day in Enumerable.Range(1, 31)
-                where DateObject.MinValue.SetValue(year, 3, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 3, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SafeCreateFromValue(year, 3, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(0));
         }
 
         private static DateObject GetMemorialDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 5, (from day in Enumerable.Range(1, 31)
-                where DateObject.MinValue.SetValue(year, 5, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 5, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SafeCreateFromValue(year, 5, day).DayOfWeek == DayOfWeek.Monday
                 select day).Last());
         }
 
         private static DateObject GetLabourDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 9, (from day in Enumerable.Range(1, 30)
-                where DateObject.MinValue.SetValue(year, 9, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 9, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SafeCreateFromValue(year, 9, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(0));
         }
 
         private static DateObject GetColumbusDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 10, (from day in Enumerable.Range(1, 31)
-                where DateObject.MinValue.SetValue(year, 10, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SafeCreateFromValue(year, 10, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SafeCreateFromValue(year, 10, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(1));
         }
 
         private static DateObject GetThanksgivingDayOfYear(int year)
         {
-            return DateObject.MinValue.SetValue(year, 11, (from day in Enumerable.Range(1, 30)
-                where DateObject.MinValue.SetValue(year, 11, day).DayOfWeek == DayOfWeek.Thursday
+            return DateObject.MinValue.SafeCreateFromValue(year, 11, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SafeCreateFromValue(year, 11, day).DayOfWeek == DayOfWeek.Thursday
                 select day).ElementAt(3));
         }
 
@@ -392,31 +392,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     internal static class TimexConstants
     {
         internal static readonly DateObject now = DateObject.Now;
-        internal static readonly DateObject yuandan = DateObject.MinValue.SetValue(now.Year, 1, 1);
-        internal static readonly DateObject chsnationalday = DateObject.MinValue.SetValue(now.Year, 10, 1);
-        internal static readonly DateObject laborday = DateObject.MinValue.SetValue(now.Year, 5, 1);
-        internal static readonly DateObject christmasday = DateObject.MinValue.SetValue(now.Year, 12, 25);
-        internal static readonly DateObject loverday = DateObject.MinValue.SetValue(now.Year, 2, 14);
-        internal static readonly DateObject chsmilbuildday = DateObject.MinValue.SetValue(now.Year, 8, 1);
-        internal static readonly DateObject foolday = DateObject.MinValue.SetValue(now.Year, 4, 1);
-        internal static readonly DateObject girlsday = DateObject.MinValue.SetValue(now.Year, 3, 7);
-        internal static readonly DateObject treeplantday = DateObject.MinValue.SetValue(now.Year, 3, 12);
-        internal static readonly DateObject femaleday = DateObject.MinValue.SetValue(now.Year, 3, 8);
-        internal static readonly DateObject childrenday = DateObject.MinValue.SetValue(now.Year, 6, 1);
-        internal static readonly DateObject youthday = DateObject.MinValue.SetValue(now.Year, 5, 4);
-        internal static readonly DateObject teacherday = DateObject.MinValue.SetValue(now.Year, 9, 10);
-        internal static readonly DateObject singlesday = DateObject.MinValue.SetValue(now.Year, 11, 11);
+        internal static readonly DateObject yuandan = new DateObject(now.Year, 1, 1);
+        internal static readonly DateObject chsnationalday = new DateObject(now.Year, 10, 1);
+        internal static readonly DateObject laborday = new DateObject(now.Year, 5, 1);
+        internal static readonly DateObject christmasday = new DateObject(now.Year, 12, 25);
+        internal static readonly DateObject loverday = new DateObject(now.Year, 2, 14);
+        internal static readonly DateObject chsmilbuildday = new DateObject(now.Year, 8, 1);
+        internal static readonly DateObject foolday = new DateObject(now.Year, 4, 1);
+        internal static readonly DateObject girlsday = new DateObject(now.Year, 3, 7);
+        internal static readonly DateObject treeplantday = new DateObject(now.Year, 3, 12);
+        internal static readonly DateObject femaleday = new DateObject(now.Year, 3, 8);
+        internal static readonly DateObject childrenday = new DateObject(now.Year, 6, 1);
+        internal static readonly DateObject youthday = new DateObject(now.Year, 5, 4);
+        internal static readonly DateObject teacherday = new DateObject(now.Year, 9, 10);
+        internal static readonly DateObject singlesday = new DateObject(now.Year, 11, 11);
 
-        internal static readonly DateObject halloweenday = DateObject.MinValue.SetValue(now.Year, 10, 31);
+        internal static readonly DateObject halloweenday = new DateObject(now.Year, 10, 31);
 
-        internal static readonly DateObject midautumnday = DateObject.MinValue.SetValue(now.Year, 8, 15);
-        internal static readonly DateObject springday = DateObject.MinValue.SetValue(now.Year, 1, 1);
-        internal static readonly DateObject chuxiday = DateObject.MinValue.SetValue(now.Year, 1, 1).AddDays(-1);
+        internal static readonly DateObject midautumnday = new DateObject(now.Year, 8, 15);
+        internal static readonly DateObject springday = new DateObject(now.Year, 1, 1);
+        internal static readonly DateObject chuxiday = new DateObject(now.Year, 1, 1).AddDays(-1);
 
-        internal static readonly DateObject lanternday = DateObject.MinValue.SetValue(now.Year, 1, 15);
-        internal static readonly DateObject qingmingday = DateObject.MinValue.SetValue(now.Year, 4, 4);
-        internal static readonly DateObject dragonboatday = DateObject.MinValue.SetValue(now.Year, 5, 5);
-        internal static readonly DateObject chongyangday = DateObject.MinValue.SetValue(now.Year, 9, 9);
+        internal static readonly DateObject lanternday = new DateObject(now.Year, 1, 15);
+        internal static readonly DateObject qingmingday = new DateObject(now.Year, 4, 4);
+        internal static readonly DateObject dragonboatday = new DateObject(now.Year, 5, 5);
+        internal static readonly DateObject chongyangday = new DateObject(now.Year, 9, 9);
     }
 
     #endregion

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/HolidayParserChs.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 if (hasYear)
                 {
                     ret.Timex = year.ToString("D4") + timexStr;
-                    ret.FutureValue = ret.PastValue = new DateObject(year, value.Month, value.Day);
+                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, value.Month, value.Day);
                     ret.Success = true;
                     return ret;
                 }
@@ -286,64 +286,64 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static DateObject GetMothersDayOfYear(int year)
         {
-            return new DateObject(year, 5, (from day in Enumerable.Range(1, 31)
-                where new DateObject(year, 5, day).DayOfWeek == DayOfWeek.Sunday
+            return DateObject.MinValue.SetValue(year, 5, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SetValue(year, 5, day).DayOfWeek == DayOfWeek.Sunday
                 select day).ElementAt(1));
         }
 
         private static DateObject GetFathersDayOfYear(int year)
         {
-            return new DateObject(year, 6, (from day in Enumerable.Range(1, 30)
-                where new DateObject(year, 6, day).DayOfWeek == DayOfWeek.Sunday
+            return DateObject.MinValue.SetValue(year, 6, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SetValue(year, 6, day).DayOfWeek == DayOfWeek.Sunday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetMartinLutherKingDayOfYear(int year)
         {
-            return new DateObject(year, 1, (from day in Enumerable.Range(1, 31)
-                where new DateObject(year, 1, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 1, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SetValue(year, 1, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetWashingtonsBirthdayOfYear(int year)
         {
-            return new DateObject(year, 2, (from day in Enumerable.Range(1, 29)
-                where new DateObject(year, 2, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 2, (from day in Enumerable.Range(1, 29)
+                where DateObject.MinValue.SetValue(year, 2, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(2));
         }
 
         private static DateObject GetCanberraDayOfYear(int year)
         {
-            return new DateObject(year, 3, (from day in Enumerable.Range(1, 31)
-                where new DateObject(year, 3, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 3, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SetValue(year, 3, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(0));
         }
 
         private static DateObject GetMemorialDayOfYear(int year)
         {
-            return new DateObject(year, 5, (from day in Enumerable.Range(1, 31)
-                where new DateObject(year, 5, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 5, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SetValue(year, 5, day).DayOfWeek == DayOfWeek.Monday
                 select day).Last());
         }
 
         private static DateObject GetLabourDayOfYear(int year)
         {
-            return new DateObject(year, 9, (from day in Enumerable.Range(1, 30)
-                where new DateObject(year, 9, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 9, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SetValue(year, 9, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(0));
         }
 
         private static DateObject GetColumbusDayOfYear(int year)
         {
-            return new DateObject(year, 10, (from day in Enumerable.Range(1, 31)
-                where new DateObject(year, 10, day).DayOfWeek == DayOfWeek.Monday
+            return DateObject.MinValue.SetValue(year, 10, (from day in Enumerable.Range(1, 31)
+                where DateObject.MinValue.SetValue(year, 10, day).DayOfWeek == DayOfWeek.Monday
                 select day).ElementAt(1));
         }
 
         private static DateObject GetThanksgivingDayOfYear(int year)
         {
-            return new DateObject(year, 11, (from day in Enumerable.Range(1, 30)
-                where new DateObject(year, 11, day).DayOfWeek == DayOfWeek.Thursday
+            return DateObject.MinValue.SetValue(year, 11, (from day in Enumerable.Range(1, 30)
+                where DateObject.MinValue.SetValue(year, 11, day).DayOfWeek == DayOfWeek.Thursday
                 select day).ElementAt(3));
         }
 
@@ -392,31 +392,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     internal static class TimexConstants
     {
         internal static readonly DateObject now = DateObject.Now;
-        internal static readonly DateObject yuandan = new DateObject(now.Year, 1, 1);
-        internal static readonly DateObject chsnationalday = new DateObject(now.Year, 10, 1);
-        internal static readonly DateObject laborday = new DateObject(now.Year, 5, 1);
-        internal static readonly DateObject christmasday = new DateObject(now.Year, 12, 25);
-        internal static readonly DateObject loverday = new DateObject(now.Year, 2, 14);
-        internal static readonly DateObject chsmilbuildday = new DateObject(now.Year, 8, 1);
-        internal static readonly DateObject foolday = new DateObject(now.Year, 4, 1);
-        internal static readonly DateObject girlsday = new DateObject(now.Year, 3, 7);
-        internal static readonly DateObject treeplantday = new DateObject(now.Year, 3, 12);
-        internal static readonly DateObject femaleday = new DateObject(now.Year, 3, 8);
-        internal static readonly DateObject childrenday = new DateObject(now.Year, 6, 1);
-        internal static readonly DateObject youthday = new DateObject(now.Year, 5, 4);
-        internal static readonly DateObject teacherday = new DateObject(now.Year, 9, 10);
-        internal static readonly DateObject singlesday = new DateObject(now.Year, 11, 11);
+        internal static readonly DateObject yuandan = DateObject.MinValue.SetValue(now.Year, 1, 1);
+        internal static readonly DateObject chsnationalday = DateObject.MinValue.SetValue(now.Year, 10, 1);
+        internal static readonly DateObject laborday = DateObject.MinValue.SetValue(now.Year, 5, 1);
+        internal static readonly DateObject christmasday = DateObject.MinValue.SetValue(now.Year, 12, 25);
+        internal static readonly DateObject loverday = DateObject.MinValue.SetValue(now.Year, 2, 14);
+        internal static readonly DateObject chsmilbuildday = DateObject.MinValue.SetValue(now.Year, 8, 1);
+        internal static readonly DateObject foolday = DateObject.MinValue.SetValue(now.Year, 4, 1);
+        internal static readonly DateObject girlsday = DateObject.MinValue.SetValue(now.Year, 3, 7);
+        internal static readonly DateObject treeplantday = DateObject.MinValue.SetValue(now.Year, 3, 12);
+        internal static readonly DateObject femaleday = DateObject.MinValue.SetValue(now.Year, 3, 8);
+        internal static readonly DateObject childrenday = DateObject.MinValue.SetValue(now.Year, 6, 1);
+        internal static readonly DateObject youthday = DateObject.MinValue.SetValue(now.Year, 5, 4);
+        internal static readonly DateObject teacherday = DateObject.MinValue.SetValue(now.Year, 9, 10);
+        internal static readonly DateObject singlesday = DateObject.MinValue.SetValue(now.Year, 11, 11);
 
-        internal static readonly DateObject halloweenday = new DateObject(now.Year, 10, 31);
+        internal static readonly DateObject halloweenday = DateObject.MinValue.SetValue(now.Year, 10, 31);
 
-        internal static readonly DateObject midautumnday = new DateObject(now.Year, 8, 15);
-        internal static readonly DateObject springday = new DateObject(now.Year, 1, 1);
-        internal static readonly DateObject chuxiday = new DateObject(now.Year, 1, 1).AddDays(-1);
+        internal static readonly DateObject midautumnday = DateObject.MinValue.SetValue(now.Year, 8, 15);
+        internal static readonly DateObject springday = DateObject.MinValue.SetValue(now.Year, 1, 1);
+        internal static readonly DateObject chuxiday = DateObject.MinValue.SetValue(now.Year, 1, 1).AddDays(-1);
 
-        internal static readonly DateObject lanternday = new DateObject(now.Year, 1, 15);
-        internal static readonly DateObject qingmingday = new DateObject(now.Year, 4, 4);
-        internal static readonly DateObject dragonboatday = new DateObject(now.Year, 5, 5);
-        internal static readonly DateObject chongyangday = new DateObject(now.Year, 9, 9);
+        internal static readonly DateObject lanternday = DateObject.MinValue.SetValue(now.Year, 1, 15);
+        internal static readonly DateObject qingmingday = DateObject.MinValue.SetValue(now.Year, 4, 4);
+        internal static readonly DateObject dragonboatday = DateObject.MinValue.SetValue(now.Year, 5, 5);
+        internal static readonly DateObject chongyangday = DateObject.MinValue.SetValue(now.Year, 9, 9);
     }
 
     #endregion

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 hour = 0;
             }
 
-            dtResult.FutureValue = dtResult.PastValue = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
+            dtResult.FutureValue = dtResult.PastValue = DateObject.MinValue.SafeCreateFromValue(year, month, day, hour, min, second);
             dtResult.Success = true;
             return dtResult;
         }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 hour = 0;
             }
 
-            dtResult.FutureValue = dtResult.PastValue = new DateObject(year, month, day, hour, min, second);
+            dtResult.FutureValue = dtResult.PastValue = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
             dtResult.Success = true;
             return dtResult;
         }

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
@@ -135,13 +135,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 min = leftResult.Minute > 0 ? leftResult.Minute : 0,
                 second = leftResult.Second > 0 ? leftResult.Second : 0;
 
-            var leftTime = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
+            var leftTime = DateObject.MinValue.SafeCreateFromValue(year, month, day, hour, min, second);
 
             hour = rightResult.Hour > 0 ? rightResult.Hour : 0;
             min = rightResult.Minute > 0 ? rightResult.Minute : 0;
             second = rightResult.Second > 0 ? rightResult.Second : 0;
 
-            var rightTime = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
+            var rightTime = DateObject.MinValue.SafeCreateFromValue(year, month, day, hour, min, second);
 
             if (rightTime.Hour < leftTime.Hour)
             {

--- a/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
@@ -135,13 +135,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 min = leftResult.Minute > 0 ? leftResult.Minute : 0,
                 second = leftResult.Second > 0 ? leftResult.Second : 0;
 
-            var leftTime = new DateObject(year, month, day, hour, min, second);
+            var leftTime = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
 
             hour = rightResult.Hour > 0 ? rightResult.Hour : 0;
             min = rightResult.Minute > 0 ? rightResult.Minute : 0;
             second = rightResult.Second > 0 ? rightResult.Second : 0;
 
-            var rightTime = new DateObject(year, month, day, hour, min, second);
+            var rightTime = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
 
             if (rightTime.Hour < leftTime.Hour)
             {

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -221,7 +221,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public bool HasConnectorToken(string text)
         {
-            return Regex.Match(text, DateTimeDefinitions.RangeConnectorRegex).Success;
+            var match = Regex.Match(text, DateTimeDefinitions.RangeConnectorRegex);
+            return match.Success && match.Length == text.Trim().Length;
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IExtractor DurationExtractor { get; }
 
+        //TODO: these three methods are the same in DatePeriod, should be abstracted
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
@@ -106,7 +107,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public bool HasConnectorToken(string text)
         {
-            return Regex.Match(text, DateTimeDefinitions.RangeConnectorRegex).Success;
+            var match = Regex.Match(text, DateTimeDefinitions.RangeConnectorRegex);
+            return match.Success && match.Length == text.Trim().Length;
         }
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
@@ -110,35 +110,35 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             };
         }
 
-        private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
-        private static DateObject NewYearEve(int year) => new DateObject(year, 12, 31);
-        private static DateObject ChristmasDay(int year) => new DateObject(year, 12, 25);
-        private static DateObject ChristmasEve(int year) => new DateObject(year, 12, 24);
-        private static DateObject ValentinesDay(int year) => new DateObject(year, 2, 14);
-        private static DateObject WhiteLoverDay(int year) => new DateObject(year, 3, 14);
-        private static DateObject FoolDay(int year) => new DateObject(year, 4, 1);
-        private static DateObject GirlsDay(int year) => new DateObject(year, 3, 7);
-        private static DateObject TreePlantDay(int year) => new DateObject(year, 3, 12);
-        private static DateObject FemaleDay(int year) => new DateObject(year, 3, 8);
-        private static DateObject ChildrenDay(int year) => new DateObject(year, 6, 1);
-        private static DateObject YouthDay(int year) => new DateObject(year, 5, 4);
-        private static DateObject TeacherDay(int year) => new DateObject(year, 9, 10);
-        private static DateObject SinglesDay(int year) => new DateObject(year, 11, 11);
-        private static DateObject MaoBirthday(int year) => new DateObject(year, 12, 26);
-        private static DateObject InaugurationDay(int year) => new DateObject(year, 1, 20);
-        private static DateObject GroundhogDay(int year) => new DateObject(year, 2, 2);
-        private static DateObject StPatrickDay(int year) => new DateObject(year, 3, 17);
-        private static DateObject StGeorgeDay(int year) => new DateObject(year, 4, 23);
-        private static DateObject Mayday(int year) => new DateObject(year, 5, 1);
-        private static DateObject CincoDeMayoday(int year) => new DateObject(year, 5, 5);
-        private static DateObject BaptisteDay(int year) => new DateObject(year, 6, 24);
-        private static DateObject UsaIndependenceDay(int year) => new DateObject(year, 7, 4);
-        private static DateObject BastilleDay(int year) => new DateObject(year, 7, 14);
-        private static DateObject HalloweenDay(int year) => new DateObject(year, 10, 31);
-        private static DateObject AllHallowDay(int year) => new DateObject(year, 11, 1);
-        private static DateObject AllSoulsday(int year) => new DateObject(year, 11, 2);
-        private static DateObject GuyFawkesDay(int year) => new DateObject(year, 11, 5);
-        private static DateObject Veteransday(int year) => new DateObject(year, 11, 11);
+        private static DateObject NewYear(int year) => DateObject.MinValue.SetValue(year, 1, 1);
+        private static DateObject NewYearEve(int year) => DateObject.MinValue.SetValue(year, 12, 31);
+        private static DateObject ChristmasDay(int year) => DateObject.MinValue.SetValue(year, 12, 25);
+        private static DateObject ChristmasEve(int year) => DateObject.MinValue.SetValue(year, 12, 24);
+        private static DateObject ValentinesDay(int year) => DateObject.MinValue.SetValue(year, 2, 14);
+        private static DateObject WhiteLoverDay(int year) => DateObject.MinValue.SetValue(year, 3, 14);
+        private static DateObject FoolDay(int year) => DateObject.MinValue.SetValue(year, 4, 1);
+        private static DateObject GirlsDay(int year) => DateObject.MinValue.SetValue(year, 3, 7);
+        private static DateObject TreePlantDay(int year) => DateObject.MinValue.SetValue(year, 3, 12);
+        private static DateObject FemaleDay(int year) => DateObject.MinValue.SetValue(year, 3, 8);
+        private static DateObject ChildrenDay(int year) => DateObject.MinValue.SetValue(year, 6, 1);
+        private static DateObject YouthDay(int year) => DateObject.MinValue.SetValue(year, 5, 4);
+        private static DateObject TeacherDay(int year) => DateObject.MinValue.SetValue(year, 9, 10);
+        private static DateObject SinglesDay(int year) => DateObject.MinValue.SetValue(year, 11, 11);
+        private static DateObject MaoBirthday(int year) => DateObject.MinValue.SetValue(year, 12, 26);
+        private static DateObject InaugurationDay(int year) => DateObject.MinValue.SetValue(year, 1, 20);
+        private static DateObject GroundhogDay(int year) => DateObject.MinValue.SetValue(year, 2, 2);
+        private static DateObject StPatrickDay(int year) => DateObject.MinValue.SetValue(year, 3, 17);
+        private static DateObject StGeorgeDay(int year) => DateObject.MinValue.SetValue(year, 4, 23);
+        private static DateObject Mayday(int year) => DateObject.MinValue.SetValue(year, 5, 1);
+        private static DateObject CincoDeMayoday(int year) => DateObject.MinValue.SetValue(year, 5, 5);
+        private static DateObject BaptisteDay(int year) => DateObject.MinValue.SetValue(year, 6, 24);
+        private static DateObject UsaIndependenceDay(int year) => DateObject.MinValue.SetValue(year, 7, 4);
+        private static DateObject BastilleDay(int year) => DateObject.MinValue.SetValue(year, 7, 14);
+        private static DateObject HalloweenDay(int year) => DateObject.MinValue.SetValue(year, 10, 31);
+        private static DateObject AllHallowDay(int year) => DateObject.MinValue.SetValue(year, 11, 1);
+        private static DateObject AllSoulsday(int year) => DateObject.MinValue.SetValue(year, 11, 2);
+        private static DateObject GuyFawkesDay(int year) => DateObject.MinValue.SetValue(year, 11, 5);
+        private static DateObject Veteransday(int year) => DateObject.MinValue.SetValue(year, 11, 11);
         
         public override int GetSwiftYear(string text)
         {

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
@@ -110,35 +110,35 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             };
         }
 
-        private static DateObject NewYear(int year) => DateObject.MinValue.SetValue(year, 1, 1);
-        private static DateObject NewYearEve(int year) => DateObject.MinValue.SetValue(year, 12, 31);
-        private static DateObject ChristmasDay(int year) => DateObject.MinValue.SetValue(year, 12, 25);
-        private static DateObject ChristmasEve(int year) => DateObject.MinValue.SetValue(year, 12, 24);
-        private static DateObject ValentinesDay(int year) => DateObject.MinValue.SetValue(year, 2, 14);
-        private static DateObject WhiteLoverDay(int year) => DateObject.MinValue.SetValue(year, 3, 14);
-        private static DateObject FoolDay(int year) => DateObject.MinValue.SetValue(year, 4, 1);
-        private static DateObject GirlsDay(int year) => DateObject.MinValue.SetValue(year, 3, 7);
-        private static DateObject TreePlantDay(int year) => DateObject.MinValue.SetValue(year, 3, 12);
-        private static DateObject FemaleDay(int year) => DateObject.MinValue.SetValue(year, 3, 8);
-        private static DateObject ChildrenDay(int year) => DateObject.MinValue.SetValue(year, 6, 1);
-        private static DateObject YouthDay(int year) => DateObject.MinValue.SetValue(year, 5, 4);
-        private static DateObject TeacherDay(int year) => DateObject.MinValue.SetValue(year, 9, 10);
-        private static DateObject SinglesDay(int year) => DateObject.MinValue.SetValue(year, 11, 11);
-        private static DateObject MaoBirthday(int year) => DateObject.MinValue.SetValue(year, 12, 26);
-        private static DateObject InaugurationDay(int year) => DateObject.MinValue.SetValue(year, 1, 20);
-        private static DateObject GroundhogDay(int year) => DateObject.MinValue.SetValue(year, 2, 2);
-        private static DateObject StPatrickDay(int year) => DateObject.MinValue.SetValue(year, 3, 17);
-        private static DateObject StGeorgeDay(int year) => DateObject.MinValue.SetValue(year, 4, 23);
-        private static DateObject Mayday(int year) => DateObject.MinValue.SetValue(year, 5, 1);
-        private static DateObject CincoDeMayoday(int year) => DateObject.MinValue.SetValue(year, 5, 5);
-        private static DateObject BaptisteDay(int year) => DateObject.MinValue.SetValue(year, 6, 24);
-        private static DateObject UsaIndependenceDay(int year) => DateObject.MinValue.SetValue(year, 7, 4);
-        private static DateObject BastilleDay(int year) => DateObject.MinValue.SetValue(year, 7, 14);
-        private static DateObject HalloweenDay(int year) => DateObject.MinValue.SetValue(year, 10, 31);
-        private static DateObject AllHallowDay(int year) => DateObject.MinValue.SetValue(year, 11, 1);
-        private static DateObject AllSoulsday(int year) => DateObject.MinValue.SetValue(year, 11, 2);
-        private static DateObject GuyFawkesDay(int year) => DateObject.MinValue.SetValue(year, 11, 5);
-        private static DateObject Veteransday(int year) => DateObject.MinValue.SetValue(year, 11, 11);
+        private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
+        private static DateObject NewYearEve(int year) => new DateObject(year, 12, 31);
+        private static DateObject ChristmasDay(int year) => new DateObject(year, 12, 25);
+        private static DateObject ChristmasEve(int year) => new DateObject(year, 12, 24);
+        private static DateObject ValentinesDay(int year) => new DateObject(year, 2, 14);
+        private static DateObject WhiteLoverDay(int year) => new DateObject(year, 3, 14);
+        private static DateObject FoolDay(int year) => new DateObject(year, 4, 1);
+        private static DateObject GirlsDay(int year) => new DateObject(year, 3, 7);
+        private static DateObject TreePlantDay(int year) => new DateObject(year, 3, 12);
+        private static DateObject FemaleDay(int year) => new DateObject(year, 3, 8);
+        private static DateObject ChildrenDay(int year) => new DateObject(year, 6, 1);
+        private static DateObject YouthDay(int year) => new DateObject(year, 5, 4);
+        private static DateObject TeacherDay(int year) => new DateObject(year, 9, 10);
+        private static DateObject SinglesDay(int year) => new DateObject(year, 11, 11);
+        private static DateObject MaoBirthday(int year) => new DateObject(year, 12, 26);
+        private static DateObject InaugurationDay(int year) => new DateObject(year, 1, 20);
+        private static DateObject GroundhogDay(int year) => new DateObject(year, 2, 2);
+        private static DateObject StPatrickDay(int year) => new DateObject(year, 3, 17);
+        private static DateObject StGeorgeDay(int year) => new DateObject(year, 4, 23);
+        private static DateObject Mayday(int year) => new DateObject(year, 5, 1);
+        private static DateObject CincoDeMayoday(int year) => new DateObject(year, 5, 5);
+        private static DateObject BaptisteDay(int year) => new DateObject(year, 6, 24);
+        private static DateObject UsaIndependenceDay(int year) => new DateObject(year, 7, 4);
+        private static DateObject BastilleDay(int year) => new DateObject(year, 7, 14);
+        private static DateObject HalloweenDay(int year) => new DateObject(year, 10, 31);
+        private static DateObject AllHallowDay(int year) => new DateObject(year, 11, 1);
+        private static DateObject AllSoulsday(int year) => new DateObject(year, 11, 2);
+        private static DateObject GuyFawkesDay(int year) => new DateObject(year, 11, 5);
+        private static DateObject Veteransday(int year) => new DateObject(year, 11, 11);
         
         public override int GetSwiftYear(string text)
         {

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 ret.Timex = "T" + hour.ToString("D2");
                 ret.FutureValue =
                     ret.PastValue =
-                        DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day, hour, 0, 0);
+                        DateObject.MinValue.SafeCreateFromValue(referenceTime.Year, referenceTime.Month, referenceTime.Day, hour, 0, 0);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 ret.Timex = "T" + hour.ToString("D2");
                 ret.FutureValue =
                     ret.PastValue =
-                        new DateObject(referenceTime.Year, referenceTime.Month, referenceTime.Day, hour, 0, 0);
+                        DateObject.MinValue.SetValue(referenceTime.Year, referenceTime.Month, referenceTime.Day, hour, 0, 0);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var tryStr = FormatUtil.LuisDate(year, month, day);
                 if (DateObject.TryParse(tryStr, out temp))
                 {
-                    futureDate = DateObject.MinValue.SetValue(year, month, day);
-                    pastDate = DateObject.MinValue.SetValue(year, month, day);
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
 
                     if (futureDate < referenceDate)
                     {
@@ -142,8 +142,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
                 else
                 {
-                    futureDate = DateObject.MinValue.SetValue(year, month + 1, day);
-                    pastDate = DateObject.MinValue.SetValue(year, month - 1, day);
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year, month + 1, day);
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year, month - 1, day);
                 }
 
 
@@ -284,8 +284,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // for LUIS format value string
             ret.Timex = FormatUtil.LuisDate(-1, month, day);
-            var futureDate = DateObject.MinValue.SetValue(year, month, day);
-            var pastDate = DateObject.MinValue.SetValue(year, month, day);
+            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
 
             if (futureDate < referenceDate)
             {
@@ -359,8 +359,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Timex = FormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SetValue(year, month, day);
-            var pastDate = DateObject.MinValue.SetValue(year, month, day);
+            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
 
             if (noYear && futureDate < referenceDate)
             {
@@ -460,7 +460,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static DateObject ComputeDate(int cardinal, int weekday, int month, int year)
         {
-            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
+            var firstDay = DateObject.MinValue.SafeCreateFromValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
 
             if (weekday == 0)

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var tryStr = FormatUtil.LuisDate(year, month, day);
                 if (DateObject.TryParse(tryStr, out temp))
                 {
-                    futureDate = new DateObject(year, month, day);
-                    pastDate = new DateObject(year, month, day);
+                    futureDate = DateObject.MinValue.SetValue(year, month, day);
+                    pastDate = DateObject.MinValue.SetValue(year, month, day);
 
                     if (futureDate < referenceDate)
                     {
@@ -142,8 +142,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
                 else
                 {
-                    futureDate = new DateObject(year, month + 1, day);
-                    pastDate = new DateObject(year, month - 1, day);
+                    futureDate = DateObject.MinValue.SetValue(year, month + 1, day);
+                    pastDate = DateObject.MinValue.SetValue(year, month - 1, day);
                 }
 
 
@@ -284,8 +284,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // for LUIS format value string
             ret.Timex = FormatUtil.LuisDate(-1, month, day);
-            var futureDate = new DateObject(year, month, day);
-            var pastDate = new DateObject(year, month, day);
+            var futureDate = DateObject.MinValue.SetValue(year, month, day);
+            var pastDate = DateObject.MinValue.SetValue(year, month, day);
 
             if (futureDate < referenceDate)
             {
@@ -359,8 +359,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Timex = FormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = new DateObject(year, month, day);
-            var pastDate = new DateObject(year, month, day);
+            var futureDate = DateObject.MinValue.SetValue(year, month, day);
+            var pastDate = DateObject.MinValue.SetValue(year, month, day);
 
             if (noYear && futureDate < referenceDate)
             {
@@ -460,7 +460,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static DateObject ComputeDate(int cardinal, int weekday, int month, int year)
         {
-            var firstDay = new DateObject(year, month, 1);
+            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
 
             if (weekday == 0)

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             int futureYear = year, pastYear = year;
-            var startDate = DateObject.MinValue.SetValue(year, month, beginDay);
+            var startDate = DateObject.MinValue.SafeCreateFromValue(year, month, beginDay);
 
             if (noYear && startDate < referenceDate)
             {
@@ -260,11 +260,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             ret.Timex = $"({beginLuisStr},{endLuisStr},P{endDay - beginDay}D)";
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(futureYear, month, beginDay),
-                DateObject.MinValue.SetValue(futureYear, month, endDay));
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, beginDay),
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, endDay));
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(pastYear, month, beginDay),
-                DateObject.MinValue.SetValue(pastYear, month, endDay));
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, beginDay),
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, endDay));
             ret.Success = true;
 
             return ret;
@@ -286,7 +286,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Timex = referenceDate.Year.ToString("D4");
                     ret.FutureValue =
                         ret.PastValue =
-                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(referenceDate.Year, 1, 1), referenceDate);
+                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(referenceDate.Year, 1, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -297,7 +297,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.FutureValue =
                         ret.PastValue =
                             new Tuple<DateObject, DateObject>(
-                                DateObject.MinValue.SetValue(referenceDate.Year, referenceDate.Month, 1), referenceDate);
+                                DateObject.MinValue.SafeCreateFromValue(referenceDate.Year, referenceDate.Month, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -377,10 +377,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                         ret.Timex = year.ToString("D4");
                         ret.FutureValue =
                             ret.PastValue =
-                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, 1, 1),
+                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, 1, 1),
                                     InclusiveEndPeriod
-                                    ? DateObject.MinValue.SetValue(year, 12, 31)
-                                    : DateObject.MinValue.SetValue(year, 12, 31).AddDays(1));
+                                    ? DateObject.MinValue.SafeCreateFromValue(year, 12, 31)
+                                    : DateObject.MinValue.SafeCreateFromValue(year, 12, 31).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
@@ -393,16 +393,16 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // only "month" will come to here
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(futureYear, month, 1),
+                DateObject.MinValue.SafeCreateFromValue(futureYear, month, 1),
                 InclusiveEndPeriod
-                ? DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1).AddDays(-1)
-                : DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1));
+                ? DateObject.MinValue.SafeCreateFromValue(futureYear, month, 1).AddMonths(1).AddDays(-1)
+                : DateObject.MinValue.SafeCreateFromValue(futureYear, month, 1).AddMonths(1));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(pastYear, month, 1),
+                DateObject.MinValue.SafeCreateFromValue(pastYear, month, 1),
                 InclusiveEndPeriod
-                ? DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1).AddDays(-1)
-                : DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1));
+                ? DateObject.MinValue.SafeCreateFromValue(pastYear, month, 1).AddMonths(1).AddDays(-1)
+                : DateObject.MinValue.SafeCreateFromValue(pastYear, month, 1).AddMonths(1));
 
             ret.Success = true;
 
@@ -441,10 +441,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                    DateObject.MinValue.SetValue(year, month, 1),
+                    DateObject.MinValue.SafeCreateFromValue(year, month, 1),
                     InclusiveEndPeriod
-                        ? DateObject.MinValue.SetValue(year, month, 1).AddMonths(1).AddDays(-1)
-                        : DateObject.MinValue.SetValue(year, month, 1).AddMonths(1));
+                        ? DateObject.MinValue.SafeCreateFromValue(year, month, 1).AddMonths(1).AddDays(-1)
+                        : DateObject.MinValue.SafeCreateFromValue(year, month, 1).AddMonths(1));
 
                 ret.Timex = year.ToString("D4") + "-" + month.ToString("D2");
 
@@ -462,11 +462,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var year = int.Parse(match.Value);
 
-                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
+                var beginDay = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
 
                 var endDay = InclusiveEndPeriod
-                        ? DateObject.MinValue.SetValue(year + 1, 1, 1).AddDays(-1)
-                        : DateObject.MinValue.SetValue(year + 1, 1, 1);
+                        ? DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1).AddDays(-1)
+                        : DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1);
 
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
@@ -749,8 +749,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             var quarterNum = this.config.CardinalMap[cardinalStr];
-            var beginDate = DateObject.MinValue.SetValue(year, quarterNum * 3 - 2, 1);
-            var endDate = DateObject.MinValue.SetValue(year, quarterNum * 3 + 1, 1);
+            var beginDate = DateObject.MinValue.SafeCreateFromValue(year, quarterNum * 3 - 2, 1);
+            var endDate = DateObject.MinValue.SafeCreateFromValue(year, quarterNum * 3 + 1, 1);
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
             ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P3M)";
             ret.Success = true;
@@ -832,15 +832,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private Tuple<DateObject, DateObject> GetMonthRangeFromDate(DateObject date)
         {
-            var startDate = DateObject.MinValue.SetValue(date.Year, date.Month, 1);
+            var startDate = DateObject.MinValue.SafeCreateFromValue(date.Year, date.Month, 1);
             DateObject endDate;
             if (date.Month < 12)
             {
-                endDate = DateObject.MinValue.SetValue(date.Year, date.Month + 1, 1);
+                endDate = DateObject.MinValue.SafeCreateFromValue(date.Year, date.Month + 1, 1);
             }
             else
             {
-                endDate = DateObject.MinValue.SetValue(date.Year + 1, 1, 1);
+                endDate = DateObject.MinValue.SafeCreateFromValue(date.Year + 1, 1, 1);
             }
             endDate = InclusiveEndPeriod ? endDate.AddDays(-1) : endDate;
             return new Tuple<DateObject, DateObject>(startDate, endDate);
@@ -855,7 +855,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var num = int.Parse(match.Groups["number"].ToString());
                 int year = referenceDate.Year;
                 ret.Timex = year.ToString("D4");
-                var firstDay = DateObject.MinValue.SetValue(year, 1, 1);
+                var firstDay = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
                 var firstWeekday = firstDay.This((DayOfWeek)1);
                 var value = firstWeekday.AddDays(7 * num);
                 var futureDate = value;
@@ -924,7 +924,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static DateObject ComputeDate(int cardinal, int weekday, int month, int year)
         {
-            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
+            var firstDay = DateObject.MinValue.SafeCreateFromValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
 
             if (weekday == 0)

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             int futureYear = year, pastYear = year;
-            var startDate = new DateObject(year, month, beginDay);
+            var startDate = DateObject.MinValue.SetValue(year, month, beginDay);
 
             if (noYear && startDate < referenceDate)
             {
@@ -260,11 +260,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             ret.Timex = $"({beginLuisStr},{endLuisStr},P{endDay - beginDay}D)";
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                new DateObject(futureYear, month, beginDay),
-                new DateObject(futureYear, month, endDay));
+                DateObject.MinValue.SetValue(futureYear, month, beginDay),
+                DateObject.MinValue.SetValue(futureYear, month, endDay));
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                new DateObject(pastYear, month, beginDay),
-                new DateObject(pastYear, month, endDay));
+                DateObject.MinValue.SetValue(pastYear, month, beginDay),
+                DateObject.MinValue.SetValue(pastYear, month, endDay));
             ret.Success = true;
 
             return ret;
@@ -286,7 +286,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Timex = referenceDate.Year.ToString("D4");
                     ret.FutureValue =
                         ret.PastValue =
-                            new Tuple<DateObject, DateObject>(new DateObject(referenceDate.Year, 1, 1), referenceDate);
+                            new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(referenceDate.Year, 1, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -297,7 +297,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.FutureValue =
                         ret.PastValue =
                             new Tuple<DateObject, DateObject>(
-                                new DateObject(referenceDate.Year, referenceDate.Month, 1), referenceDate);
+                                DateObject.MinValue.SetValue(referenceDate.Year, referenceDate.Month, 1), referenceDate);
                     ret.Success = true;
                     return ret;
                 }
@@ -377,10 +377,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                         ret.Timex = year.ToString("D4");
                         ret.FutureValue =
                             ret.PastValue =
-                                new Tuple<DateObject, DateObject>(new DateObject(year, 1, 1),
+                                new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, 1, 1),
                                     InclusiveEndPeriod
-                                    ? new DateObject(year, 12, 31)
-                                    : new DateObject(year, 12, 31).AddDays(1));
+                                    ? DateObject.MinValue.SetValue(year, 12, 31)
+                                    : DateObject.MinValue.SetValue(year, 12, 31).AddDays(1));
                         ret.Success = true;
                         return ret;
                     }
@@ -393,16 +393,16 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // only "month" will come to here
             ret.FutureValue = new Tuple<DateObject, DateObject>(
-                new DateObject(futureYear, month, 1),
+                DateObject.MinValue.SetValue(futureYear, month, 1),
                 InclusiveEndPeriod
-                ? new DateObject(futureYear, month, 1).AddMonths(1).AddDays(-1)
-                : new DateObject(futureYear, month, 1).AddMonths(1));
+                ? DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1).AddDays(-1)
+                : DateObject.MinValue.SetValue(futureYear, month, 1).AddMonths(1));
 
             ret.PastValue = new Tuple<DateObject, DateObject>(
-                new DateObject(pastYear, month, 1),
+                DateObject.MinValue.SetValue(pastYear, month, 1),
                 InclusiveEndPeriod
-                ? new DateObject(pastYear, month, 1).AddMonths(1).AddDays(-1)
-                : new DateObject(pastYear, month, 1).AddMonths(1));
+                ? DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1).AddDays(-1)
+                : DateObject.MinValue.SetValue(pastYear, month, 1).AddMonths(1));
 
             ret.Success = true;
 
@@ -441,10 +441,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                    new DateObject(year, month, 1),
+                    DateObject.MinValue.SetValue(year, month, 1),
                     InclusiveEndPeriod
-                        ? new DateObject(year, month, 1).AddMonths(1).AddDays(-1)
-                        : new DateObject(year, month, 1).AddMonths(1));
+                        ? DateObject.MinValue.SetValue(year, month, 1).AddMonths(1).AddDays(-1)
+                        : DateObject.MinValue.SetValue(year, month, 1).AddMonths(1));
 
                 ret.Timex = year.ToString("D4") + "-" + month.ToString("D2");
 
@@ -462,11 +462,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var year = int.Parse(match.Value);
 
-                var beginDay = new DateObject(year, 1, 1);
+                var beginDay = DateObject.MinValue.SetValue(year, 1, 1);
 
                 var endDay = InclusiveEndPeriod
-                        ? new DateObject(year + 1, 1, 1).AddDays(-1)
-                        : new DateObject(year + 1, 1, 1);
+                        ? DateObject.MinValue.SetValue(year + 1, 1, 1).AddDays(-1)
+                        : DateObject.MinValue.SetValue(year + 1, 1, 1);
 
                 ret.Timex = year.ToString("D4");
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
@@ -749,8 +749,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             var quarterNum = this.config.CardinalMap[cardinalStr];
-            var beginDate = new DateObject(year, quarterNum * 3 - 2, 1);
-            var endDate = new DateObject(year, quarterNum * 3 + 1, 1);
+            var beginDate = DateObject.MinValue.SetValue(year, quarterNum * 3 - 2, 1);
+            var endDate = DateObject.MinValue.SetValue(year, quarterNum * 3 + 1, 1);
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
             ret.Timex = $"({FormatUtil.LuisDate(beginDate)},{FormatUtil.LuisDate(endDate)},P3M)";
             ret.Success = true;
@@ -832,15 +832,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private Tuple<DateObject, DateObject> GetMonthRangeFromDate(DateObject date)
         {
-            var startDate = new DateObject(date.Year, date.Month, 1);
+            var startDate = DateObject.MinValue.SetValue(date.Year, date.Month, 1);
             DateObject endDate;
             if (date.Month < 12)
             {
-                endDate = new DateObject(date.Year, date.Month + 1, 1);
+                endDate = DateObject.MinValue.SetValue(date.Year, date.Month + 1, 1);
             }
             else
             {
-                endDate = new DateObject(date.Year + 1, 1, 1);
+                endDate = DateObject.MinValue.SetValue(date.Year + 1, 1, 1);
             }
             endDate = InclusiveEndPeriod ? endDate.AddDays(-1) : endDate;
             return new Tuple<DateObject, DateObject>(startDate, endDate);
@@ -855,7 +855,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var num = int.Parse(match.Groups["number"].ToString());
                 int year = referenceDate.Year;
                 ret.Timex = year.ToString("D4");
-                var firstDay = new DateObject(year, 1, 1);
+                var firstDay = DateObject.MinValue.SetValue(year, 1, 1);
                 var firstWeekday = firstDay.This((DayOfWeek)1);
                 var value = firstWeekday.AddDays(7 * num);
                 var futureDate = value;
@@ -924,7 +924,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static DateObject ComputeDate(int cardinal, int weekday, int month, int year)
         {
-            var firstDay = new DateObject(year, month, 1);
+            var firstDay = DateObject.MinValue.SetValue(year, month, 1);
             var firstWeekday = firstDay.This((DayOfWeek)weekday);
 
             if (weekday == 0)

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -192,8 +192,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 //ret.Timex += "ampm";
                 ret.Comment = "ampm";
             }
-            ret.FutureValue = new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
-            ret.PastValue = new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
+            ret.FutureValue = DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
+            ret.PastValue = DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
             ret.Success = true;
 
             return ret;
@@ -277,7 +277,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
-                ret.FutureValue = ret.PastValue = new DateObject(date.Year, date.Month, date.Day, hour, min, sec);
+                ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(date.Year, date.Month, date.Day, hour, min, sec);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -192,8 +192,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                 //ret.Timex += "ampm";
                 ret.Comment = "ampm";
             }
-            ret.FutureValue = DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
-            ret.PastValue = DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
+            ret.FutureValue = DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, hour, min, sec);
+            ret.PastValue = DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, hour, min, sec);
             ret.Success = true;
 
             return ret;
@@ -277,7 +277,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 timeStr = "T" + hour.ToString("D2") + timeStr.Substring(3);
 
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
-                ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(date.Year, date.Month, date.Day, hour, min, sec);
+                ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(date.Year, date.Month, date.Day, hour, min, sec);
                 ret.Success = true;
                 return ret;
             }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -208,12 +208,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Timex = $"({beginStr},{endStr},PT{endHour - beginHour}H)";
 
                 ret.FutureValue = new Tuple<DateObject, DateObject>(
-                    DateObject.MinValue.SetValue(futureTime.Year, futureTime.Month, futureTime.Day, beginHour, 0, 0),
-                    DateObject.MinValue.SetValue(futureTime.Year, futureTime.Month, futureTime.Day, endHour, 0, 0));
+                    DateObject.MinValue.SafeCreateFromValue(futureTime.Year, futureTime.Month, futureTime.Day, beginHour, 0, 0),
+                    DateObject.MinValue.SafeCreateFromValue(futureTime.Year, futureTime.Month, futureTime.Day, endHour, 0, 0));
 
                 ret.PastValue = new Tuple<DateObject, DateObject>(
-                    DateObject.MinValue.SetValue(pastTime.Year, pastTime.Month, pastTime.Day, beginHour, 0, 0),
-                    DateObject.MinValue.SetValue(pastTime.Year, pastTime.Month, pastTime.Day, endHour, 0, 0));
+                    DateObject.MinValue.SafeCreateFromValue(pastTime.Year, pastTime.Month, pastTime.Day, beginHour, 0, 0),
+                    DateObject.MinValue.SafeCreateFromValue(pastTime.Year, pastTime.Month, pastTime.Day, endHour, 0, 0));
 
                 ret.Success = true;
 
@@ -310,10 +310,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else if (beginHasDate)
             {
-                futureEnd = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
+                futureEnd = DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
                     futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
 
-                pastEnd = DateObject.MinValue.SetValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
+                pastEnd = DateObject.MinValue.SafeCreateFromValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
                     pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
 
                 var dateStr = pr1.TimexStr.Split('T')[0];
@@ -322,10 +322,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else if (endHasDate)
             {
-                futureBegin = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
+                futureBegin = DateObject.MinValue.SafeCreateFromValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
                     futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
 
-                pastBegin = DateObject.MinValue.SetValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
+                pastBegin = DateObject.MinValue.SafeCreateFromValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
                     pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
 
                 var dateStr = pr2.TimexStr.Split('T')[0];
@@ -414,8 +414,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
 
                 ret.Success = true;
                 return ret;
@@ -446,13 +446,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -208,12 +208,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Timex = $"({beginStr},{endStr},PT{endHour - beginHour}H)";
 
                 ret.FutureValue = new Tuple<DateObject, DateObject>(
-                    new DateObject(futureTime.Year, futureTime.Month, futureTime.Day, beginHour, 0, 0),
-                    new DateObject(futureTime.Year, futureTime.Month, futureTime.Day, endHour, 0, 0));
+                    DateObject.MinValue.SetValue(futureTime.Year, futureTime.Month, futureTime.Day, beginHour, 0, 0),
+                    DateObject.MinValue.SetValue(futureTime.Year, futureTime.Month, futureTime.Day, endHour, 0, 0));
 
                 ret.PastValue = new Tuple<DateObject, DateObject>(
-                    new DateObject(pastTime.Year, pastTime.Month, pastTime.Day, beginHour, 0, 0),
-                    new DateObject(pastTime.Year, pastTime.Month, pastTime.Day, endHour, 0, 0));
+                    DateObject.MinValue.SetValue(pastTime.Year, pastTime.Month, pastTime.Day, beginHour, 0, 0),
+                    DateObject.MinValue.SetValue(pastTime.Year, pastTime.Month, pastTime.Day, endHour, 0, 0));
 
                 ret.Success = true;
 
@@ -310,10 +310,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else if (beginHasDate)
             {
-                futureEnd = new DateObject(futureBegin.Year, futureBegin.Month, futureBegin.Day,
+                futureEnd = DateObject.MinValue.SetValue(futureBegin.Year, futureBegin.Month, futureBegin.Day,
                     futureEnd.Hour, futureEnd.Minute, futureEnd.Second);
 
-                pastEnd = new DateObject(pastBegin.Year, pastBegin.Month, pastBegin.Day,
+                pastEnd = DateObject.MinValue.SetValue(pastBegin.Year, pastBegin.Month, pastBegin.Day,
                     pastEnd.Hour, pastEnd.Minute, pastEnd.Second);
 
                 var dateStr = pr1.TimexStr.Split('T')[0];
@@ -322,10 +322,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else if (endHasDate)
             {
-                futureBegin = new DateObject(futureEnd.Year, futureEnd.Month, futureEnd.Day,
+                futureBegin = DateObject.MinValue.SetValue(futureEnd.Year, futureEnd.Month, futureEnd.Day,
                     futureBegin.Hour, futureBegin.Minute, futureBegin.Second);
 
-                pastBegin = new DateObject(pastEnd.Year, pastEnd.Month, pastEnd.Day,
+                pastBegin = DateObject.MinValue.SetValue(pastEnd.Year, pastEnd.Month, pastEnd.Day,
                     pastBegin.Hour, pastBegin.Minute, pastBegin.Second);
 
                 var dateStr = pr2.TimexStr.Split('T')[0];
@@ -414,8 +414,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(new DateObject(year, month, day, beginHour, 0, 0),
-                            new DateObject(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
 
                 ret.Success = true;
                 return ret;
@@ -446,13 +446,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (hasYear)
                 {
                     ret.Timex = year.ToString("D4") + timexStr;
-                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, value.Month, value.Day);
+                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(year, value.Month, value.Day);
                     ret.Success = true;
                     return ret;
                 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (hasYear)
                 {
                     ret.Timex = year.ToString("D4") + timexStr;
-                    ret.FutureValue = ret.PastValue = new DateObject(year, value.Month, value.Day);
+                    ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, value.Month, value.Day);
                     ret.Success = true;
                     return ret;
                 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
@@ -60,32 +60,32 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public abstract string SanitizeHolidayToken(string holiday);
 
-        private static DateObject MothersDay(int year) => DateObject.MinValue.SetValue(year, 5, GetDay(year, 5, 1, DayOfWeek.Sunday));
+        private static DateObject MothersDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 5, GetDay(year, 5, 1, DayOfWeek.Sunday));
 
-        private static DateObject FathersDay(int year) => DateObject.MinValue.SetValue(year, 6, GetDay(year, 6, 2, DayOfWeek.Sunday));
+        private static DateObject FathersDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 6, GetDay(year, 6, 2, DayOfWeek.Sunday));
 
-        private static DateObject MartinLutherKingDay(int year) => DateObject.MinValue.SetValue(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
+        private static DateObject MartinLutherKingDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
 
-        private static DateObject WashingtonsBirthday(int year) => DateObject.MinValue.SetValue(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
+        private static DateObject WashingtonsBirthday(int year) => DateObject.MinValue.SafeCreateFromValue(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
 
-        private static DateObject CanberraDay(int year) => DateObject.MinValue.SetValue(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
+        private static DateObject CanberraDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
 
-        private static DateObject MemorialDay(int year) => DateObject.MinValue.SetValue(year, 5, GetLastDay(year, 5, DayOfWeek.Monday));
+        private static DateObject MemorialDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 5, GetLastDay(year, 5, DayOfWeek.Monday));
 
-        private static DateObject LabourDay(int year) => DateObject.MinValue.SetValue(year, 9, GetDay(year, 9, 0, DayOfWeek.Monday));
+        private static DateObject LabourDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 9, GetDay(year, 9, 0, DayOfWeek.Monday));
 
-        private static DateObject ColumbusDay(int year) => DateObject.MinValue.SetValue(year, 10, GetDay(year, 10, 1, DayOfWeek.Monday));
+        private static DateObject ColumbusDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 10, GetDay(year, 10, 1, DayOfWeek.Monday));
 
-        private static DateObject ThanksgivingDay(int year) => DateObject.MinValue.SetValue(year, 11, GetDay(year, 11, 3, DayOfWeek.Thursday));
+        private static DateObject ThanksgivingDay(int year) => DateObject.MinValue.SafeCreateFromValue(year, 11, GetDay(year, 11, 3, DayOfWeek.Thursday));
 
         protected static int GetDay(int year, int month, int week, DayOfWeek dayOfWeek) =>
             (from day in Enumerable.Range(1, DateObject.DaysInMonth(year, month))
-             where DateObject.MinValue.SetValue(year, month, day).DayOfWeek == dayOfWeek
+             where DateObject.MinValue.SafeCreateFromValue(year, month, day).DayOfWeek == dayOfWeek
              select day).ElementAt(week);
 
         protected static int GetLastDay(int year, int month, DayOfWeek dayOfWeek) =>
             (from day in Enumerable.Range(1, DateObject.DaysInMonth(year, month))
-             where DateObject.MinValue.SetValue(year, month, day).DayOfWeek == dayOfWeek
+             where DateObject.MinValue.SafeCreateFromValue(year, month, day).DayOfWeek == dayOfWeek
              select day).Last();
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
@@ -60,32 +60,32 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public abstract string SanitizeHolidayToken(string holiday);
 
-        private static DateObject MothersDay(int year) => new DateObject(year, 5, GetDay(year, 5, 1, DayOfWeek.Sunday));
+        private static DateObject MothersDay(int year) => DateObject.MinValue.SetValue(year, 5, GetDay(year, 5, 1, DayOfWeek.Sunday));
 
-        private static DateObject FathersDay(int year) => new DateObject(year, 6, GetDay(year, 6, 2, DayOfWeek.Sunday));
+        private static DateObject FathersDay(int year) => DateObject.MinValue.SetValue(year, 6, GetDay(year, 6, 2, DayOfWeek.Sunday));
 
-        private static DateObject MartinLutherKingDay(int year) => new DateObject(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
+        private static DateObject MartinLutherKingDay(int year) => DateObject.MinValue.SetValue(year, 1, GetDay(year, 1, 2, DayOfWeek.Monday));
 
-        private static DateObject WashingtonsBirthday(int year) => new DateObject(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
+        private static DateObject WashingtonsBirthday(int year) => DateObject.MinValue.SetValue(year, 2, GetDay(year, 2, 2, DayOfWeek.Monday));
 
-        private static DateObject CanberraDay(int year) => new DateObject(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
+        private static DateObject CanberraDay(int year) => DateObject.MinValue.SetValue(year, 3, GetDay(year, 3, 0, DayOfWeek.Monday));
 
-        private static DateObject MemorialDay(int year) => new DateObject(year, 5, GetLastDay(year, 5, DayOfWeek.Monday));
+        private static DateObject MemorialDay(int year) => DateObject.MinValue.SetValue(year, 5, GetLastDay(year, 5, DayOfWeek.Monday));
 
-        private static DateObject LabourDay(int year) => new DateObject(year, 9, GetDay(year, 9, 0, DayOfWeek.Monday));
+        private static DateObject LabourDay(int year) => DateObject.MinValue.SetValue(year, 9, GetDay(year, 9, 0, DayOfWeek.Monday));
 
-        private static DateObject ColumbusDay(int year) => new DateObject(year, 10, GetDay(year, 10, 1, DayOfWeek.Monday));
+        private static DateObject ColumbusDay(int year) => DateObject.MinValue.SetValue(year, 10, GetDay(year, 10, 1, DayOfWeek.Monday));
 
-        private static DateObject ThanksgivingDay(int year) => new DateObject(year, 11, GetDay(year, 11, 3, DayOfWeek.Thursday));
+        private static DateObject ThanksgivingDay(int year) => DateObject.MinValue.SetValue(year, 11, GetDay(year, 11, 3, DayOfWeek.Thursday));
 
         protected static int GetDay(int year, int month, int week, DayOfWeek dayOfWeek) =>
             (from day in Enumerable.Range(1, DateObject.DaysInMonth(year, month))
-             where new DateObject(year, month, day).DayOfWeek == dayOfWeek
+             where DateObject.MinValue.SetValue(year, month, day).DayOfWeek == dayOfWeek
              select day).ElementAt(week);
 
         protected static int GetLastDay(int year, int month, DayOfWeek dayOfWeek) =>
             (from day in Enumerable.Range(1, DateObject.DaysInMonth(year, month))
-             where new DateObject(year, month, day).DayOfWeek == dayOfWeek
+             where DateObject.MinValue.SetValue(year, month, day).DayOfWeek == dayOfWeek
              select day).Last();
     }
 }

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         protected readonly IMergedParserConfiguration Config;
 
+        public static readonly string DateMinString = FormatUtil.FormatDate(DateObject.MinValue);
+        public static readonly string DateTimeMinString = FormatUtil.FormatDateTime(DateObject.MinValue);
+
         public BaseMergedParser(IMergedParserConfiguration configuration)
         {
             Config = configuration;
@@ -187,7 +190,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             // if past and future are same, keep only one
             if (resolutionFuture.OrderBy(t => t.Key).Select(t => t.Value)
-                                                    .SequenceEqual(resolutionPast.OrderBy(t => t.Key).Select(t => t.Value)))
+                .SequenceEqual(resolutionPast.OrderBy(t => t.Key).Select(t => t.Value)))
             {
                 if (resolutionPast.Count > 0)
                 {
@@ -380,7 +383,9 @@ namespace Microsoft.Recognizers.Text.DateTime
         public void AddSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type, string mod, 
             Dictionary<string, string> res)
         {
-            if (resolutionDic.ContainsKey(type))
+            if (resolutionDic.ContainsKey(type) 
+                && !resolutionDic[type].Equals(DateMinString)
+                && !resolutionDic[type].Equals(DateTimeMinString))
             {
                 if (!string.IsNullOrEmpty(mod))
                 {

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // pop, restore the MOD string
-            if (hasBefore)
+            if (hasBefore && pr.Value != null)
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -102,7 +102,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if (hasAfter)
+            if (hasAfter && pr.Value != null)
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -145,6 +145,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public SortedDictionary<string, object> DateTimeResolution(DateTimeParseResult slot, bool hasBefore, bool hasAfter)
         {
+            if (slot == null)
+            {
+                return null;
+            }
             var resolutions = new List<Dictionary<string, string>>();
             var res = new Dictionary<string, object>();
 

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Comment = "ampm";
             }
 
-            ret.FutureValue = ret.PastValue = new DateObject(year, month, day, hour, min, second);
+            ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
             ret.Success = true;
 
             return ret;

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Comment = "ampm";
             }
 
-            ret.FutureValue = ret.PastValue = DateObject.MinValue.SetValue(year, month, day, hour, min, second);
+            ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(year, month, day, hour, min, second);
             ret.Success = true;
 
             return ret;

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -167,8 +167,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Timex = $"({beginStr},{endStr},PT{endHour - beginHour}H)";
 
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                        new DateObject(year, month, day, beginHour, 0, 0),
-                        new DateObject(year, month, day, endHour, 0, 0));
+                        DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(year, month, day, endHour, 0, 0));
 
                     ret.Success = true;
 
@@ -267,8 +267,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             ret.Timex = timex;
 
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                new DateObject(year, month, day, beginHour, 0, 0),
-                new DateObject(year, month, day, endHour, endMinSeg, endMinSeg)
+                DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                DateObject.MinValue.SetValue(year, month, day, endHour, endMinSeg, endMinSeg)
                 );
 
             ret.Success = true;

--- a/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -167,8 +167,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Timex = $"({beginStr},{endStr},PT{endHour - beginHour}H)";
 
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(year, month, day, endHour, 0, 0));
+                        DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, 0, 0));
 
                     ret.Success = true;
 
@@ -267,8 +267,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             ret.Timex = timex;
 
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
-                DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                DateObject.MinValue.SetValue(year, month, day, endHour, endMinSeg, endMinSeg)
+                DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMinSeg, endMinSeg)
                 );
 
             ret.Success = true;

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -17,11 +17,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex DayRegex =
             new Regex(
-                @"(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)",
+                @"(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(?=\b|t)",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(@"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)",
+            new Regex(@"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex YearRegex = new Regex(@"(?<year>19\d{2}|20\d{2}|9\d|0\d|1\d|2\d)",
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex WeekDayRegex =
             new Regex(
-                @"(?<weekday>Domingo|Lunes|Martes|Mi[eé]rcoles|Jueves|Viernes|S[aá]bado|Lu|Ma|Mi|Ju|Vi|Sa|Do)",
+                @"(?<weekday>Domingo|Lunes|Martes|Mi[eé]rcoles|Jueves|Viernes|S[aá]bado|Lu|Ma|Mi|Ju|Vi|Sa|Do)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex OnRegex = new Regex($@"(?<=\ben\s+)({DayRegex}s?)\b",

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex YearRegex = new Regex(@"\b(?<year>19\d{2}|20\d{2})\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex RelativeMonthRegex = new Regex(@"(?<relmonth>(este|pr[oó]ximo|[uú]ltimo)\s+mes)",
+        public static readonly Regex RelativeMonthRegex = new Regex(@"(?<relmonth>(este|pr[oó]ximo|[uú]ltimo)\s+mes)\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex EngMonthRegex =

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(new DateObject(year, month, day, beginHour, 0, 0),
-                            new DateObject(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -62,13 +62,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        new DateObject(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        new DateObject(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 ret.Timex = FormatUtil.FormatDate(date) + timeStr;
                 ret.FutureValue =
                     ret.PastValue =
-                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SetValue(year, month, day, beginHour, 0, 0),
-                            DateObject.MinValue.SetValue(year, month, day, endHour, endMin, endMin));
+                        new Tuple<DateObject, DateObject>(DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
+                            DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMin, endMin));
                 ret.Success = true;
                 return ret;
             }
@@ -62,13 +62,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
                 ret.FutureValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(futureDate.Year, futureDate.Month, futureDate.Day, endHour, endMin, endMin));
 
                 ret.PastValue =
                     new Tuple<DateObject, DateObject>(
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
-                        DateObject.MinValue.SetValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, beginHour, 0, 0),
+                        DateObject.MinValue.SafeCreateFromValue(pastDate.Year, pastDate.Month, pastDate.Day, endHour, endMin, endMin));
 
                 ret.Success = true;
 

--- a/Microsoft.Recognizers.Text.DateTime/Utilities/DateObjectExtension.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Utilities/DateObjectExtension.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return from.AddDays(target - start - 7);
         }
 
-        public static System.DateTime SetValue(this System.DateTime datetime, int year, int month, int day)
+        public static System.DateTime SafeCreateFromValue(this System.DateTime datetime, int year, int month, int day)
         {
             if (IsValidDate(year, month, day))
             {
@@ -70,11 +70,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             return datetime;
         }
 
-        public static System.DateTime SetValue(this System.DateTime datetime, int year, int month, int day, int hour, int minute, int second)
+        public static System.DateTime SafeCreateFromValue(this System.DateTime datetime, int year, int month, int day, int hour, int minute, int second)
         {
             if (IsValidDate(year, month, day) && IsValidTime(hour, minute, second))
             {
-                datetime = datetime.SetValue(year, month, day);
+                datetime = datetime.SafeCreateFromValue(year, month, day);
                 datetime = datetime.AddHours(hour - datetime.Hour);
                 datetime = datetime.AddMinutes(minute - datetime.Minute);
                 datetime = datetime.AddSeconds(second - datetime.Second);

--- a/Microsoft.Recognizers.Text.DateTime/Utilities/DateObjectExtension.cs
+++ b/Microsoft.Recognizers.Text.DateTime/Utilities/DateObjectExtension.cs
@@ -57,5 +57,59 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             return from.AddDays(target - start - 7);
         }
+
+        public static System.DateTime SetValue(this System.DateTime datetime, int year, int month, int day)
+        {
+            if (IsValidDate(year, month, day))
+            {
+                datetime = datetime.AddYears(year - datetime.Year);
+                datetime = datetime.AddMonths(month - datetime.Month);
+                datetime = datetime.AddDays(day - datetime.Day);
+            }
+
+            return datetime;
+        }
+
+        public static System.DateTime SetValue(this System.DateTime datetime, int year, int month, int day, int hour, int minute, int second)
+        {
+            if (IsValidDate(year, month, day) && IsValidTime(hour, minute, second))
+            {
+                datetime = datetime.SetValue(year, month, day);
+                datetime = datetime.AddHours(hour - datetime.Hour);
+                datetime = datetime.AddMinutes(minute - datetime.Minute);
+                datetime = datetime.AddSeconds(second - datetime.Second);
+            }
+
+            return datetime;
+        }
+
+        public static bool IsValidDate(int year, int month, int day)
+        {
+            if (year < 1 || year > 9999)
+            {
+                return false;
+            }
+            int[] validDays =
+            {
+                31,
+                year %4 == 0 && year%100 != 0 || year%400 == 0 ? 29 : 28,
+                31,
+                30,
+                31,
+                30,
+                31,
+                31,
+                30,
+                31,
+                30,
+                31
+            };
+            return month >= 1 && month <= 12 && day >= 1 && day <= validDays[month - 1];
+        }
+
+        public static bool IsValidTime(int hour, int minute, int second)
+        {
+            return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59;
+        }
     }
 }

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -12,15 +12,15 @@ PastPrefixRegex: !simpleRegex
 ThisPrefixRegex: !simpleRegex
   def: (this|current|over the)\b
 DayRegex: !simpleRegex
-  def: (the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)
+  def: (the\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21|22nd|22|23rd|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)(?=\b|t)
 MonthNumRegex: !simpleRegex
-  def: (?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)
+  def: (?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b
 PeriodYearRegex: !simpleRegex
   def: \b(?<year>19\d{2}|20\d{2})\b
 WeekDayRegex: !simpleRegex
-  def: (?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)
+  def: (?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)\b
 RelativeMonthRegex: !nestedRegex
-  def: (?<relmonth>{RelativeRegex}\s+month)
+  def: (?<relmonth>{RelativeRegex}\s+month)\b
   references: [RelativeRegex]
 EngMonthRegex: !simpleRegex
   def: (?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sept|Sep)


### PR DESCRIPTION
1. change the new DateObject to DateObject.SetValue extension method which will check if the date object is valid or not to avoid argument exceptions.
2. fix the bug in "to" as a connector to restrict the exact match
3. restrict the month regex and day regex to end with '\b'