### PR TITLE
Fix JavaScript parse reference date

### DIFF
--- a/JavaScript/build.cmd
+++ b/JavaScript/build.cmd
@@ -15,25 +15,23 @@ IF ERRORLEVEL 1 (
     EXIT /B
 )
 
-IF NOT EXIST "node_modules" (
-	ECHO # Installing dependencies - npm install
-	CALL npm i
-)
+REM Prebuild each sub-module referenced on main module
+ECHO.
+ECHO # Building recognizers number module
+CALL npm run prebuild-number
 
-IF NOT EXIST "recognizers-number/node_modules" (
-    ECHO # Building recognizers number module
-    CALL npm run prebuild-number
-)
+ECHO.
+ECHO # Building recognizers number-with-unit module
+CALL npm run prebuild-number-with-unit
 
-IF NOT EXIST "recognizers-number-with-unit/node_modules" (
-    ECHO # Building recognizers number-with-unit module
-    CALL npm run prebuild-number-with-unit
-)
+ECHO.
+ECHO # Building recognizers date-time module
+CALL npm run prebuild-date-time
 
-IF NOT EXIST "recognizers-date-time/node_modules" (
-    ECHO # Building recognizers date-time module
-    CALL npm run prebuild-date-time
-)
+REM Build main module
+ECHO.
+ECHO # Installing dependencies - npm install
+CALL npm i
 
 ECHO.
 ECHO # Building - npm run build

--- a/JavaScript/test/runner-datetime.js
+++ b/JavaScript/test/runner-datetime.js
@@ -210,9 +210,14 @@ function getModel(config) {
     return findModel(options, cultureCode);
 }
 
+function parseISOLocal(s) {
+    var b = s.split(/\D/);
+    return new Date(b[0], b[1]-1, b[2], b[3], b[4], b[5]);
+}
+
 function getReferenceDate(testCase) {
     if (testCase.Context && testCase.Context.ReferenceDateTime) {
-        return new Date(Date.parse(testCase.Context.ReferenceDateTime));
+        return parseISOLocal(testCase.Context.ReferenceDateTime);
     }
 
     return null;


### PR DESCRIPTION
**Issue:** JavaScript DateTime tests fails on node js v7 or prior because `Date.parse` behavior differs from the implemented on node js v8. [Related node issue (Date parse behavior change in node-v8)](https://github.com/nodejs/node/issues/13210)

**Fix:** Use a custom `ISODateString-to-dateObject` converter to get the same behavior in all node versions.

Additionally, the JavaScript build script has been modified to force build submodules.