### PR TITLE
Fix to code signing build

### DIFF
--- a/.NET/buildtools/updateAssemblyInfo.ps1
+++ b/.NET/buildtools/updateAssemblyInfo.ps1
@@ -33,8 +33,11 @@ function UpdateAssemblyInfo()
 
 function AddCodeSign()
 {
-	$fileContent = $fileContent + "`r`n[assembly: AssemblyKeyFileAttribute(@`"..\\buildtools\\35MSSharedLib1024.snk`")] `r`n [assembly: AssemblyDelaySignAttribute(true)]"
-	return $fileContent
+
+    $csAppend = "`r`n[assembly: AssemblyKeyFileAttribute(@`"" + ($PSScriptRoot + "\35MSSharedLib1024.snk") + "`")] `r`n [assembly: AssemblyDelaySignAttribute(true)]"
+    #Write-Host ("CSAppend:" + $csAppend)
+    $fileContent = $fileContent + $csAppend
+    return $fileContent
 }
 
 function TryRemove($attributeName)


### PR DESCRIPTION
Fix to code signing build now that the .NET solution references a sub-project two directories deep.