### PR TITLE
Allowing options to be specified after acquiring instance

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -184,9 +184,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new EnglishSetExtractorConfiguration());
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.None));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(), DateTimeOptions.SkipFromToMerge);
+                    return new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
             }
 
             throw new Exception($"Extractor '{extractorName}' for English not supported");
@@ -194,7 +194,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetEnglishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration();
+            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None);
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -216,7 +216,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new EnglishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedParser(new EnglishMergedParserConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
             }
 
             throw new Exception($"Parser '{parserName}' for English not supported");
@@ -277,7 +277,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new DateTime.Chinese.SetParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Merged:
-                    return new FullDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration(), DateTimeOptions.None);
+                    return new FullDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration() );
             }
 
             throw new Exception($"Parser '{parserName}' for English not supported");
@@ -306,7 +306,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Spanish not supported");
@@ -314,7 +314,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetSpanishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration();
+            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None);
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -336,7 +337,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new SpanishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedParser(new SpanishMergedParserConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedParser(new SpanishMergedParserConfiguration(DateTimeOptions.None));
             }
 
             throw new Exception($"Parser '{parserName}' for Spanish not supported");
@@ -365,9 +366,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new FrenchSetExtractorConfiguration());
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.None));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(), DateTimeOptions.SkipFromToMerge);
+                    return new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
             }
 
             throw new Exception($"Extractor '{extractorName}' for French not supported");
@@ -375,7 +376,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetFrenchParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration();
+            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None);
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -397,7 +398,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new FrenchSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedParser(new FrenchMergedParserConfiguration(), DateTimeOptions.None);
+                    return new BaseMergedParser(new FrenchMergedParserConfiguration(DateTimeOptions.None));
             }
 
             throw new Exception($"Parser '{parserName}' for French not supported");

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/HolidayExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/HolidayExtractorChs.cs
@@ -16,5 +16,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         };
 
         public IEnumerable<Regex> HolidayRegexes => HolidayRegexList;
+
+        public ChineseHolidayExtractorConfiguration()
+        {
+            Options = DateTimeOptions.None;    
+        }
+
+        public DateTimeOptions Options { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/HolidayExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/HolidayExtractorChs.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class ChineseHolidayExtractorConfiguration : IHolidayExtractorConfiguration
+    public class ChineseHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex LunarHolidayRegex = new Regex(DateTimeDefinitions.LunarHolidayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -17,12 +17,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public IEnumerable<Regex> HolidayRegexes => HolidayRegexList;
 
-        public ChineseHolidayExtractorConfiguration()
+        public ChineseHolidayExtractorConfiguration() : base(DateTimeOptions.None)
         {
-            Options = DateTimeOptions.None;    
         }
-
-        public DateTimeOptions Options { get; }
 
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -6,11 +6,10 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class ChineseDateTimeParserConfiguration : IFullDateTimeParserConfiguration
+    public class ChineseDateTimeParserConfiguration : BaseOptionsConfiguration, IFullDateTimeParserConfiguration
     {
-        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
+        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None) : base(options)
         {
-            Options = options;
             DateParser = new DateParser(this);
             TimeParser = new TimeParserChs(this);
             DateTimeParser = new DateTimeParserChs(this);
@@ -36,8 +35,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             StrictWeekDayRegex = DateExtractorChs.WeekDayRegex;
             WeekDayOfMonthRegex = DateExtractorChs.WeekDayOfMonthRegex;
         }
-
-        public DateTimeOptions Options { get; }
 
         public string Before => DateTimeDefinitions.ParserConfigurationBefore;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -8,8 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class ChineseDateTimeParserConfiguration : IFullDateTimeParserConfiguration
     {
-        public ChineseDateTimeParserConfiguration()
+        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
         {
+            Options = options;
             DateParser = new DateParser(this);
             TimeParser = new TimeParserChs(this);
             DateTimeParser = new DateTimeParserChs(this);
@@ -35,6 +36,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             StrictWeekDayRegex = DateExtractorChs.WeekDayRegex;
             WeekDayOfMonthRegex = DateExtractorChs.WeekDayOfMonthRegex;
         }
+
+        public DateTimeOptions Options { get; }
+
         public string Before => DateTimeDefinitions.ParserConfigurationBefore;
 
         public string After => DateTimeDefinitions.ParserConfigurationAfter;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/MergedParserChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/MergedParserChs.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         //TODO implement SinceRegex
         private static readonly Regex SinceRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public MergedParserChs(IMergedParserConfiguration configuration, DateTimeOptions options) : base(configuration, options) { }
+        public MergedParserChs(IMergedParserConfiguration configuration) : base(configuration) { }
 
         public new ParseResult Parse(ExtractResult er)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseOptionsConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.Recognizers.Text.DateTime
+{
+    public class BaseOptionsConfiguration : IOptionsConfiguration
+    {
+
+        public BaseOptionsConfiguration(DateTimeOptions options)
+        {
+            Options = options;
+        }
+
+        public DateTimeOptions Options { get; }
+
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/IOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/IOptionsConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.Recognizers.Text.DateTime
+{
+    public interface IOptionsConfiguration
+    {
+        DateTimeOptions Options { get; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeOptions.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         None = 0,
         SkipFromToMerge = 1,
         SplitDateAndTime = 2,
-        Calendar = 4,
+        CalendarMode = 4,
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -10,9 +10,14 @@ namespace Microsoft.Recognizers.Text.DateTime
     public class DateTimeRecognizer : Recognizer
     {
 
-        readonly DateTimeOptions instanceOptions;
+        private DateTimeOptions instanceOptions;
 
-        public static DateTimeRecognizer GetInstance(DateTimeOptions options = DateTimeOptions.None)
+        public static DateTimeRecognizer GetInstance()
+        {
+            return new DateTimeRecognizer();
+        }
+
+        public static DateTimeRecognizer GetInstance(DateTimeOptions options)
         {
             return new DateTimeRecognizer(options);
         }
@@ -24,30 +29,35 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private DateTimeRecognizer(DateTimeOptions options)
         {
+            Initialize(options);
+        }
+
+        private void Initialize(DateTimeOptions options)
+        {
 
             instanceOptions = options;
 
             var type = typeof(DateTimeModel);
 
             RegisterModel(Culture.English, type, options.ToString(), new DateTimeModel(
-                new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
-                new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
-            ));
+                              new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
+                              new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
+                          ));
 
             RegisterModel(Culture.Chinese, type, options.ToString(), new DateTimeModel(
-                new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
-                new MergedExtractorChs(options)
-            ));
+                              new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
+                              new MergedExtractorChs(options)
+                          ));
 
             RegisterModel(Culture.Spanish, type, options.ToString(), new DateTimeModel(
-                new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
-                new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
-            ));
+                              new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
+                              new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
+                          ));
 
             RegisterModel(Culture.French, type, options.ToString(), new DateTimeModel(
-                new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
-                new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
-            ));
+                              new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
+                              new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
+                          ));
         }
 
         private DateTimeRecognizer(string cultureCode, DateTimeOptions options)
@@ -88,22 +98,38 @@ namespace Microsoft.Recognizers.Text.DateTime
             
         }
 
-        public DateTimeModel GetDateTimeModel(DateTimeOptions options = DateTimeOptions.None)
+        // Uninitialized recognizer constructor
+        private DateTimeRecognizer()
         {
-            if (options == DateTimeOptions.None) {
-                options = instanceOptions;
-            }
-
-            return GetDateTimeModel("", false, options);
         }
 
-        public DateTimeModel GetDateTimeModel(string culture, bool fallbackToDefaultCulture = true, DateTimeOptions options = DateTimeOptions.None)
+        private DateTimeOptions SanityCheck(DateTimeOptions options)
         {
+            if (!ContainsModels())
+            {
+                Initialize(options);
+            }
 
             if (options == DateTimeOptions.None)
             {
                 options = instanceOptions;
             }
+
+            return options;
+        }
+
+        public DateTimeModel GetDateTimeModel(DateTimeOptions options = DateTimeOptions.None)
+        {
+
+            options = SanityCheck(options);
+
+            return GetDateTimeModel("", false, options);
+        }
+        
+        public DateTimeModel GetDateTimeModel(string culture, bool fallbackToDefaultCulture = true, DateTimeOptions options = DateTimeOptions.None)
+        {
+
+            options = SanityCheck(options);
 
             DateTimeModel model;
             if (string.IsNullOrEmpty(culture))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -4,6 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Chinese;
 using Microsoft.Recognizers.Text.DateTime.English;
 using Microsoft.Recognizers.Text.DateTime.Spanish;
 using Microsoft.Recognizers.Text.DateTime.French;
+using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
@@ -11,6 +12,11 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
 
         private DateTimeOptions instanceOptions;
+
+        public static DateTimeOptions Convert(int value)
+        {
+            return EnumUtils.Convert<DateTimeOptions>(value);
+        }
 
         public static DateTimeRecognizer GetInstance()
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             return EnumUtils.Convert<DateTimeOptions>(value);
         }
 
-        public static DateTimeRecognizer GetInstance()
+        public static DateTimeRecognizer GetCleanInstance()
         {
             return new DateTimeRecognizer();
         }
 
-        public static DateTimeRecognizer GetInstance(DateTimeOptions options)
+        public static DateTimeRecognizer GetInstance(DateTimeOptions options = DateTimeOptions.None)
         {
             return new DateTimeRecognizer(options);
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class DateTimeRecognizer : Recognizer
     {
+
+        readonly DateTimeOptions instanceOptions;
+
         public static DateTimeRecognizer GetInstance(DateTimeOptions options = DateTimeOptions.None)
         {
             return new DateTimeRecognizer(options);
@@ -22,24 +25,26 @@ namespace Microsoft.Recognizers.Text.DateTime
         private DateTimeRecognizer(DateTimeOptions options)
         {
 
+            instanceOptions = options;
+
             var type = typeof(DateTimeModel);
 
-            RegisterModel(Culture.English, type, new DateTimeModel(
+            RegisterModel(Culture.English, type, options.ToString(), new DateTimeModel(
                 new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
                 new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
             ));
 
-            RegisterModel(Culture.Chinese, type, new DateTimeModel(
+            RegisterModel(Culture.Chinese, type, options.ToString(), new DateTimeModel(
                 new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
                 new MergedExtractorChs(options)
             ));
 
-            RegisterModel(Culture.Spanish, type, new DateTimeModel(
+            RegisterModel(Culture.Spanish, type, options.ToString(), new DateTimeModel(
                 new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
                 new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
             ));
 
-            RegisterModel(Culture.French, type, new DateTimeModel(
+            RegisterModel(Culture.French, type, options.ToString(), new DateTimeModel(
                 new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
                 new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
             ));
@@ -48,29 +53,31 @@ namespace Microsoft.Recognizers.Text.DateTime
         private DateTimeRecognizer(string cultureCode, DateTimeOptions options)
         {
 
+            instanceOptions = options;
+
             var type = typeof(DateTimeModel);
 
             switch (cultureCode) {
                 case Culture.English:
-                    RegisterModel(cultureCode, type, new DateTimeModel(
+                    RegisterModel(cultureCode, type, options.ToString(), new DateTimeModel(
                                       new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
                                       new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
                                   ));
                     break;
                 case Culture.Chinese:
-                    RegisterModel(cultureCode, type, new DateTimeModel(
+                    RegisterModel(cultureCode, type, options.ToString(), new DateTimeModel(
                                       new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
                                       new MergedExtractorChs(options)
                                   ));
                     break;
                 case Culture.Spanish:
-                    RegisterModel(Culture.Spanish, type, new DateTimeModel(
+                    RegisterModel(Culture.Spanish, type, options.ToString(), new DateTimeModel(
                                       new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
                                       new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
                                   ));
                     break;
                 case Culture.French:
-                    RegisterModel(Culture.French, type, new DateTimeModel(
+                    RegisterModel(Culture.French, type, options.ToString(), new DateTimeModel(
                                       new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
                                       new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
                                   ));
@@ -81,13 +88,22 @@ namespace Microsoft.Recognizers.Text.DateTime
             
         }
 
-        public DateTimeModel GetDateTimeModel()
+        public DateTimeModel GetDateTimeModel(DateTimeOptions options = DateTimeOptions.None)
         {
-            return GetDateTimeModel("", false);
+            if (options == DateTimeOptions.None) {
+                options = instanceOptions;
+            }
+
+            return GetDateTimeModel("", false, options);
         }
 
-        public DateTimeModel GetDateTimeModel(string culture, bool fallbackToDefaultCulture = true)
+        public DateTimeModel GetDateTimeModel(string culture, bool fallbackToDefaultCulture = true, DateTimeOptions options = DateTimeOptions.None)
         {
+
+            if (options == DateTimeOptions.None)
+            {
+                options = instanceOptions;
+            }
 
             DateTimeModel model;
             if (string.IsNullOrEmpty(culture))
@@ -96,7 +112,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else
             {
-                model = (DateTimeModel)GetModel<DateTimeModel>(culture, fallbackToDefaultCulture);
+                model = (DateTimeModel)GetModel<DateTimeModel>(culture, fallbackToDefaultCulture, options.ToString());
             }
 
             return model;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -25,24 +25,24 @@ namespace Microsoft.Recognizers.Text.DateTime
             var type = typeof(DateTimeModel);
 
             RegisterModel(Culture.English, type, new DateTimeModel(
-                    new BaseMergedParser(new EnglishMergedParserConfiguration(), options),
-                    new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(), options)
-                    ));
+                new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
+                new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
+            ));
 
             RegisterModel(Culture.Chinese, type, new DateTimeModel(
-                    new FullDateTimeParser(new ChineseDateTimeParserConfiguration(), options),
-                    new MergedExtractorChs(options)
-                    ));
+                new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
+                new MergedExtractorChs(options)
+            ));
 
             RegisterModel(Culture.Spanish, type, new DateTimeModel(
-                    new BaseMergedParser(new SpanishMergedParserConfiguration(), options),
-                    new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(), options)
-                    ));
+                new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
+                new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
+            ));
 
             RegisterModel(Culture.French, type, new DateTimeModel(
-                    new BaseMergedParser(new FrenchMergedParserConfiguration(), options),
-                    new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(), options)
-                    ));
+                new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
+                new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
+            ));
         }
 
         private DateTimeRecognizer(string cultureCode, DateTimeOptions options)
@@ -53,26 +53,26 @@ namespace Microsoft.Recognizers.Text.DateTime
             switch (cultureCode) {
                 case Culture.English:
                     RegisterModel(cultureCode, type, new DateTimeModel(
-                                      new BaseMergedParser(new EnglishMergedParserConfiguration(), options),
-                                      new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(), options)
+                                      new BaseMergedParser(new EnglishMergedParserConfiguration(options)),
+                                      new BaseMergedExtractor(new EnglishMergedExtractorConfiguration(options))
                                   ));
                     break;
                 case Culture.Chinese:
                     RegisterModel(cultureCode, type, new DateTimeModel(
-                                      new FullDateTimeParser(new ChineseDateTimeParserConfiguration(), options),
+                                      new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
                                       new MergedExtractorChs(options)
                                   ));
                     break;
                 case Culture.Spanish:
                     RegisterModel(Culture.Spanish, type, new DateTimeModel(
-                                      new BaseMergedParser(new SpanishMergedParserConfiguration(), options),
-                                      new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(), options)
+                                      new BaseMergedParser(new SpanishMergedParserConfiguration(options)),
+                                      new BaseMergedExtractor(new SpanishMergedExtractorConfiguration(options))
                                   ));
                     break;
                 case Culture.French:
                     RegisterModel(Culture.French, type, new DateTimeModel(
-                                      new BaseMergedParser(new FrenchMergedParserConfiguration(), options),
-                                      new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(), options)
+                                      new BaseMergedParser(new FrenchMergedParserConfiguration(options)),
+                                      new BaseMergedExtractor(new FrenchMergedExtractorConfiguration(options))
                                   ));
                     break;
                 default:

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public EnglishDateExtractorConfiguration()
         {
+            Options = DateTimeOptions.None;
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.English.OrdinalExtractor.GetInstance();
             NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
@@ -155,5 +156,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         Regex IDateExtractorConfiguration.RelativeMonthRegex => RelativeMonthRegex;
 
         Regex IDateExtractorConfiguration.WeekDayRegex => WeekDayRegex;
+
+        public DateTimeOptions Options { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public EnglishDatePeriodExtractorConfiguration()
         {
+            Options = DateTimeOptions.None;
             DatePointExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
@@ -198,5 +199,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             var match = Regex.Match(text, DateTimeDefinitions.RangeConnectorRegex);
             return match.Success && match.Length == text.Trim().Length;
         }
+
+        public DateTimeOptions Options { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimeExtractorConfiguration : IDateTimeExtractorConfiguration
+    public class EnglishDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.PrepositionRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex ConnectorRegex = new Regex(DateTimeDefinitions.ConnectorRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public EnglishDateTimeExtractorConfiguration()
+        public EnglishDateTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DatePointExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
             TimePointExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
@@ -88,5 +88,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                     || PrepositionRegex.IsMatch(text)
                     || ConnectorRegex.IsMatch(text));
         }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -7,9 +7,9 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimePeriodExtractorConfiguration : IDateTimePeriodExtractorConfiguration
+    public class EnglishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
-        public EnglishDateTimePeriodExtractorConfiguration()
+        public EnglishDateTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();
             SingleDateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDurationExtractorConfiguration : IDurationExtractorConfiguration
+    public class EnglishDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -44,7 +44,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex DurationConnectorRegex =
             new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public EnglishDurationExtractorConfiguration()
+        public EnglishDurationExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishHolidayExtractorConfiguration : IHolidayExtractorConfiguration
+    public class EnglishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -31,6 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             H2,
             H3
         };
+
+        public EnglishHolidayExtractorConfiguration() : base(DateTimeOptions.None)
+        {
+        }
 
         public IEnumerable<Regex> HolidayRegexes => HolidayRegexList;
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -1,7 +1,9 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
 using Microsoft.Recognizers.Definitions.English;
-using System.Collections.Generic;
 using Microsoft.Recognizers.Text.Number;
+
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishMergedExtractorConfiguration : IMergedExtractorConfiguration
@@ -33,6 +35,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             new Regex(DateTimeDefinitions.OneOnOneRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline),
         };
 
+        public DateTimeOptions Options { get; }
+
         public IDateTimeExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
@@ -53,8 +57,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IExtractor IntegerExtractor { get; }
 
-        public EnglishMergedExtractorConfiguration()
+        public EnglishMergedExtractorConfiguration(DateTimeOptions options)
         {
+            Options = options;
             DateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
             DateTimeExtractor = new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishSetExtractorConfiguration : ISetExtractorConfiguration
+    public class EnglishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex SetEachRegex =
             new Regex(DateTimeDefinitions.SetEachRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public EnglishSetExtractorConfiguration()
+        public EnglishSetExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimeExtractorConfiguration : ITimeExtractorConfiguration
+    public class EnglishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -147,7 +147,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public EnglishTimeExtractorConfiguration()
+        public EnglishTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -9,7 +9,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimePeriodExtractorConfiguration : ITimePeriodExtractorConfiguration
+    public class EnglishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex = 
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -56,7 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public EnglishTimePeriodExtractorConfiguration()
+        public EnglishTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             SingleTimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
             UtilityConfiguration = new EnlighDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public EnglishCommonDateTimeParserConfiguration()
+        public EnglishCommonDateTimeParserConfiguration(DateTimeOptions options) : base(options)
         {
             UtilityConfiguration = new EnlighDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateParserConfiguration : IDateParserConfiguration
+    public class EnglishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
         public string DateTokenPrefix { get; }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public EnglishDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDatePeriodParserConfiguration : IDatePeriodParserConfiguration
+    public class EnglishDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -84,7 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IImmutableList<string> InStringList { get; }
 
-        public EnglishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             CardinalExtractor = config.CardinalExtractor;
@@ -204,5 +204,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             var trimedText = text.Trim().ToLowerInvariant();
             return trimedText.Equals("year to date");
         }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimeParserConfiguration : IDateTimeParserConfiguration
+    public class EnglishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -51,8 +51,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public EnglishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
+
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
@@ -138,5 +139,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         }
 
         public bool HaveAmbiguousToken(string text, string matchedText) => false;
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimePeriodParserConfiguration : IDateTimePeriodParserConfiguration
+    public class EnglishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -58,8 +58,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public EnglishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
+            
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
@@ -157,5 +158,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
             return swift;
         }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDurationParserConfiguration : IDurationParserConfiguration
+    public class EnglishDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
     {
         public IExtractor CardinalExtractor { get; }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IImmutableDictionary<string, double> DoubleNumbers { get; }
 
-        public EnglishDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishDurationParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public sealed class EnglishMergedParserConfiguration : EnglishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+
         public Regex BeforeRegex { get; }
 
         public Regex AfterRegex { get; }
@@ -14,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeParser HolidayParser { get; }
 
-        public EnglishMergedParserConfiguration() : base()
+        public EnglishMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = EnglishMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = EnglishMergedExtractorConfiguration.AfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishSetParserConfiguration : ISetParserConfiguration
+    public class EnglishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
     {
         public IDateTimeExtractor DurationExtractor { get; }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public Regex SetEachRegex { get; }
 
-        public EnglishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishSetParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimeParserConfiguration : ITimeParserConfiguration
+    public class EnglishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
         public string TimeTokenPrefix { get; }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public EnglishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
             AtRegex = EnglishTimeExtractorConfiguration.AtRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimePeriodParserConfiguration : ITimePeriodParserConfiguration
+    public class EnglishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public IDateTimeExtractor TimeExtractor { get; }
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public EnglishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public EnglishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeExtractor = config.TimeExtractor;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedExtractor.cs
@@ -10,12 +10,10 @@ namespace Microsoft.Recognizers.Text.DateTime
     public class BaseMergedExtractor : IDateTimeExtractor
     {
         private readonly IMergedExtractorConfiguration config;
-        private readonly DateTimeOptions options;
 
-        public BaseMergedExtractor(IMergedExtractorConfiguration config, DateTimeOptions options)
+        public BaseMergedExtractor(IMergedExtractorConfiguration config)
         {
             this.config = config;
-            this.options = options;
         }
 
         public List<ExtractResult> Extract(string text)
@@ -43,8 +41,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             AddMod(ret, text);
 
-            //filtering
-            if ((this.options & DateTimeOptions.Calendar) != 0)
+            // filtering
+            if ((this.config.Options & DateTimeOptions.CalendarMode) != 0)
             {
                 CheckCalendarFilterList(ret, text);
             }
@@ -73,7 +71,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             foreach (var result in src)
             {
-                if ((options & DateTimeOptions.SkipFromToMerge) != 0)
+                if ((config.Options & DateTimeOptions.SkipFromToMerge) != 0)
                 {
                     if (ShouldSkipFromToMerge(result))
                     {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateExtractorConfiguration
+    public interface IDateExtractorConfiguration : IOptionsConfiguration
     {
         IEnumerable<Regex> DateRegexList { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDatePeriodExtractorConfiguration
+    public interface IDatePeriodExtractorConfiguration : IOptionsConfiguration
     {
         IEnumerable<Regex> SimpleCasesRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimeExtractorConfiguration
+    public interface IDateTimeExtractorConfiguration : IOptionsConfiguration
     {
         Regex NowRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimePeriodExtractorConfiguration
+    public interface IDateTimePeriodExtractorConfiguration : IOptionsConfiguration
     {
         IEnumerable<Regex> SimpleCasesRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDurationExtractorConfiguration
+    public interface IDurationExtractorConfiguration : IOptionsConfiguration
     {
         Regex FollowedUnit { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IHolidayExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IHolidayExtractorConfiguration
+    public interface IHolidayExtractorConfiguration: IOptionsConfiguration
     {
         IEnumerable<Regex> HolidayRegexes { get; }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
@@ -5,8 +5,9 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IMergedExtractorConfiguration
+    public interface IMergedExtractorConfiguration : IOptionsConfiguration
     {
+
         IDateTimeExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ISetExtractorConfiguration
+    public interface ISetExtractorConfiguration: IOptionsConfiguration
     {
         Regex LastRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimeExtractorConfiguration
+    public interface ITimeExtractorConfiguration : IOptionsConfiguration
     {
         IEnumerable<Regex> TimeRegexList { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimePeriodExtractorConfiguration
+    public interface ITimePeriodExtractorConfiguration : IOptionsConfiguration
     {
         IExtractor IntegerExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateExtractorConfiguration : IDateExtractorConfiguration
+    public class FrenchDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(
@@ -177,7 +177,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex NonDateUnitRegex = new Regex(@"(?<unit>heure|heures|hrs|secondes|seconde|secs|sec|minutes|minute|mins)\b",
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public FrenchDateExtractorConfiguration()
+        public FrenchDateExtractorConfiguration() : base(DateTimeOptions.None)
         {
             IntegerExtractor = new IntegerExtractor();
             OrdinalExtractor = new OrdinalExtractor();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDatePeriodExtractorConfiguration : IDatePeriodExtractorConfiguration
+    public class FrenchDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
         public static readonly Regex TillRegex = new Regex(
@@ -181,7 +181,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         private static readonly Regex ConnectorAndRegex = new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-
         private static readonly Regex[] SimpleCasesRegexes =
         {
             SimpleCasesRegex,
@@ -204,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             WeekWithWeekDayRangeRegex,
         };
 
-        public FrenchDatePeriodExtractorConfiguration()
+        public FrenchDatePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DatePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration());
             CardinalExtractor = Number.French.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimeExtractorConfiguration : IDateTimeExtractorConfiguration
+    public class FrenchDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex = 
           new Regex(  
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 DateTimeDefinitions.TimeUnitRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public FrenchDateTimeExtractorConfiguration()
+        public FrenchDateTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DatePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration());
             TimePointExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -6,9 +6,9 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimePeriodExtractorConfiguration : IDateTimePeriodExtractorConfiguration
+    public class FrenchDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
-        public FrenchDateTimePeriodExtractorConfiguration()
+        public FrenchDateTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();
             SingleDateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDuractionExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDuractionExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDurationExtractorConfiguration : IDurationExtractorConfiguration
+    public class FrenchDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(
@@ -64,7 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex DurationConnectorRegex =
             new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public FrenchDurationExtractorConfiguration()
+        public FrenchDurationExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.French.CardinalExtractor.GetInstance();
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchHolidayExtractorConfiguration : IHolidayExtractorConfiguration
+    public class FrenchHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex = 
             new Regex(
@@ -40,6 +40,10 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             H3,
             H4
         };
+
+        public FrenchHolidayExtractorConfiguration() : base(DateTimeOptions.None)
+        {
+        }
 
         public IEnumerable<Regex> HolidayRegexes => HolidayRegexList;
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchMergedExtractorConfiguration : IMergedExtractorConfiguration
+    public class FrenchMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline); // avant - 'before'
@@ -55,8 +55,9 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IExtractor IntegerExtractor { get; }
 
-        public FrenchMergedExtractorConfiguration()
+        public FrenchMergedExtractorConfiguration(DateTimeOptions options) : base(options)
         {
+
             DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());
             DateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchSetExtractorConfiguration : ISetExtractorConfiguration
+    public class FrenchSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -38,7 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex SetEachRegex =
             new Regex(DateTimeDefinitions.SetEachRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public FrenchSetExtractorConfiguration()
+        public FrenchSetExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimeExtractorConfiguration : ITimeExtractorConfiguration
+    public class FrenchTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public FrenchTimeExtractorConfiguration()
+        public FrenchTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimePeriodExtractorConfiguration : ITimePeriodExtractorConfiguration
+    public class FrenchTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; //"TimePeriod";
 
@@ -70,19 +70,25 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex TimeNumberCombinedWithUnit =
             new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly Regex FromRegex = new Regex(DateTimeDefinitions.FromRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex ConnectorAndRegex = new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        private static readonly Regex FromRegex = 
+            new Regex(DateTimeDefinitions.FromRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private static readonly Regex ConnectorAndRegex = 
+            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private static readonly Regex BeforeRegex = 
+            new Regex(DateTimeDefinitions.BeforeRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public FrenchTimePeriodExtractorConfiguration()
+        public FrenchTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             SingleTimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
         }
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public IDateTimeExtractor SingleTimeExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public FrenchCommonDateTimeParserConfiguration()
+        public FrenchCommonDateTimeParserConfiguration(DateTimeOptions options) : base(options)
         {
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateParserConfiguration : IDateParserConfiguration
+    public class FrenchDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
         public string DateTokenPrefix { get; }
 
@@ -64,8 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-
-        public FrenchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDatePeriodParserConfiguration : IDatePeriodParserConfiguration
+    public class FrenchDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IImmutableList<string> InStringList { get; }
 
-        public FrenchDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             CardinalExtractor = config.CardinalExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimeParserConfiguration : IDateTimeParserConfiguration
+    public class FrenchDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -51,7 +51,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public FrenchDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
@@ -60,10 +60,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DateParser = config.DateParser;
             TimeParser = config.TimeParser;
             NowRegex = FrenchDateTimeExtractorConfiguration.NowRegex;
-            AMTimeRegex = new Regex(DateTimeDefinitions.AMTimeRegex,
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PMTimeRegex,
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            AMTimeRegex = new Regex(DateTimeDefinitions.AMTimeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            PMTimeRegex = new Regex(DateTimeDefinitions.PMTimeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
             SimpleTimeOfTodayAfterRegex = FrenchDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
             SimpleTimeOfTodayBeforeRegex = FrenchDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
             SpecificTimeOfDayRegex = FrenchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimePeriodParserConfiguration : IDateTimePeriodParserConfiguration
+    public class FrenchDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public FrenchDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -90,10 +90,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public static readonly Regex MorningStartEndRegex = new Regex(DateTimeDefinitions.MorningStartEndRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly Regex AfternoonStartEndRegex = new Regex(DateTimeDefinitions.AfternoonStartEndRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly Regex EveningStartEndRegex = new Regex(DateTimeDefinitions.EveningStartEndRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly Regex NightStartEndRegex = new Regex(DateTimeDefinitions.NightStartEndRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -133,6 +136,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 timeStr = null;
                 return false;
             }
+
             return true;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDurationParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDurationParserConfiguration : IDurationParserConfiguration
+    public class FrenchDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
     {
         public IExtractor CardinalExtractor { get; }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IImmutableDictionary<string, double> DoubleNumbers { get; }
 
-        public FrenchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchDurationParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public sealed class FrenchMergedParserConfiguration : FrenchCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+
         public Regex BeforeRegex { get; }
 
         public Regex AfterRegex { get; }
@@ -14,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeParser HolidayParser { get; }
 
-        public FrenchMergedParserConfiguration() : base()
+        public FrenchMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = FrenchMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = FrenchMergedExtractorConfiguration.AfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchSetParserConfiguration : ISetParserConfiguration
+    public class FrenchSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
     {
         public IDateTimeExtractor DurationExtractor { get; }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public Regex SetEachRegex { get; }
 
-        public FrenchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchSetParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimeParserConfiguration : ITimeParserConfiguration
+    public class FrenchTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
         public string TimeTokenPrefix { get; }
 
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public FrenchTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix; 
             AtRegex = FrenchTimeExtractorConfiguration.AtRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimePeriodParserConfiguration : ITimePeriodParserConfiguration
+    public class FrenchTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public IDateTimeExtractor TimeExtractor { get; }
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public FrenchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public FrenchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeExtractor = config.TimeExtractor;
             IntegerExtractor = config.IntegerExtractor;
@@ -49,9 +49,11 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             {
                 trimedText = trimedText.Substring(0, trimedText.Length - 1);
             }
+
             beginHour = 0;
             endHour = 0;
             endMin = 0;
+
             if (trimedText.EndsWith("matinee") || trimedText.EndsWith("matin") || trimedText.EndsWith("matinée"))
             {
                 timex = "TMO";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Models/DateTimeModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Models/DateTimeModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
@@ -6,8 +6,13 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public abstract class BaseDateParserConfiguration : ICommonDateTimeParserConfiguration
+    public abstract class BaseDateParserConfiguration : BaseOptionsConfiguration, ICommonDateTimeParserConfiguration
     {
+
+        protected BaseDateParserConfiguration(DateTimeOptions options) : base(options)
+        {
+        }
+
         public virtual IExtractor CardinalExtractor { get; protected set; }
 
         public virtual IExtractor IntegerExtractor { get; protected set; }
@@ -63,5 +68,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         public virtual IImmutableDictionary<string, int> DayOfMonth => BaseDateTime.DayOfMonthDictionary.ToImmutableDictionary();
 
         public virtual IDateTimeUtilityConfiguration UtilityConfiguration { get; protected set; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
@@ -9,7 +9,7 @@ using Microsoft.Recognizers.Definitions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public abstract class BaseHolidayParserConfiguration : IHolidayParserConfiguration
+    public abstract class BaseHolidayParserConfiguration : BaseOptionsConfiguration, IHolidayParserConfiguration
     {
         public IImmutableDictionary<string, string> VariableHolidaysTimexDictionary { get; protected set; }
 
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public IEnumerable<Regex> HolidayRegexList { get; protected set; }
 
-        protected BaseHolidayParserConfiguration()
+        protected BaseHolidayParserConfiguration() : base(DateTimeOptions.None)
         {
             this.VariableHolidaysTimexDictionary = BaseDateTime.VariableHolidaysTimexDictionary.ToImmutableDictionary();
             this.HolidayFuncDictionary = InitHolidayFuncs().ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedParser.cs
@@ -12,15 +12,13 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string ParserTypeName = "datetimeV2";
 
         protected readonly IMergedParserConfiguration Config;
-        private readonly DateTimeOptions options;
 
         public static readonly string DateMinString = FormatUtil.FormatDate(DateObject.MinValue);
         public static readonly string DateTimeMinString = FormatUtil.FormatDateTime(DateObject.MinValue);
 
-        public BaseMergedParser(IMergedParserConfiguration configuration, DateTimeOptions options)
+        public BaseMergedParser(IMergedParserConfiguration configuration)
         {
             Config = configuration;
-            this.options = options;
         }
 
         public ParseResult Parse(ExtractResult er)
@@ -33,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var referenceTime = refTime;
             DateTimeParseResult pr = null;
 
-            // push, save teh MOD string
+            // push, save the MOD string
             bool hasBefore = false, hasAfter = false, hasSince = false;
             var modStr = string.Empty;
             var beforeMatch = Config.BeforeRegex.Match(er.Text);
@@ -136,7 +134,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if ((options & DateTimeOptions.SplitDateAndTime) != 0
+            if ((Config.Options & DateTimeOptions.SplitDateAndTime) != 0
                  && ((DateTimeResolutionResult)pr.Value)?.SubDateTimeEntities != null)
             {
                 pr.Value = DateTimeResolutionForSplit(pr);
@@ -152,14 +150,14 @@ namespace Microsoft.Recognizers.Text.DateTime
         public DateTimeParseResult SetParseResult(DateTimeParseResult slot, bool hasBefore, bool hasAfter, bool hasSince)
         {
             slot.Value = DateTimeResolution(slot, hasBefore, hasAfter, hasSince);
-            //change the type at last for the after or before mode
+            // change the type at last for the after or before modes
             slot.Type = $"{ParserTypeName}.{DetermineDateTimeType(slot.Type, hasBefore, hasAfter, hasSince)}";
             return slot;
         }
 
         public string DetermineDateTimeType(string type, bool hasBefore, bool hasAfter, bool hasSince)
         {
-            if ((options & DateTimeOptions.SplitDateAndTime) != 0)
+            if ((Config.Options & DateTimeOptions.SplitDateAndTime) != 0)
             {
                 if (type.Equals(Constants.SYS_DATETIME_DATETIME))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public const string ParserTypeName = "datetimeV2";
 
-        public FullDateTimeParser(IFullDateTimeParserConfiguration configuration, DateTimeOptions options)
+        public FullDateTimeParser(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
             beforeRegex = new Regex(config.Before, RegexOptions.IgnoreCase | RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeConfiguration.cs
@@ -5,8 +5,9 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ICommonDateTimeParserConfiguration
+    public interface ICommonDateTimeParserConfiguration : IOptionsConfiguration
     {
+
         IExtractor CardinalExtractor { get; }
 
         IExtractor IntegerExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateParserConfiguration
+    public interface IDateParserConfiguration : IOptionsConfiguration
     {
         string DateTokenPrefix { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDatePeriodParserConfiguration
+    public interface IDatePeriodParserConfiguration : IOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimeParserConfiguration
+    public interface IDateTimeParserConfiguration : IOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimePeriodParserConfiguration
+    public interface IDateTimePeriodParserConfiguration : IOptionsConfiguration
     {
         IDateTimeExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDurationParserConfiguration
+    public interface IDurationParserConfiguration : IOptionsConfiguration
     {
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IFullDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IFullDateTimeParserConfiguration.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IFullDateTimeParserConfiguration
+    public interface IFullDateTimeParserConfiguration : IOptionsConfiguration
     {
         string Before { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IHolidayParserConfiguration
+    public interface IHolidayParserConfiguration : IOptionsConfiguration
     {
         IImmutableDictionary<string, string> VariableHolidaysTimexDictionary { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public interface IMergedParserConfiguration : ICommonDateTimeParserConfiguration
     {
+
         Regex BeforeRegex { get; }
 
         Regex AfterRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ISetParserConfiguration
+    public interface ISetParserConfiguration : IOptionsConfiguration
     {
         IDateTimeExtractor DurationExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimeParserConfiguration
+    public interface ITimeParserConfiguration : IOptionsConfiguration
     {
         string TimeTokenPrefix { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimePeriodParserConfiguration
+    public interface ITimePeriodParserConfiguration : IOptionsConfiguration
     {
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -10,22 +10,49 @@ using Microsoft.Recognizers.Text.Number.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateExtractorConfiguration : IDateExtractorConfiguration
+    public class SpanishDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
     {
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex OnRegex = new Regex(DateTimeDefinitions.OnRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex RelaxedOnRegex = new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.ThisRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex LastDateRegex = new Regex(DateTimeDefinitions.LastDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex NextDateRegex = new Regex(DateTimeDefinitions.NextDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex SpecialDayRegex = new Regex(DateTimeDefinitions.SpecialDayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WeekDayOfMonthRegex = new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex SpecialDateRegex = new Regex(DateTimeDefinitions.SpecialDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex MonthRegex = 
+            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex DayRegex = 
+            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthNumRegex = 
+            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex YearRegex = 
+            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WeekDayRegex = 
+            new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex OnRegex = 
+            new Regex(DateTimeDefinitions.OnRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RelaxedOnRegex = 
+            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex ThisRegex = 
+            new Regex(DateTimeDefinitions.ThisRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex LastDateRegex = 
+            new Regex(DateTimeDefinitions.LastDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex NextDateRegex = 
+            new Regex(DateTimeDefinitions.NextDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex SpecialDayRegex = 
+            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex DateUnitRegex = 
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WeekDayOfMonthRegex = 
+            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex SpecialDateRegex = 
+            new Regex(DateTimeDefinitions.SpecialDateRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         //TODO: modify below regex according to the counterpart in English
         public static readonly Regex ForTheRegex = new Regex($@"^[.]",
@@ -84,7 +111,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
-        public SpanishDateExtractorConfiguration()
+        public SpanishDateExtractorConfiguration() : base(DateTimeOptions.None)
         {
             IntegerExtractor = new IntegerExtractor();
             OrdinalExtractor = new OrdinalExtractor();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -6,52 +6,117 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDatePeriodExtractorConfiguration : IDatePeriodExtractorConfiguration
+    public class SpanishDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
-        public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.TillRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex AndRegex = new Regex(DateTimeDefinitions.AndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex DateUnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex TillRegex = 
+            new Regex(DateTimeDefinitions.TillRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex AndRegex = 
+            new Regex(DateTimeDefinitions.AndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex DayRegex = 
+            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthNumRegex = 
+            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex YearRegex = 
+            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RelativeMonthRegex = 
+            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthRegex = 
+            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthSuffixRegex = 
+            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex DateUnitRegex = 
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex PastRegex = 
+            new Regex(DateTimeDefinitions.PastRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex FutureRegex = 
+            new Regex(DateTimeDefinitions.FutureRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         // composite regexes
-        public static readonly Regex SimpleCasesRegex = new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthFrontSimpleCasesRegex = new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthFrontBetweenRegex = new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex DayBetweenRegex = new Regex(DateTimeDefinitions.DayBetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex SimpleCasesRegex = 
+            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthFrontSimpleCasesRegex = 
+            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthFrontBetweenRegex = 
+            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex DayBetweenRegex = 
+            new Regex(DateTimeDefinitions.DayBetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         //TODO: modify it according to the related regex in English
-        public static readonly Regex OneWordPeriodRegex = new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthWithYearRegex = new Regex(DateTimeDefinitions.MonthWithYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthNumWithYearRegex = new Regex(DateTimeDefinitions.MonthNumWithYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WeekOfMonthRegex = new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WeekOfYearRegex = new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex FollowedDateUnit = new Regex(DateTimeDefinitions.FollowedDateUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex NumberCombinedWithDateUnit = new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex QuarterRegex = new Regex(DateTimeDefinitions.QuarterRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex QuarterRegexYearFront = new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WhichWeekRegex = new Regex(DateTimeDefinitions.WhichWeekRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex WeekOfRegex = new Regex(DateTimeDefinitions.WeekOfRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex MonthOfRegex = new Regex(DateTimeDefinitions.MonthOfRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex RangeUnitRegex = new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex InConnectorRegex = new Regex(DateTimeDefinitions.InConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        public static readonly Regex LaterEarlyPeriodRegex = new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex OneWordPeriodRegex = 
+            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        private static readonly Regex FromRegex = new Regex(DateTimeDefinitions.FromRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex ConnectorAndRegex = new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-        private static readonly Regex BetweenRegex = new Regex(DateTimeDefinitions.BetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex MonthWithYearRegex = 
+            new Regex(DateTimeDefinitions.MonthWithYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthNumWithYearRegex = 
+            new Regex(DateTimeDefinitions.MonthNumWithYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WeekOfMonthRegex = 
+            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WeekOfYearRegex = 
+            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex FollowedDateUnit = 
+            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex NumberCombinedWithDateUnit = 
+            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex QuarterRegex = 
+            new Regex(DateTimeDefinitions.QuarterRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex QuarterRegexYearFront = 
+            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex SeasonRegex = 
+            new Regex(DateTimeDefinitions.SeasonRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WhichWeekRegex = 
+            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex WeekOfRegex = 
+            new Regex(DateTimeDefinitions.WeekOfRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex MonthOfRegex = 
+            new Regex(DateTimeDefinitions.MonthOfRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RangeUnitRegex = 
+            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex InConnectorRegex = 
+            new Regex(DateTimeDefinitions.InConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex LaterEarlyPeriodRegex = 
+            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private static readonly Regex FromRegex = 
+            new Regex(DateTimeDefinitions.FromRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private static readonly Regex ConnectorAndRegex = 
+            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        private static readonly Regex BetweenRegex = 
+            new Regex(DateTimeDefinitions.BetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         //TODO: add this regex, let it correspond to the one in English
         public static readonly Regex RestOfDateRegex =
             new Regex(@"^[.]", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         //TODO: add this regex, let it correspond to the one in English
         public static readonly Regex WeekWithWeekDayRangeRegex =
             new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -76,7 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             WeekWithWeekDayRangeRegex,
         };
 
-        public SpanishDatePeriodExtractorConfiguration()
+        public SpanishDatePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DatePointExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration());
             CardinalExtractor = Number.Spanish.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimeExtractorConfiguration : IDateTimeExtractorConfiguration
+    public class SpanishDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.PrepositionRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex NowRegex = new Regex(DateTimeDefinitions.NowRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex ConnectorRegex = new Regex(DateTimeDefinitions.ConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public SpanishDateTimeExtractorConfiguration()
+        public SpanishDateTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DatePointExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration());
             TimePointExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimePeriodExtractorConfiguration : IDateTimePeriodExtractorConfiguration
+    public class SpanishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex ConnectorAndRegex = new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         private static readonly Regex BetweenRegex = new Regex(DateTimeDefinitions.BetweenRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public SpanishDateTimePeriodExtractorConfiguration()
+        public SpanishDateTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.Spanish.CardinalExtractor.GetInstance();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDurationExtractorConfiguration : IDurationExtractorConfiguration
+    public class SpanishDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex DurationConnectorRegex = new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public SpanishDurationExtractorConfiguration()
+        public SpanishDurationExtractorConfiguration() : base(DateTimeOptions.None)
         {
             CardinalExtractor = Number.Spanish.CardinalExtractor.GetInstance();
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishHolidayExtractorConfiguration : IHolidayExtractorConfiguration
+    public class SpanishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex[] HolidayRegexList =
         {
@@ -13,6 +13,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             new Regex(DateTimeDefinitions.HolidayRegex2, RegexOptions.IgnoreCase | RegexOptions.Singleline),
             new Regex(DateTimeDefinitions.HolidayRegex3, RegexOptions.IgnoreCase | RegexOptions.Singleline)
         };
+
+        public SpanishHolidayExtractorConfiguration() : base(DateTimeOptions.None)
+        {
+        }
 
         public IEnumerable<Regex> HolidayRegexes => HolidayRegexList;
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishMergedExtractorConfiguration : IMergedExtractorConfiguration
+    public class SpanishMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
@@ -50,7 +50,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IExtractor IntegerExtractor { get; }
 
-        public SpanishMergedExtractorConfiguration()
+        public SpanishMergedExtractorConfiguration(DateTimeOptions options) : base(options)
         {
             DateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishSetExtractorConfiguration : ISetExtractorConfiguration
+    public class SpanishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex SetEachRegex = new Regex(DateTimeDefinitions.SetEachRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public SpanishSetExtractorConfiguration()
+        public SpanishSetExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
             TimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -5,11 +5,10 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimeExtractorConfiguration : ITimeExtractorConfiguration
+    public class SpanishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
-
         public static readonly Regex DescRegex = new Regex(DateTimeDefinitions.DescRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -96,7 +95,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public SpanishTimeExtractorConfiguration()
+        public SpanishTimeExtractorConfiguration() : base(DateTimeOptions.None)
         {
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimePeriodExtractorConfiguration : ITimePeriodExtractorConfiguration
+    public class SpanishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; //"TimePeriod";
 
@@ -31,12 +31,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.TillRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public SpanishTimePeriodExtractorConfiguration()
+        public SpanishTimePeriodExtractorConfiguration() : base(DateTimeOptions.None)
         {
             SingleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
         }
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public IDateTimeExtractor SingleTimeExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public SpanishCommonDateTimeParserConfiguration()
+        public SpanishCommonDateTimeParserConfiguration(DateTimeOptions options) : base(options)
         {
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateParserConfiguration : IDateParserConfiguration
+    public class SpanishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
     {
         public string DateTokenPrefix { get; }
 
@@ -69,7 +69,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishDateParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishDateParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
             DateRegexes = SpanishDateExtractorConfiguration.DateRegexList;
@@ -161,6 +161,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimedText = text.Trim().ToLowerInvariant();
             return PastPrefixRegex.IsMatch(trimedText);
         }
+
     }
 
     public static class StringExtension

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDatePeriodParserConfiguration : IDatePeriodParserConfiguration
+    public class SpanishDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         #endregion
 
 
-        public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             CardinalExtractor = config.CardinalExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimeParserConfiguration : IDateTimeParserConfiguration
+    public class SpanishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
         public string TokenBeforeDate { get; }
 
@@ -51,7 +51,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimePeriodParserConfiguration : IDateTimePeriodParserConfiguration
+    public class SpanishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDurationParserConfiguration : IDurationParserConfiguration
+    public class SpanishDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
     {
         public IExtractor CardinalExtractor { get; }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IImmutableDictionary<string, double> DoubleNumbers { get; }
 
-        public SpanishDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishDurationParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+
         public Regex BeforeRegex { get; }
 
         public Regex AfterRegex { get; }
@@ -14,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeParser HolidayParser { get; }
 
-        public SpanishMergedParserConfiguration() : base()
+        public SpanishMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = SpanishMergedExtractorConfiguration.AfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishSetParserConfiguration : ISetParserConfiguration
+    public class SpanishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
     {
         public IDateTimeExtractor DurationExtractor { get; }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public Regex SetEachRegex { get; }
 
-        public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimeParserConfiguration : ITimeParserConfiguration
+    public class SpanishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
     {
         public string TimeTokenPrefix { get; }
 
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
             AtRegex = SpanishTimeExtractorConfiguration.AtRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimePeriodParserConfiguration : ITimePeriodParserConfiguration
+    public class SpanishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public IDateTimeExtractor TimeExtractor { get; }
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+        public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
         {
             TimeExtractor = config.TimeExtractor;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.Recognizers.Text.Number
+{
+    [Flags]
+    public enum NumberOptions
+    {
+        None = 0,
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.Number
 
         private NumberRecognizer(NumberOptions options)
         {
-            RegisterModel(Culture.English, new Dictionary<Type, IModel>
+            RegisterModel(Culture.English, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(NumberModel)] = new NumberModel(
                             AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration()),
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number
                             new English.PercentageExtractor())
             });
 
-            RegisterModel(Culture.Chinese, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Chinese, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(NumberModel)] = new NumberModel(
                             AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration()),
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.Number
                             new Chinese.PercentageExtractor())
             });
 
-            RegisterModel(Culture.Spanish, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Spanish, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(NumberModel)] = new NumberModel(
                             AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration()),
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.Number
                             new Spanish.PercentageExtractor())
             });
 
-            RegisterModel(Culture.Portuguese, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Portuguese, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(NumberModel)] = new NumberModel(
                             AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration()),
@@ -67,7 +67,7 @@ namespace Microsoft.Recognizers.Text.Number
                             new Portuguese.PercentageExtractor())
             });
 
-            RegisterModel(Culture.French, new Dictionary<Type, IModel>
+            RegisterModel(Culture.French, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(NumberModel)] = new NumberModel(
                             AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration()),
@@ -83,17 +83,17 @@ namespace Microsoft.Recognizers.Text.Number
 
         public IModel GetNumberModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<NumberModel>(culture, fallbackToDefaultCulture);
+            return GetModel<NumberModel>(culture, fallbackToDefaultCulture, NumberOptions.None.ToString());
         }
 
         public IModel GetOrdinalModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<OrdinalModel>(culture, fallbackToDefaultCulture);
+            return GetModel<OrdinalModel>(culture, fallbackToDefaultCulture, NumberOptions.None.ToString());
         }
 
         public IModel GetPercentageModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<PercentModel>(culture, fallbackToDefaultCulture);
+            return GetModel<PercentModel>(culture, fallbackToDefaultCulture, NumberOptions.None.ToString());
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Recognizers.Text.Number
 {
     public class NumberRecognizer : Recognizer
     {
-        public static readonly NumberRecognizer Instance = new NumberRecognizer();
+        public static readonly NumberRecognizer Instance = new NumberRecognizer(NumberOptions.None);
 
-        private NumberRecognizer()
+        private NumberRecognizer(NumberOptions options)
         {
             RegisterModel(Culture.English, new Dictionary<Type, IModel>
             {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.Recognizers.Text.NumberWithUnit
+{
+    [Flags]
+    public enum NumberWithUnitOptions
+    {
+        None = 0,
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitRecognizer.cs
@@ -7,10 +7,11 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 {
     public class NumberWithUnitRecognizer : Recognizer 
     {
-        public static readonly NumberWithUnitRecognizer Instance = new NumberWithUnitRecognizer();
+        public static readonly NumberWithUnitRecognizer Instance = new NumberWithUnitRecognizer(NumberWithUnitOptions.None);
 
-        private NumberWithUnitRecognizer()
+        private NumberWithUnitRecognizer(NumberWithUnitOptions options)
         {
+
             RegisterModel(Culture.English, new Dictionary<Type, IModel>
             {
                 [typeof(CurrencyModel)] = new CurrencyModel(

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/NumberWithUnitRecognizer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
         private NumberWithUnitRecognizer(NumberWithUnitOptions options)
         {
 
-            RegisterModel(Culture.English, new Dictionary<Type, IModel>
+            RegisterModel(Culture.English, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(CurrencyModel)] = new CurrencyModel(
                             new Dictionary<IExtractor, IParser>
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                             ),
             });
 
-            RegisterModel(Culture.Chinese, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Chinese, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof (CurrencyModel)] = new CurrencyModel(
                     new Dictionary<IExtractor, IParser>
@@ -108,7 +108,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                     ),
             });
 
-            RegisterModel(Culture.Spanish, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Spanish, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(CurrencyModel)] = new CurrencyModel(
                             new Dictionary<IExtractor, IParser>
@@ -148,7 +148,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                             ),
             });
 
-            RegisterModel(Culture.Portuguese, new Dictionary<Type, IModel>
+            RegisterModel(Culture.Portuguese, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(CurrencyModel)] = new CurrencyModel(
                             new Dictionary<IExtractor, IParser>
@@ -188,7 +188,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                             ),
             });
 
-            RegisterModel(Culture.French, new Dictionary<Type, IModel>
+            RegisterModel(Culture.French, options.ToString(), new Dictionary<Type, IModel>
             {
                 [typeof(CurrencyModel)] = new CurrencyModel(
                             new Dictionary<IExtractor, IParser>
@@ -231,22 +231,22 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         public IModel GetCurrencyModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<CurrencyModel>(culture, fallbackToDefaultCulture);
+            return GetModel<CurrencyModel>(culture, fallbackToDefaultCulture, NumberWithUnitOptions.None.ToString());
         }
 
         public IModel GetTemperatureModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<TemperatureModel>(culture, fallbackToDefaultCulture);
+            return GetModel<TemperatureModel>(culture, fallbackToDefaultCulture, NumberWithUnitOptions.None.ToString());
         }
 
         public IModel GetDimensionModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<DimensionModel>(culture, fallbackToDefaultCulture);
+            return GetModel<DimensionModel>(culture, fallbackToDefaultCulture, NumberWithUnitOptions.None.ToString());
         }
 
         public IModel GetAgeModel(string culture, bool fallbackToDefaultCulture = true)
         {
-            return GetModel<AgeModel>(culture, fallbackToDefaultCulture);
+            return GetModel<AgeModel>(culture, fallbackToDefaultCulture, NumberWithUnitOptions.None.ToString());
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/IRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text/IRecognizer.cs
@@ -2,10 +2,10 @@
 {
     public interface IRecognizer
     {
-        IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true);
+        IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true, string options = "");
 
-        bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture = true);
+        bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture = true, string options = "");
 
-        bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true);
+        bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true, string options = "");
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
+++ b/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
@@ -5,35 +5,36 @@ using System.Linq;
 
 namespace Microsoft.Recognizers.Text
 {
-    public class ModelContainer
+    internal class ModelContainer
     {
         public static readonly string DefaultCulture = Culture.English;
 
-        private readonly ConcurrentDictionary<KeyValuePair<string, Type>, IModel> modelInstances = new ConcurrentDictionary<KeyValuePair<string, Type>, IModel>();
+        private readonly ConcurrentDictionary<Tuple<string, Type, string>, IModel> modelInstances = 
+            new ConcurrentDictionary<Tuple<string, Type, string>, IModel>();
 
-        public IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
+        public IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture, string options)
         {
-            if (!TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture))
+            if (!TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture, options))
             {
-                throw new ArgumentException($"ERROR: No IModel instance for {culture}-{typeof(TModel)}");
+                throw new ArgumentException($"ERROR: No IModel instance for {culture}-{typeof(TModel)}--{options}");
             }
 
             return model;
         }
 
-        public bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture = true)
+        public bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture, string options)
         {
             model = null;
             var ret = true;
 
-            var key = GenerateKey(culture, typeof(TModel));
+            var key = GenerateKey(culture, typeof(TModel), options);
 
             if (!modelInstances.ContainsKey(key))
             {
                 if (fallbackToDefaultCulture)
                 {
                     culture = DefaultCulture;
-                    key = GenerateKey(culture, typeof(TModel));
+                    key = GenerateKey(culture, typeof(TModel), options);
                 }
 
                 if (!modelInstances.ContainsKey(key))
@@ -50,12 +51,12 @@ namespace Microsoft.Recognizers.Text
             return ret;
         }
 
-        public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
+        public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture, string options)
         {
-            return TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture);
+            return TryGetModel<TModel>(culture, out IModel model, fallbackToDefaultCulture, options);
         }
 
-        private static KeyValuePair<string, Type> GenerateKey(string culture, Type type)
+        private static Tuple<string, Type, string> GenerateKey(string culture, Type type, string options)
         {
             if (string.IsNullOrWhiteSpace(culture))
             {
@@ -64,12 +65,12 @@ namespace Microsoft.Recognizers.Text
 
             culture = culture.ToLower(); // Ignore Case
 
-            return new KeyValuePair<string, Type>(culture, type);
+            return new Tuple<string, Type, string>(culture, type, options);
         }
 
-        public void RegisterModel(string culture, Type type, IModel model)
+        public void RegisterModel(string culture, Type type, IModel model, string options)
         {
-            var key = GenerateKey(culture, type);
+            var key = GenerateKey(culture, type, options);
             if (modelInstances.ContainsKey(key))
             {
                 throw new ArgumentException($"ERROR: {culture}-{type} has already been registered.");
@@ -78,11 +79,11 @@ namespace Microsoft.Recognizers.Text
             modelInstances.TryAdd(key, model);
         }
 
-        public void RegisterModel(string culture, Dictionary<Type, IModel> models)
+        public void RegisterModel(string culture, Dictionary<Type, IModel> models, string options)
         {
             foreach (var model in models)
             {
-                RegisterModel(culture, model.Key, model.Value);
+                RegisterModel(culture, model.Key, model.Value, options);
             }
         }
 

--- a/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
+++ b/.NET/Microsoft.Recognizers.Text/ModelContainer.cs
@@ -103,5 +103,10 @@ namespace Microsoft.Recognizers.Text
                 throw new InvalidOperationException($"Please request a specific culture for {typeof(TModel)}.");
             }
         }
+
+        public bool ContainsModels() {
+            return modelInstances.Keys.Any();
+        }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Recognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text/Recognizer.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Recognizers.Text
             return modelContainer.TryGetModel<TModel>(culture, out model, fallbackToDefaultCulture, options);
         }
 
+        protected bool ContainsModels()
+        {
+            return modelContainer.ContainsModels();
+        }
+
         public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true, string options = "")
         {
             return modelContainer.ContainsModel<TModel>(culture, fallbackToDefaultCulture, options);

--- a/.NET/Microsoft.Recognizers.Text/Recognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text/Recognizer.cs
@@ -7,29 +7,29 @@ namespace Microsoft.Recognizers.Text
     {
         private readonly ModelContainer modelContainer = new ModelContainer();
 
-        protected void RegisterModel(string culture, Type type, IModel model)
+        protected void RegisterModel(string culture, Type type, string options, IModel model)
         {
-            modelContainer.RegisterModel(culture, type, model);
+            modelContainer.RegisterModel(culture, type, model, options);
         }
 
-        protected void RegisterModel(string culture, Dictionary<Type, IModel> models)
+        protected void RegisterModel(string culture, string options, Dictionary<Type, IModel> models)
         {
-            modelContainer.RegisterModel(culture, models);
+            modelContainer.RegisterModel(culture, models, options);
         }
 
-        public IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
+        public IModel GetModel<TModel>(string culture, bool fallbackToDefaultCulture = true, string options = "")
         {
-            return modelContainer.GetModel<TModel>(culture, fallbackToDefaultCulture);
+            return modelContainer.GetModel<TModel>(culture, fallbackToDefaultCulture, options);
         }
 
-        public bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture = true)
+        public bool TryGetModel<TModel>(string culture, out IModel model, bool fallbackToDefaultCulture = true, string options = "")
         {
-            return modelContainer.TryGetModel<TModel>(culture, out model, fallbackToDefaultCulture);
+            return modelContainer.TryGetModel<TModel>(culture, out model, fallbackToDefaultCulture, options);
         }
 
-        public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true)
+        public bool ContainsModel<TModel>(string culture, bool fallbackToDefaultCulture = true, string options = "")
         {
-            return modelContainer.ContainsModel<TModel>(culture, fallbackToDefaultCulture);
+            return modelContainer.ContainsModel<TModel>(culture, fallbackToDefaultCulture, options);
         }
 
         protected IModel GetSingleModel<TModel>()

--- a/.NET/Microsoft.Recognizers.Text/Utilities/EnumUtils.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/EnumUtils.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Microsoft.Recognizers.Text.Utilities
+{
+    public static class EnumUtils
+    {
+
+        public static bool IsFlagDefined(Enum en)
+        {
+
+            // For enums with FlagsAttribute, IsDefined() doesn't work.
+            // ToString() will return a comma-separated list of enum string values if defined and an int if not.
+            return (!int.TryParse(en.ToString(), out int val));
+        }
+        public static T Convert<T>(int value) where T : struct 
+        {
+
+            if (!typeof(T).IsEnum)
+            {
+                throw new InvalidOperationException("Invalid Enum Type. " + typeof(T).ToString() + "  must be an Enum.");
+            }
+
+            Type enumType = typeof(T);
+            var returnEnum = (T)Enum.ToObject(enumType, value);
+
+            if (IsFlagDefined((Enum)(object)returnEnum))
+            {
+                return returnEnum;
+            }
+            else
+            { 
+                throw new ArgumentOutOfRangeException(value.ToString(), "Bad configuration parameter value.");
+            }
+        }
+
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text/Utilities/FormatUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/FormatUtility.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Recognizers.Text.Utilities
             {
                 query = query.ToLowerInvariant();
             }
+
             query = query.Replace("０", "0");
             query = query.Replace("１", "1");
             query = query.Replace("２", "2");

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vs/Microsoft.Recognizers.Text/v15
+/TestResults


### PR DESCRIPTION
- Old behaviour unchanged (getting pre-configured instance via GetInstance);
- If user gets a clean instance, if will be initialized with the correct DateTimeOptions on first GetModel call;
- Options for a given instance cannot be changed once initialized;
- Adding safe method to convert int to enums with FlagsAttribute.