### PR TITLE
Fix to duration calculation when daylight saving occurs

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseTimePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseTimePeriod.ts
@@ -1,6 +1,6 @@
 import { Constants, TimeTypeConstants } from "./constants";
 import { IExtractor, ExtractResult, RegExpUtility, StringUtility } from "recognizers-text-number"
-import { Token, FormatUtil, DateTimeResolutionResult, IDateTimeUtilityConfiguration } from "./utilities";
+import { Token, FormatUtil, DateTimeResolutionResult, IDateTimeUtilityConfiguration, DateUtils } from "./utilities";
 import { IDateTimeParser, DateTimeParseResult } from "./parsers"
 import { BaseTimeExtractor, BaseTimeParser } from "./baseTime"
 
@@ -210,7 +210,7 @@ export class BaseTimePeriodParser implements IDateTimeParser {
                 endHour = Number.parseInt(hourStr, 10);
             }
 
-            // parse "pm" 
+            // parse "pm"
             let leftDesc = matches[0].groups("leftDesc").value;
             let rightDesc = matches[0].groups("rightDesc").value;
             let pmStr = matches[0].groups("pm").value;
@@ -287,7 +287,7 @@ export class BaseTimePeriodParser implements IDateTimeParser {
             pr2.value.futureValue = endTime;
         }
 
-        ret.timex = `(${pr1.timexStr},${pr2.timexStr},PT${new Date(endTime.getTime() - beginTime.getTime()).getUTCHours()}H)`;
+        ret.timex = `(${pr1.timexStr},${pr2.timexStr},PT${DateUtils.totalHours(endTime, beginTime)}H)`;
         ret.futureValue = ret.pastValue = { item1: beginTime, item2: endTime };
         ret.success = true;
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -357,11 +357,15 @@ export class DateUtils {
         // C#: Math.Round(4.5) == 4
         // C#: Convert.ToInt32(4.5) == 4
         // JS: Math.round(4.5) == 5 !!
-        return Math.round(Math.abs(from.getTime() - to.getTime() - 0.00001) / this.oneHour);
+        let fromEpoch = from.getTime() - (from.getTimezoneOffset() * 60 * 1000);
+        let toEpoch = to.getTime() - (to.getTimezoneOffset() * 60 * 1000);
+        return Math.round(Math.abs(fromEpoch - toEpoch - 0.00001) / this.oneHour);
     }
 
     static totalSeconds(from: Date, to: Date): number {
-        return Math.round(Math.abs(from.getTime() - to.getTime()) / this.oneSecond);
+        let fromEpoch = from.getTime() - (from.getTimezoneOffset() * 60 * 1000);
+        let toEpoch = to.getTime() - (to.getTimezoneOffset() * 60 * 1000);
+        return Math.round(Math.abs(fromEpoch - toEpoch) / this.oneSecond);
     }
 
     static addTime(seedDate: Date, timeToAdd: Date): Date {
@@ -418,7 +422,7 @@ export class DateUtils {
         return { weekNo: weekNo, year: referenceDate.getUTCFullYear() }
     }
 
-    static minValue(): Date { 
+    static minValue(): Date {
         let date = new Date(1, 0, 1, 0, 0, 0, 0);
         date.setFullYear(1);
         return date;


### PR DESCRIPTION
Related to https://github.com/Microsoft/Recognizers-Text/issues/172
Only happens on machines where timezone has daylight savings

Fix works out by taking in consideration the timezone offset when calculating durations between dates,  thus avoiding the +1 or -1 hours of daylight savings.