### PR TITLE
Fix percentage wrongly extracted in mixed text for Chinese

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Chinese/NumbersDefinitions.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string IntegerPercentageRegex = $@"{ZeroToNineFullHalfRegex}+\s*[个個]\s*[百佰]\s*分\s*[点點]";
 		public static readonly string IntegerPercentageWithMultiplierRegex = $@"{ZeroToNineFullHalfRegex}+\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)\s*[个個]\s*[百佰]\s*分\s*[点點]";
 		public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*[个個]\s*[百佰]\s*分\s*[点點]";
-		public static readonly string SimpleIntegerPercentageRegex = $@"(?<=(\s|^)){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%]";
+		public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)";
 		public static readonly string NumbersFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*折";
 		public static readonly string FoldsPercentageRegex = $@"{ZeroToNineIntegerRegex}(\s*[点點]?\s*{ZeroToNineIntegerRegex})?\s*折";
 		public static readonly string SimpleFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}\s*成(\s*(半|{ZeroToNineFullHalfRegex}))?";

--- a/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
+++ b/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
@@ -76,7 +76,7 @@ export namespace ChineseNumeric {
 	export const IntegerPercentageRegex = `${ZeroToNineFullHalfRegex}+\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]`;
 	export const IntegerPercentageWithMultiplierRegex = `${ZeroToNineFullHalfRegex}+\\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]`;
 	export const NumbersFractionPercentageRegex = `${ZeroToNineFullHalfRegex}{1,3}([,，]${ZeroToNineFullHalfRegex}{3})+\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]`;
-	export const SimpleIntegerPercentageRegex = `(?<=(\\s|^))${NegativeNumberTermsRegexNum}?${ZeroToNineFullHalfRegex}+([\\.．]${ZeroToNineFullHalfRegex}+)?(\\s*)[％%]`;
+	export const SimpleIntegerPercentageRegex = `(?<!%|\\d)${NegativeNumberTermsRegexNum}?${ZeroToNineFullHalfRegex}+([\\.．]${ZeroToNineFullHalfRegex}+)?(\\s*)[％%](?!\\d)`;
 	export const NumbersFoldsPercentageRegex = `${ZeroToNineFullHalfRegex}(([\\.．]?|\\s*)${ZeroToNineFullHalfRegex})?\\s*折`;
 	export const FoldsPercentageRegex = `${ZeroToNineIntegerRegex}(\\s*[点點]?\\s*${ZeroToNineIntegerRegex})?\\s*折`;
 	export const SimpleFoldsPercentageRegex = `${ZeroToNineFullHalfRegex}\\s*成(\\s*(半|${ZeroToNineFullHalfRegex}))?`;

--- a/Patterns/Chinese/Chinese-Numbers.yaml
+++ b/Patterns/Chinese/Chinese-Numbers.yaml
@@ -288,7 +288,7 @@ NumbersFractionPercentageRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+\s*[个個]\s*[百佰]\s*分\s*[点點]'
   references: [ZeroToNineFullHalfRegex]
 SimpleIntegerPercentageRegex: !nestedRegex
-  def: '(?<=(\s|^)){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%]'
+  def: '(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)'
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
 NumbersFoldsPercentageRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*折'

--- a/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
@@ -169,7 +169,7 @@ class ChineseNumeric:
     IntegerPercentageRegex = f'{ZeroToNineFullHalfRegex}+\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]'
     IntegerPercentageWithMultiplierRegex = f'{ZeroToNineFullHalfRegex}+\\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]'
     NumbersFractionPercentageRegex = f'{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\\s*[个個]\\s*[百佰]\\s*分\\s*[点點]'
-    SimpleIntegerPercentageRegex = f'(?<=(\\s|^)){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\\.．]{ZeroToNineFullHalfRegex}+)?(\\s*)[％%]'
+    SimpleIntegerPercentageRegex = f'(?<!%|\\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\\.．]{ZeroToNineFullHalfRegex}+)?(\\s*)[％%](?!\\d)'
     NumbersFoldsPercentageRegex = f'{ZeroToNineFullHalfRegex}(([\\.．]?|\\s*){ZeroToNineFullHalfRegex})?\\s*折'
     FoldsPercentageRegex = f'{ZeroToNineIntegerRegex}(\\s*[点點]?\\s*{ZeroToNineIntegerRegex})?\\s*折'
     SimpleFoldsPercentageRegex = f'{ZeroToNineFullHalfRegex}\\s*成(\\s*(半|{ZeroToNineFullHalfRegex}))?'

--- a/Specs/Number/Chinese/PercentModel.json
+++ b/Specs/Number/Chinese/PercentModel.json
@@ -1780,4 +1780,53 @@
   "Input": "你可以访问一下 https://www.test.com/search?q=30%25%2020%",
   "Results": []
 }
+,
+{
+  "Input": "百分之6酒精含量的啤酒和32.5%的白酒",
+  "NotSupported": "javascript",
+  "Results": [
+    {
+      "Text": "百分之6",  
+      "TypeName": "percentage",
+        "Resolution": {
+        "value": "6%"
+      }
+    },
+    {
+      "Text": "32.5%",  
+      "TypeName": "percentage",
+        "Resolution": {
+        "value": "32.5%"
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "百分之2等于百分之二，和2%是一样的。",
+  "NotSupported": "javascript",
+  "Results": [
+    {
+      "Text": "百分之2",  
+      "TypeName": "percentage",
+        "Resolution": {
+        "value": "2%"
+      }
+    },
+    {
+      "Text": "百分之二",  
+      "TypeName": "percentage",
+        "Resolution": {
+        "value": "2%"
+      }
+    },
+    {
+      "Text": "2%",  
+      "TypeName": "percentage",
+        "Resolution": {
+        "value": "2%"
+      }
+    }
+  ]
+}
 ]


### PR DESCRIPTION
This PR address issue #534 #538, tests marked as not supported Javascript for current issue with lookbehind regex in JS.