### PR TITLE
Fix choiceRecognizer class name

### DIFF
--- a/JavaScript/packages/recognizers-choice/src/choice/choiceRecognizer.ts
+++ b/JavaScript/packages/recognizers-choice/src/choice/choiceRecognizer.ts
@@ -10,12 +10,12 @@ export enum ChoiceOptions {
 
 export function recognizeBoolean(query: string, culture: string, options: ChoiceOptions = ChoiceOptions.None,
         fallbackToDefaultCulture: boolean = true): Array<ModelResult> {
-    let recognizer = new OptionsRecognizer(culture, options);
+    let recognizer = new ChoiceRecognizer(culture, options);
     let model = recognizer.getBooleanModel(culture, fallbackToDefaultCulture);
     return model.parse(query);
 }
 
-export default class OptionsRecognizer extends Recognizer<ChoiceOptions> {
+export default class ChoiceRecognizer extends Recognizer<ChoiceOptions> {
     constructor(culture: string, options: ChoiceOptions = ChoiceOptions.None, lazyInitialization: boolean = false) {
         super(culture, options, lazyInitialization);
     }


### PR DESCRIPTION
Fixed ChoiceRecognizer class name. Exported class is renamed as ChoiceRecognizer, so it doesn't affect  [external invokes](https://github.com/Microsoft/Recognizers-Text/blob/d7f4d27a3d32dc766ff0d3f7b71305824c361eb8/JavaScript/packages/recognizers-choice/src/recognizers-text-choice.ts#L1).