### PR TITLE
Bump up version of bigNumber.js and xregexp to their latest release

### DIFF
--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -107,11 +107,19 @@
 			"version": "file:packages/recognizers-number",
 			"requires": {
 				"@microsoft/recognizers-text": "~1.0.1",
-				"bignumber.js": "^4.1.0",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.sortby": "^4.7.0",
-				"lodash.trimend": "^4.5.1",
-				"xregexp": "^3.2.0"
+				"lodash.trimend": "^4.5.1"
+			},
+			"dependencies": {
+				"bignumber.js": {
+					"version": "7.2.1",
+					"bundled": true
+				},
+				"xregexp": {
+					"version": "4.1.1",
+					"bundled": true
+				}
 			}
 		},
 		"@microsoft/recognizers-text-number-with-unit": {
@@ -147,12 +155,6 @@
 					"bundled": true
 				}
 			}
-		},
-		"@types/bignumber.js": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-4.0.3.tgz",
-			"integrity": "sha512-KoJPKjhlWBry4fk8qcIufXFOU+zcZBfkHQWKbnAMQTMoe2GDeLpjSQHS+22gv+dg7gKdTP2WCjSeCVnfj8e+Gw==",
-			"dev": true
 		},
 		"@types/js-yaml": {
 			"version": "3.11.1",
@@ -243,12 +245,6 @@
 			"requires": {
 				"@types/node": "*"
 			}
-		},
-		"@types/xregexp": {
-			"version": "3.0.29",
-			"resolved": "https://registry.npmjs.org/@types/xregexp/-/xregexp-3.0.29.tgz",
-			"integrity": "sha512-mm6iZYQ1xbVBNsWq2VSMFuneRuO0k0wUqIT4ZfrtbD1Eb90DXmqBOPA/URyUHq6wsftxr8aXDJHTTHyyBBY95w==",
-			"dev": true
 		},
 		"JSONStream": {
 			"version": "1.3.2",
@@ -1581,9 +1577,10 @@
 			"dev": true
 		},
 		"bignumber.js": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+			"dev": true
 		},
 		"binary-extensions": {
 			"version": "1.11.0",
@@ -8888,9 +8885,10 @@
 			"dev": true
 		},
 		"xregexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
-			"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.1.1.tgz",
+			"integrity": "sha512-QJ1gfSUV7kEOLfpKFCjBJRnfPErUzkNKFMso4kDSmGpp3x6ZgkyKf74inxI7PnnQCFYq5TqYJCd7DrgDN8Q05A==",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -36,7 +36,6 @@
 		]
 	},
 	"devDependencies": {
-		"@types/bignumber.js": "^4.0.3",
 		"@types/js-yaml": "^3.9.0",
 		"@types/lodash.escaperegexp": "^4.1.3",
 		"@types/lodash.isequal": "^4.5.2",
@@ -47,7 +46,6 @@
 		"@types/lodash.trimend": "^4.5.1",
 		"@types/node": "^8.0.20",
 		"@types/npm": "^2.0.29",
-		"@types/xregexp": "^3.0.29",
 		"ava": "^0.22.0",
 		"ava-spec": "^1.1.0",
 		"babel-plugin-external-helpers": "^6.22.0",
@@ -75,7 +73,9 @@
 		"babelify": "^7.3.0",
 		"browserify": "^14.4.0",
 		"browserify-shim": "^3.8.14",
-		"express": "^4.16.1"
+		"bignumber.js": "^7.2.1",
+		"express": "^4.16.1",
+		"xregexp": "^4.1.1"
 	},
 	"dependencies": {
 		"@microsoft/recognizers-text": "file:./packages/recognizers-text",

--- a/JavaScript/packages/datatypes-date-time/package-lock.json
+++ b/JavaScript/packages/datatypes-date-time/package-lock.json
@@ -12,12 +12,12 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
 			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
 			"requires": {
-				"assertion-error": "1.1.0",
-				"check-error": "1.0.2",
-				"deep-eql": "3.0.1",
-				"get-func-name": "2.0.0",
-				"pathval": "1.1.0",
-				"type-detect": "4.0.8"
+				"assertion-error": "^1.0.1",
+				"check-error": "^1.0.1",
+				"deep-eql": "^3.0.0",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.0.0",
+				"type-detect": "^4.0.0"
 			}
 		},
 		"chai-as-promised": {
@@ -25,7 +25,7 @@
 			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
 			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
 			"requires": {
-				"check-error": "1.0.2"
+				"check-error": "^1.0.2"
 			}
 		},
 		"check-error": {
@@ -38,7 +38,7 @@
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
 			"requires": {
-				"type-detect": "4.0.8"
+				"type-detect": "^4.0.0"
 			}
 		},
 		"get-func-name": {

--- a/JavaScript/packages/recognizers-number/package-lock.json
+++ b/JavaScript/packages/recognizers-number/package-lock.json
@@ -2,11 +2,6 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
-		"bignumber.js": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -21,11 +16,6 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
 			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
-		},
-		"xregexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
-			"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
 		}
 	}
 }

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -31,11 +31,9 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "bignumber.js": "^4.1.0",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.sortby": "^4.7.0",
     "lodash.trimend": "^4.5.1",
-    "@microsoft/recognizers-text": "~1.0.1",
-    "xregexp": "^3.2.0"
+    "@microsoft/recognizers-text": "~1.0.1"
   }
 }

--- a/JavaScript/packages/recognizers-number/src/culture.ts
+++ b/JavaScript/packages/recognizers-number/src/culture.ts
@@ -1,6 +1,6 @@
 import { Culture as BaseCulture, CultureInfo as BaseCultureInfo } from "@microsoft/recognizers-text";
 import trimEnd = require("lodash.trimend");
-import { BigNumber } from 'bignumber.js';
+import { BigNumber } from 'bignumber.js/bignumber';
 import { LongFormatType } from "./number/models";
 
 export class Culture extends BaseCulture {
@@ -28,7 +28,7 @@ export class CultureInfo extends BaseCultureInfo {
     let bigNumber = new BigNumber(value);
     let s: string;
     if (bigNumber.decimalPlaces()) {
-      s = bigNumber.toDigits(15, BigNumber.ROUND_HALF_UP).toString();
+      s = bigNumber.precision(15, BigNumber.ROUND_HALF_UP).toString();
     } else {
       s = bigNumber.toString().toUpperCase();
     }

--- a/JavaScript/packages/recognizers-number/src/number/chinese/parsers.ts
+++ b/JavaScript/packages/recognizers-number/src/number/chinese/parsers.ts
@@ -6,7 +6,7 @@ import { LongFormatType } from "../models";
 import { ChineseNumeric } from "../../resources/chineseNumeric";
 import { CultureInfo, Culture } from "../../culture";
 import { RegExpUtility, StringUtility } from "@microsoft/recognizers-text";
-import { BigNumber } from 'bignumber.js';
+import { BigNumber } from 'bignumber.js/bignumber';
 import trimEnd = require("lodash.trimend");
 import sortBy = require("lodash.sortby");
 

--- a/JavaScript/packages/recognizers-number/src/number/parsers.ts
+++ b/JavaScript/packages/recognizers-number/src/number/parsers.ts
@@ -4,10 +4,8 @@ import { Constants } from "./constants";
 import trimEnd = require("lodash.trimend");
 import sortBy = require("lodash.sortby");
 import { RegExpUtility } from "@microsoft/recognizers-text";
-import { BigNumber } from 'bignumber.js';
+import { BigNumber } from 'bignumber.js/bignumber';
 
-// Disable BigNumber errors when passing number with more than 15 significant digits
-BigNumber.config({ ERRORS: false });
 // The exponent value(s) at which toString returns exponential notation.
 BigNumber.config({ EXPONENTIAL_AT: [-5, 15] });
 


### PR DESCRIPTION
- remove "ERRORS" config in bigNumber.js
- change the import method of bigNumber
- move bigNumber and xregexp to global package.json
- minor: toDigits -> precision

ref:
- Import issue https://github.com/MikeMcl/bignumber.js/issues/166
- ERRORS config https://github.com/MikeMcl/bignumber.js/issues/148
- toDigits -> precision https://github.com/MikeMcl/bignumber.js/issues/139