### PR TITLE
CI - .NET Test Fails should invalidate build

### DIFF
--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -21,8 +21,15 @@ FOR /R %%f IN (*Tests.dll) DO (
 		SET testcontainer=!testcontainer! "%%f"
 	)
 )
-CALL vstest.console %testcontainer%
+vstest.console %testcontainer% /Parallel 
+IF %ERRORLEVEL% NEQ 0 GOTO TEST_ERROR
 
 ECHO.
 ECHO # Running CreateAllPackages.cmd
 CALL CreateAllPackages.cmd
+
+EXIT /b 0
+
+:TEST_ERROR
+ECHO Test failure(s) found!
+EXIT /b 1

--- a/.NET/Build.cmd
+++ b/.NET/Build.cmd
@@ -45,4 +45,4 @@ FOR /R %%f IN (*Tests.dll) DO (
 		SET testcontainer=!testcontainer! "%%f"
 	)
 )
-CALL "!VsTestDir!\vstest.console" %testcontainer%
+CALL "!VsTestDir!\vstest.console" /Parallel %testcontainer%


### PR DESCRIPTION
- CI Fix to report failure when a .NET test fails
- Run .NET tests in parallel