### PR TITLE
Support superfluous word filter in English

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string RelaxedOnRegex = @"(?<=\b(on|at|in)\s+)((?<day>10th|11th|11st|12nd|12th|13rd|13th|14th|15th|16th|17th|18th|19th|1st|20th|21st|21th|22nd|22th|23rd|23th|24th|25th|26th|27th|28th|29th|2nd|30th|31st|3rd|4th|5th|6th|7th|8th|9th)s?)\b";
 		public static readonly string ThisRegex = $@"\b((this(\s*week)?(\s*on)?\s+){WeekDayRegex})|({WeekDayRegex}((\s+of)?\s+this\s*week))\b";
 		public static readonly string LastDateRegex = $@"\b({PastPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b";
-		public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}((\s+of)?\s+next\s*week))\b";
+		public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}((\s+of)?\s+next\s*week))\b";
 		public static readonly string SpecialDayRegex = $@"\b((the\s+)?day before yesterday|(the\s+)?day after (tomorrow|tmr)|((the\s+)?({RelativeRegex}|my)\s+day)|yesterday|tomorrow|tmr|today)\b";
 		public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+days?\s+from\s+(?<day>yesterday|tomorrow|tmr|today))\b";
 		public static readonly string RelativeDayRegex = $@"\b(((the\s+)?{RelativeRegex}\s+day))\b";
@@ -602,5 +602,14 @@ namespace Microsoft.Recognizers.Definitions.English
 			{ "two thousands", 2000 }
 		};
 		public const string DefaultLanguageFallback = "MDY";
+		public static readonly IList<string> SuperfluousWordList = new List<string>
+		{
+			"preferably",
+			"how about",
+			"maybe",
+			"say",
+			"like",
+			"around"
+		};
 	}
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.English;
+using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
@@ -38,6 +40,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             // (the)? (day|week|month|year)
             new Regex(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline),
         };
+
+        public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public DateTimeOptions Options { get; }
 
@@ -80,6 +84,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             TimeZoneExtractor = new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(options));
             DateTimeAltExtractor = new BaseDateTimeAltExtractor(new EnglishDateTimeAltExtractorConfiguration());
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
+
+            if ((options & DateTimeOptions.EnablePreview) != 0)
+            {
+                SuperfluousWordMatcher.Init(DateTimeDefinitions.SuperfluousWordList);
+            }
+
         }
 
         Regex IMergedExtractorConfiguration.AfterRegex => AfterRegex;
@@ -91,5 +101,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
         Regex IMergedExtractorConfiguration.YearAfterRegex => YearAfterRegex;
         IEnumerable<Regex> IMergedExtractorConfiguration.FilterWordRegexList => FilterWordRegexList;
+        StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public sealed class EnglishMergedParserConfiguration : EnglishCommonDateTimeParserConfiguration, IMergedParserConfiguration
@@ -21,6 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeParser TimeZoneParser { get; }
 
+        public StringMatcher SuperfluousWordMatcher { get; }
+
         public EnglishMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = EnglishMergedExtractorConfiguration.BeforeRegex;
@@ -28,6 +32,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             SinceRegex = EnglishMergedExtractorConfiguration.SinceRegex;
             YearAfterRegex = EnglishMergedExtractorConfiguration.YearAfterRegex;
             YearRegex = EnglishDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = EnglishMergedExtractorConfiguration.SuperfluousWordMatcher;
 
             DatePeriodParser = new BaseDatePeriodParser(new EnglishDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new EnglishTimePeriodParserConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeZoneExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeZoneExtractor.cs
@@ -40,6 +40,12 @@ namespace Microsoft.Recognizers.Text.DateTime
         private IEnumerable<Token> CityTimeMatch(string text)
         {
             var ret = new List<Token>();
+
+            if (config.CityTimeSuffixRegex == null)
+            {
+                return ret;
+            }
+
             var timeMatch = config.CityTimeSuffixRegex.Matches(text);
 
             if (timeMatch.Count != 0)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime
@@ -49,6 +50,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         Regex NumberEndingPattern { get; }
 
         Regex YearAfterRegex { get; }
+
+        StringMatcher SuperfluousWordMatcher { get; }
 
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 using Microsoft.Recognizers.Definitions.French;
-using System.Collections.Generic;
+using Microsoft.Recognizers.Text.Matcher;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
@@ -37,6 +38,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         {
 
         };
+
+        public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -88,5 +91,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
         Regex IMergedExtractorConfiguration.YearAfterRegex => YearAfterRegex;
         IEnumerable<Regex> IMergedExtractorConfiguration.FilterWordRegexList => FilterWordRegexList;
+        StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IEnumerable<Regex> TimeZoneRegexes => TimeZoneRegexList;
         public Regex CityTimeSuffixRegex { get; }
         public StringMatcher CityMatcher { get; }
-        public List<string> AmbiguousTimezoneList { get; }
+        public List<string> AmbiguousTimezoneList => new List<string>();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public sealed class FrenchMergedParserConfiguration : FrenchCommonDateTimeParserConfiguration, IMergedParserConfiguration
@@ -21,12 +23,15 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeParser TimeZoneParser { get; }
 
+        public StringMatcher SuperfluousWordMatcher { get; }
+
         public FrenchMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = FrenchMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = FrenchMergedExtractorConfiguration.AfterRegex;
             SinceRegex = FrenchMergedExtractorConfiguration.SinceRegex;
             YearAfterRegex = FrenchMergedExtractorConfiguration.YearAfterRegex;
+            SuperfluousWordMatcher = FrenchMergedExtractorConfiguration.SuperfluousWordMatcher;
             YearRegex = FrenchDatePeriodExtractorConfiguration.YearRegex;
             DatePeriodParser = new BaseDatePeriodParser(new FrenchDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new FrenchTimePeriodParserConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿using System.Text.RegularExpressions;
-using Microsoft.Recognizers.Definitions.German;
 using System.Collections.Generic;
+
+using Microsoft.Recognizers.Definitions.German;
+using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
@@ -29,6 +31,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public static readonly Regex YearAfterRegex =
             new Regex(DateTimeDefinitions.YearAfterRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public static readonly Regex[] FilterWordRegexList =
         {
@@ -85,5 +89,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
         Regex IMergedExtractorConfiguration.YearAfterRegex => YearAfterRegex;
         IEnumerable<Regex> IMergedExtractorConfiguration.FilterWordRegexList => FilterWordRegexList;
+        StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeZoneExtractorConfiguration.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IEnumerable<Regex> TimeZoneRegexes => TimeZoneRegexList;
         public Regex CityTimeSuffixRegex { get; }
         public StringMatcher CityMatcher { get; }
-        public List<string> AmbiguousTimezoneList { get; }
+        public List<string> AmbiguousTimezoneList => new List<string>();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public sealed class GermanMergedParserConfiguration : GermanCommonDateTimeParserConfiguration, IMergedParserConfiguration
@@ -20,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeParser TimeZoneParser { get; }
 
+        public StringMatcher SuperfluousWordMatcher { get; }
+
         public GermanMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = GermanMergedExtractorConfiguration.BeforeRegex;
@@ -27,6 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             SinceRegex = GermanMergedExtractorConfiguration.SinceRegex;
             YearAfterRegex = GermanMergedExtractorConfiguration.YearAfterRegex;
             YearRegex = GermanDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = GermanMergedExtractorConfiguration.SuperfluousWordMatcher;
             DatePeriodParser = new BaseDatePeriodParser(new GermanDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new GermanTimePeriodParserConfiguration(this));
             DateTimePeriodParser = new BaseDateTimePeriodParser(new GermanDateTimePeriodParserConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             var originText = er.Text;
             if ((this.Config.Options & DateTimeOptions.EnablePreview) != 0)
             {
-                er = PreProcessRemoveSuperfluousWords(er);
+                er.Text = MatchingUtil.PreProcessTextRemoveSuperfluousWords(er.Text, Config.SuperfluousWordMatcher, out var _);
+                er.Length += er.Text.Length - originText.Length;
             }
 
             // Push, save the MOD string
@@ -223,38 +224,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if ((this.Config.Options & DateTimeOptions.EnablePreview) != 0)
             {
-                pr = PosProcessRecoverSuperfluousWords(pr, originText);
+                pr.Length += originText.Length - pr.Text.Length;
+                pr.Text = originText;
             }
 
             return pr;
-        }
-
-
-        private ExtractResult PreProcessRemoveSuperfluousWords(ExtractResult er)
-        {
-            var text = er.Text;
-
-            var matches = Config.SuperfluousWordMatcher.Find(text).ToList();
-            var bias = 0;
-
-            foreach (var match in matches)
-            {
-                text = text.Remove(match.Start - bias, match.Length);
-                bias += match.Length;
-            }
-
-            er.Length += text.Length - er.Text.Length;
-            er.Text = text;
-
-            return er;
-        }
-
-        private DateTimeParseResult PosProcessRecoverSuperfluousWords(DateTimeParseResult parseResult, string originText)
-        {
-            parseResult.Length += originText.Length - parseResult.Text.Length;
-            parseResult.Text = originText;
-
-            return parseResult;
         }
 
         public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime
 {
     public interface IMergedParserConfiguration : ICommonDateTimeParserConfiguration
@@ -20,5 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         IDateTimeParser HolidayParser { get; }
 
         IDateTimeParser TimeZoneParser { get; }
+
+        StringMatcher SuperfluousWordMatcher { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 using Microsoft.Recognizers.Definitions.Portuguese;
-using System.Collections.Generic;
+using Microsoft.Recognizers.Text.Matcher;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
@@ -28,6 +29,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public static readonly Regex YearAfterRegex =
             new Regex(DateTimeDefinitions.YearAfterRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public static readonly Regex[] FilterWordRegexList =
         {
@@ -82,5 +85,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
         Regex IMergedExtractorConfiguration.YearAfterRegex => YearAfterRegex;
         IEnumerable<Regex> IMergedExtractorConfiguration.FilterWordRegexList => FilterWordRegexList;
+        StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeZoneExtractorConfiguration.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IEnumerable<Regex> TimeZoneRegexes => TimeZoneRegexList;
         public Regex CityTimeSuffixRegex { get; }
         public StringMatcher CityMatcher { get; }
-        public List<string> AmbiguousTimezoneList { get; }
+        public List<string> AmbiguousTimezoneList => new List<string>();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public sealed class PortugueseMergedParserConfiguration : PortugueseCommonDateTimeParserConfiguration, IMergedParserConfiguration
@@ -21,6 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeParser TimeZoneParser { get; }
 
+        public StringMatcher SuperfluousWordMatcher { get; }
+
         public PortugueseMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = PortugueseMergedExtractorConfiguration.BeforeRegex;
@@ -28,6 +32,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             SinceRegex = PortugueseMergedExtractorConfiguration.SinceRegex;
             YearAfterRegex = PortugueseMergedExtractorConfiguration.YearAfterRegex;
             YearRegex = PortugueseDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = PortugueseMergedExtractorConfiguration.SuperfluousWordMatcher;
 
             DatePeriodParser = new BaseDatePeriodParser(new PortugueseDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new PortugueseTimePeriodParserConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 using Microsoft.Recognizers.Definitions.Spanish;
-using System.Collections.Generic;
+using Microsoft.Recognizers.Text.Matcher;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
@@ -32,6 +33,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex[] FilterWordRegexList =
         {
         };
+
+        public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -82,5 +85,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
         Regex IMergedExtractorConfiguration.YearAfterRegex => YearAfterRegex;
         IEnumerable<Regex> IMergedExtractorConfiguration.FilterWordRegexList => FilterWordRegexList;
+        StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeZoneExtractorConfiguration.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IEnumerable<Regex> TimeZoneRegexes => TimeZoneRegexList;
         public Regex CityTimeSuffixRegex { get; }
         public StringMatcher CityMatcher { get; }
-        public List<string> AmbiguousTimezoneList { get; }
+        public List<string> AmbiguousTimezoneList => new List<string>();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Matcher;
+
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
@@ -21,6 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeParser TimeZoneParser { get; }
 
+        public StringMatcher SuperfluousWordMatcher { get; }
+
         public SpanishMergedParserConfiguration(DateTimeOptions options) : base(options)
         {
             BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
@@ -28,6 +32,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             SinceRegex = SpanishMergedExtractorConfiguration.SinceRegex;
             YearAfterRegex = SpanishMergedExtractorConfiguration.YearAfterRegex;
             YearRegex = SpanishDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = SpanishMergedExtractorConfiguration.SuperfluousWordMatcher;
 
             DatePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
             TimePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -70,7 +70,7 @@ export namespace EnglishDateTime {
 	export const RelaxedOnRegex = `(?<=\\b(on|at|in)\\s+)((?<day>10th|11th|11st|12nd|12th|13rd|13th|14th|15th|16th|17th|18th|19th|1st|20th|21st|21th|22nd|22th|23rd|23th|24th|25th|26th|27th|28th|29th|2nd|30th|31st|3rd|4th|5th|6th|7th|8th|9th)s?)\\b`;
 	export const ThisRegex = `\\b((this(\\s*week)?(\\s*on)?\\s+)${WeekDayRegex})|(${WeekDayRegex}((\\s+of)?\\s+this\\s*week))\\b`;
 	export const LastDateRegex = `\\b(${PastPrefixRegex}(\\s*week)?\\s+${WeekDayRegex})|(${WeekDayRegex}(\\s+last\\s*week))\\b`;
-	export const NextDateRegex = `\\b(${NextPrefixRegex}(\\s*week(\\s*on)?)?\\s+${WeekDayRegex})|((on\\s+)?${WeekDayRegex}((\\s+of)?\\s+next\\s*week))\\b`;
+	export const NextDateRegex = `\\b(${NextPrefixRegex}(\\s*week(\\s*,?\\s*on)?)?\\s+${WeekDayRegex})|((on\\s+)?${WeekDayRegex}((\\s+of)?\\s+next\\s*week))\\b`;
 	export const SpecialDayRegex = `\\b((the\\s+)?day before yesterday|(the\\s+)?day after (tomorrow|tmr)|((the\\s+)?(${RelativeRegex}|my)\\s+day)|yesterday|tomorrow|tmr|today)\\b`;
 	export const SpecialDayWithNumRegex = `\\b((?<number>${WrittenNumRegex})\\s+days?\\s+from\\s+(?<day>yesterday|tomorrow|tmr|today))\\b`;
 	export const RelativeDayRegex = `\\b(((the\\s+)?${RelativeRegex}\\s+day))\\b`;
@@ -241,4 +241,5 @@ export namespace EnglishDateTime {
 	export const WrittenDecades: ReadonlyMap<string, number> = new Map<string, number>([["hundreds", 0],["tens", 10],["twenties", 20],["thirties", 30],["forties", 40],["fifties", 50],["sixties", 60],["seventies", 70],["eighties", 80],["nineties", 90]]);
 	export const SpecialDecadeCases: ReadonlyMap<string, number> = new Map<string, number>([["noughties", 2000],["two thousands", 2000]]);
 	export const DefaultLanguageFallback = 'MDY';
+	export const SuperfluousWordList = [ 'preferably','how about','maybe','say','like','around' ];
 }

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -155,7 +155,7 @@ LastDateRegex: !nestedRegex
   def: \b({PastPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+last\s*week))\b
   references: [ PastPrefixRegex, WeekDayRegex ]
 NextDateRegex: !nestedRegex
-  def: \b({NextPrefixRegex}(\s*week(\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}((\s+of)?\s+next\s*week))\b
+  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*on)?)?\s+{WeekDayRegex})|((on\s+)?{WeekDayRegex}((\s+of)?\s+next\s*week))\b
   references: [ NextPrefixRegex, WeekDayRegex ]
 SpecialDayRegex: !nestedRegex
   def: \b((the\s+)?day before yesterday|(the\s+)?day after (tomorrow|tmr)|((the\s+)?({RelativeRegex}|my)\s+day)|yesterday|tomorrow|tmr|today)\b
@@ -915,4 +915,13 @@ SpecialDecadeCases: !dictionary
     'noughties': 2000
     'two thousands': 2000
 DefaultLanguageFallback: 'MDY'
+SuperfluousWordList: !list
+  types: [ string ]
+  entries:
+    - preferably
+    - how about
+    - maybe
+    - say
+    - like
+    - around
 ...

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -2694,5 +2694,133 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Let's meet 3PM get at the book shop.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-14T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "3pm get",
+        "Start": 11,
+        "End": 17,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T15",
+              "type": "time",
+              "timezone": "UTC+04:00",
+              "timezoneText": "get",
+              "utcOffsetMins": "240",
+              "value": "15:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Let's catch up next week, how about on Wednesday?",
+    "Context": {
+      "ReferenceDateTime": "2018-06-14T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "next week, how about on wednesday",
+        "Start": 16,
+        "End": 48,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-20",
+              "type": "date",
+              "value": "2018-06-20"
+            }
+          ]
+        }
+      } 
+    ]
+  },
+  {
+    "Input": "Let's catch up next week maybe, say on Wednesday?",
+    "Context": {
+      "ReferenceDateTime": "2018-06-14T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "next week maybe, say on wednesday",
+        "Start": 15,
+        "End": 47,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-20",
+              "type": "date",
+              "value": "2018-06-20"
+            }
+          ]
+        }
+      } 
+    ]
+  },
+  {
+    "Input": "OK, let’s find some time to discuss it next week, preferably on Tuesday",
+    "Context": {
+      "ReferenceDateTime": "2018-06-14T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "next week, preferably on tuesday",
+        "Start": 39,
+        "End": 70,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-19",
+              "type": "date",
+              "value": "2018-06-19"
+            }
+          ]
+        }
+      } 
+    ]
+  },
+  {
+    "Input": "How about this sunday around 7:00.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-14T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "this sunday around 7:00",
+        "Start": 10,
+        "End": 32,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-17T07:00",
+              "type": "datetime",
+              "value": "2018-06-17 07:00:00"
+            },
+            {
+              "timex": "2018-06-17T19:00",
+              "type": "datetime",
+              "value": "2018-06-17 19:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Support superfluous word filter in English under the preview mode.
For cases like "OK, let’s find some time to discuss it next week, preferably on Tuesday" in which "preferably" is a superfluous word.