### PR TITLE
Updates to timex expression parser

### DIFF
--- a/.NET/Build.cmd
+++ b/.NET/Build.cmd
@@ -45,6 +45,7 @@ FOR /R %%f IN (*Tests.dll) DO (
 		SET testcontainer=!testcontainer! "%%f"
 	)
 )
+ECHO "!VsTestDir!\vstest.console"
 CALL "!VsTestDir!\vstest.console" /Parallel %testcontainer%
 
 ECHO.

--- a/.NET/CreateAllPackages.cmd
+++ b/.NET/CreateAllPackages.cmd
@@ -30,6 +30,9 @@ popd
 pushd Microsoft.Recognizers.Text.Choice
 call CreatePackage.cmd
 popd
+pushd Microsoft.Recognizers.DataTypes.DateTime
+call CreatePackage.cmd
+popd
 rem Exit .NET dir
 popd
 

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/Microsoft.Recognizers.DataTypes.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/Microsoft.Recognizers.DataTypes.DataDrivenTests.csproj
@@ -1,19 +1,87 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{32A4593C-3D2D-412E-8EC5-07346266A358}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Recognizers.DataTypes.DataDrivenTests</RootNamespace>
+    <AssemblyName>Microsoft.Recognizers.DataTypes.DataDrivenTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Recognizers.DataTypes.DateTime\Microsoft.Recognizers.DataTypes.DateTime.csproj" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestTime.cs" />
+    <Compile Include="TestTimex.cs" />
+    <Compile Include="TestTimexConvert.cs" />
+    <Compile Include="TestTimexCreator.cs" />
+    <Compile Include="TestTimexDateHelpers.cs" />
+    <Compile Include="TestTimexFormat.cs" />
+    <Compile Include="TestTimexHelpers.cs" />
+    <Compile Include="TestTimexParsing.cs" />
+    <Compile Include="TestTimexRangeResolve.cs" />
+    <Compile Include="TestTimexRelativeConvert.cs" />
+    <Compile Include="TestTimexResolver.cs" />
   </ItemGroup>
-
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Recognizers.DataTypes.DateTime\Microsoft.Recognizers.DataTypes.DateTime.csproj">
+      <Project>{e4fcbde9-d436-4d39-a67f-707e6cbd45cb}</Project>
+      <Name>Microsoft.Recognizers.DataTypes.DateTime</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Recognizers.DataTypes.DataDrivenTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Recognizers.DataTypes.DataDrivenTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("32a4593c-3d2d-412e-8ec5-07346266a358")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTime.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTime.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTime
     {
         [TestMethod]
-        public void Time_Constructor()
+        public void DataTypes_Time_Constructor()
         {
             var t = new Time(23, 45, 32);
             Assert.AreEqual(23, t.Hour);
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Time_GetTime()
+        public void DataTypes_Time_GetTime()
         {
             var t = new Time(23, 45, 32);
             Assert.AreEqual(85532000, t.GetTime());

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimex.cs
@@ -9,19 +9,19 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimex
     {
         [TestMethod]
-        public void Timex_FromDate()
+        public void DataTypes_Timex_FromDate()
         {
             Assert.AreEqual("2017-12-05", Timex.FromDate(new System.DateTime(2017, 12, 5)).TimexValue);
         }
 
         [TestMethod]
-        public void Timex_FromDateTime()
+        public void DataTypes_Timex_FromDateTime()
         {
             Assert.AreEqual("2017-12-05T23:57:35", Timex.FromDateTime(new System.DateTime(2017, 12, 5, 23, 57, 35)).TimexValue);
         }
 
         [TestMethod]
-        public void Timex_FromTime()
+        public void DataTypes_Timex_FromTime()
         {
             Assert.AreEqual("T23:59:30", Timex.FromTime(new Time(23, 59, 30)).TimexValue);
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_Date()
+        public void DataTypes_Timex_Roundtrip_Date()
         {
             Roundtrip("2017-09-27");
             Roundtrip("XXXX-WXX-3");
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_Time()
+        public void DataTypes_Timex_Roundtrip_Time()
         {
             Roundtrip("T17:30:45");
             Roundtrip("T05:06:07");
@@ -49,7 +49,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_Duration()
+        public void DataTypes_Timex_Roundtrip_Duration()
         {
             Roundtrip("P50Y");
             Roundtrip("P6M");
@@ -61,20 +61,20 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_Now()
+        public void DataTypes_Timex_Roundtrip_Now()
         {
             Roundtrip("PRESENT_REF");
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_DateTime()
+        public void DataTypes_Timex_Roundtrip_DateTime()
         {
             Roundtrip("XXXX-WXX-3T04");
             Roundtrip("2017-09-27T11:41:30");
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_DateRange()
+        public void DataTypes_Timex_Roundtrip_DateRange()
         {
             Roundtrip("2017");
             Roundtrip("SU");
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_DateRange_Start_End_Duration()
+        public void DataTypes_Timex_Roundtrip_DateRange_Start_End_Duration()
         {
             Roundtrip("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
             Roundtrip("(XXXX-01-01,XXXX-08-05,P216D)");
@@ -95,38 +95,38 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_TimeRange()
+        public void DataTypes_Timex_Roundtrip_TimeRange()
         {
             Roundtrip("TEV");
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_TimeRange_Start_End_Duration()
+        public void DataTypes_Timex_Roundtrip_TimeRange_Start_End_Duration()
         {
             Roundtrip("(T16,T19,PT3H)");
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_DateTimeRange()
+        public void DataTypes_Timex_Roundtrip_DateTimeRange()
         {
             Roundtrip("2017-09-27TEV");
         }
 
         [TestMethod]
-        public void Timex_Roundtrip_DateTimeRange_Start_End_Duration()
+        public void DataTypes_Timex_Roundtrip_DateTimeRange_Start_End_Duration()
         {
             Roundtrip("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
             Roundtrip("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)");
         }
 
         [TestMethod]
-        public void Timex_ToString()
+        public void DataTypes_Timex_ToString()
         {
             Assert.AreEqual("5th May", (new Timex("XXXX-05-05")).ToString());
         }
 
         [TestMethod]
-        public void Timex_ToNaturalLanguage()
+        public void DataTypes_Timex_ToNaturalLanguage()
         {
             var today = new System.DateTime(2017, 10, 16);
             Assert.AreEqual("tomorrow", (new Timex("2017-10-17")).ToNaturalLanguage(today));

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexConvert.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexConvert.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexConvert
     {
         [TestMethod]
-        public void Convert_CompleteDate()
+        public void DataTypes_Convert_CompleteDate()
         {
             Assert.AreEqual("29th May 2017", TimexConvert.ConvertTimexToString(new Timex("2017-05-29")));
         }
 
         [TestMethod]
-        public void Convert_MonthAndDayOfMonth()
+        public void DataTypes_Convert_MonthAndDayOfMonth()
         {
             Assert.AreEqual("5th January", TimexConvert.ConvertTimexToString(new Timex("XXXX-01-05")));
             Assert.AreEqual("5th February", TimexConvert.ConvertTimexToString(new Timex("XXXX-02-05")));
@@ -32,7 +32,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_MonthAndDayOfMonthWithCorrectAbbreviation()
+        public void DataTypes_Convert_MonthAndDayOfMonthWithCorrectAbbreviation()
         {
             Assert.AreEqual("1st June", TimexConvert.ConvertTimexToString(new Timex("XXXX-06-01")));
             Assert.AreEqual("2nd June", TimexConvert.ConvertTimexToString(new Timex("XXXX-06-02")));
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_DayOfWeek()
+        public void DataTypes_Convert_DayOfWeek()
         {
             Assert.AreEqual("Monday", TimexConvert.ConvertTimexToString(new Timex("XXXX-WXX-1")));
             Assert.AreEqual("Tuesday", TimexConvert.ConvertTimexToString(new Timex("XXXX-WXX-2")));
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_Time()
+        public void DataTypes_Convert_Time()
         {
             Assert.AreEqual("5:30:05PM", TimexConvert.ConvertTimexToString(new Timex("T17:30:05")));
             Assert.AreEqual("2:30:30AM", TimexConvert.ConvertTimexToString(new Timex("T02:30:30")));
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_HourAndMinute()
+        public void DataTypes_Convert_HourAndMinute()
         {
             Assert.AreEqual("5:30PM", TimexConvert.ConvertTimexToString(new Timex("T17:30")));
             Assert.AreEqual("5PM", TimexConvert.ConvertTimexToString(new Timex("T17:00")));
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_Hour()
+        public void DataTypes_Convert_Hour()
         {
             Assert.AreEqual("midnight", TimexConvert.ConvertTimexToString(new Timex("T00")));
             Assert.AreEqual("1AM", TimexConvert.ConvertTimexToString(new Timex("T01")));
@@ -85,13 +85,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_Now()
+        public void DataTypes_Convert_Now()
         {
             Assert.AreEqual("now", TimexConvert.ConvertTimexToString(new Timex("PRESENT_REF")));
         }
 
         [TestMethod]
-        public void Convert_FullDatetime()
+        public void DataTypes_Convert_FullDatetime()
         {
             Assert.AreEqual("6:30:45PM 3rd January 1984", TimexConvert.ConvertTimexToString(new Timex("1984-01-03T18:30:45")));
             Assert.AreEqual("midnight 1st January 2000", TimexConvert.ConvertTimexToString(new Timex("2000-01-01T00")));
@@ -99,31 +99,31 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_ParicularTimeOnParticularDayOfWeek()
+        public void DataTypes_Convert_ParicularTimeOnParticularDayOfWeek()
         {
             Assert.AreEqual("4PM Wednesday", TimexConvert.ConvertTimexToString(new Timex("XXXX-WXX-3T16")));
             Assert.AreEqual("6:30PM Friday", TimexConvert.ConvertTimexToString(new Timex("XXXX-WXX-5T18:30")));
         }
 
         [TestMethod]
-        public void Convert_Year()
+        public void DataTypes_Convert_Year()
         {
             Assert.AreEqual("2016", TimexConvert.ConvertTimexToString(new Timex("2016")));
         }
 
         [TestMethod]
-        public void Convert_YearSeason()
+        public void DataTypes_Convert_YearSeason()
         {
             Assert.AreEqual("summer 1999", TimexConvert.ConvertTimexToString(new Timex("1999-SU")));
         }
-        public void Convert_Season()
+        public void DataTypes_Convert_Season()
         {
             Assert.AreEqual("summer", TimexConvert.ConvertTimexToString(new Timex("SU")));
             Assert.AreEqual("winter", TimexConvert.ConvertTimexToString(new Timex("WI")));
         }
 
         [TestMethod]
-        public void Convert_Month()
+        public void DataTypes_Convert_Month()
         {
             Assert.AreEqual("January", TimexConvert.ConvertTimexToString(new Timex("XXXX-01")));
             Assert.AreEqual("May", TimexConvert.ConvertTimexToString(new Timex("XXXX-05")));
@@ -131,20 +131,20 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_MonthAndYear()
+        public void DataTypes_Convert_MonthAndYear()
         {
             Assert.AreEqual("May 2018", TimexConvert.ConvertTimexToString(new Timex("2018-05")));
         }
 
         [TestMethod]
-        public void Convert_WeekOfMonth()
+        public void DataTypes_Convert_WeekOfMonth()
         {
             Assert.AreEqual("first week of January", TimexConvert.ConvertTimexToString(new Timex("XXXX-01-W01")));
             Assert.AreEqual("third week of August", TimexConvert.ConvertTimexToString(new Timex("XXXX-08-W03")));
         }
 
         [TestMethod]
-        public void Convert_PartOfTheDay()
+        public void DataTypes_Convert_PartOfTheDay()
         {
             Assert.AreEqual("daytime", TimexConvert.ConvertTimexToString(new Timex("TDT")));
             Assert.AreEqual("night", TimexConvert.ConvertTimexToString(new Timex("TNI")));
@@ -154,19 +154,19 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_FridayEvening()
+        public void DataTypes_Convert_FridayEvening()
         {
             Assert.AreEqual("Friday evening", TimexConvert.ConvertTimexToString(new Timex("XXXX-WXX-5TEV")));
         }
 
         [TestMethod]
-        public void Convert_DateAndPartOfDay()
+        public void DataTypes_Convert_DateAndPartOfDay()
         {
             Assert.AreEqual("7th September 2017 night", TimexConvert.ConvertTimexToString(new Timex("2017-09-07TNI")));
         }
 
         [TestMethod]
-        public void Convert_Last5Minutes()
+        public void DataTypes_Convert_Last5Minutes()
         {
             // date + time + duration
             var timex = new Timex("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
@@ -174,7 +174,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_WednesdayToSaturday()
+        public void DataTypes_Convert_WednesdayToSaturday()
         {
             // date + duration
             var timex = new Timex("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
@@ -182,14 +182,14 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_Years()
+        public void DataTypes_Convert_Years()
         {
             Assert.AreEqual("2 years", TimexConvert.ConvertTimexToString(new Timex("P2Y")));
             Assert.AreEqual("1 year", TimexConvert.ConvertTimexToString(new Timex("P1Y")));
         }
 
         [TestMethod]
-        public void Convert_Months()
+        public void DataTypes_Convert_Months()
         {
             Assert.AreEqual("4 months", TimexConvert.ConvertTimexToString(new Timex("P4M")));
             Assert.AreEqual("1 month", TimexConvert.ConvertTimexToString(new Timex("P1M")));
@@ -197,89 +197,89 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Convert_Weeks()
+        public void DataTypes_Convert_Weeks()
         {
             Assert.AreEqual("6 weeks", TimexConvert.ConvertTimexToString(new Timex("P6W")));
             Assert.AreEqual("9.5 weeks", TimexConvert.ConvertTimexToString(new Timex("P9.5W")));
         }
 
         [TestMethod]
-        public void Convert_Days()
+        public void DataTypes_Convert_Days()
         {
             Assert.AreEqual("5 days", TimexConvert.ConvertTimexToString(new Timex("P5D")));
             Assert.AreEqual("1 day", TimexConvert.ConvertTimexToString(new Timex("P1D")));
         }
 
         [TestMethod]
-        public void Convert_Hours()
+        public void DataTypes_Convert_Hours()
         {
             Assert.AreEqual("5 hours", TimexConvert.ConvertTimexToString(new Timex("PT5H")));
             Assert.AreEqual("1 hour", TimexConvert.ConvertTimexToString(new Timex("PT1H")));
         }
 
         [TestMethod]
-        public void Convert_Minutes()
+        public void DataTypes_Convert_Minutes()
         {
             Assert.AreEqual("30 minutes", TimexConvert.ConvertTimexToString(new Timex("PT30M")));
             Assert.AreEqual("1 minute", TimexConvert.ConvertTimexToString(new Timex("PT1M")));
         }
 
         [TestMethod]
-        public void Convert_Seconds()
+        public void DataTypes_Convert_Seconds()
         {
             Assert.AreEqual("45 seconds", TimexConvert.ConvertTimexToString(new Timex("PT45S")));
         }
 
         [TestMethod]
-        public void Convert_Every2Days()
+        public void DataTypes_Convert_Every2Days()
         {
             Assert.AreEqual("every 2 days", TimexConvert.ConvertTimexSetToString(new TimexSet("P2D")));
         }
 
         [TestMethod]
-        public void Convert_EveryWeek()
+        public void DataTypes_Convert_EveryWeek()
         {
             Assert.AreEqual("every week", TimexConvert.ConvertTimexSetToString(new TimexSet("P1W")));
         }
 
         [TestMethod]
-        public void Convert_EveryOctober()
+        public void DataTypes_Convert_EveryOctober()
         {
             Assert.AreEqual("every October", TimexConvert.ConvertTimexSetToString(new TimexSet("XXXX-10")));
         }
 
         [TestMethod]
-        public void Convert_EverySunday()
+        public void DataTypes_Convert_EverySunday()
         {
             Assert.AreEqual("every Sunday", TimexConvert.ConvertTimexSetToString(new TimexSet("XXXX-WXX-7")));
         }
 
         [TestMethod]
-        public void Convert_EveryDay()
+        public void DataTypes_Convert_EveryDay()
         {
             Assert.AreEqual("every day", TimexConvert.ConvertTimexSetToString(new TimexSet("P1D")));
         }
 
         [TestMethod]
-        public void Convert_EveryYear()
+        public void DataTypes_Convert_EveryYear()
         {
             Assert.AreEqual("every year", TimexConvert.ConvertTimexSetToString(new TimexSet("P1Y")));
         }
 
         [TestMethod]
-        public void Convert_EverySpring()
+        public void DataTypes_Convert_EverySpring()
         {
             Assert.AreEqual("every spring", TimexConvert.ConvertTimexSetToString(new TimexSet("SP")));
         }
 
         [TestMethod]
-        public void Convert_EveryWinter()
+        public void DataTypes_Convert_EveryWinter()
         {
             Assert.AreEqual("every winter", TimexConvert.ConvertTimexSetToString(new TimexSet("WI")));
         }
 
         [TestMethod]
-        public void Convert_EveryEvening()
+        public void DataTypes_Convert_EveryEvening()
         {
             Assert.AreEqual("every evening", TimexConvert.ConvertTimexSetToString(new TimexSet("TEV")));
         }

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexConvert.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexConvert.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         public void Convert_MonthAndDayOfMonth()
         {
             Assert.AreEqual("5th January", TimexConvert.ConvertTimexToString(new Timex("XXXX-01-05")));
-            Assert.AreEqual("5th Februrary", TimexConvert.ConvertTimexToString(new Timex("XXXX-02-05")));
+            Assert.AreEqual("5th February", TimexConvert.ConvertTimexToString(new Timex("XXXX-02-05")));
             Assert.AreEqual("5th March", TimexConvert.ConvertTimexToString(new Timex("XXXX-03-05")));
             Assert.AreEqual("5th April", TimexConvert.ConvertTimexToString(new Timex("XXXX-04-05")));
             Assert.AreEqual("5th May", TimexConvert.ConvertTimexToString(new Timex("XXXX-05-05")));

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexCreator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexCreator
     {
         [TestMethod]
-        public void Creator_Today()
+        public void DataTypes_Creator_Today()
         {
             var d = System.DateTime.Now;
             var expected = TimexFormat.Format(new Timex
@@ -23,13 +23,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_Today_Relative()
+        public void DataTypes_Creator_Today_Relative()
         {
             Assert.AreEqual("2017-10-05", TimexCreator.Today(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_Tomorrow()
+        public void DataTypes_Creator_Tomorrow()
         {
             var d = System.DateTime.Now;
             d = d.AddDays(1);
@@ -43,13 +43,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_Tomorrow_Relative()
+        public void DataTypes_Creator_Tomorrow_Relative()
         {
             Assert.AreEqual("2017-10-06", TimexCreator.Tomorrow(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_Yesterday()
+        public void DataTypes_Creator_Yesterday()
         {
             var d = System.DateTime.Now;
             d = d.AddDays(-1);
@@ -63,13 +63,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_Yesterday_Relative()
+        public void DataTypes_Creator_Yesterday_Relative()
         {
             Assert.AreEqual("2017-10-04", TimexCreator.Yesterday(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_WeekFromToday()
+        public void DataTypes_Creator_WeekFromToday()
         {
             var d = System.DateTime.Now;
             var expected = TimexFormat.Format(new Timex
@@ -83,13 +83,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_WeekFromToday_Relative()
+        public void DataTypes_Creator_WeekFromToday_Relative()
         {
             Assert.AreEqual("(2017-10-05,2017-10-12,P7D)", TimexCreator.WeekFromToday(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_WeekBackFromToday()
+        public void DataTypes_Creator_WeekBackFromToday()
         {
             var d = System.DateTime.Now;
             d = d.AddDays(-7);
@@ -104,13 +104,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_WeekBackFromToday_Relative()
+        public void DataTypes_Creator_WeekBackFromToday_Relative()
         {
             Assert.AreEqual("(2017-09-28,2017-10-05,P7D)", TimexCreator.WeekBackFromToday(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_nextWeek()
+        public void DataTypes_Creator_nextWeek()
         {
             var start = TimexDateHelpers.DateOfNextDay(DayOfWeek.Monday, System.DateTime.Now);
             var t = Timex.FromDate(start);
@@ -120,13 +120,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_NextWeek_Relative()
+        public void DataTypes_Creator_NextWeek_Relative()
         {
             Assert.AreEqual("(2017-10-09,2017-10-16,P7D)", TimexCreator.NextWeek(new System.DateTime(2017, 10, 5)));
         }
         
         [TestMethod]
-        public void Creator_lastWeek()
+        public void DataTypes_Creator_lastWeek()
         {
             var start = TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, System.DateTime.Now);
             start = start.AddDays(-7);
@@ -137,13 +137,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_LastWeek_Relative()
+        public void DataTypes_Creator_LastWeek_Relative()
         {
             Assert.AreEqual("(2017-09-25,2017-10-02,P7D)", TimexCreator.LastWeek(new System.DateTime(2017, 10, 5)));
         }
 
         [TestMethod]
-        public void Creator_NextWeeksFromToday()
+        public void DataTypes_Creator_NextWeeksFromToday()
         {
             var d = System.DateTime.Now;
             var expected = TimexFormat.Format(new Timex
@@ -157,7 +157,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Creator_NextWeeksFromToday_Relative()
+        public void DataTypes_Creator_NextWeeksFromToday_Relative()
         {
             Assert.AreEqual("(2017-10-05,2017-10-19,P14D)", TimexCreator.NextWeeksFromToday(2, new System.DateTime(2017, 10, 5)));
         }

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexDateHelpers
     {
         [TestMethod]
-        public void DateHelpers_tomorrow()
+        public void DataTypes_DateHelpers_tomorrow()
         {
             Assert.AreEqual(new System.DateTime(2017, 1, 1), TimexDateHelpers.Tomorrow(new System.DateTime(2016, 12, 31)));
             Assert.AreEqual(new System.DateTime(2017, 1, 2), TimexDateHelpers.Tomorrow(new System.DateTime(2017, 1, 1)));
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_yesterday()
+        public void DataTypes_DateHelpers_yesterday()
         {
             Assert.AreEqual(new System.DateTime(2016, 12, 31), TimexDateHelpers.Yesterday(new System.DateTime(2017, 1, 1)));
             Assert.AreEqual(new System.DateTime(2017, 1, 1), TimexDateHelpers.Yesterday(new System.DateTime(2017, 1, 2)));
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_datePartEquals()
+        public void DataTypes_DateHelpers_datePartEquals()
         {
             Assert.IsTrue(TimexDateHelpers.DatePartEquals(new System.DateTime(2017, 5, 29), new System.DateTime(2017, 5, 29)));
             Assert.IsTrue(TimexDateHelpers.DatePartEquals(new System.DateTime(2017, 5, 29, 19, 30, 0), new System.DateTime(2017, 5, 29)));
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_isNextWeek()
+        public void DataTypes_DateHelpers_isNextWeek()
         {
             var today = new System.DateTime(2017, 9, 25);
             Assert.IsTrue(TimexDateHelpers.IsNextWeek(new System.DateTime(2017, 10, 4), today));
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_isLastWeek()
+        public void DataTypes_DateHelpers_isLastWeek()
         {
             var today = new System.DateTime(2017, 9, 25);
             Assert.IsTrue(TimexDateHelpers.IsLastWeek(new System.DateTime(2017, 9, 20), today));
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_weekOfyear()
+        public void DataTypes_DateHelpers_weekOfyear()
         {
             Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 1)));
             Assert.AreEqual(2, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 2)));
@@ -69,7 +69,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_invariance()
+        public void DataTypes_DateHelpers_invariance()
         {
             var d = new System.DateTime(2017, 8, 25);
             var before = d;
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_dateOfLastDay_Friday_last_week()
+        public void DataTypes_DateHelpers_dateOfLastDay_Friday_last_week()
         {
             var day = DayOfWeek.Friday;
             var date = new System.DateTime(2017, 9, 28);
@@ -94,7 +94,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_dateOfNextDay_Wednesday_next_week()
+        public void DataTypes_DateHelpers_dateOfNextDay_Wednesday_next_week()
         {
             var day = DayOfWeek.Wednesday;
             var date = new System.DateTime(2017, 9, 28);
@@ -102,7 +102,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_dateOfNextDay_today()
+        public void DataTypes_DateHelpers_dateOfNextDay_today()
         {
             var day = DayOfWeek.Thursday;
             var date = new System.DateTime(2017, 9, 28);
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void DateHelpers_datesMatchingDay()
+        public void DataTypes_DateHelpers_datesMatchingDay()
         {
             var day = DayOfWeek.Thursday;
             var start = new System.DateTime(2017, 3, 1);

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexFormat.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexFormat
     {
         [TestMethod]
-        public void Format_Date()
+        public void DataTypes_Format_Date()
         {
             Assert.AreEqual("2017-09-27", (new Timex { Year = 2017, Month = 9, DayOfMonth = 27 }).TimexValue);
             Assert.AreEqual("XXXX-WXX-3", (new Timex { DayOfWeek = 3 }).TimexValue);
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Format_Time()
+        public void DataTypes_Format_Time()
         {
             Assert.AreEqual("T17:30:45", (new Timex { Hour = 17, Minute = 30, Second = 45 }).TimexValue);
             Assert.AreEqual("T05:06:07", (new Timex { Hour = 5, Minute = 6, Second = 7 }).TimexValue);
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Format_Duration()
+        public void DataTypes_Format_Duration()
         {
             Assert.AreEqual("P50Y", (new Timex { Years = 50 }).TimexValue);
             Assert.AreEqual("P6M", (new Timex { Months = 6 }).TimexValue);
@@ -38,20 +38,20 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Format_Present()
+        public void DataTypes_Format_Present()
         {
             Assert.AreEqual("PRESENT_REF", (new Timex { Now = true }).TimexValue);
         }
 
         [TestMethod]
-        public void Format_DateTime()
+        public void DataTypes_Format_DateTime()
         {
             Assert.AreEqual("XXXX-WXX-3T04", (new Timex { DayOfWeek = 3, Hour = 4, Minute = 0, Second = 0 }).TimexValue);
             Assert.AreEqual("2017-09-27T11:41:30", (new Timex { Year = 2017, Month = 9, DayOfMonth = 27, Hour = 11, Minute = 41, Second = 30 }).TimexValue);
         }
 
         [TestMethod]
-        public void Format_DateRange()
+        public void DataTypes_Format_DateRange()
         {
             Assert.AreEqual("2017", (new Timex { Year = 2017 }).TimexValue);
             Assert.AreEqual("SU", (new Timex { Season = "SU" }).TimexValue);
@@ -63,13 +63,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Format_TimeRange()
+        public void DataTypes_Format_TimeRange()
         {
             Assert.AreEqual("TEV", (new Timex { PartOfDay = "EV" }).TimexValue);
         }
 
         [TestMethod]
-        public void Format_DateTimeRange()
+        public void DataTypes_Format_DateTimeRange()
         {
             Assert.AreEqual("2017-09-27TEV", (new Timex { Year = 2017, Month = 9, DayOfMonth = 27, PartOfDay = "EV" }).TimexValue);
         }

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexHelpers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexHelpers
     {
         [TestMethod]
-        public void Helpers_ExpandDateTimeRange_Short()
+        public void DataTypes_Helpers_ExpandDateTimeRange_Short()
         {
             var timex = new Timex("(2017-09-27,2017-09-29,P2D)");
             var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_ExpandDateTimeRange_Long()
+        public void DataTypes_Helpers_ExpandDateTimeRange_Long()
         {
             var timex = new Timex("(2006-01-01,2008-06-01,P882D)");
             var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_ExpandDateTimeRange_Include_Time()
+        public void DataTypes_Helpers_ExpandDateTimeRange_Include_Time()
         {
             var timex = new Timex("(2017-10-10T16:02:04,2017-10-10T16:07:04,PT5M)");
             var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_ExpandDateTimeRange_Month()
+        public void DataTypes_Helpers_ExpandDateTimeRange_Month()
         {
             var timex = new Timex("2017-05");
             var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_ExpandDateTimeRange_Year()
+        public void DataTypes_Helpers_ExpandDateTimeRange_Year()
         {
             var timex = new Timex("1999");
             var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_ExpandTimeRange()
+        public void DataTypes_Helpers_ExpandTimeRange()
         {
             var timex = new Timex("(T14,T16,PT2H)");
             var range = TimexHelpers.ExpandTimeRange(timex);
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_DateRangeFromTimex()
+        public void DataTypes_Helpers_DateRangeFromTimex()
         {
             var timex = new Timex("(2017-09-27,2017-09-29,P2D)");
             var range = TimexHelpers.DateRangeFromTimex(timex);
@@ -72,7 +72,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_TimeRangeFromTimex()
+        public void DataTypes_Helpers_TimeRangeFromTimex()
         {
             var timex = new Timex("(T14,T16,PT2H)");
             var range = TimexHelpers.TimeRangeFromTimex(timex);
@@ -81,7 +81,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_DateFromTimex()
+        public void DataTypes_Helpers_DateFromTimex()
         {
             var timex = new Timex("2017-09-27");
             var date = TimexHelpers.DateFromTimex(timex);
@@ -89,7 +89,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Helpers_TimeFromTimex()
+        public void DataTypes_Helpers_TimeFromTimex()
         {
             var timex = new Timex("T00:05:00");
             var time = TimexHelpers.TimeFromTimex(timex);

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexParsing.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("2017-05-29");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Definite, Constants.TimexTypes.Date }, timex.Types.ToList());
+
             Assert.AreEqual(2017, timex.Year);
             Assert.AreEqual(5, timex.Month);
             Assert.AreEqual(29, timex.DayOfMonth);
@@ -41,6 +42,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("XXXX-12-05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.AreEqual(12, timex.Month);
             Assert.AreEqual(5, timex.DayOfMonth);
@@ -68,6 +70,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("XXXX-WXX-3");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -95,6 +98,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("T17:30:05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -122,6 +126,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("T17:30");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -149,6 +154,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("T17");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -180,6 +186,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Time,
                 Constants.TimexTypes.DateTime }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -211,6 +218,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Time,
                 Constants.TimexTypes.DateTime }, timex.Types.ToList());
+
             Assert.AreEqual(1984, timex.Year);
             Assert.AreEqual(1, timex.Month);
             Assert.AreEqual(3, timex.DayOfMonth);
@@ -237,7 +245,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         public void DataTypes_Parsing_ParicularTimeOnParticularDayOfWeek()
         {
             var timex = new Timex("XXXX-WXX-3T16");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, timex.Types.ToList());
+            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, 
+                                           timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -265,6 +275,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("2016");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(2016, timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -292,6 +303,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("1999-SU");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(1999, timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -319,6 +331,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("2017-W37");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(2017, timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -346,6 +359,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("SU");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -373,6 +387,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("WI");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -400,6 +415,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("2017-W37-WE");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(2017, timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -427,6 +443,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("XXXX-05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.AreEqual(5, timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -454,6 +471,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("2020-07");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(2020, timex.Year);
             Assert.AreEqual(7, timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -481,6 +499,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("XXXX-01-W01");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.AreEqual(1, timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -511,6 +530,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -541,6 +561,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.AreEqual(1, timex.Month);
             Assert.AreEqual(1, timex.DayOfMonth);
@@ -572,6 +593,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.DateRange }, timex.Types.ToList());
+
             Assert.AreEqual(2015, timex.Year);
             Assert.AreEqual(1, timex.Month);
             Assert.AreEqual(1, timex.DayOfMonth);
@@ -599,6 +621,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("TDT");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -626,6 +649,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("TNI");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -653,6 +677,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("TMO");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -680,6 +705,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("TAF");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -707,6 +733,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("TEV");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -737,6 +764,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Time,
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -767,6 +795,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
                 Constants.TimexTypes.DateTimeRange }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -798,6 +827,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Date,
                 Constants.TimexTypes.TimeRange,
                 Constants.TimexTypes.DateTimeRange }, timex.Types.ToList());
+
             Assert.AreEqual(2017, timex.Year);
             Assert.AreEqual(9, timex.Month);
             Assert.AreEqual(7, timex.DayOfMonth);
@@ -834,6 +864,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.DateRange,
                 Constants.TimexTypes.Definite
             }, timex.Types.ToList());
+
             Assert.AreEqual(2017, timex.Year);
             Assert.AreEqual(9, timex.Month);
             Assert.AreEqual(8, timex.DayOfMonth);
@@ -869,6 +900,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
                 Constants.TimexTypes.Duration,
                 Constants.TimexTypes.DateRange,
             }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -896,6 +928,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("P2Y");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -923,6 +956,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("P4M");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -950,6 +984,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("P6W");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -977,6 +1012,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("P2.5W");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -1004,6 +1040,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("P1D");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -1031,6 +1068,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("PT5H");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -1058,6 +1096,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("PT30M");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);
@@ -1085,6 +1124,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         {
             var timex = new Timex("PT45S");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
             Assert.IsNull(timex.DayOfMonth);

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexParsing.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexParsing
     {
         [TestMethod]
-        public void Parsing_CompleteDate()
+        public void DataTypes_Parsing_CompleteDate()
         {
             var timex = new Timex("2017-05-29");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Definite, Constants.TimexTypes.Date }, timex.Types.ToList());
@@ -35,8 +35,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_MonthAndDayOfMonth()
+        public void DataTypes_Parsing_MonthAndDayOfMonth()
         {
             var timex = new Timex("XXXX-12-05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
@@ -61,8 +62,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DayOfWeek()
+        public void DataTypes_Parsing_DayOfWeek()
         {
             var timex = new Timex("XXXX-WXX-3");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
@@ -87,8 +89,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_HoursMinutesAndSeconds()
+        public void DataTypes_Parsing_HoursMinutesAndSeconds()
         {
             var timex = new Timex("T17:30:05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
@@ -113,8 +116,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_HoursAndMinutes()
+        public void DataTypes_Parsing_HoursAndMinutes()
         {
             var timex = new Timex("T17:30");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
@@ -139,8 +143,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Hours()
+        public void DataTypes_Parsing_Hours()
         {
             var timex = new Timex("T17");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
@@ -165,8 +170,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Now()
+        public void DataTypes_Parsing_Now()
         {
             var timex = new Timex("PRESENT_REF");
             CollectionAssert.AreEquivalent(new[] {
@@ -195,8 +201,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.AreEqual(true, timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_FullDatetime()
+        public void DataTypes_Parsing_FullDatetime()
         {
             var timex = new Timex("1984-01-03T18:30:45");
             CollectionAssert.AreEquivalent(new[] {
@@ -225,8 +232,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_ParicularTimeOnParticularDayOfWeek()
+        public void DataTypes_Parsing_ParicularTimeOnParticularDayOfWeek()
         {
             var timex = new Timex("XXXX-WXX-3T16");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, timex.Types.ToList());
@@ -251,8 +259,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Year()
+        public void DataTypes_Parsing_Year()
         {
             var timex = new Timex("2016");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -277,8 +286,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_SummerOf1999()
+        public void DataTypes_Parsing_SummerOf1999()
         {
             var timex = new Timex("1999-SU");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -303,8 +313,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_YearAndWeek()
+        public void DataTypes_Parsing_YearAndWeek()
         {
             var timex = new Timex("2017-W37");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -329,8 +340,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_SeasonSummer()
+        public void DataTypes_Parsing_SeasonSummer()
         {
             var timex = new Timex("SU");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -355,8 +367,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_SeasonWinter()
+        public void DataTypes_Parsing_SeasonWinter()
         {
             var timex = new Timex("WI");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -381,8 +394,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_YearAndWeekend()
+        public void DataTypes_Parsing_YearAndWeekend()
         {
             var timex = new Timex("2017-W37-WE");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -407,8 +421,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_May()
+        public void DataTypes_Parsing_May()
         {
             var timex = new Timex("XXXX-05");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -433,8 +448,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_July2020()
+        public void DataTypes_Parsing_July2020()
         {
             var timex = new Timex("2020-07");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -459,8 +475,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_WeekOfMonth()
+        public void DataTypes_Parsing_WeekOfMonth()
         {
             var timex = new Timex("XXXX-01-W01");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
@@ -485,8 +502,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_WednesdayToSaturday()
+        public void DataTypes_Parsing_WednesdayToSaturday()
         {
             var timex = new Timex("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
             CollectionAssert.AreEquivalent(new[] {
@@ -514,8 +532,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Jan1ToAug5()
+        public void DataTypes_Parsing_Jan1ToAug5()
         {
             var timex = new Timex("(XXXX-01-01,XXXX-08-05,P216D)");
             CollectionAssert.AreEquivalent(new[] {
@@ -543,8 +562,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Jan1ToAug5Year2015()
+        public void DataTypes_Parsing_Jan1ToAug5Year2015()
         {
             var timex = new Timex("(2015-01-01,2015-08-05,P216D)");
             CollectionAssert.AreEquivalent(new[] {
@@ -573,8 +593,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DayTime()
+        public void DataTypes_Parsing_DayTime()
         {
             var timex = new Timex("TDT");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
@@ -599,8 +620,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_NightTime()
+        public void DataTypes_Parsing_NightTime()
         {
             var timex = new Timex("TNI");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
@@ -625,8 +647,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Morning()
+        public void DataTypes_Parsing_Morning()
         {
             var timex = new Timex("TMO");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
@@ -651,8 +674,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Afternoon()
+        public void DataTypes_Parsing_Afternoon()
         {
             var timex = new Timex("TAF");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
@@ -677,8 +701,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Evening()
+        public void DataTypes_Parsing_Evening()
         {
             var timex = new Timex("TEV");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
@@ -703,8 +728,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Timerange430pmTo445pm()
+        public void DataTypes_Parsing_Timerange430pmTo445pm()
         {
             var timex = new Timex("(T16:30,T16:45,PT15M)");
             CollectionAssert.AreEquivalent(new[] {
@@ -732,8 +758,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DateTimeRange()
+        public void DataTypes_Parsing_DateTimeRange()
         {
             var timex = new Timex("XXXX-WXX-5TEV");
             CollectionAssert.AreEquivalent(new[] {
@@ -761,8 +788,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_LastNight()
+        public void DataTypes_Parsing_LastNight()
         {
             var timex = new Timex("2017-09-07TNI");
             CollectionAssert.AreEquivalent(new[] {
@@ -791,8 +819,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Last5Minutes()
+        public void DataTypes_Parsing_Last5Minutes()
         {
             var timex = new Timex("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
             CollectionAssert.AreEquivalent(new[] {
@@ -826,8 +855,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_Wed4PMToSat3PM()
+        public void DataTypes_Parsing_Wed4PMToSat3PM()
         {
             var timex = new Timex("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)");
             CollectionAssert.AreEquivalent(new[] {
@@ -860,8 +890,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationYears()
+        public void DataTypes_Parsing_DurationYears()
         {
             var timex = new Timex("P2Y");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -886,8 +917,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationMonths()
+        public void DataTypes_Parsing_DurationMonths()
         {
             var timex = new Timex("P4M");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -912,8 +944,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationWeeks()
+        public void DataTypes_Parsing_DurationWeeks()
         {
             var timex = new Timex("P6W");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -938,8 +971,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationWeeksFloatingPoint()
+        public void DataTypes_Parsing_DurationWeeksFloatingPoint()
         {
             var timex = new Timex("P2.5W");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -964,8 +998,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationDays()
+        public void DataTypes_Parsing_DurationDays()
         {
             var timex = new Timex("P1D");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -990,8 +1025,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationHours()
+        public void DataTypes_Parsing_DurationHours()
         {
             var timex = new Timex("PT5H");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -1016,8 +1052,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationMinutes()
+        public void DataTypes_Parsing_DurationMinutes()
         {
             var timex = new Timex("PT30M");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
@@ -1042,8 +1079,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(timex.Seconds);
             Assert.IsNull(timex.Now);
         }
+		
         [TestMethod]
-        public void Parsing_DurationSeconds()
+        public void DataTypes_Parsing_DurationSeconds()
         {
             var timex = new Timex("PT45S");
             CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexRangeResolve
     {
         [TestMethod]
-        public void RangeResolve_daterange_definite()
+        public void DataTypes_RangeResolve_daterange_definite()
         {
             var candidates = new[] { "2017-09-28" };
             var constraints = new[] { (new Timex { Year = 2017, Month = 9, DayOfMonth = 27, Days = 2 }).TimexValue };
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_definite_constrainst_as_timex()
+        public void DataTypes_RangeResolve_daterange_definite_constrainst_as_timex()
         {
             var candidates = new[] { "2017-09-28" };
             var constraints = new[] { "(2017-09-27,2017-09-29,P2D)" };
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_month_and_date()
+        public void DataTypes_RangeResolve_daterange_month_and_date()
         {
             var candidates = new[] { "XXXX-05-29" };
             var constraints = new[] { (new Timex { Year = 2006, Month = 1, DayOfMonth = 1, Years = 2 }).TimexValue };
@@ -51,7 +51,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_month_and_date_conditional()
+        public void DataTypes_RangeResolve_daterange_month_and_date_conditional()
         {
             var candidates = new[] { "XXXX-05-29" };
             var constraints = new[] { "(2006-01-01,2008-06-01,P882D)" };
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_Saturdays_in_September()
+        public void DataTypes_RangeResolve_daterange_Saturdays_in_September()
         {
             var candidates = new[] { "XXXX-WXX-6" };
             var constraints = new[] { "2017-09" };
@@ -83,7 +83,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_Saturdays_in_September_expressed_as_range()
+        public void DataTypes_RangeResolve_daterange_Saturdays_in_September_expressed_as_range()
         {
             var candidates = new[] { "XXXX-WXX-6" };
             var constraints = new[] { "(2017-09-01,2017-10-01,P30D)" };
@@ -100,7 +100,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_year()
+        public void DataTypes_RangeResolve_daterange_year()
         {
             var candidates = new[] { "XXXX-05-29" };
             var constraints = new[] { "2018" };
@@ -113,7 +113,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_expressed_as_range()
+        public void DataTypes_RangeResolve_daterange_expressed_as_range()
         {
             var candidates = new[] { "XXXX-05-29" };
             var constraints = new[] { "(2018-01-01,2019-01-01,P365D)" };
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_multiple_constraints()
+        public void DataTypes_RangeResolve_daterange_multiple_constraints()
         {
             var candidates = new[] { "XXXX-WXX-3" };
             var constraints = new[] { "(2017-09-01,2017-09-08,P7D)", "(2017-10-01,2017-10-08,P7D)" };
@@ -140,7 +140,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_multiple_candidates_with_multiple_constraints()
+        public void DataTypes_RangeResolve_daterange_multiple_candidates_with_multiple_constraints()
         {
             var candidates = new[]
             {
@@ -164,7 +164,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_daterange_multiple_overlapping_constraints()
+        public void DataTypes_RangeResolve_daterange_multiple_overlapping_constraints()
         {
             var candidates = new[] { "XXXX-WXX-3" };
             var constraints = new[] { "(2017-09-03,2017-09-07,P4D)", "(2017-09-01,2017-09-08,P7D)", "(2017-09-01,2017-09-16,P15D)" };
@@ -177,7 +177,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_timerange_time_within_range()
+        public void DataTypes_RangeResolve_timerange_time_within_range()
         {
             var candidates = new[] { "T16" };
             var constraints = new[] { (new Timex { Hour = 14, Hours = 4 }).TimexValue };
@@ -190,7 +190,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_timerange_multiple_times_within_range()
+        public void DataTypes_RangeResolve_timerange_multiple_times_within_range()
         {
             var candidates = new[] { "T12", "T16", "T16:30", "T17", "T18" };
             var constraints = new[] { (new Timex { Hour = 14, Hours = 4 }).TimexValue };
@@ -205,7 +205,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_timerange_time_with_overlapping_ranges()
+        public void DataTypes_RangeResolve_timerange_time_with_overlapping_ranges()
         {
             var constraints = new List<string> { (new Timex { Hour = 16, Hours = 4 }).TimexValue };
 
@@ -230,7 +230,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_multiple_times_with_overlapping_ranges()
+        public void DataTypes_RangeResolve_multiple_times_with_overlapping_ranges()
         {
             var constraints = new List<string> { (new Timex { Hour = 16, Hours = 4 }).TimexValue };
 
@@ -257,7 +257,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_filter_duplicate()
+        public void DataTypes_RangeResolve_filter_duplicate()
         {
             var constraints = new List<string> { (new Timex { Hour = 16, Hours = 4 }).TimexValue };
 
@@ -269,7 +269,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_definite()
+        public void DataTypes_RangeResolve_carry_through_time_definite()
         {
             var constraints = new List<string>
             {
@@ -284,7 +284,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_definite_constrainst_expressed_as_timex()
+        public void DataTypes_RangeResolve_carry_through_time_definite_constrainst_expressed_as_timex()
         {
             var constraints = new List<string> { "(2017-09-27,2017-09-29,P2D)" };
 
@@ -296,7 +296,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_month_and_date()
+        public void DataTypes_RangeResolve_carry_through_time_month_and_date()
         {
             var constraints = new List<string>
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_month_and_date_conditional()
+        public void DataTypes_RangeResolve_carry_through_time_month_and_date_conditional()
         {
             var constraints = new List<string> { "(2006-01-01,2008-06-01,P882D)" };
 
@@ -326,7 +326,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_Saturdays_in_September()
+        public void DataTypes_RangeResolve_carry_through_time_Saturdays_in_September()
         {
             var constraints = new List<string> { "(2017-09-01,2017-10-01,P30D)" };
 
@@ -342,7 +342,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_carry_through_time_multiple_constraints()
+        public void DataTypes_RangeResolve_carry_through_time_multiple_constraints()
         {
             var constraints = new List<string>
             {
@@ -359,7 +359,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_combined_daterange_and_timerange_next_week_and_any_time()
+        public void DataTypes_RangeResolve_combined_daterange_and_timerange_next_week_and_any_time()
         {
             var constraints = new List<string>
             {
@@ -376,7 +376,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_combined_daterange_and_timerange_next_week_and_business_hours()
+        public void DataTypes_RangeResolve_combined_daterange_and_timerange_next_week_and_business_hours()
         {
             var constraints = new List<string>
             {
@@ -392,7 +392,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_adding_times_add_specific_time_to_date()
+        public void DataTypes_RangeResolve_adding_times_add_specific_time_to_date()
         {
             var constraints = new List<string>
             {
@@ -408,7 +408,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_adding_times_add_specific_time_to_date_2()
+        public void DataTypes_RangeResolve_adding_times_add_specific_time_to_date_2()
         {
             var constraints = new List<string>
             {
@@ -426,7 +426,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_duration_specific_datetime()
+        public void DataTypes_RangeResolve_duration_specific_datetime()
         {
             var constraints = new List<string>
             {
@@ -441,7 +441,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_duration_specific_time()
+        public void DataTypes_RangeResolve_duration_specific_time()
         {
             var constraints = new List<string>
             {
@@ -456,7 +456,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_duration_no_constraints()
+        public void DataTypes_RangeResolve_duration_no_constraints()
         {
             var constraints = new List<string>
             {
@@ -470,7 +470,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RangeResolve_duration_no_time_component()
+        public void DataTypes_RangeResolve_duration_no_time_component()
         {
             var constraints = new List<string>
             {

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexRelativeConvert
     {
         [TestMethod]
-        public void RelativeConvert_Date_Today()
+        public void DataTypes_RelativeConvert_Date_Today()
         {
             var timex = new Timex("2017-09-25");
             var today = new System.DateTime(2017, 9, 25);
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_Tomorrow()
+        public void DataTypes_RelativeConvert_Date_Tomorrow()
         {
             var timex = new Timex("2017-09-23");
             var today = new System.DateTime(2017, 9, 22);
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_tomorrow_cross_year_month_boundary()
+        public void DataTypes_RelativeConvert_Date_tomorrow_cross_year_month_boundary()
         {
             var timex = new Timex("2018-01-01");
             var today = new System.DateTime(2017, 12, 31);
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_yesterday()
+        public void DataTypes_RelativeConvert_Date_yesterday()
         {
             var timex = new Timex("2017-09-21");
             var today = new System.DateTime(2017, 9, 22);
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_yesterday_cross_year_month_boundary()
+        public void DataTypes_RelativeConvert_Date_yesterday_cross_year_month_boundary()
         {
             var timex = new Timex("2017-12-31");
             var today = new System.DateTime(2018, 1, 1);
@@ -49,7 +49,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_this_week()
+        public void DataTypes_RelativeConvert_Date_this_week()
         {
             var timex = new Timex("2017-10-18");
             var today = new System.DateTime(2017, 10, 16);
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_this_week_cross_year_month_boundary()
+        public void DataTypes_RelativeConvert_Date_this_week_cross_year_month_boundary()
         {
             var timex = new Timex("2017-11-03");
             var today = new System.DateTime(2017, 10, 31);
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_next_week()
+        public void DataTypes_RelativeConvert_Date_next_week()
         {
             var timex = new Timex("2017-09-27");
             var today = new System.DateTime(2017, 9, 22);
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_next_week_cross_year_month_boundary()
+        public void DataTypes_RelativeConvert_Date_next_week_cross_year_month_boundary()
         {
             var timex = new Timex("2018-01-05");
             var today = new System.DateTime(2017, 12, 28);
@@ -81,7 +81,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_last_week()
+        public void DataTypes_RelativeConvert_Date_last_week()
         {
             var timex = new Timex("2017-09-14");
             var today = new System.DateTime(2017, 9, 22);
@@ -89,7 +89,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_last_week_cross_year_month_boundary()
+        public void DataTypes_RelativeConvert_Date_last_week_cross_year_month_boundary()
         {
             var timex = new Timex("2017-12-25");
             var today = new System.DateTime(2018, 1, 4);
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_this_week_2()
+        public void DataTypes_RelativeConvert_Date_this_week_2()
         {
             var timex = new Timex("2017-10-25");
             var today = new System.DateTime(2017, 9, 9);
@@ -105,7 +105,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_next_week_2()
+        public void DataTypes_RelativeConvert_Date_next_week_2()
         {
             var timex = new Timex("2017-10-04");
             var today = new System.DateTime(2017, 9, 22);
@@ -113,7 +113,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Date_last_week_2()
+        public void DataTypes_RelativeConvert_Date_last_week_2()
         {
             var timex = new Timex("2017-09-07");
             var today = new System.DateTime(2017, 9, 22);
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateTime_today()
+        public void DataTypes_RelativeConvert_DateTime_today()
         {
             var timex = new Timex("2017-09-25T16:00:00");
             var today = new System.DateTime(2017, 9, 25);
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateTime_tomorrow()
+        public void DataTypes_RelativeConvert_DateTime_tomorrow()
         {
             var timex = new Timex("2017-09-23T16:00:00");
             var today = new System.DateTime(2017, 9, 22);
@@ -137,7 +137,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateTime_yesterday()
+        public void DataTypes_RelativeConvert_DateTime_yesterday()
         {
             var timex = new Timex("2017-09-21T16:00:00");
             var today = new System.DateTime(2017, 9, 22);
@@ -145,21 +145,21 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_this_week(){
+        public void DataTypes_RelativeConvert_DateRange_this_week(){
             var timex = new Timex("2017-W40");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("this week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_next_week(){
+        public void DataTypes_RelativeConvert_DateRange_next_week(){
             var timex = new Timex("2017-W41");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_last_week()
+        public void DataTypes_RelativeConvert_DateRange_last_week()
         {
             var timex = new Timex("2017-W39");
             var today = new System.DateTime(2017, 9, 25);
@@ -167,7 +167,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_this_week_2()
+        public void DataTypes_RelativeConvert_DateRange_this_week_2()
         {
             var timex = new Timex("2017-W41");
             var today = new System.DateTime(2017, 10, 4);
@@ -175,7 +175,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_next_week_2()
+        public void DataTypes_RelativeConvert_DateRange_next_week_2()
         {
             var timex = new Timex("2017-W42");
             var today = new System.DateTime(2017, 10, 4);
@@ -183,7 +183,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_DateRange_last_week_2()
+        public void DataTypes_RelativeConvert_DateRange_last_week_2()
         {
             var timex = new Timex("2017-W40");
             var today = new System.DateTime(2017, 10, 4);
@@ -191,7 +191,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Weekend_this_weekend()
+        public void DataTypes_RelativeConvert_Weekend_this_weekend()
         {
             var timex = new Timex("2017-W40-WE");
             var today = new System.DateTime(2017, 9, 25);
@@ -199,14 +199,14 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Weekend_next_weekend()
+        public void DataTypes_RelativeConvert_Weekend_next_weekend()
         {
             var timex = new Timex("2017-W41-WE");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next weekend", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
         [TestMethod]
-        public void RelativeConvert_Weekend_last_weekend()
+        public void DataTypes_RelativeConvert_Weekend_last_weekend()
         {
             var timex = new Timex("2017-W39-WE");
             var today = new System.DateTime(2017, 9, 25);
@@ -214,7 +214,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Month_this_month()
+        public void DataTypes_RelativeConvert_Month_this_month()
         {
             var timex = new Timex("2017-09");
             var today = new System.DateTime(2017, 9, 25);
@@ -222,7 +222,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Month_next_month()
+        public void DataTypes_RelativeConvert_Month_next_month()
         {
             var timex = new Timex("2017-10");
             var today = new System.DateTime(2017, 9, 25);
@@ -230,14 +230,14 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Month_last_month()
+        public void DataTypes_RelativeConvert_Month_last_month()
         {
             var timex = new Timex("2017-08");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("last month", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
         [TestMethod]
-        public void RelativeConvert_Year_this_year()
+        public void DataTypes_RelativeConvert_Year_this_year()
         {
             var timex = new Timex("2017");
             var today = new System.DateTime(2017, 9, 25);
@@ -245,7 +245,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Year_next_year()
+        public void DataTypes_RelativeConvert_Year_next_year()
         {
             var timex = new Timex("2018");
             var today = new System.DateTime(2017, 9, 25);
@@ -253,7 +253,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Year_last_year()
+        public void DataTypes_RelativeConvert_Year_last_year()
         {
             var timex = new Timex("2016");
             var today = new System.DateTime(2017, 9, 25);
@@ -261,7 +261,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Season_this_summer()
+        public void DataTypes_RelativeConvert_Season_this_summer()
         {
             var timex = new Timex("2017-SU");
             var today = new System.DateTime(2017, 9, 25);
@@ -269,7 +269,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Season_next_summer()
+        public void DataTypes_RelativeConvert_Season_next_summer()
         {
             var timex = new Timex("2018-SU");
             var today = new System.DateTime(2017, 9, 25);
@@ -277,7 +277,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_Season_last_summer()
+        public void DataTypes_RelativeConvert_Season_last_summer()
         {
             var timex = new Timex("2016-SU");
             var today = new System.DateTime(2017, 9, 25);
@@ -285,7 +285,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_PartOfDay_this_evening()
+        public void DataTypes_RelativeConvert_PartOfDay_this_evening()
         {
             var timex = new Timex("2017-09-25TEV");
             var today = new System.DateTime(2017, 9, 25);
@@ -293,7 +293,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_PartOfDay_tonight()
+        public void DataTypes_RelativeConvert_PartOfDay_tonight()
         {
             var timex = new Timex("2017-09-25TNI");
             var today = new System.DateTime(2017, 9, 25);
@@ -301,7 +301,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_PartOfDay_tomorrow_morning()
+        public void DataTypes_RelativeConvert_PartOfDay_tomorrow_morning()
         {
             var timex = new Timex("2017-09-26TMO");
             var today = new System.DateTime(2017, 9, 25);
@@ -309,7 +309,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_PartOfDay_yesterday_afternoon()
+        public void DataTypes_RelativeConvert_PartOfDay_yesterday_afternoon()
         {
             var timex = new Timex("2017-09-24TAF");
             var today = new System.DateTime(2017, 9, 25);
@@ -317,7 +317,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void RelativeConvert_PartOfDay_next_wednesday_evening()
+        public void DataTypes_RelativeConvert_PartOfDay_next_wednesday_evening()
         {
             var timex = new Timex("2017-10-04TEV");
             var today = new System.DateTime(2017, 9, 25);

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(resolution.Values[1].Start);
             Assert.IsNull(resolution.Values[1].End);
         }
+
         [TestMethod]
         public void DataTypes_Resolver_DateTime_Next_Wednesday_4_am()
         {

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
     public class TestTimexResolver
     {
         [TestMethod]
-        public void Resolver_Date_Definite()
+        public void DataTypes_Resolver_Date_Definite()
         {
             var today = new System.DateTime(2017, 9, 26, 15, 30, 0);
             var resolution = TimexResolver.Resolve(new[] { "2017-09-28" }, today);
@@ -23,7 +23,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Date_Saturday()
+        public void DataTypes_Resolver_Date_Saturday()
         {
             var today = new System.DateTime(2017, 9, 26, 15, 30, 0);
             var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-6" }, today);
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateTime_Wednesday_4()
+        public void DataTypes_Resolver_DateTime_Wednesday_4()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
             var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-3T04", "XXXX-WXX-3T16" }, today);
@@ -75,7 +75,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateTime_Wednesday_4_am()
+        public void DataTypes_Resolver_DateTime_Wednesday_4_am()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
             var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-3T04" }, today);
@@ -94,7 +94,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
             Assert.IsNull(resolution.Values[1].End);
         }
         [TestMethod]
-        public void Resolver_DateTime_Next_Wednesday_4_am()
+        public void DataTypes_Resolver_DateTime_Next_Wednesday_4_am()
         {
             var today = new System.DateTime(2017, 9, 7);
             var resolution = TimexResolver.Resolve(new [] { "2017-10-11T04" }, today);
@@ -108,7 +108,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_2years()
+        public void DataTypes_Resolver_Duration_2years()
         {
             var resolution = TimexResolver.Resolve(new [] { "P2Y" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_6months()
+        public void DataTypes_Resolver_Duration_6months()
         {
             var resolution = TimexResolver.Resolve(new [] { "P6M" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -134,7 +134,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_3weeks()
+        public void DataTypes_Resolver_Duration_3weeks()
         {
             var resolution = TimexResolver.Resolve(new [] { "P3W" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -147,7 +147,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_5days()
+        public void DataTypes_Resolver_Duration_5days()
         {
             var resolution = TimexResolver.Resolve(new [] { "P5D" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_8hours()
+        public void DataTypes_Resolver_Duration_8hours()
         {
             var resolution = TimexResolver.Resolve(new [] { "PT8H" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -173,7 +173,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_15minutes()
+        public void DataTypes_Resolver_Duration_15minutes()
         {
             var resolution = TimexResolver.Resolve(new [] { "PT15M" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -186,7 +186,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Duration_10seconds()
+        public void DataTypes_Resolver_Duration_10seconds()
         {
             var resolution = TimexResolver.Resolve(new [] { "PT10S" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateRange_September()
+        public void DataTypes_Resolver_DateRange_September()
         {
             var today = new System.DateTime(2017, 9, 28);
             var resolution = TimexResolver.Resolve(new [] { "XXXX-09" }, today);
@@ -219,7 +219,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateRange_Winter()
+        public void DataTypes_Resolver_DateRange_Winter()
         {
             var resolution = TimexResolver.Resolve(new [] { "WI" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -232,7 +232,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_TimeRange_4am_to_8pm()
+        public void DataTypes_Resolver_TimeRange_4am_to_8pm()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new [] { "(T04,T20,PT16H)" }, today);
@@ -246,7 +246,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_TimeRange_Morning()
+        public void DataTypes_Resolver_TimeRange_Morning()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new [] { "TMO" }, today);
@@ -260,7 +260,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_TimeRange_Afternoon()
+        public void DataTypes_Resolver_TimeRange_Afternoon()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new [] { "TAF" }, today);
@@ -274,7 +274,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_TimeRange_Evening()
+        public void DataTypes_Resolver_TimeRange_Evening()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new [] { "TEV" }, today);
@@ -288,7 +288,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateTimeRange_This_Morning()
+        public void DataTypes_Resolver_DateTimeRange_This_Morning()
         {
             var resolution = TimexResolver.Resolve(new [] { "2017-10-07TMO" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -301,7 +301,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_DateTimeRange_next_monday_4am_to_next_thursday_3pm()
+        public void DataTypes_Resolver_DateTimeRange_next_monday_4am_to_next_thursday_3pm()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new [] { "(2017-10-09T04,2017-10-12T15,PT83H)" }, today);
@@ -315,7 +315,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Time_4am()
+        public void DataTypes_Resolver_Time_4am()
         {
             var resolution = TimexResolver.Resolve(new [] { "T04" });
             Assert.AreEqual(1, resolution.Values.Count);
@@ -328,7 +328,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
-        public void Resolver_Time_4_oclock()
+        public void DataTypes_Resolver_Time_4_oclock()
         {
             var resolution = TimexResolver.Resolve(new [] { "T04", "T16" });
             Assert.AreEqual(2, resolution.Values.Count);

--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/packages.config
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net462" />
+</packages>

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/CreatePackage.cmd
@@ -1,0 +1,24 @@
+@echo off
+echo *** Building Microsoft.Recognizers.DataTypes.DateTime
+setlocal
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+for /f "usebackq tokens=*" %%i in (`..\packages\vswhere.2.2.7\tools\vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+  set MSBuildDir=%%i\MSBuild\15.0\Bin\
+)
+
+if not exist ..\nuget mkdir ..\nuget
+if exist ..\nuget\Microsoft.Recognizers.DataTypes.DateTime*.nupkg erase /s ..\nuget\Microsoft.Recognizers.DataTypes.DateTime*.nupkg
+"%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.DataTypes.DateTime.csproj
+for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.DataTypes.DateTime.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
+..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.DataTypes.DateTime.nuspec -symbols -properties version=%numberVersion% -OutputDirectory ..\nuget
+
+set error=%errorlevel%
+set packageName=Microsoft.Recognizers.DataTypes.DateTime
+if %error% NEQ 0 (
+	echo *** Failed to build %packageName%
+	exit /b %error%
+) else (
+	echo *** Succeeded to build %packageName%
+)

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/DateRange.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/DateRange.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
     public class DateRange
     {
         public System.DateTime Start { get; set; }
+
         public System.DateTime End { get; set; }
     }
 }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexConstantsEnglish.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexConstantsEnglish.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Recognizers.DataTypes.DateTime
 {
-    internal static class TimexConstantsEn
+    internal static class TimexConstantsEnglish
     {
         public static readonly string[] Days =
         {

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexConvertEnglish.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Recognizers.DataTypes.DateTime
 {
-    internal static class TimexConvertEn
+    internal static class TimexConvertEnglish
     {
         public static string ConvertTimexToString(Timex timex)
         {
@@ -15,10 +15,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return "now";
             }
+
             if (types.Contains(Constants.TimexTypes.DateTimeRange))
             {
                 return ConvertDateTimeRange(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.DateRange))
             {
                 return ConvertDateRange(timex);
@@ -50,6 +52,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return ConvertTime(timex);
             }
+
             return string.Empty;
         }
 
@@ -60,7 +63,8 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"every {ConvertTimexDurationToString(timex, false)}";
             }
-            else {
+            else
+            {
                 return $"every {ConvertTimexToString(timex)}";
             }
         }
@@ -71,6 +75,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return "midnight";
             }
+
             if (timex.Hour == 12 && timex.Minute == 0 && timex.Second == 0)
             {
                 return "midday";
@@ -88,12 +93,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             if (timex.DayOfWeek != null)
             {
-                return TimexConstantsEn.Days[timex.DayOfWeek.Value - 1];
+                return TimexConstantsEnglish.Days[timex.DayOfWeek.Value - 1];
             }
 
-            var month = TimexConstantsEn.Months[timex.Month.Value - 1];
+            var month = TimexConstantsEnglish.Months[timex.Month.Value - 1];
             var date = timex.DayOfMonth.ToString();
-            var abbreviation = TimexConstantsEn.DateAbbreviation[int.Parse(date[date.Length - 1].ToString())];
+            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString())];
 
             if (timex.Year != null)
             {
@@ -121,30 +126,37 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return ConvertDurationPropertyToString(timex.Years.Value, "year", includeSingleCount);
             }
+
             if (timex.Months != null)
             {
                 return ConvertDurationPropertyToString(timex.Months.Value, "month", includeSingleCount);
             }
+
             if (timex.Weeks != null)
             {
                 return ConvertDurationPropertyToString(timex.Weeks.Value, "week", includeSingleCount);
             }
+
             if (timex.Days != null)
             {
                 return ConvertDurationPropertyToString(timex.Days.Value, "day", includeSingleCount);
             }
+
             if (timex.Hours != null)
             {
                 return ConvertDurationPropertyToString(timex.Hours.Value, "hour", includeSingleCount);
             }
+
             if (timex.Minutes != null)
             {
                 return ConvertDurationPropertyToString(timex.Minutes.Value, "minute", includeSingleCount);
             }
+
             if (timex.Seconds != null)
             {
                 return ConvertDurationPropertyToString(timex.Seconds.Value, "second", includeSingleCount);
             }
+
             return string.Empty;
         }
 
@@ -155,7 +167,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
         private static string ConvertDateRange(Timex timex)
         {
-            var season = (timex.Season != null) ? TimexConstantsEn.Seasons[timex.Season] : string.Empty;
+            var season = (timex.Season != null) ? TimexConstantsEnglish.Seasons[timex.Season] : string.Empty;
 
             var year = (timex.Year != null) ? timex.Year.ToString() : string.Empty;
 
@@ -169,22 +181,23 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
             if (timex.Month != null)
             {
-                var month = $"{TimexConstantsEn.Months[timex.Month.Value - 1]}";
+                var month = $"{TimexConstantsEnglish.Months[timex.Month.Value - 1]}";
                 if (timex.WeekOfMonth != null)
                 {
-                    return $"{TimexConstantsEn.Weeks[timex.WeekOfMonth.Value - 1]} week of {month}";
+                    return $"{TimexConstantsEnglish.Weeks[timex.WeekOfMonth.Value - 1]} week of {month}";
                 }
                 else
                 {
                     return $"{month} {year}".Trim();
                 }
             }
+
             return $"{season} {year}".Trim();
         }
 
         private static string ConvertTimeRange(Timex timex)
         {
-            return TimexConstantsEn.DayParts[timex.PartOfDay];
+            return TimexConstantsEnglish.DayParts[timex.PartOfDay];
         }
 
         private static string ConvertDateTime(Timex timex)

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexRelativeConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/English/TimexRelativeConvertEnglish.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Recognizers.DataTypes.DateTime
 {
-    internal static class TimexRelativeConvertEn
+    internal static class TimexRelativeConvertEnglish
     {
         public static string ConvertTimexToStringRelative(Timex timex, System.DateTime date)
         {
@@ -15,14 +15,17 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return ConvertDateTimeRange(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.DateRange))
             {
                 return ConvertDateRange(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.DateTime))
             {
                 return ConvertDateTime(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.Date))
             {
                 return ConvertDate(timex, date);
@@ -34,7 +37,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         private static string GetDateDay(DayOfWeek day)
         {
             var index = ((int)day == 0) ? 6 : (int)day - 1;
-            return TimexConstantsEn.Days[index];
+            return TimexConstantsEnglish.Days[index];
         }
 
         private static string ConvertDate(Timex timex, System.DateTime date)
@@ -47,35 +50,41 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 {
                     return "today";
                 }
+
                 var tomorrow = TimexDateHelpers.Tomorrow(date);
                 if (TimexDateHelpers.DatePartEquals(timexDate, tomorrow))
                 {
                     return "tomorrow";
                 }
+
                 var yesterday = TimexDateHelpers.Yesterday(date);
                 if (TimexDateHelpers.DatePartEquals(timexDate, yesterday))
                 {
                     return "yesterday";
                 }
+
                 if (TimexDateHelpers.IsThisWeek(timexDate, date))
                 {
                     return $"this {GetDateDay(timexDate.DayOfWeek)}";
                 }
+
                 if (TimexDateHelpers.IsNextWeek(timexDate, date))
                 {
                     return $"next {GetDateDay(timexDate.DayOfWeek)}";
                 }
+
                 if (TimexDateHelpers.IsLastWeek(timexDate, date))
                 {
                     return $"last {GetDateDay(timexDate.DayOfWeek)}";
                 }
             }
-            return TimexConvertEn.ConvertDate(timex);
+
+            return TimexConvertEnglish.ConvertDate(timex);
         }
 
         private static string ConvertDateTime(Timex timex, System.DateTime date)
         {
-            return $"{ConvertDate(timex, date)} {TimexConvertEn.ConvertTime(timex)}";
+            return $"{ConvertDate(timex, date)} {TimexConvertEnglish.ConvertTime(timex)}";
         }
 
         private static string ConvertDateRange(Timex timex, System.DateTime date)
@@ -91,38 +100,46 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         {
                             return timex.Weekend != null ? "this weekend" : "this week";
                         }
+
                         if (thisWeek == timex.WeekOfYear + 1)
                         {
                             return timex.Weekend != null ? "last weekend" : "last week";
                         }
+
                         if (thisWeek == timex.WeekOfYear - 1) {
                             return timex.Weekend != null ? "next weekend" : "next week";
                         }
                     }
+
                     if (timex.Month != null)
                     {
                         if (timex.Month == date.Month)
                         {
                             return "this month";
                         }
+
                         if (timex.Month == date.Month + 1)
                         {
                             return "next month";
                         }
+
                         if (timex.Month == date.Month - 1)
                         {
                             return "last month";
                         }
                     }
-                    return (timex.Season != null) ? $"this {TimexConstantsEn.Seasons[timex.Season]}" : "this year";
+
+                    return (timex.Season != null) ? $"this {TimexConstantsEnglish.Seasons[timex.Season]}" : "this year";
                 }
+
                 if (timex.Year == year + 1)
                 {
-                    return (timex.Season != null) ? $"next {TimexConstantsEn.Seasons[timex.Season]}" : "next year";
+                    return (timex.Season != null) ? $"next {TimexConstantsEnglish.Seasons[timex.Season]}" : "next year";
                 }
+
                 if (timex.Year == year - 1)
                 {
-                    return (timex.Season != null) ? $"last {TimexConstantsEn.Seasons[timex.Season]}" : "last year";
+                    return (timex.Season != null) ? $"last {TimexConstantsEnglish.Seasons[timex.Season]}" : "last year";
                 }
             }
             return string.Empty;
@@ -142,32 +159,36 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         {
                             return "tonight";
                         }
-                        else {
-                            return $"this {TimexConstantsEn.DayParts[timex.PartOfDay]}";
+                        else
+                        {
+                            return $"this {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                         }
                     }
+
                     var tomorrow = TimexDateHelpers.Tomorrow(date);
                     if (TimexDateHelpers.DatePartEquals(timexDate, tomorrow))
                     {
-                        return $"tomorrow {TimexConstantsEn.DayParts[timex.PartOfDay]}";
+                        return $"tomorrow {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
+
                     var yesterday = TimexDateHelpers.Yesterday(date);
                     if (TimexDateHelpers.DatePartEquals(timexDate, yesterday))
                     {
-                        return $"yesterday {TimexConstantsEn.DayParts[timex.PartOfDay]}";
+                        return $"yesterday {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
 
                     if (TimexDateHelpers.IsNextWeek(timexDate, date))
                     {
-                        return $"next {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEn.DayParts[timex.PartOfDay]}";
+                        return $"next {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
 
                     if (TimexDateHelpers.IsLastWeek(timexDate, date))
                     {
-                        return $"last {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEn.DayParts[timex.PartOfDay]}";
+                        return $"last {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
                 }
             }
+
             return string.Empty;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Microsoft.Recognizers.DataTypes.DateTime.csproj
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Microsoft.Recognizers.DataTypes.DateTime.csproj
@@ -1,8 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Copyright>Copyright ©  2017</Copyright>
+    <TargetFrameworks>netstandard2.0;net462;net452;net45</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="(robocopy /E /XO /R:3 /W:3 &quot;$(TargetDir)..&quot; &quot;$(SolutionDir)build\package&quot; *.*) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0" />
+  </Target>
 
 </Project>

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Microsoft.Recognizers.DataTypes.DateTime.nuspec
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Microsoft.Recognizers.DataTypes.DateTime.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Microsoft.Recognizers.DataTypes.DateTime</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Microsoft.Recognizers.DataTypes.DateTime provides parsing and evaluation of TIMEX expressions.</description>
+    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
+    <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>nlp entity-extraction parser-library recognizer timex datatime netstandard2.0</tags>
+  </metadata>
+  <files>
+    <file src="..\build\package\net45\Microsoft.Recognizers.DataTypes.DateTime.dll" target="lib\net45"/>
+    <file src="..\build\package\net452\Microsoft.Recognizers.DataTypes.DateTime.dll" target="lib\net452"/>
+    <file src="..\build\package\net462\Microsoft.Recognizers.DataTypes.DateTime.dll" target="lib\net462"/>
+    <file src="..\build\package\netstandard2.0\Microsoft.Recognizers.DataTypes.DateTime.dll" target="lib\netstandard2.0"/>
+    <file src="**\*.cs" exclude="**\obj\**\*.cs" target="src" />
+  </files>
+</package>

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Recognizers.Text.DateTime")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Recognizers.Text.DateTime")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("19522b81-c63f-4dd5-ab4c-674cd44d67d6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Recognizers.Text.DateTime")]
+[assembly: AssemblyTitle("Microsoft.Recognizers.DataTypes.DateTime")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.Recognizers.Text.DateTime")]
+[assembly: AssemblyProduct("Microsoft.Recognizers.DataTypes.DateTime")]
 [assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("19522b81-c63f-4dd5-ab4c-674cd44d67d6")]
+[assembly: Guid("6C1FE715-E09B-409A-920A-5BCC3C5AB2CD")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Time.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Time.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         }
 
         public int Hour { get; set; }
+
         public int Minute { get; set; }
+
         public int Second { get; set; }
     }
 }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/Timex.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/Timex.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 {
     public class Timex
     {
-        private Time _time;
+        private Time time;
 
         public Timex()
         {
@@ -27,6 +27,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 DayOfMonth = date.Day
             };
         }
+		
         public static Timex FromDateTime(System.DateTime datetime)
         {
             var timex = FromDate(datetime);
@@ -35,6 +36,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             timex.Second = datetime.Second;
             return timex;
         }
+		
         public static Timex FromTime(Time time)
         {
             return new Timex
@@ -45,21 +47,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             };
         }
 
-        public string TimexValue
-        {
-            get
-            {
-                return TimexFormat.Format(this);
-            }
-        }
+        public string TimexValue => TimexFormat.Format(this);
 
-        public HashSet<string> Types
-        {
-            get
-            {
-                return TimexInference.Infer(this);
-            }
-        }
+        public HashSet<string> Types => TimexInference.Infer(this);
 
         public override string ToString()
         {
@@ -132,69 +122,72 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
         public int? Hour
         {
-            get { return _time?.Hour; }
+            get { return time?.Hour; }
+
             set
             {
                 if (value.HasValue)
                 {
-                    if (_time == null)
+                    if (time == null)
                     {
-                        _time = new Time(value.Value, 0, 0);
+                        time = new Time(value.Value, 0, 0);
                     }
                     else
                     {
-                        _time.Hour = value.Value;
+                        time.Hour = value.Value;
                     }
                 }
                 else
                 {
-                    _time = null;
+                    time = null;
                 }
             }
         }
 
         public int? Minute
         {
-            get { return _time?.Minute; }
+            get { return time?.Minute; }
+
             set
             {
                 if (value.HasValue)
                 {
-                    if (_time == null)
+                    if (time == null)
                     {
-                        _time = new Time(0, value.Value, 0);
+                        time = new Time(0, value.Value, 0);
                     }
                     else
                     {
-                        _time.Minute = value.Value;
+                        time.Minute = value.Value;
                     }
                 }
                 else
                 {
-                    _time = null;
+                    time = null;
                 }
             }
         }
 
         public int? Second
         {
-            get { return _time?.Second; }
+            get { return time?.Second; }
+
             set
             {
                 if (value.HasValue)
                 {
-                    if (_time == null)
+                    if (time == null)
                     {
-                        _time = new Time(0, 0, value.Value);
+                        time = new Time(0, 0, value.Value);
                     }
                     else
                     {
-                        _time.Second = value.Value;
+                        time.Second = value.Value;
                     }
                 }
                 else
                 {
-                    _time = null;
+                    time = null;
                 }
             }
         }
@@ -210,42 +203,54 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     case "year":
                         Year = int.Parse(item.Value);
                         break;
+
                     case "month":
                         Month = int.Parse(item.Value);
                         break;
+
                     case "dayOfMonth":
                         DayOfMonth = int.Parse(item.Value);
                         break;
+
                     case "dayOfWeek":
                         DayOfWeek = int.Parse(item.Value);
                         break;
+
                     case "season":
                         Season = item.Value;
                         break;
+
                     case "weekOfYear":
                         WeekOfYear = int.Parse(item.Value);
                         break;
+
                     case "weekend":
                         Weekend = true;
                         break;
+
                     case "weekOfMonth":
                         WeekOfMonth = int.Parse(item.Value);
                         break;
+
                     case "hour":
                         Hour = int.Parse(item.Value);
                         break;
+
                     case "minute":
                         Minute = int.Parse(item.Value);
                         break;
                     case "second":
                         Second = int.Parse(item.Value);
                         break;
+
                     case "partOfDay":
                         PartOfDay = item.Value;
                         break;
+
                     case "dateUnit":
                         AssignDateDuration(source);
                         break;
+
                     case "timeUnit":
                         AssignTimeDuration(source);
                         break;
@@ -260,12 +265,15 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 case "Y":
                     Years = decimal.Parse(source["amount"]);
                     break;
+
                 case "M":
                     Months = decimal.Parse(source["amount"]);
                     break;
+
                 case "W":
                     Weeks = decimal.Parse(source["amount"]);
                     break;
+
                 case "D":
                     Days = decimal.Parse(source["amount"]);
                     break;
@@ -279,9 +287,11 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 case "H":
                     Hours = decimal.Parse(source["amount"]);
                     break;
+
                 case "M":
                     Minutes = decimal.Parse(source["amount"]);
                     break;
+
                 case "S":
                     Seconds = decimal.Parse(source["amount"]);
                     break;

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexConstraintsHelper.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexConstraintsHelper.cs
@@ -12,8 +12,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         public static IEnumerable<TimeRange> Collapse(IEnumerable<TimeRange> ranges)
         {
             var r = ranges.ToList();
-            while (InnerCollapse(r))
-                ;
+
+            while (InnerCollapse(r)) { }
+
             r.Sort((a, b) => a.Start.GetTime() - b.Start.GetTime());
             return r;
         }
@@ -21,16 +22,17 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         public static IEnumerable<DateRange> Collapse(IEnumerable<DateRange> ranges)
         {
             var r = ranges.ToList();
-            while (InnerCollapse(r))
-                ;
+
+            while (InnerCollapse(r)) { }
+
             r.Sort((a, b) => System.DateTime.Compare(a.Start, b.Start));
             return r;
         }
 
         private static bool IsOverlapping(TimeRange r1, TimeRange r2)
         {
-            return r1.End.GetTime() > r2.Start.GetTime() && r1.Start.GetTime() <= r2.Start.GetTime()
-                || r1.Start.GetTime() < r2.End.GetTime() && r1.Start.GetTime() >= r2.Start.GetTime();
+            return r1.End.GetTime() > r2.Start.GetTime() && r1.Start.GetTime() <= r2.Start.GetTime() || 
+                   r1.Start.GetTime() < r2.End.GetTime() && r1.Start.GetTime() >= r2.Start.GetTime();
         }
 
         private static TimeRange CollapseOverlapping(TimeRange r1, TimeRange r2) 
@@ -48,6 +50,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return false;
             }
+
             for (int i = 0; i < ranges.Count; i++)
             {
                 var r1 = ranges[i];
@@ -63,12 +66,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     }
                 }
             }
+
             return false;
         }
         private static bool IsOverlapping(DateRange r1, DateRange r2)
         {
-            return r1.End > r2.Start && r1.Start <= r2.Start
-                || r1.Start < r2.End && r1.Start >= r2.Start;
+            return r1.End > r2.Start && r1.Start <= r2.Start || 
+                   r1.Start < r2.End && r1.Start >= r2.Start;
         }
 
         private static DateRange CollapseOverlapping(DateRange r1, DateRange r2)
@@ -86,6 +90,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return false;
             }
+
             for (int i = 0; i < ranges.Count; i++)
             {
                 var r1 = ranges[i];
@@ -101,6 +106,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     }
                 }
             }
+
             return false;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexConvert.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexConvert.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
     {
         public static string ConvertTimexToString(Timex timex)
         {
-            return TimexConvertEn.ConvertTimexToString(timex);
+            return TimexConvertEnglish.ConvertTimexToString(timex);
         }
 
         public static string ConvertTimexSetToString(TimexSet timexSet)
         {
-            return TimexConvertEn.ConvertTimexSetToString(timexSet);
+            return TimexConvertEnglish.ConvertTimexSetToString(timexSet);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexDateHelpers.cs
@@ -20,9 +20,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
         public static bool DatePartEquals(System.DateTime dateX, System.DateTime dateY)
         {
-            return (dateX.Year == dateY.Year)
-                && (dateX.Month == dateY.Month)
-                && (dateX.Day == dateY.Day);
+            return (dateX.Year == dateY.Year) && (dateX.Month == dateY.Month) && (dateX.Day == dateY.Day);
         }
 
         public static bool IsDateInWeek(System.DateTime date, System.DateTime startOfWeek)
@@ -34,8 +32,10 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 {
                     return true;
                 }
+
                 d = d.AddDays(1);
             }
+
             return false;
         }
 
@@ -47,6 +47,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 startOfWeek = startOfWeek.AddDays(-1);
             }
+
             return IsDateInWeek(date, startOfWeek);
         }
 
@@ -67,16 +68,20 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             var ds = new System.DateTime(date.Year, 1, 1);
             var de = new System.DateTime(date.Year, date.Month, date.Day);
             int weeks = 1;
+
             while (ds < de)
             {
                 var csDayOfWeek = ds.DayOfWeek;
+
                 var isoDayOfWeek = (csDayOfWeek == 0) ? 7 : (int)csDayOfWeek;
                 if (isoDayOfWeek == 7)
                 {
                     weeks++;
                 }
+
                 ds = ds.AddDays(1);
             }
+
             return weeks;
         }
 
@@ -89,10 +94,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             var result = referenceDate;
             result = result.AddDays(-1);
+
             while (result.DayOfWeek != day)
             {
                 result = result.AddDays(-1);
             }
+
             return result;
         }
 
@@ -100,10 +107,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             var result = referenceDate;
             result = result.AddDays(1);
+
             while (result.DayOfWeek != day)
             {
                 result = result.AddDays(1);
             }
+
             return result;
         }
 
@@ -111,14 +120,17 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             var result = new List<System.DateTime>();
             var d = start;
+
             while (!DatePartEquals(d, end))
             {
                 if (d.DayOfWeek == day)
                 {
                     result.Add(d);
                 }
+
                 d = d.AddDays(1);
             }
+
             return result;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexFormat.cs
@@ -12,39 +12,49 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             if (types.Contains(Constants.TimexTypes.Present)) {
                 return "PRESENT_REF";
             }
-            if ((types.Contains(Constants.TimexTypes.DateTimeRange) || types.Contains(Constants.TimexTypes.DateRange) || types.Contains(Constants.TimexTypes.TimeRange)) && types.Contains(Constants.TimexTypes.Duration))
+
+            if ((types.Contains(Constants.TimexTypes.DateTimeRange) || types.Contains(Constants.TimexTypes.DateRange) || 
+                 types.Contains(Constants.TimexTypes.TimeRange)) && types.Contains(Constants.TimexTypes.Duration))
             {
                 var range = TimexHelpers.ExpandDateTimeRange(timex);
                 return $"({Format(range.Start)},{Format(range.End)},{Format(range.Duration)})";
             }
+
             if (types.Contains(Constants.TimexTypes.DateTimeRange))
             {
                 return $"{FormatDate(timex)}{FormatTimeRange(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.DateRange))
             {
                 return $"{FormatDateRange(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.TimeRange))
             {
                 return $"{FormatTimeRange(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.DateTime))
             {
                 return $"{FormatDate(timex)}{FormatTime(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.Duration))
             {
                 return $"{FormatDuration(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.Date))
             {
                 return $"{FormatDate(timex)}";
             }
+
             if (types.Contains(Constants.TimexTypes.Time))
             {
                 return $"{FormatTime(timex)}";
             }
+
             return string.Empty;
         }
 
@@ -54,29 +64,36 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"P{timex.Years}Y";
             }
+
             if (timex.Months != null)
             {
                 return $"P{timex.Months}M";
             }
+
             if (timex.Weeks != null) {
                 return $"P{timex.Weeks}W";
             }
+
             if (timex.Days != null)
             {
                 return $"P{timex.Days}D";
             }
+
             if (timex.Hours != null)
             {
                 return $"PT{timex.Hours}H";
             }
+
             if (timex.Minutes != null)
             {
                 return $"PT{timex.Minutes}M";
             }
+
             if (timex.Seconds != null)
             {
                 return $"PT{timex.Seconds}S";
             }
+
             return string.Empty;
         }
 
@@ -86,10 +103,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"T{TimexDateHelpers.FixedFormatNumber(timex.Hour, 2)}";
             }
+
             if (timex.Second == 0)
             {
                 return $"T{TimexDateHelpers.FixedFormatNumber(timex.Hour, 2)}:{TimexDateHelpers.FixedFormatNumber(timex.Minute, 2)}";
             }
+
             return $"T{TimexDateHelpers.FixedFormatNumber(timex.Hour, 2)}:{TimexDateHelpers.FixedFormatNumber(timex.Minute, 2)}:{TimexDateHelpers.FixedFormatNumber(timex.Second, 2)}";
         }
 
@@ -99,14 +118,17 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
             }
+
             if (timex.Month != null && timex.DayOfMonth != null)
             {
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
             }
+
             if (timex.DayOfWeek != null) 
             {
                 return $"XXXX-WXX-{timex.DayOfWeek}";
             }
+
             return string.Empty;
         }
 
@@ -116,37 +138,46 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-W{TimexDateHelpers.FixedFormatNumber(timex.WeekOfYear, 2)}-WE";
             }
+
             if (timex.Year != null && timex.WeekOfYear != null)
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-W{TimexDateHelpers.FixedFormatNumber(timex.WeekOfYear, 2)}";
             }
+
             if (timex.Year != null && timex.Season != null) {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{timex.Season}";
             }
+
             if (timex.Season != null)
             {
                 return $"{timex.Season}";
             }
+
             if (timex.Year != null && timex.Month != null)
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}";
             }
+
             if (timex.Year != null)
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}";
             }
+
             if (timex.Month != null && timex.WeekOfMonth != null && timex.DayOfWeek != null)
             {
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}-{timex.DayOfWeek}";
             }
+
             if (timex.Month != null && timex.WeekOfMonth != null)
             {
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}";
             }
+
             if (timex.Month != null)
             {
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}";
             }
+
             return string.Empty;
         }
 
@@ -156,6 +187,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"T{timex.PartOfDay}";
             }
+
             return string.Empty;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexHelpers.cs
@@ -43,9 +43,11 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         range.End.Month = 1;
                         range.End.DayOfMonth = 1;
                     }
+
                     return range;
                 }
             }
+
             return new TimexRange { Start = new Timex(), End = new Timex() };
         }
 
@@ -53,6 +55,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             var start = new Timex { Hour = timex.Hour, Minute = timex.Minute, Second = timex.Second };
             var duration = CloneDuration(timex);
+
             return new TimexRange
             {
                 Start = start,
@@ -69,8 +72,10 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 {
                     end.DayOfWeek += (int)duration.Days;
                 }
+
                 return end;
             }
+
             if (start.Month != null && start.DayOfMonth != null)
             {
                 if (duration.Days != null)
@@ -79,6 +84,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     {
                         var d = new System.DateTime(start.Year.Value, start.Month.Value, start.DayOfMonth.Value, 0, 0, 0);
                         d = d.AddDays((double)duration.Days.Value);
+
                         return new Timex {
                             Year = d.Year,
                             Month = d.Month,
@@ -89,6 +95,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     {
                         var d = new System.DateTime(2001, start.Month.Value, start.DayOfMonth.Value, 0, 0, 0);
                         d = d.AddDays((double)duration.Days.Value);
+
                         return new Timex
                         {
                             Month = d.Month,
@@ -96,6 +103,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         };
                     }
                 }
+
                 if (duration.Years != null)
                 {
                     if (start.Year != null)
@@ -108,6 +116,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         };
                     }
                 }
+
                 if (duration.Month != null)
                 {
                     if (start.Month != null)
@@ -144,14 +153,17 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         result.Year = d.Year;
                         result.Month = d.Month;
                         result.DayOfMonth = d.Day;
+
                         return result;
                     }
+
                     if (result.DayOfWeek != null)
                     {
                         result.DayOfWeek += (int)days;
                         return result;
                     }
                 }
+
                 return result;
             }
 
@@ -159,13 +171,16 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 var result = start.Clone();
                 result.Minute += (int)duration.Minutes.Value;
+
                 if (result.Minute.Value > 59)
                 {
                     result.Hour++;
                     result.Minute = 0;
                 }
+
                 return result;
             }
+
             return start;
         }
 
@@ -178,11 +193,11 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         {
             return new System.DateTime(timex.Year ?? 2001, timex.Month ?? 1, timex.DayOfMonth ?? 1, timex.Hour ?? 0, timex.Minute ?? 0, timex.Second ?? 0);
         }
+
         public static Time TimeFromTimex(Timex timex)
         {
             return new Time(timex.Hour ?? 0, timex.Minute ?? 0, timex.Second ?? 0);
         }
-
 
         public static DateRange DateRangeFromTimex(Timex timex)
         {

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexInference.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexInference.cs
@@ -15,55 +15,68 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 types.Add(Constants.TimexTypes.Present);
             }
+
             if (IsDefinite(obj))
             {
                 types.Add(Constants.TimexTypes.Definite);
             }
+
             if (IsDate(obj))
             {
                 types.Add(Constants.TimexTypes.Date);
             }
+
             if (IsDateRange(obj))
             {
                 types.Add(Constants.TimexTypes.DateRange);
             }
+
             if (IsDuration(obj))
             {
                 types.Add(Constants.TimexTypes.Duration);
             }
+
             if (IsTime(obj))
             {
                 types.Add(Constants.TimexTypes.Time);
             }
+
             if (IsTimeRange(obj))
             {
                 types.Add(Constants.TimexTypes.TimeRange);
             }
+
             if (types.Contains(Constants.TimexTypes.Present))
             {
                 types.Add(Constants.TimexTypes.Date);
                 types.Add(Constants.TimexTypes.Time);
             }
+
             if (types.Contains(Constants.TimexTypes.Time) && types.Contains(Constants.TimexTypes.Duration))
             {
                 types.Add(Constants.TimexTypes.TimeRange);
             }
+
             if (types.Contains(Constants.TimexTypes.Date) && types.Contains(Constants.TimexTypes.Time))
             {
                 types.Add(Constants.TimexTypes.DateTime);
             }
+
             if (types.Contains(Constants.TimexTypes.Date) && types.Contains(Constants.TimexTypes.Duration))
             {
                 types.Add(Constants.TimexTypes.DateRange);
             }
+
             if (types.Contains(Constants.TimexTypes.DateTime) && types.Contains(Constants.TimexTypes.Duration))
             {
                 types.Add(Constants.TimexTypes.DateTimeRange);
             }
+
             if (types.Contains(Constants.TimexTypes.Date) && types.Contains(Constants.TimexTypes.TimeRange))
             {
                 types.Add(Constants.TimexTypes.DateTimeRange);
             }
+
             return types;
         }
 
@@ -74,13 +87,8 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
         private static bool IsDuration(Timex obj)
         {
-            return obj.Years != null
-                || obj.Months != null
-                || obj.Weeks != null
-                || obj.Days != null
-                || obj.Hours != null
-                || obj.Minutes != null
-                || obj.Seconds != null;
+            return obj.Years != null || obj.Months != null || obj.Weeks != null || obj.Days != null ||
+                   obj.Hours != null || obj.Minutes != null || obj.Seconds != null;
         }
 
         private static bool IsTime(Timex obj)
@@ -100,12 +108,10 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
 
         private static bool IsDateRange(Timex obj)
         {
-            return (obj.Year != null && obj.DayOfMonth == null)
-                || (obj.Year != null && obj.Month != null && obj.DayOfMonth == null)
-                || (obj.Month != null && obj.DayOfMonth == null)
-                || obj.Season != null
-                || obj.WeekOfYear != null
-                || obj.WeekOfMonth != null;
+            return (obj.Year != null && obj.DayOfMonth == null) || 
+                   (obj.Year != null && obj.Month != null && obj.DayOfMonth == null) || 
+                   (obj.Month != null && obj.DayOfMonth == null) || 
+                   obj.Season != null || obj.WeekOfYear != null || obj.WeekOfMonth != null;
         }
 
         private static bool IsDefinite(Timex obj)

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexParsing.cs
@@ -14,19 +14,16 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 obj.Now = true;
             }
-            // duration
             else if (timex.StartsWith("P"))
-            {
+            { // duration 
                 ExtractDuration(timex, obj);
             }
-            // range indicated with start and end dates and a duration
             else if (timex.StartsWith("(") && timex.EndsWith(")"))
-            {
+            { // range indicated with start and end dates and a duration
                 ExtractStartEndRange(timex, obj);
             }
-            // date and time and their respective ranges
             else
-            {
+            { // date and time and their respective ranges
                 ExtractDateTime(timex, obj);
             }
         }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRange.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRange.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
     public class TimexRange
     {
         public Timex Start { get; set; }
+
         public Timex End { get; set; }
+
         public Timex Duration { get; set; }
     }
 }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRangeResolver.cs
@@ -16,9 +16,11 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             var candidatesAccordingToDate = ResolveByDateRangeConstraints(candidatesWithDurationsResolved, timexConstraints);
             var candidatesWithAddedTime = ResolveByTimeConstraints(candidatesAccordingToDate, timexConstraints);
             var candidatesFilteredByTime = ResolveByTimeRangeConstraints(candidatesWithAddedTime, timexConstraints);
+
             var timexResults = candidatesFilteredByTime
                 .Select((x) => { return new Timex(x); })
                 .ToList();
+
             return timexResults;
         }
         private static List<string> ResolveDurations(IEnumerable<string> candidates, IEnumerable<Timex> constraints)
@@ -40,6 +42,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     results.Add(candidate);
                 }
             }
+
             return results;
         }
 
@@ -57,6 +60,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     results.Add(TimexHelpers.TimexTimeAdd(constraint, candidate));
                 }
             }
+
             return results;
         }
 
@@ -94,6 +98,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 result.AddRange(ResolveDateAgainstConstraint(timex, constraint));
             }
+
             return result;
         }
 
@@ -132,6 +137,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 result.AddRange(ResolveTimeAgainstConstraint(timex, constraint));
             }
+
             return result;
         }
 
@@ -142,6 +148,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return new [] { timex.TimexValue };
             }
+
             return Enumerable.Empty<string>();
         }
 
@@ -157,6 +164,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return new[] { timex.TimexValue };
             }
+
             return Enumerable.Empty<string>();
         }
 
@@ -171,13 +179,16 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     t.Year = year;
                     result.AddRange(ResolveDefiniteAgainstConstraint(t, constraint));
                 }
+
                 return result;
             }
+
             if (timex.DayOfWeek != null)
             {
                 var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
                 var dates = TimexDateHelpers.DatesMatchingDay(day, constraint.Start, constraint.End);
                 var result = new List<string>();
+
                 foreach (var d in dates)
                 {
                     var t = timex.Clone();
@@ -187,8 +198,10 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     t.DayOfMonth = d.Day;
                     result.Add(t.TimexValue);
                 }
+
                 return result;
             }
+
             return Enumerable.Empty<string>();
         }
 
@@ -224,6 +237,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     resolution.Add(timex.TimexValue);
                 }
             }
+
             return RemoveDuplicates(resolution);
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRegex.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)-(?<dayOfMonth>\d\d)$"),
                     new Regex(@"^XXXX-WXX-(?<dayOfWeek>\d)$"),
                     new Regex(@"^XXXX-(?<month>\d\d)-(?<dayOfMonth>\d\d)$"),
+
                     // daterange
                     new Regex(@"^(?<year>\d\d\d\d)$"),
                     new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)$"),
@@ -36,6 +37,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     new Regex(@"^T(?<hour>\d\d)$"),
                     new Regex(@"^T(?<hour>\d\d):(?<minute>\d\d)$"),
                     new Regex(@"^T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)$"),
+
                     // timerange
                     new Regex(@"^T(?<partOfDay>DT|NI|MO|AF|EV)$")
                 }
@@ -56,10 +58,12 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return false;
             }
+
             foreach (var groupName in regex.GetGroupNames())
             {
                 result[groupName] = regexResult.Groups[groupName].Value;
             }
+
             return true;
         }
 
@@ -72,6 +76,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     return true;
                 }
             }
+
             return false;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRelativeConvert.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexRelativeConvert.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
     {
         public static string ConvertTimexToStringRelative(Timex timex, System.DateTime referenceDate)
         {
-            return TimexRelativeConvertEn.ConvertTimexToStringRelative(timex, referenceDate);
+            return TimexRelativeConvertEnglish.ConvertTimexToStringRelative(timex, referenceDate);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexResolver.cs
@@ -13,9 +13,13 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             public class Entry
             {
                 public string Timex { get; set; }
+
                 public string Type { get; set; }
+
                 public string Value { get; set; }
+
                 public string Start { get; set; }
+
                 public string End { get; set; }
             }
 
@@ -36,6 +40,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 var r = ResolveTimex(t, date);
                 resolution.Values.AddRange(r);
             }
+
             return resolution;
         }
 
@@ -47,38 +52,47 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return ResolveDateTimeRange(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.Definite) && types.Contains(Constants.TimexTypes.Time))
             {
                 return ResolveDefiniteTime(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.Definite))
             {
                 return ResolveDefinite(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.DateRange))
             {
                 return ResolveDateRange(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.TimeRange))
             {
                 return ResolveTimeRange(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.DateTime))
             {
                 return ResolveDateTime(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.Duration))
             {
                 return ResolveDuration(timex);
             }
+
             if (types.Contains(Constants.TimexTypes.Date))
             {
                 return ResolveDate(timex, date);
             }
+
             if (types.Contains(Constants.TimexTypes.Time))
             {
                 return ResolveTime(timex);
             }
+
             return new List<Resolution.Entry>();
         }
 
@@ -137,6 +151,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     DayOfMonth = timex.DayOfMonth
                 });
             }
+
             if (timex.DayOfWeek != null)
             {
                 var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
@@ -148,6 +163,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     DayOfMonth = result.Day
                 });
             }
+
             return string.Empty;
         }
 
@@ -162,6 +178,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     DayOfMonth = timex.DayOfMonth
                 });
             }
+
             if (timex.DayOfWeek != null)
             {
                 var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
@@ -173,6 +190,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     DayOfMonth = result.Day
                 });
             }
+
             return string.Empty;
         }
 
@@ -239,6 +257,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         }
                     };
                 }
+
                 if (timex.Month != null)
                 {
                     var y = date.Year;
@@ -263,6 +282,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                         }
                     };
                 }
+
                 return new List<Resolution.Entry>();
             }
         }
@@ -275,6 +295,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 case "AF": return new Tuple<string, string>("12:00:00", "16:00:00");
                 case "EV": return new Tuple<string, string>("16:00:00", "20:00:00");
             }
+
             return new Tuple<string, string>("not resolved", "not resolved");
         }
 
@@ -294,7 +315,8 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                     }
                 };
             }
-            else {
+            else
+            {
                 var range = TimexHelpers.ExpandTimeRange(timex);
                 return new List<Resolution.Entry>
                 {
@@ -317,6 +339,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 resolved.Type = "datetime";
                 resolved.Value = $"{resolved.Value} {TimexValue.TimeValue(timex)}";
             }
+
             return resolvedDates;
         }
 

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexValue.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexValue.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(obj.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(obj.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(obj.DayOfMonth, 2)}";
             }
+
             return string.Empty;
         }
 
@@ -20,6 +21,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(obj.Hour, 2)}:{TimexDateHelpers.FixedFormatNumber(obj.Minute, 2)}:{TimexDateHelpers.FixedFormatNumber(obj.Second, 2)}";
             }
+
             return string.Empty;
         }
 
@@ -34,24 +36,37 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
             {
                 return (31536000 * obj.Years).ToString();
             }
-            if (obj.Months != null) {
+
+            if (obj.Months != null)
+            {
                 return (2592000 * obj.Months).ToString();
             }
-            if (obj.Weeks != null) {
+
+            if (obj.Weeks != null)
+            {
                 return (604800 * obj.Weeks).ToString();
             }
-            if (obj.Days != null) {
+
+            if (obj.Days != null)
+            {
                 return (86400 * obj.Days).ToString();
             }
-            if (obj.Hours != null) {
+
+            if (obj.Hours != null)
+            {
                 return (3600 * obj.Hours).ToString();
             }
-            if (obj.Minutes != null) {
+
+            if (obj.Minutes != null)
+            {
                 return (60 * obj.Minutes).ToString();
             }
-            if (obj.Seconds != null) {
+
+            if (obj.Seconds != null)
+            {
                 return obj.Seconds.ToString();
             }
+
             return string.Empty;
         }
     }

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/en/TimexConstantsEn.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/en/TimexConstantsEn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
         public static readonly string[] Months =
         {
             "January",
-            "Februrary",
+            "February",
             "March",
             "April",
             "May",

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Microsoft.Recognizers.Text.DataDrivenTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\vswhere.2.2.11\build\vswhere.props" Condition="Exists('..\packages\vswhere.2.2.11\build\vswhere.props')" />
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,10 +41,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -132,9 +132,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\packages\vswhere.2.2.11\build\vswhere.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vswhere.2.2.11\build\vswhere.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/packages.config
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net46" />
-  <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net46" />
+  <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NuGet.CommandLine" version="4.3.0" targetFramework="net462" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net462" />

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.German;
 using System.Collections.Generic;
-using Microsoft.Recognizers.Text.Number;
+
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration

--- a/.NET/Microsoft.Recognizers.Text.sln
+++ b/.NET/Microsoft.Recognizers.Text.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{ED7B6456-AB0A-48CE-8F85-711FE87F09C2}"
 EndProject
@@ -70,6 +70,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Recognizers.Text.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Recognizers.Text.Choice", "Microsoft.Recognizers.Text.Choice\Microsoft.Recognizers.Text.Choice.csproj", "{9318EA22-C36A-48C8-9882-8A0D2D74C356}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Recognizers.DataTypes.DateTime", "Microsoft.Recognizers.DataTypes.DateTime\Microsoft.Recognizers.DataTypes.DateTime.csproj", "{E4FCBDE9-D436-4D39-A67F-707E6CBD45CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Recognizers.DataTypes.DataDrivenTests", "Microsoft.Recognizers.DataTypes.DataDrivenTests\Microsoft.Recognizers.DataTypes.DataDrivenTests.csproj", "{32A4593C-3D2D-412E-8EC5-07346266A358}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -120,6 +124,14 @@ Global
 		{9318EA22-C36A-48C8-9882-8A0D2D74C356}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9318EA22-C36A-48C8-9882-8A0D2D74C356}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9318EA22-C36A-48C8-9882-8A0D2D74C356}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4FCBDE9-D436-4D39-A67F-707E6CBD45CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4FCBDE9-D436-4D39-A67F-707E6CBD45CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4FCBDE9-D436-4D39-A67F-707E6CBD45CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4FCBDE9-D436-4D39-A67F-707E6CBD45CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32A4593C-3D2D-412E-8EC5-07346266A358}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32A4593C-3D2D-412E-8EC5-07346266A358}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32A4593C-3D2D-412E-8EC5-07346266A358}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32A4593C-3D2D-412E-8EC5-07346266A358}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -131,6 +143,7 @@ Global
 		{8FD9E85D-D0BF-4DEA-959A-7449D5AD0F4A} = {452C724B-66C1-4F67-A718-E7733F79961D}
 		{E6BAD17F-2FB0-4A3C-B897-BA9331DEB88A} = {F070C131-80C0-4B0E-A462-2F6DB796759D}
 		{9A4EED9D-A3CE-4BA2-9021-042768D14A48} = {F070C131-80C0-4B0E-A462-2F6DB796759D}
+		{32A4593C-3D2D-412E-8EC5-07346266A358} = {ED7B6456-AB0A-48CE-8F85-711FE87F09C2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FCFA9AFA-4914-4449-A66D-AE20900F0AA5}


### PR DESCRIPTION
- put datetypes csproj back in build
- add package creation to build
- update nuget.exe in buildtools (the more recent versions can restore netstandard2)
- moved datatypes test assembly down to 4.6.2 (because netcore command line is "dotnet test" not vstest)
- updated nuget test adapter packages across test assemblies