### PR TITLE
JavaScript -Version bump to RC 29 (1.0.0-rc.29.0)

### DIFF
--- a/JavaScript/lerna.json
+++ b/JavaScript/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/recognizers-*"
   ],
-  "version": "1.0.0-rc.27"
+  "version": "1.0.0-rc.29.0"
 }

--- a/JavaScript/packages/recognizers-date-time/package.json
+++ b/JavaScript/packages/recognizers-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text-date-time",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text provides robust recognition and resolution of date/time expressed in multiple languages. Support for English, Spanish, Chinese and French.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -35,8 +35,8 @@
   "dependencies": {
     "lodash.isequal": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
-    "recognizers-text": "^1.0.0-rc.27",
-    "recognizers-text-number": "^1.0.0-rc.27",
-    "recognizers-text-number-with-unit": "^1.0.0-rc.27"
+    "recognizers-text": "^1.0.0-rc.29.0",
+    "recognizers-text-number": "^1.0.0-rc.29.0",
+    "recognizers-text-number-with-unit": "^1.0.0-rc.29.0"
   }
 }

--- a/JavaScript/packages/recognizers-number-with-unit/package.json
+++ b/JavaScript/packages/recognizers-number-with-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text-number-with-unit",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text-number-with-unit provides robust recognition and resolution of numbers with units expressed in multiple languages. Support for English, Spanish, Chinese and Portuguese.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -34,7 +34,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.last": "^3.0.0",
     "lodash.max": "^4.0.1",
-    "recognizers-text": "^1.0.0-rc.27",
-    "recognizers-text-number": "^1.0.0-rc.27"
+    "recognizers-text": "^1.0.0-rc.29.0",
+    "recognizers-text-number": "^1.0.0-rc.29.0"
   }
 }

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text-number",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text-number provides robust recognition and resolution of numbers expressed in multiple languages. Support for English, Spanish, Chinese, French and Portuguese.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -35,7 +35,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.sortby": "^4.7.0",
     "lodash.trimend": "^4.5.1",
-    "xregexp": "^3.2.0",
-    "recognizers-text": "^1.0.0-rc.27"
+    "recognizers-text": "^1.0.0-rc.29.0",
+    "xregexp": "^3.2.0"
   }
 }

--- a/JavaScript/packages/recognizers-options/package.json
+++ b/JavaScript/packages/recognizers-options/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text-options",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text-options abstract",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -31,6 +31,6 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "recognizers-text": "^1.0.0-rc.27"
+    "recognizers-text": "^1.0.0-rc.29.0"
   }
 }

--- a/JavaScript/packages/recognizers-text-suite/package.json
+++ b/JavaScript/packages/recognizers-text-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text-suite",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text-suite provides robust recognition and resolution of numbers, units, and date/time expressed in multiple languages. Support for English, Spanish, and Chinese (full); and French and Portuguese (partial).",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,9 +32,9 @@
     "prepare": "npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "recognizers-text-options": "^1.0.0-rc.27",
-    "recognizers-text-date-time": "^1.0.0-rc.27",
-    "recognizers-text-number": "^1.0.0-rc.27",
-    "recognizers-text-number-with-unit": "^1.0.0-rc.27"
+    "recognizers-text-date-time": "^1.0.0-rc.29.0",
+    "recognizers-text-number": "^1.0.0-rc.29.0",
+    "recognizers-text-number-with-unit": "^1.0.0-rc.29.0",
+    "recognizers-text-options": "^1.0.0-rc.29.0"
   }
 }

--- a/JavaScript/packages/recognizers-text/package.json
+++ b/JavaScript/packages/recognizers-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recognizers-text",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.29.0",
   "description": "recognizers-text README",
   "author": "Microsoft Corp.",
   "license": "MIT",


### PR DESCRIPTION
To match latest internal prerelease publish