### PR TITLE
Change target framework to netstandard2.0

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Microsoft.Recognizers.Definitions.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -50,8 +50,9 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/packages.config
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/packages.config
@@ -4,6 +4,6 @@
   <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NuGet.CommandLine" version="4.3.0" targetFramework="net462" developmentDependency="true" />
-  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net462" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />
   <package id="vswhere" version="2.2.11" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/CreatePackage.cmd
@@ -11,10 +11,10 @@ for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -lat
 if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text.DateTime*nupkg erase /s ..\nuget\Microsoft.Recognizers.Text.DateTime*nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.DateTime.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set numberWithUnit=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.DateTime.dll).FileVersionInfo.FileVersion"') do set version=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set numberWithUnit=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll).FileVersionInfo.FileVersion"') do set version=%%v
 ..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.DateTime.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number%;numberWithUnit=%numberWithUnit% -OutputDirectory ..\nuget
 
 set error=%errorlevel%

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
@@ -19,9 +19,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net45"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net452"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
   </files>
 </package>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
@@ -19,8 +19,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net452"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net452"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />

--- a/.NET/Microsoft.Recognizers.Text.Number/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.Number/CreatePackage.cmd
@@ -11,8 +11,8 @@ for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -lat
 if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text.Number*.nupkg erase /s ..\nuget\Microsoft.Recognizers.Text.Number*.nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.Number.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
 ..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.Number.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
 
 set error=%errorlevel%

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
@@ -17,9 +17,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Text.Number.dll" target="lib\net45"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Text.Number.dll" target="lib\net452"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Text.Number.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
   </files>
 </package>

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
@@ -17,8 +17,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net452"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Text.Number.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Text.Number.dll" target="lib\net452"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Number.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/CreatePackage.cmd
@@ -11,9 +11,9 @@ for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -lat
 if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text.NumberWithUnit*nupkg erase /s ..\nuget\Microsoft.Recognizers.Text.NumberWithUnit*nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.NumberWithUnit.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set version=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set version=%%v
 ..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.NumberWithUnit.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number% -OutputDirectory ..\nuget
 
 set error=%errorlevel%

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
@@ -18,9 +18,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net45"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net452"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
   </files>
 </package>

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
@@ -18,8 +18,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net452"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net452"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />

--- a/.NET/Microsoft.Recognizers.Text.Sequence/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/CreatePackage.cmd
@@ -11,8 +11,8 @@ for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -lat
 if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text.Sequence*.nupkg erase /s ..\nuget\Microsoft.Recognizers.Text.Sequence*.nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.Sequence.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.Sequence.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
 ..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.Sequence.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
 
 set error=%errorlevel%

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
@@ -17,9 +17,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net45"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net452"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
   </files>
 </package>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
@@ -17,8 +17,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net452"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net452"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />

--- a/.NET/Microsoft.Recognizers.Text/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text/CreatePackage.cmd
@@ -11,7 +11,7 @@ for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -lat
 if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text*.nupkg erase /s ..\nuget\Microsoft.Recognizers.Text*.nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.csproj
-for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\net462\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basicVersion=%%v
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basicVersion=%%v
 ..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.nuspec -symbols -properties version=%basicVersion% -OutputDirectory ..\nuget
 
 set error=%errorlevel%

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452;net45</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net452;net45</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="NuGet.CommandLine" Version="4.3.0" />
     <PackageReference Include="vswhere" Version="2.2.11" />
   </ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
@@ -16,10 +16,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net45"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net452"/>
-    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net452"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Text.dll" target="lib\net45"/>
+    <file src="..\build\package\net45\Microsoft.Recognizers.Definitions.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Text.dll" target="lib\net452"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.Definitions.dll" target="lib\net452"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net462"/>
     <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\netstandard2.0"/>

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
@@ -16,12 +16,14 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Text.dll" target="lib\net45"/>
-    <file src="..\build\package\net45\Microsoft.Recognizers.Definitions.dll" target="lib\net45"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Text.dll" target="lib\net452"/>
-    <file src="..\build\package\net452\Microsoft.Recognizers.Definitions.dll" target="lib\net452"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Text.dll" target="lib\net462"/>
-    <file src="..\build\package\net462\Microsoft.Recognizers.Definitions.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net45"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net452"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Text.dll" target="lib\netstandard2.0"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.Definitions.dll" target="lib\netstandard2.0"/>
     <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
     <file src="..\Microsoft.Recognizers.Definitions\**\*.cs" exclude="..\Microsoft.Recognizers.Definitions\**\obj\**\*.cs" target="src\Definitions" />
   </files>

--- a/.NET/Samples/BotBuilder/Web.config
+++ b/.NET/Samples/BotBuilder/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,9 +6,9 @@
 <configuration>
   <appSettings>
     <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
-    <add key="BotId" value="YourBotId" />
-    <add key="MicrosoftAppId" value="" />
-    <add key="MicrosoftAppPassword" value="" />
+    <add key="BotId" value="YourBotId"/>
+    <add key="MicrosoftAppId" value=""/>
+    <add key="MicrosoftAppPassword" value=""/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -19,65 +19,277 @@
       </system.Web>
   -->
   <system.web>
-    <customErrors mode="Off" />
-    <compilation debug="true" targetFramework="4.6.2" />
-    <httpRuntime targetFramework="4.6.2" />
+    <customErrors mode="Off"/>
+    <compilation debug="true" targetFramework="4.6.2"/>
+    <httpRuntime targetFramework="4.6.2"/>
   </system.web>
   <system.webServer>
     <defaultDocument>
       <files>
-        <clear />
-        <add value="default.htm" />
+        <clear/>
+        <add value="default.htm"/>
       </files>
     </defaultDocument>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Overlapped" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encoding" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.RegularExpressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.SecureString" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Sockets" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.ReaderWriter" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Debug" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Resources.ResourceManager" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Queryable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.InteropServices" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.NetworkInformation" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Timer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.IO.Compression" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Contracts" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Numerics" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ComponentModel.EventBasedAsync" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Concurrent" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Dynamic.Runtime" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Principal" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Security.Cryptography.Algorithms" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Json" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XmlSerializer" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.ObjectModel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Globalization.Extensions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Linq.Expressions" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Parallel" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Diagnostics.Tools" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Requests" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Data.Common" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
+			</dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.30826.1200" newVersion="4.0.30826.1200" />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.30826.1200" newVersion="4.0.30826.1200"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.3.42" newVersion="1.0.3.42" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.3.42" newVersion="1.0.3.42"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.11.1.0" newVersion="3.11.1.0" />
+        <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.11.1.0" newVersion="3.11.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Changed Target framework to netstandard 2.0. It was necessary to downgrade System.Collections.Immutable package to version 1.3.1 to work with .Net Framework 4.6.2 projects ([related issue](https://github.com/dotnet/standard/issues/534#issuecomment-358712093)).