### PR TITLE
Fix classic style resolution for tonight (NI)

### DIFF
--- a/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -302,6 +302,19 @@ namespace Microsoft.Recognizers.DataTypes.DateTime.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_Tonight()
+        {
+            var resolution = TimexResolver.Resolve(new[] { "2018-03-18TNI" });
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("2018-03-18TNI", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2018-03-18 20:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2018-03-18 24:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_DateTimeRange_next_monday_4am_to_next_thursday_3pm()
         {
             var today = System.DateTime.Now;

--- a/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.DataTypes.DateTime/TimexResolver.cs
@@ -294,6 +294,7 @@ namespace Microsoft.Recognizers.DataTypes.DateTime
                 case "MO": return new Tuple<string, string>("08:00:00", "12:00:00");
                 case "AF": return new Tuple<string, string>("12:00:00", "16:00:00");
                 case "EV": return new Tuple<string, string>("16:00:00", "20:00:00");
+                case "NI": return new Tuple<string, string>("20:00:00", "24:00:00");
             }
 
             return new Tuple<string, string>("not resolved", "not resolved");

--- a/JavaScript/packages/datatypes-date-time/src/timexResolver.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexResolver.js
@@ -88,6 +88,7 @@ const partOfDayTimeRange = function (timex) {
         case 'MO': return { start: '08:00:00', end: '12:00:00' };
         case 'AF': return { start: '12:00:00', end: '16:00:00' };
         case 'EV': return { start: '16:00:00', end: '20:00:00' };
+        case 'NI': return { start: '20:00:00', end: '24:00:00' };
     }
     return { start: 'not resolved', end: 'not resolved' };
 };

--- a/JavaScript/packages/datatypes-date-time/test/timexResolver.spec.js
+++ b/JavaScript/packages/datatypes-date-time/test/timexResolver.spec.js
@@ -191,6 +191,14 @@ describe('No Network', () => {
                     resolution.values[0].should.have.property('start', '2017-10-07 08:00:00');
                     resolution.values[0].should.have.property('end', '2017-10-07 12:00:00');
                 });
+                it('tonight', () => {
+                    const resolution = resolver.resolve(['2018-03-18TNI']);
+                    resolution.should.have.property('values').that.is.an('array').of.length(1);
+                    resolution.values[0].should.have.property('timex', '2018-03-18TNI');
+                    resolution.values[0].should.have.property('type', 'datetimerange');
+                    resolution.values[0].should.have.property('start', '2018-03-18 20:00:00');
+                    resolution.values[0].should.have.property('end', '2018-03-18 24:00:00');
+                });
                 it('next monday 4am to next thursday 3pm', () => {
                     const resolution = resolver.resolve(['(2017-10-09T04,2017-10-12T15,PT83H)']);
                     resolution.should.have.property('values').that.is.an('array').of.length(1);


### PR DESCRIPTION
This fixes a bug reported as follows: From what I use from LUIS I get the timex equal to “2018-03-18TNI” Native LUIS resolves it as: 

      "entity": "tonight",
      "type": "builtin.datetimeV2.datetimerange",
      "startIndex": 13,
      "endIndex": 19,
      "resolution": {
        "values": [
          {
            "timex": "2018-03-18TNI",
            "type": "datetimerange",
            "start": "2018-03-18 20:00:00",
            "end": "2018-03-18 23:59:59"
          }
        ]
      }

But when I use var r = TimexResolver.Resolve(new[] {“2018-03-18TNI” }, DateTime.Now);

Except that the resolver resolves the end date to 2018-03-18 24:00:00 which is consistent with the other date time ranges.


