### PR TITLE
Fix "please book 2 hours next week" returning either blank resolution or two entities "2 hours next" and "next week"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
@@ -107,17 +107,30 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             foreach (var tuple in Enumerable.Zip(expectedResults, actualResults, Tuple.Create))
             {
                 var expected = tuple.Item1;
+                var actualHelper = tuple.Item2;
                 var actual = tuple.Item2 as ExtendedModelResult;
 
-                Assert.AreEqual(expected.TypeName, actual.TypeName, GetMessage(TestSpec));
-                Assert.AreEqual(expected.Text, actual.Text, GetMessage(TestSpec));
+                if (actual == null)
+                {
+                    Assert.AreEqual(expected.TypeName, actualHelper.TypeName, GetMessage(TestSpec));
+                    Assert.AreEqual(expected.Text, actualHelper.Text, GetMessage(TestSpec));
+                }
+                else
+                {
+                    Assert.AreEqual(expected.TypeName, actual.TypeName, GetMessage(TestSpec));
+                    Assert.AreEqual(expected.Text, actual.Text, GetMessage(TestSpec));
+                }
 
                 if (expected.ParentText != null)
                 {
                     Assert.AreEqual(expected.ParentText, actual.ParentText, GetMessage(TestSpec));
                 }
 
-                var values = actual.Resolution as IDictionary<string, object>;
+                var values = actualHelper.Resolution as IDictionary<string, object>;
+                if (actual != null)
+                {
+                    values = actual.Resolution as IDictionary<string, object>;
+                }
                 var listValues = values[ResolutionKey.ValueSet] as IList<Dictionary<string, string>>;
                 var actualValues = listValues.FirstOrDefault();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -74,7 +74,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex WithinNextPrefixRegex =
             new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex DateUnitRegex =
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        Regex IDateTimePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
+        
         public Regex FollowedUnit => TimeFollowedUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => TimeNumberCombinedWithUnit;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -398,24 +398,28 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Add(new Token(match.Index, duration.End));
                     continue;
                 }
-                
-                match = this.config.PastPrefixRegex.Match(afterStr);
-                if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
-                {
-                    ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
-                    continue;
-                }
 
-                match = this.config.NextPrefixRegex.Match(afterStr);
-                if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
+                var matchDateUnit = this.config.DateUnitRegex.Match(afterStr);
+                if (!matchDateUnit.Success)
                 {
-                    ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
-                }
+                    match = this.config.PastPrefixRegex.Match(afterStr);
+                    if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
+                    {
+                        ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
+                        continue;
+                    }
 
-                match = this.config.FutureSuffixRegex.Match(afterStr);
-                if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
-                {
-                    ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
+                    match = this.config.NextPrefixRegex.Match(afterStr);
+                    if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
+                    {
+                        ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
+                    }
+
+                    match = this.config.FutureSuffixRegex.Match(afterStr);
+                    if (match.Success && string.IsNullOrWhiteSpace(afterStr.Substring(0, match.Index)))
+                    {
+                        ret.Add(new Token(duration.Start, duration.Start + duration.Length + match.Index + match.Length));
+                    }
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex WithinNextPrefixRegex { get; }
 
+        Regex DateUnitRegex { get; }
+
         IExtractor CardinalExtractor { get; }
 
         IDateTimeExtractor SingleDateExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex WithinNextPrefixRegex =
             new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex DateUnitRegex =
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        Regex IDateTimePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
+
         public Regex FollowedUnit => TimeFollowedUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => TimeNumberCombinedWithUnit;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex WithinNextPrefixRegex =
             new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex DateUnitRegex =
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        Regex IDateTimePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
+
         public Regex FollowedUnit => TimeFollowedUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => TimeNumberCombinedWithUnit;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex WithinNextPrefixRegex =
             new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex DateUnitRegex =
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        Regex IDateTimePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
+
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => NumberCombinedWithUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.WeekDayRegex => WeekDayRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex WithinNextPrefixRegex =
             new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex DateUnitRegex =
+            new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        Regex IDateTimePeriodExtractorConfiguration.DateUnitRegex => DateUnitRegex;
+
         Regex IDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit => NumberCombinedWithUnit;
 
         Regex IDateTimePeriodExtractorConfiguration.WeekDayRegex => WeekDayRegex;

--- a/Specs/DateTime/English/DateTimeModelExtendedTypes.json
+++ b/Specs/DateTime/English/DateTimeModelExtendedTypes.json
@@ -371,4 +371,172 @@
     }
   ]
 }
+,
+{
+  "Input": "Cortana, please book 2 hours next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-25T01:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Start": 21,
+      "End": 27,
+      "TypeName": "datetimeV2.duration",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "PT2H",
+            "type": "duration",
+            "value": "7200"
+          }
+        ]
+      }
+    },
+    {
+      "Text": "next week",
+      "Start": 29,
+      "End": 37,
+      "TypeName": "datetimeV2.daterange",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "2018-W13",
+            "type": "daterange",
+            "start": "2018-03-26",
+            "end": "2018-04-02"
+          }
+        ]
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "Cortana, please book 2 hours next month",
+  "Context": {
+    "ReferenceDateTime": "2018-03-25T01:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Start": 21,
+      "End": 27,
+      "TypeName": "datetimeV2.duration",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "PT2H",
+            "type": "duration",
+            "value": "7200"
+          }
+        ]
+      }
+    },
+    {
+      "Text": "next month",
+      "Start": 29,
+      "End": 38,
+      "TypeName": "datetimeV2.daterange",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "2018-04",
+            "type": "daterange",
+            "start": "2018-04-01",
+            "end": "2018-05-01"
+          }
+        ]
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "Cortana, please check my work 2 hours last week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-25T01:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Start": 30,
+      "End": 36,
+      "TypeName": "datetimeV2.duration",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "PT2H",
+            "type": "duration",
+            "value": "7200"
+          }
+        ]
+      }
+    },
+    {
+      "Text": "last week",
+      "Start": 38,
+      "End": 46,
+      "TypeName": "datetimeV2.daterange",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "2018-W11",
+            "type": "daterange",
+            "start": "2018-03-12",
+            "end": "2018-03-19"
+          }
+        ]
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "Cortana, I'd like to take a break 10 minutes coming week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-25T01:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "10 minutes",
+      "Start": 34,
+      "End": 43,
+      "TypeName": "datetimeV2.duration",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "PT10M",
+            "type": "duration",
+            "value": "600"
+          }
+        ]
+      }
+    },
+    {
+      "Text": "coming week",
+      "Start": 45,
+      "End": 55,
+      "TypeName": "datetimeV2.daterange",
+      "Resolution": {
+        "values": [
+          {
+            "timex": "2018-W13",
+            "type": "daterange",
+            "start": "2018-03-26",
+            "end": "2018-04-02"
+          }
+        ]
+      }
+    }
+  ]
+}
 ]

--- a/Specs/DateTime/English/MergedExtractor.json
+++ b/Specs/DateTime/English/MergedExtractor.json
@@ -753,4 +753,152 @@
     }
   ]
 }
+,
+{
+  "Input": "2 hours next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T08:30:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "three hours next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "three hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "4 hours coming week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "4 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "coming week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "4 hours upcoming week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "4 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "upcoming week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "4 hours last week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "4 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "last week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "five hours past week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "five hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "past week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "five hours previous week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "five hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "previous week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours next",
+      "Type": "datetimerange"
+    }
+  ]
+}
 ]

--- a/Specs/DateTime/English/MergedExtractor.json
+++ b/Specs/DateTime/English/MergedExtractor.json
@@ -901,4 +901,441 @@
     }
   ]
 }
+,
+{
+  "Input": "8 hours next month",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "8 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next month",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next day",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next day",
+      "Type": "date"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next year",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next year",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "1 hour next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "1 hour",
+      "Type": "duration"
+    },
+    {
+      "Text": "next week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next two years",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two years",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next two months",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two months",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 hours next two days",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 hours",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two days",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next two weeks",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two weeks",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next day",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next day",
+      "Type": "date"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next two days",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two days",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next month",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next month",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next two months",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two months",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next year",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next year",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 minutes next two years",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 minutes",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two years",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next week",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next week",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next two weeks",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two weeks",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next day",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next day",
+      "Type": "date"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next two days",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two days",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next month",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next month",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next two months",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two months",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next year",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next year",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2 seconds next two years",
+  "Context": {
+    "ReferenceDateTime": "2018-03-23T11:00:00"
+  },
+  "NotSupported": "javascript",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2 seconds",
+      "Type": "duration"
+    },
+    {
+      "Text": "next two years",
+      "Type": "daterange"
+    }
+  ]
+}
 ]


### PR DESCRIPTION
Fix wrong return values of DateTimePeriodExtractor, by adding a new regex DateUnitRegex. 
If "next" and similar phrases are followed by DateUnitRegex, don't add "next" to tokens. 