### PR TITLE
Add build script for MacOS and Linux

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
@@ -440,8 +440,12 @@
     <DotNetCliToolReference Include="T5.TextTransform.Tool" Version="1.1.0-*" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' ">
     <Exec Command="BuildResources.cmd $(TargetPath)" />
+  </Target>
+
+  <Target Name="PostBuildUnix" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="cp -r $(TargetDir)/../* $(TargetDir)../../../../build/package\" />
   </Target>
 
 </Project>

--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
@@ -41,4 +41,7 @@
     <Exec Command="(robocopy /E /XO /R:3 /W:3 &quot;$(TargetDir)..&quot; &quot;$(ProjectDir)..\build\package&quot; *.*) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0" />
   </Target>
 
+  <Target Name="PostBuildUnix" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="cp -r $(TargetDir)/../* $(TargetDir)../../../../build/package\" />
+  </Target>
 </Project>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.csproj
@@ -21,6 +21,10 @@
     <Exec Command="(robocopy /E /XO /R:3 /W:3 &quot;$(TargetDir)..&quot; &quot;$(ProjectDir)..\build\package&quot; *.*) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0" />
   </Target>
 
+  <Target Name="PostBuildUnix" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="cp -r $(TargetDir)/../* $(TargetDir)../../../../build/package\" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
@@ -40,5 +40,8 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' ">
     <Exec Command="(robocopy /E /XO /R:3 /W:3 &quot;$(TargetDir)..&quot; &quot;$(ProjectDir)..\build\package&quot; *.*) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0" />
   </Target>  
-  
+
+  <Target Name="PostBuildUnix" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="cp -r $(TargetDir)/../* $(TargetDir)../../../../build/package\" />
+  </Target>
 </Project>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
@@ -39,4 +39,7 @@
     <Exec Command="(robocopy /E /XO /R:3 /W:3 &quot;$(TargetDir)..&quot; &quot;$(ProjectDir)..\build\package&quot; *.*) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0" />
   </Target>
 
+  <Target Name="PostBuildUnix" AfterTargets="PostBuildEvent" Condition="'$(OS)' != 'Windows_NT'">
+    <Exec Command="cp -r $(TargetDir)/../* $(TargetDir)../../../../build/package\" />
+  </Target>
 </Project>

--- a/.NET/README.md
+++ b/.NET/README.md
@@ -9,7 +9,7 @@ Recognizer's are organized into groups and designed to be used in C#, Node.js, P
 
 ## Setup
 
-You can choose between build the solution manually or through an automatized build.cmd file.
+You can choose between build the solution manually or through an automatized build.cmd file (or build.sh file on MacOS and Linux).
 
 ### Manual Build
 * Open `Microsoft.Recognizers.Text.sln` and build solution.

--- a/.NET/build.sh
+++ b/.NET/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Debug}
+
+echo "// Building .NET platform"
+
+command -v dotnet >/dev/null 2>&1 || { echo >&2 "dotnet not found. Make sure it's installed and included in PATH. Aborting."; exit 1; }
+command -v nuget >/dev/null 2>&1 || { echo >&2 "NuGet not found. Make sure it's installed and included in PATH. Aborting."; exit 1; }
+command -v msbuild >/dev/null 2>&1 || { echo >&2 "MSBuild not found. Make sure it's installed and included in PATH. Aborting."; exit 1; }
+
+echo "// Restoring NuGet dependencies"
+nuget restore
+
+echo "// Build .NET solution ($BUILD_CONFIGURATION)"
+rm -rf build
+mkdir -p build/package
+msbuild Microsoft.Recognizers.Text.sln \
+        /p:Configuration="$BUILD_CONFIGURATION" \
+        /t:Clean,Build
+
+# Run tests if build was successful
+if [ $? -eq 0 ]; then
+    echo "// Running .NET Tests"
+    test_files=$(find . | grep 'bin/Debug.*Tests.dll')
+    for file in "${test_files[@]}"
+    do :
+        dotnet vstest --Parallel --Diag:log.txt $file
+    done
+fi
+
+echo "done."


### PR DESCRIPTION
### An early tentative build for Recognizers-Text as a library on linux and macOS.

**Status**
* It builds :)
* It can be imported as a .net assembly by the demo applications, compile with them and executed perfectly as far as I could try.

**Issues**
* Had to manually create the target platform on buildfiles for that purpose (sorry, I'm clueless with MSBuild)
* Could not make vstest run on macOS.
* Was only tested on macOS 10.13.2 and Arch Linux with kernel 4.14.4 (both with dotnet-sdk 2.1 and msbuild 15.4), so I don't really know how solid this is different environments.


Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>