### PR TITLE
Moving out var declarations inline to make sure build uses VS2017

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void ModelInitialize(IDictionary<string, IModel> models)
         {
             var key = TestContext.TestName;
-            IModel model;
-            if (!models.TryGetValue(key, out model))
+            if (!models.TryGetValue(key, out IModel model))
             {
                 model = TestContext.GetModel();
                 models.Add(key, model);
@@ -44,8 +43,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void ExtractorInitialize(IDictionary<string, IExtractor> extractors)
         {
             var key = TestContext.TestName;
-            IExtractor extractor;
-            if (!extractors.TryGetValue(key, out extractor))
+            if (!extractors.TryGetValue(key, out IExtractor extractor))
             {
                 extractor = TestContext.GetExtractor();
                 extractors.Add(key, extractor);
@@ -57,8 +55,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void ParserInitialize(IDictionary<string, IDateTimeParser> parsers)
         {
             var key = TestContext.TestName;
-            IDateTimeParser parser;
-            if (!parsers.TryGetValue(key, out parser))
+            if (!parsers.TryGetValue(key, out IDateTimeParser parser))
             {
                 parser = TestContext.GetDateTimeParser();
                 parsers.Add(key, parser);
@@ -69,8 +66,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public void TestNumber()
         {
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message);
             }
@@ -99,8 +95,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void TestNumberWithUnit()
         {
 
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message);
             }
@@ -130,8 +125,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void TestDateTime()
         {
 
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message);
             }
@@ -170,8 +164,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void TestDateTimeExtractor()
         {
 
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message);
             }
@@ -199,8 +192,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void TestDateTimeParser()
         {
 
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message, GetMessage(TestSpec));
             }
@@ -239,8 +231,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public void TestDateTimeMergedParser()
         {
 
-            string message;
-            if (TestUtils.EvaluateSpec(TestSpec, out message))
+            if (TestUtils.EvaluateSpec(TestSpec, out string message))
             {
                 Assert.Inconclusive(message);
             }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -431,8 +431,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         public static DateObject GetReferenceDateTime(this TestModel testSpec)
         {
 
-            object dateTimeObject;
-            if (testSpec.Context.TryGetValue("ReferenceDateTime", out dateTimeObject))
+            if (testSpec.Context.TryGetValue("ReferenceDateTime", out object dateTimeObject))
             {
                 return (DateObject)dateTimeObject;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -69,9 +69,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             foreach (var result in er)
             {
-                var num = 0;
 
-                Int32.TryParse((this.config.NumberParser.Parse(result).Value ?? 0).ToString(), out num);
+                Int32.TryParse((this.config.NumberParser.Parse(result).Value ?? 0).ToString(), out int num);
 
                 if (num < 1 || num > 31)
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "desde"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int fromIndex;
-                    if (this.config.GetFromTokenIndex(beforeStr, out fromIndex)
+                    if (this.config.GetFromTokenIndex(beforeStr, out int fromIndex)
                         || this.config.GetBetweenTokenIndex(beforeStr, out fromIndex))
                     {
                         periodBegin = fromIndex;
@@ -88,8 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "entre"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int beforeIndex;
-                    if (this.config.GetBetweenTokenIndex(beforeStr, out beforeIndex))
+                    if (this.config.GetBetweenTokenIndex(beforeStr, out int beforeIndex))
                     {
                         periodBegin = beforeIndex;
                         ret.Add(new Token(periodBegin, periodEnd));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -133,9 +133,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "from"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int fromIndex;
 
-                    if (this.config.GetFromTokenIndex(beforeStr, out fromIndex)
+                    if (this.config.GetFromTokenIndex(beforeStr, out int fromIndex)
                         || this.config.GetBetweenTokenIndex(beforeStr, out fromIndex))
                     {
                         periodBegin = fromIndex;
@@ -154,9 +153,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "between"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int beforeIndex;
 
-                    if (this.config.GetBetweenTokenIndex(beforeStr, out beforeIndex))
+                    if (this.config.GetBetweenTokenIndex(beforeStr, out int beforeIndex))
                     {
                         periodBegin = beforeIndex;
                         ret.Add(new Token(periodBegin, periodEnd));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
@@ -135,16 +135,15 @@ namespace Microsoft.Recognizers.Text.DateTime
             foreach (var er in ers)
             {
                 var beforeStr = text.Substring(lastEnd, er.Start ?? 0).ToLowerInvariant();
-                int tokenIndex;
-                
-                if (HasTokenIndex(beforeStr.TrimEnd(), config.BeforeRegex, out tokenIndex))
+
+                if (HasTokenIndex(beforeStr.TrimEnd(), config.BeforeRegex, out int tokenIndex))
                 {
                     var modLengh = beforeStr.Length - tokenIndex;
                     er.Length += modLengh;
                     er.Start -= modLengh;
                     er.Text = text.Substring(er.Start ?? 0, er.Length ?? 0);
                 }
-                
+
                 if (HasTokenIndex(beforeStr.TrimEnd(), config.AfterRegex, out tokenIndex))
                 {
                     var modLengh = beforeStr.Length - tokenIndex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -69,8 +69,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "from"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int fromIndex;
-                    if (this.config.GetFromTokenIndex(beforeStr, out fromIndex))
+                    if (this.config.GetFromTokenIndex(beforeStr, out int fromIndex))
                     {
                         periodBegin = fromIndex;
                     }
@@ -87,8 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // handle "between"
                     var beforeStr = text.Substring(0, periodBegin).Trim().ToLowerInvariant();
-                    int betweenIndex;
-                    if (this.config.GetBetweenTokenIndex(beforeStr, out betweenIndex))
+                    if (this.config.GetBetweenTokenIndex(beforeStr, out int betweenIndex))
                     {
                         periodBegin = betweenIndex;
                         ret.Add(new Token(periodBegin, periodEnd));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -132,9 +132,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.Timex = FormatUtil.LuisDate(-1, -1, day);
 
-                DateObject futureDate, pastDate, temp;
+                DateObject futureDate, pastDate;
                 var tryStr = FormatUtil.LuisDate(year, month, day);
-                if (DateObject.TryParse(tryStr, out temp))
+                if (DateObject.TryParse(tryStr, out DateObject temp))
                 {
                     futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
                     pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
@@ -276,9 +276,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 ret.Timex = FormatUtil.LuisDate(-1, -1, day);
 
-                DateObject futureDate, temp;
+                DateObject futureDate;
                 var tryStr = FormatUtil.LuisDate(year, month, day);
-                if (DateObject.TryParse(tryStr, out temp))
+                if (DateObject.TryParse(tryStr, out DateObject temp))
                 {
                     futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -658,8 +658,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var numberString = dateTimex.Replace("P", "").Substring(0, dateTimex.Length - 2);
             string unit = dateTimex.Substring(dateTimex.Length - 1);
 
-            double swiftValue = 0;
-            Double.TryParse(numberString, out swiftValue);
+            Double.TryParse(numberString, out double swiftValue);
 
             if (swiftValue == 0)
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -87,8 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var match = this.config.NowRegex.Match(trimedText);
             if (match.Success && match.Index == 0 && match.Length == trimedText.Length)
             {
-                var timex = "";
-                this.config.GetMatchedNowTimex(trimedText, out timex);
+                this.config.GetMatchedNowTimex(trimedText, out string timex);
                 ret.Timex = timex;
                 ret.FutureValue = ret.PastValue = referenceTime;
                 ret.Success = true;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -467,11 +467,10 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // handle time of day
-            int beginHour, endHour, endMin = 0;
-            string timeStr;
+
             // late/early is only working iwth time of day
             // only standard time of day (morinng, afternoon, evening and night) will not directly return
-            if (!this.Config.GetMatchedTimeRange(timeText, out timeStr, out beginHour, out endHour, out endMin))
+            if (!this.Config.GetMatchedTimeRange(timeText, out string timeStr, out int beginHour, out int endHour, out int endMin))
             {
                 return ret;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
@@ -122,8 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (!string.IsNullOrEmpty(holidayKey))
             {
                 var value = referenceDate;
-                Func<int, DateObject> function;
-                if (this.config.HolidayFuncDictionary.TryGetValue(holidayKey, out function))
+                if (this.config.HolidayFuncDictionary.TryGetValue(holidayKey, out Func<int, DateObject> function))
                 {
                     value = function(year);
                     this.config.VariableHolidaysTimexDictionary.TryGetValue(holidayKey, out timexStr);
@@ -169,8 +168,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             if (value < referenceDate)
             {
-                Func<int, DateObject> function;
-                if (this.config.HolidayFuncDictionary.TryGetValue(holiday, out function))
+                if (this.config.HolidayFuncDictionary.TryGetValue(holiday, out Func<int, DateObject> function))
                 {
                     return function(value.Year + 1);
                 }
@@ -183,8 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             if (value >= referenceDate)
             {
-                Func<int, DateObject> function;
-                if (this.config.HolidayFuncDictionary.TryGetValue(holiday, out function))
+                if (this.config.HolidayFuncDictionary.TryGetValue(holiday, out Func<int, DateObject> function))
                 {
                     return function(value.Year - 1);
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
@@ -128,8 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var match = this.config.PeriodicRegex.Match(text);
             if (match.Success)
             {
-                string timex;
-                if (!this.config.GetMatchedDailyTimex(text, out timex))
+                if (!this.config.GetMatchedDailyTimex(text, out string timex))
                 {
                     return ret;
                 }
@@ -148,8 +147,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var sourceUnit = match.Groups["unit"].Value;
                 if (!string.IsNullOrEmpty(sourceUnit) && this.config.UnitMap.ContainsKey(sourceUnit))
                 {
-                    string timex;
-                    if (!this.config.GetMatchedUnitTimex(sourceUnit, out timex))
+                    if (!this.config.GetMatchedUnitTimex(sourceUnit, out string timex))
                     {
                         return ret;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -104,16 +104,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var hourGroup = match.Groups["hour"];
                 var hourStr = hourGroup.Captures[0].Value;
 
-                int beginHour;
-                if (!this.config.Numbers.TryGetValue(hourStr, out beginHour))
+                if (!this.config.Numbers.TryGetValue(hourStr, out int beginHour))
                 {
                     beginHour = int.Parse(hourStr);
                 }
 
                 hourStr = hourGroup.Captures[1].Value;
 
-                int endHour;
-                if (!this.config.Numbers.TryGetValue(hourStr, out endHour))
+                if (!this.config.Numbers.TryGetValue(hourStr, out int endHour))
                 {
                     endHour = int.Parse(hourStr);
                 }
@@ -241,8 +239,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             int day = referenceTime.Day,
                 month = referenceTime.Month,
                 year = referenceTime.Year;
-            string timex;
-            int beginHour, endHour, endMinSeg;
             var ret = new DateTimeResolutionResult();
 
             // extract early/late prefix from text
@@ -267,7 +263,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            if (!this.config.GetMatchedTimexRange(text, out timex, out beginHour, out endHour, out endMinSeg))
+            if (!this.config.GetMatchedTimexRange(text, out string timex, out int beginHour, out int endHour, out int endMinSeg))
             {
                 return new DateTimeResolutionResult();
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -16,9 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimedText = text.Trim().ToLowerInvariant();
 
             // handle morning, afternoon..
-            int beginHour, endHour, endMin = 0;
-            string timeStr;
-            if (!this.Config.GetMatchedTimeRange(trimedText, out timeStr, out beginHour, out endHour, out endMin))
+            if (!this.Config.GetMatchedTimeRange(trimedText, out string timeStr, out int beginHour, out int endHour, out int endMin))
             {
                 return ret;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
@@ -76,8 +76,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             .Replace("P", "")
                             .Replace("T", "");
 
-                        double number = 0;
-                        if (double.TryParse(numStr, out number))
+                        if (double.TryParse(numStr, out double number))
                         {
                             return GetAgoLaterResult(
                                 pr,

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -203,8 +203,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
                 int start = (int)number.Start, length = (int)number.Length;
                 var maxFindLen = sourceLen - start - length;
-                PrefixUnitResult prefixUnit;
-                mappingPrefix.TryGetValue(start, out prefixUnit);
+                mappingPrefix.TryGetValue(start, out PrefixUnitResult prefixUnit);
 
                 if (maxFindLen > 0)
                 {

--- a/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
+++ b/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Recognizers.Text
 
         public IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
         {
-            IModel model;
-            if (!TryGetModel<TModel>(culture, out model, fallbackToDefaultCulture))
+            if (!TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture))
             {
                 throw new ArgumentException($"ERROR: No IModel instance for {culture}-{typeof(TModel)}");
             }
@@ -53,8 +52,7 @@ namespace Microsoft.Recognizers.Text
 
         public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
         {
-            IModel model;
-            return TryGetModel<TModel>(culture, out model, fallbackToDefaultCulture);
+            return TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture);
         }
 
         private static KeyValuePair<string, Type> GenerateKey(string culture, Type type)


### PR DESCRIPTION
Moving out var declarations inline to make sure builds are now properly configured to use VS2017.