### PR TITLE
Remove NeoSmart.Unicode (no strong named) dependency form Choice*

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="Unicode.net" Version="0.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We implemented the only piece of logic we used from the NeoSmart.Unicode package within the class.
- bool IsEmoji(string letter)
- IEnumerable<string> Letters(string text)