### PR TITLE
[Java] NumberWithUnit - Spanish

### DIFF
--- a/Java/build-resources.cmd
+++ b/Java/build-resources.cmd
@@ -1,0 +1,4 @@
+@echo off
+mvn compile -pl libraries/resource-generator/
+mvn exec:java -pl libraries/resource-generator/
+

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -151,6 +151,23 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                 new CurrencyModel(ImmutableMap.of(
                     new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.CurrencyExtractorConfiguration()),
                     new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.CurrencyParserConfiguration()))));
+        registerModel(TemperatureModel.class, Culture.Spanish, (options) ->
+                new TemperatureModel(ImmutableMap.of(
+                    new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.TemperatureExtractorConfiguration()),
+                    new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.TemperatureParserConfiguration()))));
+//        RegisterModel<DimensionModel>(
+//                Culture.Spanish,
+//                (options) => new DimensionModel(new Dictionary<IExtractor, IParser>
+//        {
+//            {
+//                new NumberWithUnitExtractor(new Spanish.DimensionExtractorConfiguration()),
+//                        new NumberWithUnitParser(new Spanish.DimensionParserConfiguration())
+//            }
+//        }));
+        registerModel(AgeModel.class, Culture.Spanish, (options) ->
+                new AgeModel(ImmutableMap.of(
+                    new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.AgeExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.AgeParserConfiguration()))));
         //endregion
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -155,15 +155,10 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                 new TemperatureModel(ImmutableMap.of(
                     new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.TemperatureExtractorConfiguration()),
                     new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.TemperatureParserConfiguration()))));
-//        RegisterModel<DimensionModel>(
-//                Culture.Spanish,
-//                (options) => new DimensionModel(new Dictionary<IExtractor, IParser>
-//        {
-//            {
-//                new NumberWithUnitExtractor(new Spanish.DimensionExtractorConfiguration()),
-//                        new NumberWithUnitParser(new Spanish.DimensionParserConfiguration())
-//            }
-//        }));
+        registerModel(DimensionModel.class, Culture.Spanish, (options) ->
+                new DimensionModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.DimensionExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.DimensionParserConfiguration()))));
         registerModel(AgeModel.class, Culture.Spanish, (options) ->
                 new AgeModel(ImmutableMap.of(
                     new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.AgeExtractorConfiguration()),

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -145,5 +145,12 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                         new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.english.extractors.AgeExtractorConfiguration()),
                         new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.english.parsers.AgeParserConfiguration()))));
         //endregion
+
+        //region Spanish
+        registerModel(CurrencyModel.class, Culture.Spanish, (options) ->
+                new CurrencyModel(ImmutableMap.of(
+                    new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.CurrencyExtractorConfiguration()),
+                    new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.CurrencyParserConfiguration()))));
+        //endregion
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
@@ -128,7 +128,7 @@ public class NumberWithUnitExtractor implements IExtractor {
                         int endpos = m.end();
                         if (m.start() >= 0) {
                             String midStr = rightSub.substring(0, Math.min(m.start(), rightSub.length()));
-                            if (maxlen < endpos && (midStr.isEmpty() || midStr.trim().equalsIgnoreCase(this.config.getConnectorToken()))) {
+                            if (maxlen < endpos && (midStr.trim().isEmpty() || midStr.trim().equalsIgnoreCase(this.config.getConnectorToken()))) {
                                 maxlen = endpos;
                             }
                         }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/ChineseNumericWithUnit.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/ChineseNumericWithUnit.java
@@ -538,11 +538,11 @@ public class ChineseNumericWithUnit {
     public static final List<String> CurrencyAmbiguousValues = Arrays.asList("元", "仙", "分", "圆", "块", "毛", "盾", "箍", "蚊", "角");
 
     public static final Map<String, String> DimensionSuffixList = ImmutableMap.<String, String>builder()
-        .put("Meter", "米|公尺")
-        .put("Kilometer", "千米|公里")
-        .put("Decimeter", "分米|公寸")
-        .put("Centimeter", "釐米|厘米|公分")
-        .put("Micrometer", "毫米|公釐")
+        .put("Meter", "米|公尺|m")
+        .put("Kilometer", "千米|公里|km")
+        .put("Decimeter", "分米|公寸|dm")
+        .put("Centimeter", "釐米|厘米|公分|cm")
+        .put("Micrometer", "毫米|公釐|mm")
         .put("Microns", "微米")
         .put("Picometer", "皮米")
         .put("Nanometer", "纳米")
@@ -558,10 +558,10 @@ public class ChineseNumericWithUnit {
         .put("Yard", "码")
         .put("Knot", "海里")
         .put("Light year", "光年")
-        .put("Meter per second", "米每秒|米/秒")
-        .put("Kilometer per hour", "公里每小时|千米每小时|公里/小时|千米/小时")
-        .put("Kilometer per minute", "公里每分钟|千米每分钟|公里/分钟|千米/分钟")
-        .put("Kilometer per second", "公里每秒|千米每秒|公里/秒|千米/秒")
+        .put("Meter per second", "米每秒|米/秒|m/s")
+        .put("Kilometer per hour", "公里每小时|千米每小时|公里/小时|千米/小时|km/h")
+        .put("Kilometer per minute", "公里每分钟|千米每分钟|公里/分钟|千米/分钟|km/min")
+        .put("Kilometer per second", "公里每秒|千米每秒|公里/秒|千米/秒|km/s")
         .put("Mile per hour", "英里每小时|英里/小时")
         .put("Foot per second", "英尺每小时|英尺/小时")
         .put("Foot per minute", "英尺每分钟|英尺/分钟")
@@ -574,8 +574,8 @@ public class ChineseNumericWithUnit {
         .put("Acre", "英亩|公亩")
         .put("Hectare", "公顷")
         .put("Mu", "亩|市亩")
-        .put("Liter", "公升|升")
-        .put("Milliliter", "毫升")
+        .put("Liter", "公升|升|l")
+        .put("Milliliter", "毫升|ml")
         .put("Cubic meter", "立方米")
         .put("Cubic decimeter", "立方分米")
         .put("Cubic millimeter", "立方毫米")
@@ -584,31 +584,31 @@ public class ChineseNumericWithUnit {
         .put("Pint", "品脱")
         .put("Dou", "市斗|斗")
         .put("Dan", "市石|石")
-        .put("Kilogram", "千克|公斤")
+        .put("Kilogram", "千克|公斤|kg")
         .put("Jin", "市斤|斤")
-        .put("Milligram", "毫克")
+        .put("Milligram", "毫克|mg")
         .put("Barrel", "桶")
         .put("Pot", "罐")
-        .put("Gram", "克")
-        .put("Ton", "公吨|吨")
+        .put("Gram", "克|g")
+        .put("Ton", "公吨|吨|t")
         .put("Pound", "磅")
         .put("Ounce", "盎司")
-        .put("Bit", "比特|位")
-        .put("Byte", "字节")
-        .put("Kilobyte", "千字节")
-        .put("Megabyte", "兆字节")
-        .put("Gigabyte", "十亿字节|千兆字节")
-        .put("Terabyte", "万亿字节|兆兆字节")
-        .put("Petabyte", "千兆兆|千万亿字节")
+        .put("Bit", "比特|位|b")
+        .put("Byte", "字节|byte")
+        .put("Kilobyte", "千字节|kb")
+        .put("Megabyte", "兆字节|mb")
+        .put("Gigabyte", "十亿字节|千兆字节|gb")
+        .put("Terabyte", "万亿字节|兆兆字节|tb")
+        .put("Petabyte", "千兆兆|千万亿字节|pb")
         .build();
 
-    public static final List<String> DimensionAmbiguousValues = Arrays.asList("丈", "位", "克", "分", "升", "寸", "尺", "斗", "斤", "桶", "毫", "石", "码", "磅", "米", "罐", "里");
+    public static final List<String> DimensionAmbiguousValues = Arrays.asList("丈", "位", "克", "分", "升", "寸", "尺", "斗", "斤", "桶", "毫", "石", "码", "磅", "米", "罐", "里", "m", "km", "dm", "cm", "mm", "l", "ml", "kg", "mg", "g", "t", "b", "byte", "kb", "mb", "gb", "tb", "pb");
 
     public static final Map<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
-        .put("F", "华氏温度|华氏度")
+        .put("F", "华氏温度|华氏度|°f")
         .put("K", "k|开尔文温度|开氏度|凯氏度")
-        .put("R", "兰氏温度")
-        .put("C", "摄氏温度|摄氏度")
+        .put("R", "兰氏温度|°r")
+        .put("C", "摄氏温度|摄氏度|°c")
         .put("Degree", "度")
         .build();
 
@@ -619,5 +619,5 @@ public class ChineseNumericWithUnit {
         .put("C", "摄氏温度|摄氏")
         .build();
 
-    public static final List<String> TemperatureAmbiguousValues = Arrays.asList("度");
+    public static final List<String> TemperatureAmbiguousValues = Arrays.asList("度", "k");
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/AgeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/AgeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AgeExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public AgeExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public AgeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AGE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AgeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AgeSuffixList = SpanishNumericWithUnit.AgeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/AreaExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/AreaExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AreaExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public AreaExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public AreaExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AREA;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AreaSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AreaSuffixList = SpanishNumericWithUnit.AreaSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/CurrencyExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/CurrencyExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+
+public class CurrencyExtractorConfiguration  extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public CurrencyExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public CurrencyExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_CURRENCY;
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return SpanishNumericWithUnit.AmbiguousCurrencyUnitList;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return CurrencySuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return CurrencyPrefixList;
+    }
+
+    public static Map<String, String> CurrencySuffixList = SpanishNumericWithUnit.CurrencySuffixList;
+    public static Map<String, String> CurrencyPrefixList = SpanishNumericWithUnit.CurrencyPrefixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/DimensionExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/DimensionExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DimensionExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public DimensionExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public DimensionExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_DIMENSION;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return DimensionSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return SpanishNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> DimensionSuffixList = SpanishNumericWithUnit.DimensionSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/LengthExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/LengthExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LengthExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public LengthExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public LengthExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_LENGTH;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return LenghtSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return SpanishNumericWithUnit.AmbiguousLengthUnitList;
+    }
+
+    public static Map<String, String> LenghtSuffixList = SpanishNumericWithUnit.LengthSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpanishNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpanishNumberWithUnitExtractorConfiguration.java
@@ -1,0 +1,37 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.numberwithunit.extractors.INumberWithUnitExtractorConfiguration;
+import com.microsoft.recognizers.text.number.spanish.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class SpanishNumberWithUnitExtractorConfiguration implements INumberWithUnitExtractorConfiguration {
+
+    private final CultureInfo cultureInfo;
+    private final IExtractor unitNumExtractor;
+    private final Pattern compoundUnitConnectorRegex;
+
+    protected SpanishNumberWithUnitExtractorConfiguration(CultureInfo cultureInfo) {
+        this.cultureInfo = cultureInfo;
+
+        this.unitNumExtractor = new NumberExtractor();
+        this.compoundUnitConnectorRegex = Pattern.compile(SpanishNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+    }
+
+    public CultureInfo getCultureInfo() { return this.cultureInfo; }
+    public IExtractor getUnitNumExtractor() { return this.unitNumExtractor; }
+    public String getBuildPrefix() { return SpanishNumericWithUnit.BuildPrefix; }
+    public String getBuildSuffix() { return SpanishNumericWithUnit.BuildSuffix; }
+    public String getConnectorToken() { return SpanishNumericWithUnit.ConnectorToken; }
+    public Pattern getCompoundUnitConnectorRegex() { return this.compoundUnitConnectorRegex; }
+
+    public abstract String getExtractType();
+    public abstract Map<String, String> getSuffixList();
+    public abstract Map<String, String> getPrefixList();
+    public abstract List<String> getAmbiguousUnitList();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpeedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpeedExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SpeedExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public SpeedExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public SpeedExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_SPEED;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return SpeedSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> SpeedSuffixList = SpanishNumericWithUnit.SpeedSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/TemperatureExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/TemperatureExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TemperatureExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public TemperatureExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public TemperatureExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_TEMPERATURE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return TemperatureSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> TemperatureSuffixList = new HashMap(SpanishNumericWithUnit.TemperatureSuffixList);
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/VolumeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/VolumeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class VolumeExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public VolumeExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public VolumeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_VOLUME;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return VolumeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> VolumeSuffixList = SpanishNumericWithUnit.VolumeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/WeightExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/WeightExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class WeightExtractorConfiguration extends SpanishNumberWithUnitExtractorConfiguration {
+
+    public WeightExtractorConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public WeightExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_WEIGHT;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return WeightSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return SpanishNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> WeightSuffixList = SpanishNumericWithUnit.WeightSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/AgeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/AgeParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.AgeExtractorConfiguration;
+
+public class AgeParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public AgeParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public AgeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AgeExtractorConfiguration.AgeSuffixList);
+    }
+}
+

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/AreaParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/AreaParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.AreaExtractorConfiguration;
+
+public class AreaParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public AreaParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public AreaParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AreaExtractorConfiguration.AreaSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/CurrencyParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/CurrencyParserConfiguration.java
@@ -7,7 +7,7 @@ import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.Currency
 public class CurrencyParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
 
     public CurrencyParserConfiguration() {
-        this(new CultureInfo(Culture.English));
+        this(new CultureInfo(Culture.Spanish));
     }
 
     public CurrencyParserConfiguration(CultureInfo cultureInfo) {

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/CurrencyParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/CurrencyParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.CurrencyExtractorConfiguration;
+
+public class CurrencyParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public CurrencyParserConfiguration() {
+        this(new CultureInfo(Culture.English));
+    }
+
+    public CurrencyParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/DimensionParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/DimensionParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.DimensionExtractorConfiguration;
+
+public class DimensionParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public DimensionParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public DimensionParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/LengthParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/LengthParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.LengthExtractorConfiguration;
+
+public class LengthParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public LengthParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public LengthParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(LengthExtractorConfiguration.LenghtSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/SpanishNumberWithUnitParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/SpanishNumberWithUnitParserConfiguration.java
@@ -1,0 +1,39 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.number.NumberMode;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserFactory;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserType;
+import com.microsoft.recognizers.text.number.spanish.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.parsers.BaseNumberWithUnitParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.SpanishNumericWithUnit;
+
+public class SpanishNumberWithUnitParserConfiguration extends BaseNumberWithUnitParserConfiguration {
+
+    private final IParser internalNumberParser;
+    private final IExtractor internalNumberExtractor;
+
+    @Override
+    public IParser getInternalNumberParser() {
+        return this.internalNumberParser;
+    }
+
+    @Override
+    public IExtractor getInternalNumberExtractor() {
+        return this.internalNumberExtractor;
+    }
+
+    @Override
+    public String getConnectorToken() {
+        return SpanishNumericWithUnit.ConnectorToken;
+    }
+
+    public SpanishNumberWithUnitParserConfiguration(CultureInfo ci) {
+        super(ci);
+        this.internalNumberExtractor = new NumberExtractor(NumberMode.Default);
+        this.internalNumberParser = AgnosticNumberParserFactory.getParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration());
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/SpeedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/SpeedParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.SpeedExtractorConfiguration;
+
+public class SpeedParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public SpeedParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public SpeedParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/TemperatureParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/TemperatureParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.TemperatureExtractorConfiguration;
+
+public class TemperatureParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public TemperatureParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public TemperatureParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/VolumeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/VolumeParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.VolumeExtractorConfiguration;
+
+public class VolumeParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public VolumeParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public VolumeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/WeightParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/parsers/WeightParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.spanish.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.spanish.extractors.WeightExtractorConfiguration;
+
+public class WeightParserConfiguration extends SpanishNumberWithUnitParserConfiguration {
+
+    public WeightParserConfiguration() {
+        this(new CultureInfo(Culture.Spanish));
+    }
+
+    public WeightParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(WeightExtractorConfiguration.WeightSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/ChineseNumeric.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/ChineseNumeric.java
@@ -367,7 +367,7 @@ public class ChineseNumeric {
 
     public static final String SpecialsFoldsPercentageRegex = "半\\s*成|(?<=打)[对對]\\s*折|半\\s*折";
 
-    public static final String TillRegex = "(到|至|--|-|—|——|~)";
+    public static final String TillRegex = "(到|至|--|-|—|——|~|–)";
 
     public static final String MoreRegex = "(大于|多于|高于|超过|大於|多於|高於|超過|>)";
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/EnglishNumeric.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/EnglishNumeric.java
@@ -163,7 +163,7 @@ public class EnglishNumeric {
     public static final String NumberWithPrepositionPercentage = "({BaseNumbers.NumberReplaceToken})\\s*(in|out\\s+of)\\s*({BaseNumbers.NumberReplaceToken})"
             .replace("{BaseNumbers.NumberReplaceToken}", BaseNumbers.NumberReplaceToken);
 
-    public static final String TillRegex = "(to|through|--|-|—|——|~)";
+    public static final String TillRegex = "(to|through|--|-|—|——|~|–)";
 
     public static final String MoreRegex = "((bigger|greater|more|higher|larger)(\\s+than)?|above|over|>)";
 

--- a/Specs/NumberWithUnit/Spanish/AgeModel.json
+++ b/Specs/NumberWithUnit/Spanish/AgeModel.json
@@ -224,7 +224,7 @@
 ,
 {
   "Input": "Tiene unos 40 - 50 años",
-  "NotSupported": "javascript",
+  "NotSupported": "javascript, java",
   "Results": [
     {
       "Text": "50 años",

--- a/Specs/NumberWithUnit/Spanish/DimensionModel.json
+++ b/Specs/NumberWithUnit/Spanish/DimensionModel.json
@@ -518,7 +518,7 @@
 ,
 {
   "Input": "En 1995 Cannon introdujo la primera lente SLR comercialmente disponible con estabilización de imagen interna, 75 - 300 mm f / 4 - 5. 6 es usm.",
-  "NotSupported": "javascript, python",
+  "NotSupported": "javascript, python, java",
   "Results": [
     {
       "Text": "300 mm",


### PR DESCRIPTION
The PR contains the following (Spanish) models:
- Ages
- Currencies
- Dimensions
- Temperatures

Two tests had to be disabled due to the same issue identified on the NumberRecognizer:
- English/AgeModel/"Tiene unos 40 - 50 años"
- English/DimensionModel/"En 1995 Cannon introdujo la primera lente SLR comercialmente disponible con estabilización de imagen interna, 75 - 300 mm f / 4 - 5. 6 es usm."