### PR TITLE
TypeScript - Proper filename casing when importing modules

### DIFF
--- a/JavaScript/src/dateTime/english/dateTimeConfiguration.ts
+++ b/JavaScript/src/dateTime/english/dateTimeConfiguration.ts
@@ -11,7 +11,7 @@ import { EnglishDateTimeUtilityConfiguration } from "./baseConfiguration"
 import { IDateTimeUtilityConfiguration } from "../utilities";
 import { EnglishDurationExtractorConfiguration } from "./durationConfiguration"
 import { EnglishDateExtractorConfiguration } from "./dateConfiguration"
-import { EnglishTimeExtractorConfiguration } from "./TimeConfiguration"
+import { EnglishTimeExtractorConfiguration } from "./timeConfiguration"
 
 export class EnglishDateTimeExtractorConfiguration implements IDateTimeExtractorConfiguration {
     readonly datePointExtractor: BaseDateExtractor

--- a/JavaScript/test/mergedExtractor-english.test.js
+++ b/JavaScript/test/mergedExtractor-english.test.js
@@ -2,7 +2,7 @@ var describe = require('ava-spec').describe;
 var EnglishMergedExtractorConfiguration = require('../compiled/dateTime/english/mergedConfiguration').EnglishMergedExtractorConfiguration;
 var BaseMergedExtractor = require('../compiled/dateTime/baseMerged').BaseMergedExtractor;
 var DateTimeOptions = require('../compiled/dateTime/baseMerged').DateTimeOptions;
-var Constants = require('../compiled/dateTime/Constants').Constants;
+var Constants = require('../compiled/dateTime/constants').Constants;
 
 describe('Merged Extractor', it => {
     let extractor = new BaseMergedExtractor(new EnglishMergedExtractorConfiguration());


### PR DESCRIPTION
Issue: In case-sensitive filesystems these imports were failing
Solution: use same casing as filenames