### PR TITLE
Johtaylo/resolve timerange

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
@@ -83,116 +83,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_RangeResolve_dateranges()
-        {
-            var candidates = new[] { "XXXX-WXX-7" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Evening
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            var r = new HashSet<string>(result.Select(t => t.TimexValue));
-            Assert.IsTrue(r.Contains("2018-06-10T16"));
-            Assert.IsTrue(r.Contains("2018-06-17T16"));
-            Assert.AreEqual(2, r.Count);
-        }
-
-        [TestMethod]
-        public void DataTypes_RangeResolve_dateranges_no_time_constraint()
-        {
-            var candidates = new[] { "XXXX-WXX-7TEV" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)"   // e.g. next week
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            var r = new HashSet<string>(result.Select(t => t.TimexValue));
-            Assert.IsTrue(r.Contains("2018-06-10TEV"));
-            Assert.IsTrue(r.Contains("2018-06-17TEV"));
-            Assert.AreEqual(2, r.Count);
-        }
-
-        [TestMethod]
-        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_1()
-        {
-            var candidates = new[] { "XXXX-WXX-7TEV" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                "(T18,T22,PT4H)"
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            var r = new HashSet<string>(result.Select(t => t.TimexValue));
-            Assert.IsTrue(r.Contains("2018-06-10T18"));
-            Assert.IsTrue(r.Contains("2018-06-17T18"));
-            Assert.AreEqual(2, r.Count);
-        }
-
-        [TestMethod]
-        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_2()
-        {
-            var candidates = new[] { "XXXX-WXX-7TEV" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                "(T15,T19,PT4H)"
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            var r = new HashSet<string>(result.Select(t => t.TimexValue));
-            Assert.IsTrue(r.Contains("2018-06-10T16"));
-            Assert.IsTrue(r.Contains("2018-06-17T16"));
-            Assert.AreEqual(2, r.Count);
-        }
-
-        [TestMethod]
-        public void DataTypes_RangeResolve_dateranges_non_overlapping_constraint()
-        {
-            var candidates = new[] { "XXXX-WXX-7TEV" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Morning
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            Assert.IsFalse(result.Any());
-        }
-
-        [TestMethod]
-        public void DataTypes_RangeResolve_dateranges_Sunday_Evening()
-        {
-            var candidates = new[] { "XXXX-WXX-7TEV" };
-            var constraints = new[]
-            {
-                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
-                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
-                TimexCreator.Evening
-            };
-
-            var result = TimexRangeResolver.Evaluate(candidates, constraints);
-
-            var r = new HashSet<string>(result.Select(t => t.TimexValue));
-            Assert.IsTrue(r.Contains("2018-06-10T16"));
-            Assert.IsTrue(r.Contains("2018-06-17T16"));
-            Assert.AreEqual(2, r.Count);
-        }
-
-        [TestMethod]
         public void DataTypes_RangeResolve_daterange_Saturdays_in_September_expressed_as_range()
         {
             var candidates = new[] { "XXXX-WXX-6" };
@@ -591,6 +481,116 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
 
             var r = new HashSet<string>(result.Select(t => t.TimexValue));
             Assert.IsFalse(r.Any());
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges()
+        {
+            var candidates = new[] { "XXXX-WXX-7" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Evening
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_no_time_constraint()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)"   // e.g. next week
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10TEV"));
+            Assert.IsTrue(r.Contains("2018-06-17TEV"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_1()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                "(T18,T22,PT4H)"
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T18"));
+            Assert.IsTrue(r.Contains("2018-06-17T18"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_2()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                "(T15,T19,PT4H)"
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_non_overlapping_constraint()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Morning
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            Assert.IsFalse(result.Any());
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_Sunday_Evening()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Evening
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
@@ -83,6 +83,116 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_RangeResolve_dateranges()
+        {
+            var candidates = new[] { "XXXX-WXX-7" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Evening
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_no_time_constraint()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)"   // e.g. next week
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10TEV"));
+            Assert.IsTrue(r.Contains("2018-06-17TEV"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_1()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                "(T18,T22,PT4H)"
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T18"));
+            Assert.IsTrue(r.Contains("2018-06-17T18"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_overlapping_constraint_2()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                "(T15,T19,PT4H)"
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_non_overlapping_constraint()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Morning
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            Assert.IsFalse(result.Any());
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_dateranges_Sunday_Evening()
+        {
+            var candidates = new[] { "XXXX-WXX-7TEV" };
+            var constraints = new[]
+            {
+                "(2018-06-04,2018-06-11,P7D)",  // e.g. this week
+                "(2018-06-11,2018-06-18,P7D)",  // e.g. next week
+                TimexCreator.Evening
+            };
+
+            var result = TimexRangeResolver.Evaluate(candidates, constraints);
+
+            var r = new HashSet<string>(result.Select(t => t.TimexValue));
+            Assert.IsTrue(r.Contains("2018-06-10T16"));
+            Assert.IsTrue(r.Contains("2018-06-17T16"));
+            Assert.AreEqual(2, r.Count);
+        }
+
+        [TestMethod]
         public void DataTypes_RangeResolve_daterange_Saturdays_in_September_expressed_as_range()
         {
             var candidates = new[] { "XXXX-WXX-6" };

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexConstraintsHelper.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexConstraintsHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return r;
         }
 
-        private static bool IsOverlapping(TimeRange r1, TimeRange r2)
+        public static bool IsOverlapping(TimeRange r1, TimeRange r2)
         {
             return r1.End.GetTime() > r2.Start.GetTime() && r1.Start.GetTime() <= r2.Start.GetTime() || 
                    r1.Start.GetTime() < r2.End.GetTime() && r1.Start.GetTime() >= r2.Start.GetTime();

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public static readonly string Afternoon = "(T12,T16,PT4H)";
         public static readonly string Evening = "(T16,T20,PT4H)";
         public static readonly string Daytime = "(T08,T18,PT10H)";
+        public static readonly string Night = "(T20,T24,PT10H)";
 
         public static string Today(System.DateTime date = default(System.DateTime))
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     public static class TimexCreator
     {
-
+        // The following constants are consistent with the Recognizer results
         public static readonly string Monday = "XXXX-WXX-1";
         public static readonly string Tuesday = "XXXX-WXX-2";
         public static readonly string Wednesday = "XXXX-WXX-3";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     case "NI":
                         timex = new TimexProperty(TimexCreator.Night);
                         break;
+                    default:
+                        throw new ArgumentException("unrecognized part of day timerange", nameof(timex));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -65,9 +65,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     case "DT":
                         timex = new TimexProperty(TimexCreator.Daytime);
                         break;
-                    case "NI":
-                        timex = new TimexProperty(TimexCreator.Afternoon);
-                        break;
                     case "MO":
                         timex = new TimexProperty(TimexCreator.Morning);
                         break;
@@ -76,6 +73,9 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         break;
                     case "EV":
                         timex = new TimexProperty(TimexCreator.Evening);
+                        break;
+                    case "NI":
+                        timex = new TimexProperty(TimexCreator.Night);
                         break;
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -53,6 +53,33 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static TimexRange ExpandTimeRange(TimexProperty timex)
         {
+            if (!timex.Types.Contains(Constants.TimexTypes.TimeRange))
+            {
+                throw new ArgumentException("argument must be a timerange", nameof(timex));
+            }
+
+            if (timex.PartOfDay != null)
+            {
+                switch (timex.PartOfDay)
+                {
+                    case "DT":
+                        timex = new TimexProperty(TimexCreator.Daytime);
+                        break;
+                    case "NI":
+                        timex = new TimexProperty(TimexCreator.Afternoon);
+                        break;
+                    case "MO":
+                        timex = new TimexProperty(TimexCreator.Morning);
+                        break;
+                    case "AF":
+                        timex = new TimexProperty(TimexCreator.Afternoon);
+                        break;
+                    case "EV":
+                        timex = new TimexProperty(TimexCreator.Evening);
+                        break;
+                }
+            }
+
             var start = new TimexProperty { Hour = timex.Hour, Minute = timex.Minute, Second = timex.Second };
             var duration = CloneDuration(timex);
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
@@ -123,11 +123,48 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var resolution = new List<string>();
             foreach (var timex in candidates)
             {
-                var r = ResolveTime(new TimexProperty(timex), collapsedTimeRanges);
-                resolution.AddRange(r);
+                var t = new TimexProperty(timex);
+                if (t.Types.Contains(Constants.TimexTypes.TimeRange))
+                {
+                    var r = ResolveTimeRange(t, collapsedTimeRanges);
+                    resolution.AddRange(r);
+                }
+                else if (t.Types.Contains(Constants.TimexTypes.Time))
+                {
+                    var r = ResolveTime(t, collapsedTimeRanges);
+                    resolution.AddRange(r);
+                }
             }
 
             return RemoveDuplicates(resolution);
+        }
+        
+        private static IEnumerable<string> ResolveTimeRange(TimexProperty timex, IEnumerable<TimeRange> constraints)
+        {
+            var candidate = TimexHelpers.TimeRangeFromTimex(timex);
+
+            var result = new List<string>();
+            foreach (var constraint in constraints)
+            {
+                if (TimexConstraintsHelper.IsOverlapping(candidate, constraint))
+                {
+                    var start = Math.Max(candidate.Start.GetTime(), constraint.Start.GetTime());
+                    var time = new Time(start);
+
+                    var resolved = timex.Clone();
+                    resolved.PartOfDay = null;
+                    resolved.Seconds = null;
+                    resolved.Minutes = null;
+                    resolved.Hours = null;
+                    resolved.Second = time.Second;
+                    resolved.Minute = time.Minute;
+                    resolved.Hour = time.Hour;
+
+                    result.Add(resolved.TimexValue);
+                }
+            }
+
+            return result;
         }
 
         private static IEnumerable<string> ResolveTime(TimexProperty timex, IEnumerable<TimeRange> constraints)
@@ -185,7 +222,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
-                var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
+                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
                 var dates = TimexDateHelpers.DatesMatchingDay(day, constraint.Start, constraint.End);
                 var result = new List<string>();
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     var start = Math.Max(candidate.Start.GetTime(), constraint.Start.GetTime());
                     var time = new Time(start);
 
+                    // TODO: consider a method on TimexProperty to do this clone/overwrite pattern
                     var resolved = timex.Clone();
                     resolved.PartOfDay = null;
                     resolved.Seconds = null;
@@ -222,6 +223,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
+                // convert between ISO day of week and .NET day of week
                 var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
                 var dates = TimexDateHelpers.DatesMatchingDay(day, constraint.Start, constraint.End);
                 var result = new List<string>();

--- a/JavaScript/packages/datatypes-date-time/src/timexConstraintsHelper.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexConstraintsHelper.js
@@ -39,4 +39,7 @@ const collapse = function (ranges, T) {
     return r;
 };
 
-module.exports.collapse = collapse;
+module.exports = {
+    collapse: collapse,
+    isOverlapping: isOverlapping
+};

--- a/JavaScript/packages/datatypes-date-time/src/timexCreator.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexCreator.js
@@ -56,6 +56,7 @@ const nextWeeksFromToday = function (n, date) {
     return (new TimexProperty(Object.assign(TimexProperty.fromDate(d), { days: 7 * n }))).timex;
 };
 
+// The following constants are consistent with the Recognizer results
 const monday = 'XXXX-WXX-1';
 const tuesday = 'XXXX-WXX-2';
 const wednesday = 'XXXX-WXX-3';

--- a/JavaScript/packages/datatypes-date-time/src/timexHelpers.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexHelpers.js
@@ -150,6 +150,32 @@ const timeAdd = function (start, duration) {
 };
 
 const expandTimeRange = function (timex) {
+
+    if (!timex.types.has('timerange'))
+    {
+        throw new exception('argument must be a timerange');
+    }
+
+    if (timex.partOfDay !== undefined) {
+        switch (timex.partOfDay) {
+            case 'DT':
+                timex = { hour: 8, minute: 0, second: 0, hours: 10, minutes: 0, seconds: 0 };
+                break;
+            case 'MO':
+                timex = { hour: 8, minute: 0, second: 0, hours: 4, minutes: 0, seconds: 0 };
+                break;
+            case 'AF':
+                timex = { hour: 12, minute: 0, second: 0, hours: 4, minutes: 0, seconds: 0 };
+                break;
+            case 'EV':
+                timex = { hour: 16, minute: 0, second: 0, hours: 4, minutes: 0, seconds: 0 };
+                break;
+            case 'NI':
+                timex = { hour: 20, minute: 0, second: 0, hours: 4, minutes: 0, seconds: 0 };
+                break;
+        }
+    }
+
     const start = { hour: timex.hour, minute: timex.minute, second: timex.second };
     const duration = cloneDuration(timex);
     return { start: start, end: timeAdd(start, duration), duration: duration };

--- a/JavaScript/packages/datatypes-date-time/src/timexHelpers.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexHelpers.js
@@ -173,6 +173,8 @@ const expandTimeRange = function (timex) {
             case 'NI':
                 timex = { hour: 20, minute: 0, second: 0, hours: 4, minutes: 0, seconds: 0 };
                 break;
+            default:
+                throw new exception('unrecognized part of day timerange');
         }
     }
 

--- a/JavaScript/packages/datatypes-date-time/src/timexRangeResolver.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexRangeResolver.js
@@ -172,6 +172,7 @@ const resolveTimeRange = function (timex, constraints) {
             const start = Math.max(candidate.start.getTime(), constraint.start.getTime());
             const time = new Time(start);
 
+            // TODO: refer to comments in C# - consider first classing this clone/overwrite behavior
             const resolved = new TimexProperty(timex.timex);
             delete resolved.partOfDay;
             delete resolved.seconds;

--- a/JavaScript/packages/datatypes-date-time/src/timexRangeResolver.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexRangeResolver.js
@@ -146,11 +146,45 @@ const resolveByTimeRangeConstraints = function (candidates, timexConstraints) {
 
     const resolution = [];
     for (const timex of candidates) {
-        const r = resolveTime(new TimexProperty(timex), collapsedTimeRanges);
-        Array.prototype.push.apply(resolution, r);
+        const t = new TimexProperty(timex);
+        if (t.types.has('timerange')) {
+            const r = resolveTimeRange(t, collapsedTimeRanges);
+            Array.prototype.push.apply(resolution, r);
+        }
+        else if (t.types.has('time')) {
+            const r = resolveTime(t, collapsedTimeRanges);
+            Array.prototype.push.apply(resolution, r);
+        }
     }
 
     return removeDuplicates(resolution);
+};
+
+const resolveTimeRange = function (timex, constraints) {
+
+    const candidate = timexHelpers.timeRangeFromTimex(timex);
+
+    const result = [];
+    for (const constraint of constraints) {
+
+        if (timexConstraintsHelper.isOverlapping(candidate, constraint)) {
+
+            const start = Math.max(candidate.start.getTime(), constraint.start.getTime());
+            const time = new Time(start);
+
+            const resolved = new TimexProperty(timex.timex);
+            delete resolved.partOfDay;
+            delete resolved.seconds;
+            delete resolved.minutes;
+            delete resolved.hours;
+            resolved.second = time.second;
+            resolved.minute = time.minute;
+            resolved.hour = time.hour;
+
+            result.push(resolved.timex);
+        }
+    }
+    return result;
 };
 
 const resolveDuration = function (candidate, constraints) {

--- a/JavaScript/packages/datatypes-date-time/test/timexRangeResolver.spec.js
+++ b/JavaScript/packages/datatypes-date-time/test/timexRangeResolver.spec.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 const chai = require('chai');
-const { TimexProperty, resolver } = require('../index.js');
+const { TimexProperty, creator, resolver } = require('../index.js');
 
 const assert = chai.assert;
 const expect = chai.expect;
@@ -166,6 +166,55 @@ describe('No Network', () => {
                         { year: 2017, month: 10, dayOfMonth: 5, days: 7 }
                     ];
                     resolver.evaluate(['PT5M'], constraints).map(t => t.timex).should.have.length(0);
+                });
+            });
+            describe('candidate includes a timerange', () => {
+                it('basic resolve day against daterange', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)'),
+                        creator.evening
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7'], constraints).map(t => t.timex).should.have.members(['2018-06-10T16', '2018-06-17T16']);
+                });
+                it('no time constraint', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)')
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7TEV'], constraints).map(t => t.timex).should.have.members(['2018-06-10TEV', '2018-06-17TEV']);
+                });
+                it('overlapping constraint 1', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)'),
+                        new TimexProperty('(T18,T22,PT4H)')
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7TEV'], constraints).map(t => t.timex).should.have.members(['2018-06-10T18', '2018-06-17T18']);
+                });
+                it('overlapping constraint 2', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)'),
+                        new TimexProperty('(T15,T19,PT4H)')
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7TEV'], constraints).map(t => t.timex).should.have.members(['2018-06-10T16', '2018-06-17T16']);
+                });
+                it('non overlapping constraint', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)'),
+                        creator.morning
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7TEV'], constraints).map(t => t.timex).should.have.length(0);
+                });
+                it('sunday evening as the candidate and the constraint', () => {
+                    const constraints = [
+                        new TimexProperty('(2018-06-04,2018-06-11,P7D)'),
+                        new TimexProperty('(2018-06-11,2018-06-18,P7D)'),
+                        creator.evening
+                    ];
+                    resolver.evaluate(['XXXX-WXX-7TEV'], constraints).map(t => t.timex).should.have.members(['2018-06-10T16', '2018-06-17T16']);
                 });
             });
         });


### PR DESCRIPTION
Two things covered under #589 

1) extend timex resolution to include timex expressions that contain a timerange. For example, resolve "Sunday Evening" (code is implemented in C# and JavaScript)
2) fix bug in C# implementation around days of the week being a 1-based indexed from Monday