### PR TITLE
Fix ipv6 bug for single ‘:’

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/BaseIp.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/BaseIp.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Definitions
 		public static readonly string Ipv6EllipsisRegex6 = $@"(({BasicIpv6Element}:){{5}}((:{BasicIpv6Element}){{1,2}}))";
 		public static readonly string Ipv6EllipsisRegex7 = $@"(({BasicIpv6Element}:){{6}}((:{BasicIpv6Element}){{1}}))";
 		public static readonly string Ipv6EllipsisRegex8 = $@"(({BasicIpv6Element}:){{7}}(:))";
-		public static readonly string Ipv6EllipsisRegexOther = $@"\B::\B|\B:(:{BasicIpv6Element}){{0,7}}\b|\b({BasicIpv6Element}:){{0,7}}:\B";
+		public static readonly string Ipv6EllipsisRegexOther = $@"\B::\B|\B:(:{BasicIpv6Element}){{1,7}}\b|\b({BasicIpv6Element}:){{1,7}}:\B";
 		public static readonly string MergedIpv6Regex = $@"({BasicIpv6Regex}|{Ipv6EllipsisRegex1}|{Ipv6EllipsisRegex2}|{Ipv6EllipsisRegex3}|{Ipv6EllipsisRegex4}|{Ipv6EllipsisRegex5}|{Ipv6EllipsisRegex6}|{Ipv6EllipsisRegex7}|{Ipv6EllipsisRegex8})";
 		public static readonly string Ipv6Regex = $@"(\b{MergedIpv6Regex}\b)|({Ipv6EllipsisRegexOther})";
 	}

--- a/JavaScript/packages/recognizers-sequence/src/resources/baseIp.ts
+++ b/JavaScript/packages/recognizers-sequence/src/resources/baseIp.ts
@@ -18,7 +18,7 @@ export namespace BaseIp {
 	export const Ipv6EllipsisRegex6 = `((${BasicIpv6Element}:){5}((:${BasicIpv6Element}){1,2}))`;
 	export const Ipv6EllipsisRegex7 = `((${BasicIpv6Element}:){6}((:${BasicIpv6Element}){1}))`;
 	export const Ipv6EllipsisRegex8 = `((${BasicIpv6Element}:){7}(:))`;
-	export const Ipv6EllipsisRegexOther = `\\B::\\B|\\B:(:${BasicIpv6Element}){0,7}\\b|\\b(${BasicIpv6Element}:){0,7}:\\B`;
+	export const Ipv6EllipsisRegexOther = `\\B::\\B|\\B:(:${BasicIpv6Element}){1,7}\\b|\\b(${BasicIpv6Element}:){1,7}:\\B`;
 	export const MergedIpv6Regex = `(${BasicIpv6Regex}|${Ipv6EllipsisRegex1}|${Ipv6EllipsisRegex2}|${Ipv6EllipsisRegex3}|${Ipv6EllipsisRegex4}|${Ipv6EllipsisRegex5}|${Ipv6EllipsisRegex6}|${Ipv6EllipsisRegex7}|${Ipv6EllipsisRegex8})`;
 	export const Ipv6Regex = `(\\b${MergedIpv6Regex}\\b)|(${Ipv6EllipsisRegexOther})`;
 }

--- a/Patterns/Base-Ip.yaml
+++ b/Patterns/Base-Ip.yaml
@@ -31,7 +31,7 @@ Ipv6EllipsisRegex8: !nestedRegex
   def: (({BasicIpv6Element}:){7}(:))
   references: [BasicIpv6Element]
 Ipv6EllipsisRegexOther: !nestedRegex
-  def: \B::\B|\B:(:{BasicIpv6Element}){0,7}\b|\b({BasicIpv6Element}:){0,7}:\B
+  def: \B::\B|\B:(:{BasicIpv6Element}){1,7}\b|\b({BasicIpv6Element}:){1,7}:\B
   references: [BasicIpv6Element]
 MergedIpv6Regex: !nestedRegex
   def: ({BasicIpv6Regex}|{Ipv6EllipsisRegex1}|{Ipv6EllipsisRegex2}|{Ipv6EllipsisRegex3}|{Ipv6EllipsisRegex4}|{Ipv6EllipsisRegex5}|{Ipv6EllipsisRegex6}|{Ipv6EllipsisRegex7}|{Ipv6EllipsisRegex8})

--- a/Specs/Sequence/English/IpAddressModel.json
+++ b/Specs/Sequence/English/IpAddressModel.json
@@ -329,6 +329,41 @@
     "Results": []
   },
   {
+    "Input": "wrong IPV6 address :",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": "I say:",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": "I said :",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": "lync:",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": "lync: :",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": ":as you say",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
+    "Input": ": as you say",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
     "Input": "wrong IPV6 address 12::44:f:45::1",
     "NotSupportedByDesign": "python",
     "Results": []

--- a/Specs/Sequence/English/IpAddressModel.json
+++ b/Specs/Sequence/English/IpAddressModel.json
@@ -324,6 +324,11 @@
     ]
   },
   {
+    "Input": "the train arrives at 10:00",
+    "NotSupportedByDesign": "python",
+    "Results": []
+  },
+  {
     "Input": "wrong IPV6 address FE06::1::2",
     "NotSupportedByDesign": "python",
     "Results": []


### PR DESCRIPTION
fix ipv6 bug for ellipsis
example: sync: