### PR TITLE
Remove global property from recognizer options token regular expression

### DIFF
--- a/JavaScript/packages/recognizers-options/src/options/english/boolean.ts
+++ b/JavaScript/packages/recognizers-options/src/options/english/boolean.ts
@@ -11,7 +11,7 @@ export class EnglishBooleanExtractorConfiguration implements IBooleanExtractorCo
     constructor(onlyTopMatch: boolean = true) {
         this.regexTrue = RegExpUtility.getSafeRegExp(EnglishOptions.TrueRegex);
         this.regexFalse = RegExpUtility.getSafeRegExp(EnglishOptions.FalseRegex);
-        this.tokenRegex = RegExpUtility.getSafeRegExp(EnglishOptions.TokenizerRegex);
+        this.tokenRegex = RegExpUtility.getSafeRegExp(EnglishOptions.TokenizerRegex, 'is');
         this.onlyTopMatch = onlyTopMatch;
     }
 }

--- a/Specs/Options/English/BooleanModel.json
+++ b/Specs/Options/English/BooleanModel.json
@@ -67,7 +67,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 0.5
+		"score": 0.52
       }
     }
   ]


### PR DESCRIPTION
The 'global' property from token regular expression was removed since this RegExp is used several times in different contexts, so it causes getting unexpected results