### PR TITLE
Fix to failing unit test spec with timezone in reference time

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     {
                         {TimeTypeConstants.DATETIME, FormatUtil.FormatDateTime((DateObject) innerResult.PastValue)}
                     };
+
                     value = innerResult;
                 }
             }
@@ -73,6 +74,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 TimexStr = value == null ? "" : ((DateTimeResolutionResult) value).Timex,
                 ResolutionStr = ""
             };
+
             return ret;
         }
 

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -1771,7 +1771,7 @@
 {
   "Input": "I'll go back now",
   "Context": {
-    "ReferenceDateTime": "2017-09-28T14:11:10.9626841-03:00"
+    "ReferenceDateTime": "2017-09-28T14:11:10.9626841"
   },
   "NotSupportedByDesign": "python",
   "Results": [


### PR DESCRIPTION
Removing timezone info from reference time in json spec.
Current timex expects external code to handle timezones.