### PR TITLE
Fix bugs in Chinese year regexes

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Chinese/DateTimeDefinitions.cs
@@ -56,8 +56,8 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public const string DatePeriodLastRegex = @"上个|上一个|上|上一";
 		public const string DatePeriodNextRegex = @"下个|下一个|下|下一";
 		public static readonly string RelativeMonthRegex = $@"(?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)";
-		public const string DatePeriodYearRegex = @"(?<year>(\d{2,4}))\s*年?";
-		public const string StrictYearRegex = @"(?<year>(\d{3,4}))\s*年?";
+		public static readonly string DatePeriodYearRegex = $@"(({YearNumRegex})(\s*年)?|({YearRegex})\s*年)(?=[\u4E00-\u9FFF]|\s|$|\W)";
+		public static readonly string StrictYearRegex = $@"{DatePeriodYearRegex}";
 		public const string YearRegexInNumber = @"(?<year>(\d{3,4}))";
 		public static readonly string DatePeriodYearInChineseRegex = $@"(?<yearchs>({ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}|{ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}|{ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}{ZeroToNineIntegerRegexChs}))年";
 		public static readonly string MonthSuffixRegex = $@"(?<msuf>({RelativeMonthRegex}|{MonthRegex}))";

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -47,8 +47,8 @@ export namespace ChineseDateTime {
 	export const DatePeriodLastRegex = `上个|上一个|上|上一`;
 	export const DatePeriodNextRegex = `下个|下一个|下|下一`;
 	export const RelativeMonthRegex = `(?<relmonth>(${DatePeriodThisRegex}|${DatePeriodLastRegex}|${DatePeriodNextRegex})\\s*月)`;
-	export const DatePeriodYearRegex = `(?<year>(\\d{2,4}))\\s*年?`;
-	export const StrictYearRegex = `(?<year>(\\d{3,4}))\\s*年?`;
+	export const DatePeriodYearRegex = `((${YearNumRegex})(\\s*年)?|(${YearRegex})\\s*年)(?=[\\u4E00-\\u9FFF]|\\s|$|\\W)`;
+	export const StrictYearRegex = `${DatePeriodYearRegex}`;
 	export const YearRegexInNumber = `(?<year>(\\d{3,4}))`;
 	export const DatePeriodYearInChineseRegex = `(?<yearchs>(${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}|${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}|${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}${ZeroToNineIntegerRegexChs}))年`;
 	export const MonthSuffixRegex = `(?<msuf>(${RelativeMonthRegex}|${MonthRegex}))`;

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -102,10 +102,12 @@ DatePeriodNextRegex: !simpleRegex
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>({DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})\s*月)
   references: [DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex]
-DatePeriodYearRegex: !simpleRegex
-  def: (?<year>(\d{2,4}))\s*年?
-StrictYearRegex: !simpleRegex
-  def: (?<year>(\d{3,4}))\s*年?
+DatePeriodYearRegex: !nestedRegex
+  def: (({YearNumRegex})(\s*年)?|({YearRegex})\s*年)(?=[\u4E00-\u9FFF]|\s|$|\W)
+  references: [YearNumRegex, YearRegex]
+StrictYearRegex: !nestedRegex
+  def: '{DatePeriodYearRegex}'
+  references: [DatePeriodYearRegex]
 YearRegexInNumber: !simpleRegex
   def: (?<year>(\d{3,4}))
 DatePeriodYearInChineseRegex: !nestedRegex

--- a/Specs/DateTime/Chinese/DatePeriodExtractor.json
+++ b/Specs/DateTime/Chinese/DatePeriodExtractor.json
@@ -347,4 +347,55 @@
     }
   ]
 }
+,
+{
+  "Input": "100只是一个数字",
+  "NotSupportedByDesign": "python",
+  "Results": []
+}
+,
+{
+  "Input": "1499只是一个数字",
+  "NotSupportedByDesign": "python",
+  "Results": []
+}
+,
+{
+  "Input": "2101只是一个数字",
+  "NotSupportedByDesign": "python",
+  "Results": []
+}
+,
+{
+  "Input": "2018看起来是一个年份",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2018",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "2100看起来是一个年份",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2100",
+      "Type": "daterange"
+    }
+  ]
+}
+,
+{
+  "Input": "1500看起来是一个年份",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "1500",
+      "Type": "daterange"
+    }
+  ]
+}
 ]

--- a/Specs/DateTime/Chinese/DatePeriodParser.json
+++ b/Specs/DateTime/Chinese/DatePeriodParser.json
@@ -901,4 +901,29 @@
     }
   ]
 }
+,
+{
+  "Input": "2018 看起来是一个年份",
+  "NotSupported": "python,javascript",
+  "Context": {
+    "ReferenceDateTime": "2017-03-22T00:00:00"
+  },
+  "Results": [
+    {
+      "Text": "2018",
+      "Type": "daterange",
+      "Value": {
+        "Timex": "2018",
+        "FutureResolution": {
+          "startDate": "2018-01-01",
+          "endDate": "2019-01-01"
+        },
+        "PastResolution": {
+          "startDate": "2018-01-01",
+          "endDate": "2019-01-01"
+        }
+      }
+    }
+  ]
+}
 ]


### PR DESCRIPTION
GitHub issue #532, this PR also address an issue that year improperly extracted from number sequences. Parse test marked as not supported Javascript because of known issue #541.

- fix number beyond valid range wrongly recognized as years (#532)
- fix year improperly extracted from number sequences