### PR TITLE
Fix specs test runners with missing spec file updates

### DIFF
--- a/JavaScript/test/datadriven-tests.js
+++ b/JavaScript/test/datadriven-tests.js
@@ -54,10 +54,13 @@ function getSpecFilePaths(specsPath) {
     if(!fs.existsSync(specsPath)) {
         throw new Error(`Specs directory not found at ${path.resolve(specsPath)}`);
     }
+
     return fs
         .readdirSync(specsPath).map(s => path.join(specsPath, s))
+        .filter(p => fs.lstatSync(p).isDirectory())
         .map(s1 => fs.readdirSync(s1).map(s2 => path.join(s1, s2)))
         .reduce((a, b) => a.concat(b), [])                      // flatten
+        .filter(p => fs.lstatSync(p).isDirectory())
         .map(s1 => fs.readdirSync(s1).map(s2 => path.join(s1, s2)))
         .reduce((a, b) => a.concat(b), [])                      // flatten
         .filter(s => s.indexOf('.json') !== -1);

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -415,7 +415,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T00:00:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -425,7 +424,7 @@
         "values": [
           {
             "timex": "2016-11-08",
-            "mod": "since",
+            "Mod": "since",
             "type": "daterange",
             "start": "2016-11-08"
           }
@@ -440,7 +439,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T00:00:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -450,13 +448,13 @@
         "values": [
           {
             "timex": "XXXX-08",
-            "mod": "since",
+            "Mod": "since",
             "type": "daterange",
             "start": "2016-08-01"
           },
           {
             "timex": "XXXX-08",
-            "mod": "since",
+            "Mod": "since",
             "type": "daterange",
             "start": "2017-08-01"
           }
@@ -471,7 +469,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T00:00:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -481,7 +478,7 @@
         "values": [
           {
             "timex": "2016-08",
-            "mod": "since",
+            "Mod": "since",
             "type": "daterange",
             "start": "2016-08-01"
           }
@@ -690,7 +687,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T16:12:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -700,10 +696,15 @@
         "values": [
           {
             "timex": "(2016-11-07T05,2016-11-07T07,PT2H)",
-            "comment": "ampm",
             "type": "datetimerange",
             "start": "2016-11-07 05:00:00",
             "end": "2016-11-07 07:00:00"
+          },
+          {
+            "timex": "(2016-11-07T17,2016-11-07T19,PT2H)",
+            "type": "datetimerange",
+            "start": "2016-11-07 17:00:00",
+            "end": "2016-11-07 19:00:00"
           }
         ]
       }
@@ -746,7 +747,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T16:12:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -756,10 +756,15 @@
         "values": [
           {
             "timex": "(2016-11-08T03:00,2016-11-08T04:00,PT1H)",
-            "comment": "ampm",
             "type": "datetimerange",
             "start": "2016-11-08 03:00:00",
             "end": "2016-11-08 04:00:00"
+          },
+          {
+            "timex": "(2016-11-08T15:00,2016-11-08T16:00,PT1H)",
+            "type": "datetimerange",
+            "start": "2016-11-08 15:00:00",
+            "end": "2016-11-08 16:00:00"
           }
         ]
       }
@@ -1381,7 +1386,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T00:00:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -1391,9 +1395,13 @@
         "values": [
           {
             "timex": "T07:30",
-            "comment": "ampm",
             "type": "time",
             "value": "07:30:00"
+          },
+          {
+            "timex": "T19:30",
+            "type": "time",
+            "value": "19:30:00"
           }
         ]
       }
@@ -1639,7 +1647,6 @@
   "Context": {
     "ReferenceDateTime": "2016-11-07T16:12:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -1649,10 +1656,15 @@
         "values": [
           {
             "timex": "(T04:00,T07,PT3H)",
-            "comment": "ampm",
             "type": "timerange",
             "start": "04:00:00",
             "end": "07:00:00"
+          },
+          {
+            "timex": "(T16:00,T19,PT3H)",
+            "type": "timerange",
+            "start": "16:00:00",
+            "end": "19:00:00"
           }
         ]
       }
@@ -1759,9 +1771,8 @@
 {
   "Input": "I'll go back now",
   "Context": {
-    "ReferenceDateTime": "2017-09-26T19:37:54.4097576+08:00"
+    "ReferenceDateTime": "2017-09-28T14:11:10.9626841-03:00"
   },
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {
@@ -1772,7 +1783,7 @@
           {
             "timex": "PRESENT_REF",
             "type": "datetime",
-            "value": "2017-09-26 19:37:54"
+            "value": "2017-09-28 14:11:10"
           }
         ]
       }

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -1,4 +1,32 @@
 [{
+  "Input": "at 715ampm",
+  "Context": {
+    "ReferenceDateTime": "2016-11-07T00:00:00"
+  },
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "715ampm",
+      "Type": "datetimeV2.time",
+      "Value": {
+        "values": [
+          {
+            "timex": "T07:15",
+            "type": "time",
+            "value": "07:15:00"
+          },
+          {
+            "timex": "T19:15",
+            "type": "time",
+            "value": "19:15:00"
+          }
+        ]
+      }
+    }
+  ]
+}
+,
+{
   "Input": "ADD LUNCH AT 12:30 PM ON FRI ",
   "Context": {
     "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -40,14 +68,12 @@
         "values": [
           {
             "timex": "XXXX-11-30",
-            "comment": "WeekOf",
             "type": "daterange",
             "start": "2015-11-30",
             "end": "2015-12-07"
           },
           {
             "timex": "XXXX-11-30",
-            "comment": "WeekOf",
             "type": "daterange",
             "start": "2016-11-28",
             "end": "2016-12-05"
@@ -483,7 +509,7 @@
         "values": [
           {
             "timex": "T20",
-            "mod": "after",
+            "Mod": "after",
             "type": "timerange",
             "start": "20:00:00"
           }
@@ -507,7 +533,7 @@
         "values": [
           {
             "timex": "T20",
-            "mod": "before",
+            "Mod": "before",
             "type": "timerange",
             "end": "20:00:00"
           }
@@ -531,7 +557,7 @@
         "values": [
           {
             "timex": "T20",
-            "mod": "since",
+            "Mod": "since",
             "type": "timerange",
             "start": "20:00:00"
           }

--- a/Specs/NumberWithUnit/English/DimensionModel.json
+++ b/Specs/NumberWithUnit/English/DimensionModel.json
@@ -570,7 +570,6 @@
 ,
 {
   "Input": "in 1995 canon introduced the first commercially available slr lens with internal image stabilization , ef 75 -300mm f / 4 - 5 . 6 is usm.",
-  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {


### PR DESCRIPTION
Some tests are failing in Microsoft.Recognizers.Text.with.Spec.Tests.sln due to outdated spec files.
Specs files can be updated running the instrumented tests in Microsoft.Recognizers.Text.sln.
This commit include those updates that fix the failing tests.