### PR TITLE
Fixing 2 broken unit tests in French

### DIFF
--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -297,17 +297,10 @@
   "NotSupportedByDesign": "python",
   "Results": [
     {
-      "Text": "192",
+      "Text": "192.168",
       "TypeName": "number",
       "Resolution": {
-        "value": "192"
-      }
-    },
-    {
-      "Text": "168",
-      "TypeName": "number",
-      "Resolution": {
-        "value": "168"
+        "value": "192168"
       }
     },
     {

--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -294,6 +294,7 @@
 ,
 {
   "Input": "192.168.1.2",
+  "NotSupported": "javascript",
   "NotSupportedByDesign": "python",
   "Results": [
     {

--- a/Specs/NumberWithUnit/French/CurrencyModel.json
+++ b/Specs/NumberWithUnit/French/CurrencyModel.json
@@ -78,10 +78,25 @@
   "NotSupportedByDesign": "python",
   "Results": [
     {
+      "Text": "94000 $",
+      "TypeName": "currency",
+      "Resolution": {
+        "value": "94000",
+        "unit": "Dollar"
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "Siegel payé national et 94.000 $ shuster pour laisser tomber toutes les réclamations.",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
       "Text": "94.000 $",
       "TypeName": "currency",
       "Resolution": {
-        "value": "94.000",
+        "value": "94000",
         "unit": "Dollar"
       }
     }


### PR DESCRIPTION
- Fixing broken currency case;
- Workaround for failing test in numbers (IPs shouldn't be recognized as numbers, or all 4 segments should be recog separately); temporarily reverting to same behaviour as other languages.