### PR TITLE
Add missing case for xxx割xxx分xxx厘 (#634)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Japanese/ChoiceDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Japanese/ChoiceDefinitions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 	{
 		public const string LangMarker = "Jpn";
 		public const string TokenizerRegex = @"[^\w\d\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]";
-		public const string TrueRegex = @"(はい|そうです|そう|よい)|(\uD83D\uDC4D|\uD83D\uDC4C)";
+		public const string TrueRegex = @"(はい(！)*|そうです|よい(です)*)|(\uD83D\uDC4D|\uD83D\uDC4C)";
 		public const string FalseRegex = @"(いいえ|ではありません|ではない|じゃない|じゃありません)|(\uD83D\uDC4E|\u270B|\uD83D\uDD90)";
 	}
 }

--- a/.NET/Microsoft.Recognizers.Definitions/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Japanese/NumbersDefinitions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 		public const string NegativeNumberTermsRegex = @"(マ\s*イ\s*ナ\s*ス)";
 		public const string NegativeNumberTermsRegexNum = @"(?<!(\d+\s*)|[-－])[-－]";
 		public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*";
-		public static readonly string SpeGetNumberRegex = $@"{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[半対]";
+		public static readonly string SpeGetNumberRegex = $@"{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[半対]|[分厘]";
 		public const string PairRegex = ".*[対膳足]$";
 		public const string RoundNumberIntegerRegex = @"[十百千万億兆]";
 		public const string WhiteListRegex = @"(。|，|、|（|）|”｜国|週間|時間|時|匹|キロ|トン|年|個|足|本|\s|$)";
@@ -157,7 +157,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 		public static readonly string SimpleIntegerPercentageRegex = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%]";
 		public static readonly string NumbersFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*[の]*\s*割引";
 		public static readonly string FoldsPercentageRegex = $@"{ZeroToNineIntegerRegex}(\s*[.]?\s*{ZeroToNineIntegerRegex})?\s*[の]\s*割引";
-		public static readonly string SimpleFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}\s*割(\s*(半|{ZeroToNineFullHalfRegex}))?";
+		public static readonly string SimpleFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}\s*割(\s*(半|({ZeroToNineFullHalfRegex}\s*分\s*{ZeroToNineFullHalfRegex}\s*厘)|{ZeroToNineFullHalfRegex}))?";
 		public static readonly string SpecialsPercentageRegex = $@"({ZeroToNineIntegerRegex}|[十])\s*割(\s*(半|{ZeroToNineIntegerRegex}))?";
 		public static readonly string NumbersSpecialsPercentageRegex = $@"({ZeroToNineFullHalfRegex}[\.．]{ZeroToNineFullHalfRegex}|[1１][0０])\s*割";
 		public static readonly string SimpleSpecialsPercentageRegex = $@"{ZeroToNineIntegerRegex}\s*[.]\s*{ZeroToNineIntegerRegex}\s*割";

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -222,6 +222,19 @@ namespace Microsoft.Recognizers.Text.Number
 
                         result.Value = (intNumber + pointNumber) * 10;
                     }
+                    else if(matches.Count == 5)
+                    {
+                        var intNumberChar = matches[0].Value[0];
+                        var pointNumberChar = matches[1].Value[0];
+                        var dotNumberChar = matches[3].Value[0];
+                        
+                        double pointNumber = Config.ZeroToNineMap[pointNumberChar] * 0.1;
+                        double dotNumber = Config.ZeroToNineMap[dotNumberChar] * 0.01;
+
+                        intNumber = Config.ZeroToNineMap[intNumberChar];
+
+                        result.Value = (intNumber + pointNumber + dotNumber) * 10;
+                    }
                     else
                     {
                         var intNumberChar = matches[0].Value[0];

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -222,8 +222,9 @@ namespace Microsoft.Recognizers.Text.Number
 
                         result.Value = (intNumber + pointNumber) * 10;
                     }
-                    else if(matches.Count == 5)
+                    else if (matches.Count == 5)
                     {
+                        // Deal the Japanese percentage case like "xxx割xxx分xxx厘", get the integer value and convert into result. 
                         var intNumberChar = matches[0].Value[0];
                         var pointNumberChar = matches[1].Value[0];
                         var dotNumberChar = matches[3].Value[0];

--- a/JavaScript/packages/recognizers-choice/src/resources/japaneseChoice.ts
+++ b/JavaScript/packages/recognizers-choice/src/resources/japaneseChoice.ts
@@ -9,6 +9,6 @@
 export namespace JapaneseChoice {
 	export const LangMarker = 'Jpn';
 	export const TokenizerRegex = `[^\\w\\d\\u3040-\\u309f\\u30a0-\\u30ff\\uff00-\\uff9f\\u4e00-\\u9faf\\u3400-\\u4dbf]`;
-	export const TrueRegex = `(はい|そうです|そう|よい)|(\\uD83D\\uDC4D|\\uD83D\\uDC4C)`;
+	export const TrueRegex = `(はい(！)*|そうです|よい(です)*)|(\\uD83D\\uDC4D|\\uD83D\\uDC4C)`;
 	export const FalseRegex = `(いいえ|ではありません|ではない|じゃない|じゃありません)|(\\uD83D\\uDC4E|\\u270B|\\uD83D\\uDD90)`;
 }

--- a/Patterns/Japanese/Japanese-Choice.yaml
+++ b/Patterns/Japanese/Japanese-Choice.yaml
@@ -5,6 +5,6 @@ TokenizerRegex: !simpleRegex
 #https://stackoverflow.com/questions/15033196/using-javascript-to-check-whether-a-string-contains-japanese-characters-includi
   def: '[^\w\d\u3040-\u309f\u30a0-\u30ff\uff00-\uff9f\u4e00-\u9faf\u3400-\u4dbf]'
 TrueRegex: !simpleRegex
-  def: (はい|そうです|そう|よい)|(\uD83D\uDC4D|\uD83D\uDC4C)
+  def: (はい(！)*|そうです|よい(です)*)|(\uD83D\uDC4D|\uD83D\uDC4C)
 FalseRegex: !simpleRegex
   def: (いいえ|ではありません|ではない|じゃない|じゃありません)|(\uD83D\uDC4E|\u270B|\uD83D\uDD90)

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -109,7 +109,7 @@ NegativeNumberSignRegex: !nestedRegex
   def: ^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*
   references: [NegativeNumberTermsRegex, NegativeNumberTermsRegexNum]
 SpeGetNumberRegex: !nestedRegex
-  def: '{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[半対]'
+  def: '{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[半対]|[分厘]'
   references: [ZeroToNineFullHalfRegex, ZeroToNineIntegerRegex]
 PairRegex: .*[対膳足]$
 #IntegerExtractor
@@ -250,7 +250,7 @@ FoldsPercentageRegex: !nestedRegex
   def: '{ZeroToNineIntegerRegex}(\s*[.]?\s*{ZeroToNineIntegerRegex})?\s*[の]\s*割引'
   references: [ZeroToNineIntegerRegex]
 SimpleFoldsPercentageRegex: !nestedRegex
-  def: '{ZeroToNineFullHalfRegex}\s*割(\s*(半|{ZeroToNineFullHalfRegex}))?'
+  def: '{ZeroToNineFullHalfRegex}\s*割(\s*(半|({ZeroToNineFullHalfRegex}\s*分\s*{ZeroToNineFullHalfRegex}\s*厘)|{ZeroToNineFullHalfRegex}))?'
   references: [ZeroToNineFullHalfRegex]
 SpecialsPercentageRegex: !nestedRegex
   def: ({ZeroToNineIntegerRegex}|[十])\s*割(\s*(半|{ZeroToNineIntegerRegex}))?

--- a/Specs/Choice/Japanese/BooleanModel.json
+++ b/Specs/Choice/Japanese/BooleanModel.json
@@ -7,7 +7,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 1.0
+        "score": 1.0
       }
     }
   ]
@@ -22,7 +22,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 1.0
+        "score": 1.0
       }
     }
   ]
@@ -37,7 +37,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 1.0
+        "score": 1.0
       }
     }
   ]
@@ -52,7 +52,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 1.0
+        "score": 1.0
       }
     }
   ]
@@ -67,7 +67,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 1.0
+        "score": 1.0
       }
     }
   ]
@@ -82,7 +82,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": false,
-		"score": 0.7
+        "score": 0.7
       }
     }
   ]
@@ -97,7 +97,7 @@
       "TypeName": "boolean",
       "Resolution": {
         "value": true,
-		"score": 0.6
+        "score": 0.6
       }
     }
   ]

--- a/Specs/Choice/Japanese/BooleanModel.json
+++ b/Specs/Choice/Japanese/BooleanModel.json
@@ -14,6 +14,66 @@
 }
 ,
 {
+  "Input": "はい！",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "はい！",
+      "TypeName": "boolean",
+      "Resolution": {
+        "value": true,
+		"score": 1.0
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "よい",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "よい",
+      "TypeName": "boolean",
+      "Resolution": {
+        "value": true,
+		"score": 1.0
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "よいです",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "よいです",
+      "TypeName": "boolean",
+      "Resolution": {
+        "value": true,
+		"score": 1.0
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "そうです",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "そうです",
+      "TypeName": "boolean",
+      "Resolution": {
+        "value": true,
+		"score": 1.0
+      }
+    }
+  ]
+}
+,
+{
   "Input": "いいえ、駄目です.",
   "NotSupportedByDesign": "python",
   "Results": [

--- a/Specs/Number/Japanese/PercentModel.json
+++ b/Specs/Number/Japanese/PercentModel.json
@@ -761,4 +761,18 @@
     }
   ]
 }
+,
+{
+  "Input": "今シーズンの打率は3割8分7厘でした",
+  "NotSupported": "javascript, python",
+  "Results": [
+    {
+      "Text": "3割8分7厘",
+      "TypeName": "percentage",
+      "Resolution": {
+        "value": "38.7%"
+      }
+    }
+  ]
+}
 ]


### PR DESCRIPTION
{
"Input": "今シーズンの打率は3割8分7厘でした",
"NotSupported": "javascript, python",
"Results": [
{
"Text": "3割8分7厘",
"TypeName": "percentage",
"Resolution": {
"value": "38.7%"
}
}
]
}