### PR TITLE
Change from using List.Sort unstable sort to stable LINQ OrderBy

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimeExtractorChs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
@@ -65,21 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 return ret;
             }
 
-            ers.Sort(delegate(ExtractResult er1, ExtractResult er2)
-            {
-                var start1 = er1.Start ?? 0;
-                var start2 = er2.Start ?? 0;
-                if (start1 < start2)
-                {
-                    return -1;
-                }
-
-                if (start1 == start2)
-                {
-                    return 0;
-                }
-                return 1;
-            });
+            ers = ers.OrderBy(o => o.Start).ToList();
 
             var i = 0;
             while (i < ers.Count - 1)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Text.Number.Chinese;
@@ -110,17 +111,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 timePoints.Add(er2[j]);
             }
 
-            timePoints.Sort(delegate(ExtractResult er_1, ExtractResult er_2)
-            {
-                var start1 = er_1.Start ?? 0;
-                var start2 = er_2.Start ?? 0;
-                if (start1 < start2)
-                {
-                    return -1;
-                }
-
-                return start1 == start2 ? 0 : 1;
-            });
+            timePoints = timePoints.OrderBy(o => o.Start).ToList();
 
             // merge {Date} {TimePeriod}
             var idx = 0;
@@ -178,17 +169,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 timePoints.Add(er2[j]);
             }
 
-            timePoints.Sort(delegate(ExtractResult er_1, ExtractResult er_2)
-            {
-                var start1 = er_1.Start ?? 0;
-                var start2 = er_2.Start ?? 0;
-                if (start1 < start2)
-                {
-                    return -1;
-                }
-
-                return start1 == start2 ? 0 : 1;
-            });
+            timePoints = timePoints.OrderBy(o => o.Start).ToList();
 
             // merge "{TimePoint} to {TimePoint}", "between {TimePoint} and {TimePoint}"
             var idx = 0;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
@@ -60,22 +60,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 return ret;
             }
 
-            ers.Sort(delegate (ExtractResult er1, ExtractResult er2)
-            {
-                var start1 = er1.Start ?? 0;
-                var start2 = er2.Start ?? 0;
-                if (start1 < start2)
-                {
-                    return -1;
-                }
-
-                if (start1 == start2)
-                {
-                    return 0;
-                }
-
-                return 1;
-            });
+            ers = ers.OrderBy(o => o.Start).ToList();
 
             var i = 0;
             while (i < ers.Count - 1)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Linq;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
@@ -103,22 +104,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 timePoints.Add(er2[j]);
             }
 
-            timePoints.Sort(delegate (ExtractResult er_1, ExtractResult er_2)
-            {
-                var start1 = er_1.Start ?? 0;
-                var start2 = er_2.Start ?? 0;
-                if (start1 < start2)
-                {
-                    return -1;
-                }
-
-                if (start1 == start2)
-                {
-                    return 0;
-                }
-
-                return 1;
-            });
+            timePoints = timePoints.OrderBy(o => o.Start).ToList();
 
 
             // merge "{TimePoint} to {TimePoint}", "between {TimePoint} and {TimePoint}"


### PR DESCRIPTION
An issue arise when running the tests through MsTest.exe
Sorting two extraction results with the same Start index (and different length) returns different orders using MsTest.exe and Visual Studio Test Runner.
The first extraction may be placed second, making the extraction behave differently between test runners.

Cause:  C# List.Sort uses quicksort internally which is  unstable (see remarks on https://msdn.microsoft.com/en-us/library/w56d4y5z(v=vs.110).aspx)
   "This implementation performs an unstable sort; that is, if two elements are equal, their order might not be preserved. In contrast, a stable sort preserves the order of elements that are equal."

Fix: use LINQ OrderBy which is stable - https://msdn.microsoft.com/en-us/library/bb534966.aspx
   "This method performs a stable sort; that is, if the keys of two elements are equal, the order of the elements is preserved. "