### PR TITLE
[Java] NumberWithUnit - More Languages support

### DIFF
--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -183,5 +183,24 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                         new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.AgeExtractorConfiguration()),
                         new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.portuguese.parsers.AgeParserConfiguration()))));
         //endregion
+
+        //region French
+        registerModel(CurrencyModel.class, Culture.French, (options) ->
+                new CurrencyModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.french.extractors.CurrencyExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.french.parsers.CurrencyParserConfiguration()))));
+        registerModel(TemperatureModel.class, Culture.French, (options) ->
+                new TemperatureModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.french.extractors.TemperatureExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.french.parsers.TemperatureParserConfiguration()))));
+        registerModel(DimensionModel.class, Culture.French, (options) ->
+                new DimensionModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.french.extractors.DimensionExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.french.parsers.DimensionParserConfiguration()))));
+        registerModel(AgeModel.class, Culture.French, (options) ->
+                new AgeModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.french.extractors.AgeExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.french.parsers.AgeParserConfiguration()))));
+        //endregion
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -202,5 +202,24 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                         new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.french.extractors.AgeExtractorConfiguration()),
                         new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.french.parsers.AgeParserConfiguration()))));
         //endregion
+
+        //region German
+        registerModel(CurrencyModel.class, Culture.German, (options) ->
+                new CurrencyModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.german.extractors.CurrencyExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.german.parsers.CurrencyParserConfiguration()))));
+        registerModel(TemperatureModel.class, Culture.German, (options) ->
+                new TemperatureModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.german.extractors.TemperatureExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.german.parsers.TemperatureParserConfiguration()))));
+        registerModel(DimensionModel.class, Culture.German, (options) ->
+                new DimensionModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.german.extractors.DimensionExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.german.parsers.DimensionParserConfiguration()))));
+        registerModel(AgeModel.class, Culture.German, (options) ->
+                new AgeModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.german.extractors.AgeExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.german.parsers.AgeParserConfiguration()))));
+        //endregion
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/NumberWithUnitRecognizer.java
@@ -164,5 +164,24 @@ public class NumberWithUnitRecognizer extends Recognizer<NumberWithUnitOptions> 
                     new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.spanish.extractors.AgeExtractorConfiguration()),
                         new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.spanish.parsers.AgeParserConfiguration()))));
         //endregion
+
+        //region Portuguese
+        registerModel(CurrencyModel.class, Culture.Portuguese, (options) ->
+                new CurrencyModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.CurrencyExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.portuguese.parsers.CurrencyParserConfiguration()))));
+        registerModel(TemperatureModel.class, Culture.Portuguese, (options) ->
+                new TemperatureModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.TemperatureExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.portuguese.parsers.TemperatureParserConfiguration()))));
+        registerModel(DimensionModel.class, Culture.Portuguese, (options) ->
+                new DimensionModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.DimensionExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.portuguese.parsers.DimensionParserConfiguration()))));
+        registerModel(AgeModel.class, Culture.Portuguese, (options) ->
+                new AgeModel(ImmutableMap.of(
+                        new NumberWithUnitExtractor(new com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.AgeExtractorConfiguration()),
+                        new NumberWithUnitParser(new com.microsoft.recognizers.text.numberwithunit.portuguese.parsers.AgeParserConfiguration()))));
+        //endregion
     }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/english/extractors/EnglishNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/english/extractors/EnglishNumberWithUnitExtractorConfiguration.java
@@ -19,7 +19,7 @@ public abstract class EnglishNumberWithUnitExtractorConfiguration implements INu
         this.cultureInfo = cultureInfo;
 
         this.unitNumExtractor = NumberExtractor.getInstance();
-        this.compoundUnitConnectorRegex = Pattern.compile(EnglishNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+        this.compoundUnitConnectorRegex = Pattern.compile(EnglishNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 
     public CultureInfo getCultureInfo() { return this.cultureInfo; }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
@@ -249,7 +249,7 @@ public class NumberWithUnitExtractor implements IExtractor {
                     String.join("|", regexTokens),
                     this.config.getBuildSuffix());
 
-            int options = ignoreCase ? Pattern.CASE_INSENSITIVE : 0;
+            int options = Pattern.UNICODE_CHARACTER_CLASS | (ignoreCase ? Pattern.CASE_INSENSITIVE : 0);
 
             Pattern regex = Pattern.compile(pattern, options);
             regexes.add(regex);
@@ -307,7 +307,7 @@ public class NumberWithUnitExtractor implements IExtractor {
                 this.config.getBuildPrefix(),
                 String.join("|", regexTokens),
                 this.config.getBuildSuffix());
-        int options = ignoreCase ? Pattern.CASE_INSENSITIVE : 0;
+        int options = Pattern.UNICODE_CHARACTER_CLASS | (ignoreCase ? Pattern.CASE_INSENSITIVE : 0);
 
         Pattern regex = Pattern.compile(pattern, options);
         return regex;

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/AgeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/AgeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AgeExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public AgeExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public AgeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AGE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AgeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AgeSuffixList = FrenchNumericWithUnit.AgeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/AreaExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/AreaExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AreaExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public AreaExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public AreaExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AREA;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AreaSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AreaSuffixList = FrenchNumericWithUnit.AreaSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/CurrencyExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/CurrencyExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+
+public class CurrencyExtractorConfiguration  extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public CurrencyExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public CurrencyExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_CURRENCY;
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return FrenchNumericWithUnit.AmbiguousCurrencyUnitList;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return CurrencySuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return CurrencyPrefixList;
+    }
+
+    public static Map<String, String> CurrencySuffixList = FrenchNumericWithUnit.CurrencySuffixList;
+    public static Map<String, String> CurrencyPrefixList = FrenchNumericWithUnit.CurrencyPrefixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/DimensionExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/DimensionExtractorConfiguration.java
@@ -1,0 +1,51 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DimensionExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public DimensionExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public DimensionExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_DIMENSION;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return DimensionSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return FrenchNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> DimensionSuffixList = new ImmutableMap.Builder<String, String>()
+            .putAll(FrenchNumericWithUnit.InformationSuffixList)
+            .putAll(AreaExtractorConfiguration.AreaSuffixList)
+            .putAll(LengthExtractorConfiguration.LenghtSuffixList)
+            .putAll(SpeedExtractorConfiguration.SpeedSuffixList)
+            .putAll(VolumeExtractorConfiguration.VolumeSuffixList)
+            .putAll(WeightExtractorConfiguration.WeightSuffixList)
+            .build();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/FrenchNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/FrenchNumberWithUnitExtractorConfiguration.java
@@ -20,7 +20,7 @@ public abstract class FrenchNumberWithUnitExtractorConfiguration implements INum
         this.cultureInfo = cultureInfo;
 
         this.unitNumExtractor = NumberExtractor.getInstance();
-        this.compoundUnitConnectorRegex = Pattern.compile(FrenchNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+        this.compoundUnitConnectorRegex = Pattern.compile(FrenchNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 
     public CultureInfo getCultureInfo() { return this.cultureInfo; }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/FrenchNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/FrenchNumberWithUnitExtractorConfiguration.java
@@ -1,0 +1,37 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.numberwithunit.extractors.INumberWithUnitExtractorConfiguration;
+import com.microsoft.recognizers.text.number.french.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class FrenchNumberWithUnitExtractorConfiguration implements INumberWithUnitExtractorConfiguration {
+
+    private final CultureInfo cultureInfo;
+    private final IExtractor unitNumExtractor;
+    private final Pattern compoundUnitConnectorRegex;
+
+    protected FrenchNumberWithUnitExtractorConfiguration(CultureInfo cultureInfo) {
+        this.cultureInfo = cultureInfo;
+
+        this.unitNumExtractor = NumberExtractor.getInstance();
+        this.compoundUnitConnectorRegex = Pattern.compile(FrenchNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+    }
+
+    public CultureInfo getCultureInfo() { return this.cultureInfo; }
+    public IExtractor getUnitNumExtractor() { return this.unitNumExtractor; }
+    public String getBuildPrefix() { return FrenchNumericWithUnit.BuildPrefix; }
+    public String getBuildSuffix() { return FrenchNumericWithUnit.BuildSuffix; }
+    public String getConnectorToken() { return FrenchNumericWithUnit.ConnectorToken; }
+    public Pattern getCompoundUnitConnectorRegex() { return this.compoundUnitConnectorRegex; }
+
+    public abstract String getExtractType();
+    public abstract Map<String, String> getSuffixList();
+    public abstract Map<String, String> getPrefixList();
+    public abstract List<String> getAmbiguousUnitList();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/LengthExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/LengthExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LengthExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public LengthExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public LengthExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_LENGTH;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return LenghtSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return FrenchNumericWithUnit.AmbiguousLengthUnitList;
+    }
+
+    public static Map<String, String> LenghtSuffixList = FrenchNumericWithUnit.LengthSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/SpeedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/SpeedExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SpeedExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public SpeedExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public SpeedExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_SPEED;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return SpeedSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> SpeedSuffixList = FrenchNumericWithUnit.SpeedSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/TemperatureExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/TemperatureExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TemperatureExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public TemperatureExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public TemperatureExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_TEMPERATURE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return TemperatureSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> TemperatureSuffixList = new HashMap(FrenchNumericWithUnit.TemperatureSuffixList);
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/VolumeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/VolumeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class VolumeExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public VolumeExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public VolumeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_VOLUME;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return VolumeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return FrenchNumericWithUnit.AmbiguousVolumeUnitList;
+    }
+
+    public static Map<String, String> VolumeSuffixList = FrenchNumericWithUnit.VolumeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/WeightExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/extractors/WeightExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.french.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class WeightExtractorConfiguration extends FrenchNumberWithUnitExtractorConfiguration {
+
+    public WeightExtractorConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public WeightExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_WEIGHT;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return WeightSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return FrenchNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> WeightSuffixList = FrenchNumericWithUnit.WeightSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/AgeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/AgeParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.AgeExtractorConfiguration;
+
+public class AgeParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public AgeParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public AgeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AgeExtractorConfiguration.AgeSuffixList);
+    }
+}
+

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/AreaParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/AreaParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.AreaExtractorConfiguration;
+
+public class AreaParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public AreaParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public AreaParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AreaExtractorConfiguration.AreaSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/CurrencyParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/CurrencyParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.CurrencyExtractorConfiguration;
+
+public class CurrencyParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public CurrencyParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public CurrencyParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/DimensionParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/DimensionParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.DimensionExtractorConfiguration;
+
+public class DimensionParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public DimensionParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public DimensionParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/FrenchNumberWithUnitParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/FrenchNumberWithUnitParserConfiguration.java
@@ -1,0 +1,39 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.number.NumberMode;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserFactory;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserType;
+import com.microsoft.recognizers.text.number.french.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.parsers.BaseNumberWithUnitParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.FrenchNumericWithUnit;
+
+public class FrenchNumberWithUnitParserConfiguration extends BaseNumberWithUnitParserConfiguration {
+
+    private final IParser internalNumberParser;
+    private final IExtractor internalNumberExtractor;
+
+    @Override
+    public IParser getInternalNumberParser() {
+        return this.internalNumberParser;
+    }
+
+    @Override
+    public IExtractor getInternalNumberExtractor() {
+        return this.internalNumberExtractor;
+    }
+
+    @Override
+    public String getConnectorToken() {
+        return FrenchNumericWithUnit.ConnectorToken;
+    }
+
+    public FrenchNumberWithUnitParserConfiguration(CultureInfo ci) {
+        super(ci);
+        this.internalNumberExtractor = NumberExtractor.getInstance();
+        this.internalNumberParser = AgnosticNumberParserFactory.getParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration());
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/LengthParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/LengthParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.LengthExtractorConfiguration;
+
+public class LengthParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public LengthParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public LengthParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(LengthExtractorConfiguration.LenghtSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/SpeedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/SpeedParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.SpeedExtractorConfiguration;
+
+public class SpeedParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public SpeedParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public SpeedParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/TemperatureParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/TemperatureParserConfiguration.java
@@ -1,0 +1,23 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.TemperatureExtractorConfiguration;
+
+public class TemperatureParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public TemperatureParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public TemperatureParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
+    }
+
+    @Override
+    public String getConnectorToken() {
+        return null;
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/VolumeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/VolumeParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.VolumeExtractorConfiguration;
+
+public class VolumeParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public VolumeParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public VolumeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/WeightParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/french/parsers/WeightParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.french.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.french.extractors.WeightExtractorConfiguration;
+
+public class WeightParserConfiguration extends FrenchNumberWithUnitParserConfiguration {
+
+    public WeightParserConfiguration() {
+        this(new CultureInfo(Culture.French));
+    }
+
+    public WeightParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(WeightExtractorConfiguration.WeightSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/AgeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/AgeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AgeExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public AgeExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public AgeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AGE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AgeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AgeSuffixList = GermanNumericWithUnit.AgeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/AreaExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/AreaExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AreaExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public AreaExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public AreaExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AREA;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AreaSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AreaSuffixList = GermanNumericWithUnit.AreaSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/CurrencyExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/CurrencyExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CurrencyExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public CurrencyExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public CurrencyExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_CURRENCY;
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousCurrencyUnitList;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return CurrencySuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return CurrencyPrefixList;
+    }
+
+    public static Map<String, String> CurrencySuffixList = GermanNumericWithUnit.CurrencySuffixList;
+    public static Map<String, String> CurrencyPrefixList = GermanNumericWithUnit.CurrencyPrefixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/DimensionExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/DimensionExtractorConfiguration.java
@@ -1,0 +1,51 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DimensionExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public DimensionExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public DimensionExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_DIMENSION;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return DimensionSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> DimensionSuffixList = new ImmutableMap.Builder<String, String>()
+            .putAll(GermanNumericWithUnit.InformationSuffixList)
+            .putAll(AreaExtractorConfiguration.AreaSuffixList)
+            .putAll(LengthExtractorConfiguration.LenghtSuffixList)
+            .putAll(SpeedExtractorConfiguration.SpeedSuffixList)
+            .putAll(VolumeExtractorConfiguration.VolumeSuffixList)
+            .putAll(WeightExtractorConfiguration.WeightSuffixList)
+            .build();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/GermanNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/GermanNumberWithUnitExtractorConfiguration.java
@@ -1,0 +1,36 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.number.german.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.numberwithunit.extractors.INumberWithUnitExtractorConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class GermanNumberWithUnitExtractorConfiguration implements INumberWithUnitExtractorConfiguration {
+    private final CultureInfo cultureInfo;
+    private final IExtractor unitNumExtractor;
+    private final Pattern compoundUnitConnectorRegex;
+
+    protected GermanNumberWithUnitExtractorConfiguration(CultureInfo cultureInfo) {
+        this.cultureInfo = cultureInfo;
+
+        this.unitNumExtractor = NumberExtractor.getInstance();
+        this.compoundUnitConnectorRegex = Pattern.compile(GermanNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+    }
+
+    public CultureInfo getCultureInfo() { return this.cultureInfo; }
+    public IExtractor getUnitNumExtractor() { return this.unitNumExtractor; }
+    public String getBuildPrefix() { return GermanNumericWithUnit.BuildPrefix; }
+    public String getBuildSuffix() { return GermanNumericWithUnit.BuildSuffix; }
+    public String getConnectorToken() { return ""; }
+    public Pattern getCompoundUnitConnectorRegex() { return this.compoundUnitConnectorRegex; }
+
+    public abstract String getExtractType();
+    public abstract Map<String, String> getSuffixList();
+    public abstract Map<String, String> getPrefixList();
+    public abstract List<String> getAmbiguousUnitList();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/LengthExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/LengthExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LengthExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public LengthExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public LengthExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_LENGTH;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return LenghtSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousLengthUnitList;
+    }
+
+    public static Map<String, String> LenghtSuffixList = GermanNumericWithUnit.LenghtSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/SpeedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/SpeedExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SpeedExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public SpeedExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public SpeedExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_SPEED;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return SpeedSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> SpeedSuffixList = GermanNumericWithUnit.SpeedSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/TemperatureExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/TemperatureExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TemperatureExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public TemperatureExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public TemperatureExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_TEMPERATURE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return TemperatureSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousTemperatureUnitList;
+    }
+
+    public static Map<String, String> TemperatureSuffixList = new HashMap(GermanNumericWithUnit.TemperatureSuffixList);
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/VolumeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/VolumeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class VolumeExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public VolumeExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public VolumeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_VOLUME;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return VolumeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousVolumeUnitList;
+    }
+
+    public static Map<String, String> VolumeSuffixList = GermanNumericWithUnit.VolumeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/WeightExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/WeightExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.german.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class WeightExtractorConfiguration extends GermanNumberWithUnitExtractorConfiguration {
+
+    public WeightExtractorConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public WeightExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_WEIGHT;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return WeightSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return GermanNumericWithUnit.AmbiguousWeightUnitList;
+    }
+
+    public static Map<String, String> WeightSuffixList = GermanNumericWithUnit.WeightSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/AgeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/AgeParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.AgeExtractorConfiguration;
+
+public class AgeParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public AgeParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public AgeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AgeExtractorConfiguration.AgeSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/AreaParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/AreaParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.AreaExtractorConfiguration;
+
+public class AreaParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public AreaParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public AreaParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AreaExtractorConfiguration.AreaSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/CurrencyParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/CurrencyParserConfiguration.java
@@ -1,0 +1,21 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.CurrencyExtractorConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
+
+import java.util.Map;
+
+public class CurrencyParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+    public CurrencyParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public CurrencyParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/DimensionParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/DimensionParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.DimensionExtractorConfiguration;
+
+public class DimensionParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public DimensionParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public DimensionParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/GermanNumberWithUnitParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/GermanNumberWithUnitParserConfiguration.java
@@ -1,0 +1,37 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.number.german.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.number.german.parsers.GermanNumberParserConfiguration;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserFactory;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserType;
+import com.microsoft.recognizers.text.numberwithunit.parsers.BaseNumberWithUnitParserConfiguration;
+
+public abstract class GermanNumberWithUnitParserConfiguration extends BaseNumberWithUnitParserConfiguration {
+
+    private final IParser internalNumberParser;
+    private final IExtractor internalNumberExtractor;
+
+    @Override
+    public IParser getInternalNumberParser() {
+        return this.internalNumberParser;
+    }
+
+    @Override
+    public IExtractor getInternalNumberExtractor() {
+        return this.internalNumberExtractor;
+    }
+
+    @Override
+    public String getConnectorToken() {
+        return "";
+    }
+
+    public GermanNumberWithUnitParserConfiguration(CultureInfo ci) {
+        super(ci);
+        this.internalNumberExtractor = NumberExtractor.getInstance();
+        this.internalNumberParser = AgnosticNumberParserFactory.getParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration());
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/LengthParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/LengthParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.LengthExtractorConfiguration;
+
+public class LengthParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public LengthParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public LengthParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(LengthExtractorConfiguration.LenghtSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/SpeedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/SpeedParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.SpeedExtractorConfiguration;
+
+public class SpeedParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public SpeedParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public SpeedParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/TemperatureParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/TemperatureParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.TemperatureExtractorConfiguration;
+
+public class TemperatureParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public TemperatureParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public TemperatureParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/VolumeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/VolumeParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.VolumeExtractorConfiguration;
+
+public class VolumeParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public VolumeParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public VolumeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/WeightParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/WeightParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.german.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.german.extractors.WeightExtractorConfiguration;
+
+public class WeightParserConfiguration extends GermanNumberWithUnitParserConfiguration {
+
+    public WeightParserConfiguration() {
+        this(new CultureInfo(Culture.German));
+    }
+
+    public WeightParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(WeightExtractorConfiguration.WeightSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/AgeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/AgeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AgeExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public AgeExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public AgeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AGE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AgeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AgeSuffixList = PortugueseNumericWithUnit.AgeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/AreaExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/AreaExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AreaExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public AreaExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public AreaExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_AREA;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return AreaSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> AreaSuffixList = PortugueseNumericWithUnit.AreaSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/CurrencyExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/CurrencyExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+
+public class CurrencyExtractorConfiguration  extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public CurrencyExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public CurrencyExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_CURRENCY;
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return PortugueseNumericWithUnit.AmbiguousCurrencyUnitList;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return CurrencySuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return CurrencyPrefixList;
+    }
+
+    public static Map<String, String> CurrencySuffixList = PortugueseNumericWithUnit.CurrencySuffixList;
+    public static Map<String, String> CurrencyPrefixList = PortugueseNumericWithUnit.CurrencyPrefixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/DimensionExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/DimensionExtractorConfiguration.java
@@ -1,0 +1,51 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DimensionExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public DimensionExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public DimensionExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_DIMENSION;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return DimensionSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return PortugueseNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> DimensionSuffixList = new ImmutableMap.Builder<String, String>()
+            .putAll(PortugueseNumericWithUnit.InformationSuffixList)
+            .putAll(AreaExtractorConfiguration.AreaSuffixList)
+            .putAll(LengthExtractorConfiguration.LenghtSuffixList)
+            .putAll(SpeedExtractorConfiguration.SpeedSuffixList)
+            .putAll(VolumeExtractorConfiguration.VolumeSuffixList)
+            .putAll(WeightExtractorConfiguration.WeightSuffixList)
+            .build();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/LengthExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/LengthExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LengthExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public LengthExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public LengthExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_LENGTH;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return LenghtSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return PortugueseNumericWithUnit.AmbiguousLengthUnitList;
+    }
+
+    public static Map<String, String> LenghtSuffixList = PortugueseNumericWithUnit.LenghtSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/PortugueseNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/PortugueseNumberWithUnitExtractorConfiguration.java
@@ -1,0 +1,37 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.numberwithunit.extractors.INumberWithUnitExtractorConfiguration;
+import com.microsoft.recognizers.text.number.portuguese.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class PortugueseNumberWithUnitExtractorConfiguration implements INumberWithUnitExtractorConfiguration {
+
+    private final CultureInfo cultureInfo;
+    private final IExtractor unitNumExtractor;
+    private final Pattern compoundUnitConnectorRegex;
+
+    protected PortugueseNumberWithUnitExtractorConfiguration(CultureInfo cultureInfo) {
+        this.cultureInfo = cultureInfo;
+
+        this.unitNumExtractor = new NumberExtractor();
+        this.compoundUnitConnectorRegex = Pattern.compile(PortugueseNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+    }
+
+    public CultureInfo getCultureInfo() { return this.cultureInfo; }
+    public IExtractor getUnitNumExtractor() { return this.unitNumExtractor; }
+    public String getBuildPrefix() { return PortugueseNumericWithUnit.BuildPrefix; }
+    public String getBuildSuffix() { return PortugueseNumericWithUnit.BuildSuffix; }
+    public String getConnectorToken() { return PortugueseNumericWithUnit.ConnectorToken; }
+    public Pattern getCompoundUnitConnectorRegex() { return this.compoundUnitConnectorRegex; }
+
+    public abstract String getExtractType();
+    public abstract Map<String, String> getSuffixList();
+    public abstract Map<String, String> getPrefixList();
+    public abstract List<String> getAmbiguousUnitList();
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/PortugueseNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/PortugueseNumberWithUnitExtractorConfiguration.java
@@ -20,7 +20,7 @@ public abstract class PortugueseNumberWithUnitExtractorConfiguration implements 
         this.cultureInfo = cultureInfo;
 
         this.unitNumExtractor = new NumberExtractor();
-        this.compoundUnitConnectorRegex = Pattern.compile(PortugueseNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+        this.compoundUnitConnectorRegex = Pattern.compile(PortugueseNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 
     public CultureInfo getCultureInfo() { return this.cultureInfo; }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/SpeedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/SpeedExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SpeedExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public SpeedExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public SpeedExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_SPEED;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return SpeedSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> SpeedSuffixList = PortugueseNumericWithUnit.SpeedSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/TemperatureExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/TemperatureExtractorConfiguration.java
@@ -1,0 +1,44 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TemperatureExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public TemperatureExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public TemperatureExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_TEMPERATURE;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return TemperatureSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> TemperatureSuffixList = new HashMap(PortugueseNumericWithUnit.TemperatureSuffixList);
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/VolumeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/VolumeExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class VolumeExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public VolumeExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public VolumeExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_VOLUME;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return VolumeSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return Collections.emptyList();
+    }
+
+    public static Map<String, String> VolumeSuffixList = PortugueseNumericWithUnit.VolumeSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/WeightExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/extractors/WeightExtractorConfiguration.java
@@ -1,0 +1,43 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.extractors;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class WeightExtractorConfiguration extends PortugueseNumberWithUnitExtractorConfiguration {
+
+    public WeightExtractorConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public WeightExtractorConfiguration(CultureInfo ci) {
+        super(ci);
+    }
+
+    @Override
+    public String getExtractType() {
+        return Constants.SYS_UNIT_WEIGHT;
+    }
+
+    @Override
+    public Map<String, String> getSuffixList() {
+        return WeightSuffixList;
+    }
+
+    @Override
+    public Map<String, String> getPrefixList() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getAmbiguousUnitList() {
+        return PortugueseNumericWithUnit.AmbiguousDimensionUnitList;
+    }
+
+    public static Map<String, String> WeightSuffixList = PortugueseNumericWithUnit.WeightSuffixList;
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/AgeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/AgeParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.AgeExtractorConfiguration;
+
+public class AgeParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public AgeParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public AgeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AgeExtractorConfiguration.AgeSuffixList);
+    }
+}
+

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/AreaParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/AreaParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.AreaExtractorConfiguration;
+
+public class AreaParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public AreaParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public AreaParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(AreaExtractorConfiguration.AreaSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/CurrencyParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/CurrencyParserConfiguration.java
@@ -1,0 +1,19 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.CurrencyExtractorConfiguration;
+
+public class CurrencyParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public CurrencyParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public CurrencyParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
+        this.bindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/DimensionParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/DimensionParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.DimensionExtractorConfiguration;
+
+public class DimensionParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public DimensionParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public DimensionParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/LengthParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/LengthParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.LengthExtractorConfiguration;
+
+public class LengthParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public LengthParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public LengthParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(LengthExtractorConfiguration.LenghtSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/PortugueseNumberWithUnitParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/PortugueseNumberWithUnitParserConfiguration.java
@@ -1,0 +1,39 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.number.NumberMode;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserFactory;
+import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserType;
+import com.microsoft.recognizers.text.number.portuguese.extractors.NumberExtractor;
+import com.microsoft.recognizers.text.number.portuguese.parsers.PortugueseNumberParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.parsers.BaseNumberWithUnitParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.PortugueseNumericWithUnit;
+
+public class PortugueseNumberWithUnitParserConfiguration extends BaseNumberWithUnitParserConfiguration {
+
+    private final IParser internalNumberParser;
+    private final IExtractor internalNumberExtractor;
+
+    @Override
+    public IParser getInternalNumberParser() {
+        return this.internalNumberParser;
+    }
+
+    @Override
+    public IExtractor getInternalNumberExtractor() {
+        return this.internalNumberExtractor;
+    }
+
+    @Override
+    public String getConnectorToken() {
+        return PortugueseNumericWithUnit.ConnectorToken;
+    }
+
+    public PortugueseNumberWithUnitParserConfiguration(CultureInfo ci) {
+        super(ci);
+        this.internalNumberExtractor = new NumberExtractor(NumberMode.Default);
+        this.internalNumberParser = AgnosticNumberParserFactory.getParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration());
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/SpeedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/SpeedParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.SpeedExtractorConfiguration;
+
+public class SpeedParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public SpeedParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public SpeedParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/TemperatureParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/TemperatureParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.TemperatureExtractorConfiguration;
+
+public class TemperatureParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public TemperatureParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public TemperatureParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/VolumeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/VolumeParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.VolumeExtractorConfiguration;
+
+public class VolumeParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public VolumeParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public VolumeParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/WeightParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/portuguese/parsers/WeightParserConfiguration.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.numberwithunit.portuguese.parsers;
+
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.CultureInfo;
+import com.microsoft.recognizers.text.numberwithunit.portuguese.extractors.WeightExtractorConfiguration;
+
+public class WeightParserConfiguration extends PortugueseNumberWithUnitParserConfiguration {
+
+    public WeightParserConfiguration() {
+        this(new CultureInfo(Culture.Portuguese));
+    }
+
+    public WeightParserConfiguration(CultureInfo cultureInfo) {
+        super(cultureInfo);
+
+        this.bindDictionary(WeightExtractorConfiguration.WeightSuffixList);
+    }
+}

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpanishNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/spanish/extractors/SpanishNumberWithUnitExtractorConfiguration.java
@@ -20,7 +20,7 @@ public abstract class SpanishNumberWithUnitExtractorConfiguration implements INu
         this.cultureInfo = cultureInfo;
 
         this.unitNumExtractor = new NumberExtractor();
-        this.compoundUnitConnectorRegex = Pattern.compile(SpanishNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE);
+        this.compoundUnitConnectorRegex = Pattern.compile(SpanishNumericWithUnit.CompoundUnitConnectorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 
     public CultureInfo getCultureInfo() { return this.cultureInfo; }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/DoubleExtractor.java
@@ -60,13 +60,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     private DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(EnglishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE), "DoubleEng");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleEng");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(Pattern.compile(EnglishNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumCommaDot, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumBlankDot, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceDot, placeholder), "DoubleNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/FractionExtractor.java
@@ -53,15 +53,15 @@ public class FractionExtractor extends BaseNumberExtractor {
 
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(EnglishNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(EnglishNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE), "FracEng");
-        builder.put(Pattern.compile(EnglishNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE), "FracEng");
+        builder.put(Pattern.compile(EnglishNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(EnglishNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(EnglishNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracEng");
+        builder.put(Pattern.compile(EnglishNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracEng");
 
         if ((options.ordinal() & NumberOptions.PercentageMode.ordinal()) != 0) {
-            builder.put(Pattern.compile(EnglishNumeric.FractionPrepositionWithinPercentModeRegex, Pattern.CASE_INSENSITIVE), "FracEng");
+            builder.put(Pattern.compile(EnglishNumeric.FractionPrepositionWithinPercentModeRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracEng");
         } else {
-            builder.put(Pattern.compile(EnglishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE), "FracEng");
+            builder.put(Pattern.compile(EnglishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracEng");
         }
 
         this.regexes = Collections.unmodifiableMap(builder);

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/IntegerExtractor.java
@@ -60,12 +60,12 @@ public class IntegerExtractor extends BaseNumberExtractor {
     private IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE), "IntegerNum");
+        builder.put(Pattern.compile(EnglishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         builder.put(Pattern.compile(EnglishNumeric.NumbersWithSuffix), "IntegerNum");
-        builder.put(Pattern.compile(EnglishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(EnglishNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerEng");
-        builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE), "IntegerEng");
+        builder.put(Pattern.compile(EnglishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(EnglishNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerEng");
+        builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerEng");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/NumberExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/NumberExtractor.java
@@ -59,7 +59,7 @@ public class NumberExtractor extends BaseNumberExtractor {
 
     private NumberExtractor(NumberMode mode, NumberOptions options) {
         this.options = options;
-        this.negativeNumberTermsRegex = Pattern.compile(EnglishNumeric.NegativeNumberTermsRegex + '$', Pattern.CASE_INSENSITIVE);
+        this.negativeNumberTermsRegex = Pattern.compile(EnglishNumeric.NegativeNumberTermsRegex + '$', Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 
         HashMap<Pattern, String> builder = new HashMap<>();
 
@@ -70,7 +70,7 @@ public class NumberExtractor extends BaseNumberExtractor {
                 cardinalExtractor = CardinalExtractor.getInstance(EnglishNumeric.PlaceHolderPureNumber);
                 break;
             case Currency:
-                builder.put(Pattern.compile(EnglishNumeric.CurrencyRegex, Pattern.CASE_INSENSITIVE), "IntegerNum");
+                builder.put(Pattern.compile(EnglishNumeric.CurrencyRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
                 break;
             case Default:
                 break;

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/NumberRangeExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/NumberRangeExtractor.java
@@ -22,27 +22,27 @@ public class NumberRangeExtractor extends BaseNumberRangeExtractor {
         HashMap<Pattern, String> builder = new HashMap<>();
 
         // between...and...
-        builder.put(Pattern.compile(EnglishNumeric.TwoNumberRangeRegex1, Pattern.CASE_INSENSITIVE), NumberRangeConstants.TWONUMBETWEEN);
+        builder.put(Pattern.compile(EnglishNumeric.TwoNumberRangeRegex1, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.TWONUMBETWEEN);
         // more than ... less than ...
-        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.TwoNumberRangeRegex2), Pattern.CASE_INSENSITIVE), NumberRangeConstants.TWONUM);
+        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.TwoNumberRangeRegex2), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.TWONUM);
         // less than ... more than ...
-        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.TwoNumberRangeRegex3), Pattern.CASE_INSENSITIVE), NumberRangeConstants.TWONUM);
+        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.TwoNumberRangeRegex3), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.TWONUM);
         // from ... to/~/- ...
-        builder.put(Pattern.compile(EnglishNumeric.TwoNumberRangeRegex4, Pattern.CASE_INSENSITIVE), NumberRangeConstants.TWONUMTILL);
+        builder.put(Pattern.compile(EnglishNumeric.TwoNumberRangeRegex4, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.TWONUMTILL);
         // more/greater/higher than ...
-        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeMoreRegex1, Pattern.CASE_INSENSITIVE), NumberRangeConstants.MORE);
+        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeMoreRegex1, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.MORE);
         // 30 and/or greater/higher
-        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeMoreRegex2, Pattern.CASE_INSENSITIVE), NumberRangeConstants.MORE);
+        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeMoreRegex2, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.MORE);
         // less/smaller/lower than ...
-        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeLessRegex1, Pattern.CASE_INSENSITIVE), NumberRangeConstants.LESS);
+        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeLessRegex1, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.LESS);
         // 30 and/or less/smaller/lower
-        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeLessRegex2, Pattern.CASE_INSENSITIVE), NumberRangeConstants.LESS);
+        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeLessRegex2, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.LESS);
         // equal to ...
-        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeEqualRegex, Pattern.CASE_INSENSITIVE), NumberRangeConstants.EQUAL);
+        builder.put(Pattern.compile(EnglishNumeric.OneNumberRangeEqualRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.EQUAL);
         // equal to 30 or more than, larger than 30 or equal to ...
-        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeMoreSeparateRegex), Pattern.CASE_INSENSITIVE), NumberRangeConstants.MORE);
+        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeMoreSeparateRegex), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.MORE);
         // equal to 30 or less, smaller than 30 or equal ...
-        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeLessSeparateRegex), Pattern.CASE_INSENSITIVE), NumberRangeConstants.LESS);
+        builder.put(Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeLessSeparateRegex), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), NumberRangeConstants.LESS);
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/OrdinalExtractor.java
@@ -54,10 +54,10 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     private OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(EnglishNumeric.OrdinalNumericRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(EnglishNumeric.OrdinalEnglishRegex, Pattern.CASE_INSENSITIVE), "OrdEng");
-        builder.put(Pattern.compile(EnglishNumeric.OrdinalRoundNumberRegex, Pattern.CASE_INSENSITIVE), "OrdEng");
+        builder.put(Pattern.compile(EnglishNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(EnglishNumeric.OrdinalNumericRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(EnglishNumeric.OrdinalEnglishRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdEng");
+        builder.put(Pattern.compile(EnglishNumeric.OrdinalRoundNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdEng");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/parsers/EnglishNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/parsers/EnglishNumberParserConfiguration.java
@@ -38,10 +38,10 @@ public class EnglishNumberParserConfiguration extends BaseNumberParserConfigurat
                 EnglishNumeric.CardinalNumberMap,
                 EnglishNumeric.OrdinalNumberMap,
                 EnglishNumeric.RoundNumberMap,
-                Pattern.compile(EnglishNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(EnglishNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(EnglishNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(EnglishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE));
+                Pattern.compile(EnglishNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(EnglishNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(EnglishNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(EnglishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     @Override

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/parsers/EnglishNumberRangeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/parsers/EnglishNumberRangeParserConfiguration.java
@@ -58,11 +58,11 @@ public class EnglishNumberRangeParserConfiguration implements INumberRangeParser
         this.ordinalExtractor = OrdinalExtractor.getInstance();
         this.numberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
 
-        this.moreOrEqual = Pattern.compile(EnglishNumeric.MoreOrEqual, Pattern.CASE_INSENSITIVE);
-        this.lessOrEqual = Pattern.compile(EnglishNumeric.LessOrEqual, Pattern.CASE_INSENSITIVE);
-        this.moreOrEqualSuffix = Pattern.compile(EnglishNumeric.MoreOrEqualSuffix, Pattern.CASE_INSENSITIVE);
-        this.lessOrEqualSuffix = Pattern.compile(EnglishNumeric.LessOrEqualSuffix, Pattern.CASE_INSENSITIVE);
-        this.moreOrEqualSeparate = Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeMoreSeparateRegex), Pattern.CASE_INSENSITIVE);
-        this.lessOrEqualSeparate = Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeLessSeparateRegex), Pattern.CASE_INSENSITIVE);
+        this.moreOrEqual = Pattern.compile(EnglishNumeric.MoreOrEqual, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        this.lessOrEqual = Pattern.compile(EnglishNumeric.LessOrEqual, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        this.moreOrEqualSuffix = Pattern.compile(EnglishNumeric.MoreOrEqualSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        this.lessOrEqualSuffix = Pattern.compile(EnglishNumeric.LessOrEqualSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        this.moreOrEqualSeparate = Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeMoreSeparateRegex), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        this.lessOrEqualSeparate = Pattern.compile(RegExpUtility.sanitize(EnglishNumeric.OneNumberRangeLessSeparateRegex), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberExtractor.java
@@ -102,6 +102,6 @@ public abstract class BaseNumberExtractor implements IExtractor {
                 ? BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark)
                 : BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
 
-        return Pattern.compile(regexDefinition, Pattern.CASE_INSENSITIVE);
+        return Pattern.compile(regexDefinition, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/DoubleExtractor.java
@@ -31,13 +31,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(FrenchNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE), "DoubleFr");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleFr");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(Pattern.compile(FrenchNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/FractionExtractor.java
@@ -24,11 +24,11 @@ public class FractionExtractor extends BaseNumberExtractor {
 
     public FractionExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
-        builder.put(Pattern.compile(FrenchNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE), "FracFr");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE), "FracFr");
-        builder.put(Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE), "FracFr");
+        builder.put(Pattern.compile(FrenchNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(FrenchNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(FrenchNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+        builder.put(Pattern.compile(FrenchNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+        builder.put(Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
         this.regexes = Collections.unmodifiableMap(builder);
     }
 }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/IntegerExtractor.java
@@ -31,13 +31,13 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE), "IntegerNum");
+        builder.put(Pattern.compile(FrenchNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         builder.put(Pattern.compile(FrenchNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerFr");
-        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE), "IntegerFr");
+        builder.put(Pattern.compile(FrenchNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(FrenchNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
+        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/OrdinalExtractor.java
@@ -26,8 +26,8 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(FrenchNumeric.OrdinalFrenchRegex, Pattern.CASE_INSENSITIVE), "OrdFr");
+        builder.put(Pattern.compile(FrenchNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(FrenchNumeric.OrdinalFrenchRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdFr");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
@@ -40,10 +40,10 @@ public class FrenchNumberParserConfiguration extends BaseNumberParserConfigurati
                 FrenchNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 FrenchNumeric.RoundNumberMap,
-                Pattern.compile(FrenchNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(FrenchNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(FrenchNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE));
+                Pattern.compile(FrenchNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     @Override

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/DoubleExtractor.java
@@ -31,13 +31,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE),"DoubleNum");
+        builder.put(Pattern.compile(GermanNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(GermanNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
         builder.put(Pattern.compile(GermanNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE),"DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE), "DoubleGer");
-        builder.put(Pattern.compile(GermanNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
-        builder.put(Pattern.compile(GermanNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
+        builder.put(Pattern.compile(GermanNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
+        builder.put(Pattern.compile(GermanNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleGer");
+        builder.put(Pattern.compile(GermanNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(Pattern.compile(GermanNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/FractionExtractor.java
@@ -26,11 +26,11 @@ public class FractionExtractor extends BaseNumberExtractor {
     public FractionExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(GermanNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(GermanNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE), "FracGer");
-        builder.put(Pattern.compile(GermanNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE), "FracGer");
-        builder.put(Pattern.compile(GermanNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE), "FracGer");
+        builder.put(Pattern.compile(GermanNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(GermanNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(GermanNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
+        builder.put(Pattern.compile(GermanNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
+        builder.put(Pattern.compile(GermanNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/IntegerExtractor.java
@@ -31,12 +31,12 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE), "IntegerNum");
+        builder.put(Pattern.compile(GermanNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         builder.put(Pattern.compile(GermanNumeric.NumbersWithSuffix), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.NumbersWithDozenSuffix,Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerGer");
-        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE), "IntegerGer");
+        builder.put(Pattern.compile(GermanNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(GermanNumeric.NumbersWithDozenSuffix,Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
+        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/OrdinalExtractor.java
@@ -26,10 +26,10 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalNumericRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalGermanRegex, Pattern.CASE_INSENSITIVE), "OrdGer");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalRoundNumberRegex, Pattern.CASE_INSENSITIVE), "OrdGer");
+        builder.put(Pattern.compile(GermanNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(GermanNumeric.OrdinalNumericRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(GermanNumeric.OrdinalGermanRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
+        builder.put(Pattern.compile(GermanNumeric.OrdinalRoundNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/parsers/GermanNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/parsers/GermanNumberParserConfiguration.java
@@ -39,10 +39,10 @@ public class GermanNumberParserConfiguration extends BaseNumberParserConfigurati
                 GermanNumeric.CardinalNumberMap,
                 GermanNumeric.OrdinalNumberMap,
                 GermanNumeric.RoundNumberMap,
-                Pattern.compile(GermanNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(GermanNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(GermanNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(GermanNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE));
+                Pattern.compile(GermanNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(GermanNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(GermanNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(GermanNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
     }
 
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
@@ -35,12 +35,12 @@ public class BaseNumberParser implements IParser {
 
         // Necessary for the german language because bigger numbers are not separated by whitespaces or special characters like in other languages
         if (config.getCultureInfo().cultureCode.equalsIgnoreCase("de-DE")) {
-            this.textNumberRegex = Pattern.compile("(" + singleIntFrac + ")", Pattern.CASE_INSENSITIVE);
+            this.textNumberRegex = Pattern.compile("(" + singleIntFrac + ")", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
         } else {
-            this.textNumberRegex = Pattern.compile("(?<=\\b)(" + singleIntFrac + ")(?=\\b)", Pattern.CASE_INSENSITIVE);
+            this.textNumberRegex = Pattern.compile("(?<=\\b)(" + singleIntFrac + ")(?=\\b)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
         }
 
-        this.longFormatRegex = Pattern.compile("\\d+", Pattern.CASE_INSENSITIVE);
+        this.longFormatRegex = Pattern.compile("\\d+", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 
         this.roundNumberSet = new HashSet<>(config.getRoundNumberMap().keySet());
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/DoubleExtractor.java
@@ -31,13 +31,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(PortugueseNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE), "DoublePor");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePor");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(Pattern.compile(PortugueseNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/FractionExtractor.java
@@ -26,11 +26,11 @@ public class FractionExtractor extends BaseNumberExtractor {
     public FractionExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE) , "FracNum");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE), "FracPor");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE) , "FracPor");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE), "FracPor");
+        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "FracNum");
+        builder.put(Pattern.compile(PortugueseNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
+        builder.put(Pattern.compile(PortugueseNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "FracPor");
+        builder.put(Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/IntegerExtractor.java
@@ -31,16 +31,16 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE), "IntegerNum");
+        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         builder.put(Pattern.compile(PortugueseNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozen2Suffix, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerPor");
-        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE), "IntegerPor");
+        builder.put(Pattern.compile(PortugueseNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozen2Suffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
+        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/OrdinalExtractor.java
@@ -26,8 +26,8 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(PortugueseNumeric. OrdinalEnglishRegex, Pattern.CASE_INSENSITIVE), "OrdinalPor");
+        builder.put(Pattern.compile(PortugueseNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(PortugueseNumeric. OrdinalEnglishRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/parsers/PortugueseNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/parsers/PortugueseNumberParserConfiguration.java
@@ -41,10 +41,10 @@ public class PortugueseNumberParserConfiguration extends BaseNumberParserConfigu
                 PortugueseNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 PortugueseNumeric.RoundNumberMap,
-                Pattern.compile(PortugueseNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(PortugueseNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(PortugueseNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE));
+                Pattern.compile(PortugueseNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(PortugueseNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(PortugueseNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
     }
 
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/DoubleExtractor.java
@@ -31,13 +31,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE), "DoubleNum");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(SpanishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE), "DoubleSpa");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE), "DoublePow");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleSpa");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(Pattern.compile(SpanishNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/FractionExtractor.java
@@ -26,11 +26,11 @@ public class FractionExtractor extends BaseNumberExtractor {
     public FractionExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE), "FracNum");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE), "FracSpa");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE), "FracSpa");
-        builder.put(Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE), "FracSpa");
+        builder.put(Pattern.compile(SpanishNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(SpanishNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(Pattern.compile(SpanishNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
+        builder.put(Pattern.compile(SpanishNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
+        builder.put(Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
@@ -31,15 +31,15 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE) , "IntegerNum");
+        builder.put(Pattern.compile(SpanishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "IntegerNum");
         builder.put(Pattern.compile(SpanishNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE), "IntegerSpa");
-        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE), "IntegerSpa");
+        builder.put(Pattern.compile(SpanishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(SpanishNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
+        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/NumberExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/NumberExtractor.java
@@ -42,7 +42,7 @@ public class NumberExtractor extends BaseNumberExtractor {
                 cardExtract = CardinalExtractor.getInstance(SpanishNumeric.PlaceHolderPureNumber);
                 break;
             case Currency:
-                builder.put(Pattern.compile(SpanishNumeric.CurrencyRegex, Pattern.CASE_INSENSITIVE), "IntegerNum");
+                builder.put(Pattern.compile(SpanishNumeric.CurrencyRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
                 break;
             case Default:
                 break;

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/OrdinalExtractor.java
@@ -26,8 +26,8 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE), "OrdinalNum");
-        builder.put(Pattern.compile(SpanishNumeric.OrdinalNounRegex, Pattern.CASE_INSENSITIVE), "OrdinalSpa");
+        builder.put(Pattern.compile(SpanishNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(Pattern.compile(SpanishNumeric.OrdinalNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/parsers/SpanishNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/parsers/SpanishNumberParserConfiguration.java
@@ -41,10 +41,10 @@ public class SpanishNumberParserConfiguration extends BaseNumberParserConfigurat
                 SpanishNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 SpanishNumeric.RoundNumberMap,
-                Pattern.compile(SpanishNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(SpanishNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(SpanishNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE),
-                Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE));
+                Pattern.compile(SpanishNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(SpanishNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(SpanishNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     @Override

--- a/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/utilities/RegExpUtility.java
+++ b/Java/libraries/recognizers-text/src/main/java/com/microsoft/recognizers/text/utilities/RegExpUtility.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 
 public abstract class RegExpUtility {
 
-    private static final Pattern matchGroup = Pattern.compile("\\?<(?<name>\\w+)>", Pattern.CASE_INSENSITIVE);
+    private static final Pattern matchGroup = Pattern.compile("\\?<(?<name>\\w+)>", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     private static final Pattern matchGroupNames = Pattern.compile("\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>");
     private static final String groupNameIndexSep = "iii";
     private static final String groupNameIndexSepRegex = Pattern.quote(groupNameIndexSep);

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/LongFormTestConfiguration.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/number/LongFormTestConfiguration.java
@@ -48,7 +48,7 @@ public class LongFormTestConfiguration implements INumberParserConfiguration {
 
     @Override
     public Pattern getDigitalNumberRegex() {
-        return Pattern.compile("((?<=\\b)(hundred|thousand|million|billion|trillion|dozen(s)?)(?=\\b))|((?<=(\\d|\\b))(k|t|m|g|b)(?=\\b))", Pattern.CASE_INSENSITIVE);
+        return Pattern.compile("((?<=\\b)(hundred|thousand|million|billion|trillion|dozen(s)?)(?=\\b))|((?<=(\\d|\\b))(k|t|m|g|b)(?=\\b))", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     }
 
     @Override

--- a/Specs/NumberWithUnit/French/AgeModel.json
+++ b/Specs/NumberWithUnit/French/AgeModel.json
@@ -210,7 +210,7 @@
 ,
 {
   "Input": "Il a environ 40 - 50 ans",
-  "NotSupported": "javascript",
+  "NotSupported": "javascript, java",
   "Results": [
     {
       "Text": "50 ans",

--- a/Specs/NumberWithUnit/French/DimensionModel.json
+++ b/Specs/NumberWithUnit/French/DimensionModel.json
@@ -561,7 +561,7 @@
 ,
 {
   "Input": "En 1995 le canon a présenté la première lentille slr disponible dans le commerce avec la stabilisation d'image interne, ef 75 - 300mm f / 4 - 5. 6 est usm.",
-  "NotSupported": "javascript, python",
+  "NotSupported": "javascript, python, java",
   "Results": [
     {
       "Text": "300mm",

--- a/Specs/NumberWithUnit/German/AgeModel.json
+++ b/Specs/NumberWithUnit/German/AgeModel.json
@@ -193,7 +193,7 @@
 {
   "Input": "Er ist ungefähr 40 - 50 Jahre alt.",
   "NotSupportedByDesign": "python",
-  "NotSupported": "javascript",
+  "NotSupported": "javascript, java",
   "Results": [
     {
       "Text": "50 Jahre alt",

--- a/Specs/NumberWithUnit/German/CurrencyModel.json
+++ b/Specs/NumberWithUnit/German/CurrencyModel.json
@@ -337,7 +337,7 @@
 {
   "Input": "zwei Euro fünfzig",
   "NotSupportedByDesign": "python",
-  "NotSupported": "javascript,dotnet",
+  "NotSupported": "javascript,dotnet,java",
   "Results": [
     {
       "Text": "zwei Euro fünfzig",

--- a/Specs/NumberWithUnit/Portuguese/AgeModel.json
+++ b/Specs/NumberWithUnit/Portuguese/AgeModel.json
@@ -224,7 +224,7 @@
 ,
 {
   "Input": "Ele tem cerca de 40 - 50 anos",
-  "NotSupported": "javascript",
+  "NotSupported": "javascript, java",
   "Results": [
     {
       "Text": "50 anos",

--- a/Specs/NumberWithUnit/Portuguese/DimensionModel.json
+++ b/Specs/NumberWithUnit/Portuguese/DimensionModel.json
@@ -546,7 +546,7 @@
 ,
 {
   "Input": "Em 1995 a Cannon introduziu a primeira lente SLR disponível comercialmente com estabilização de imagem interna, 75 - 300 mm f / 4 - 5. 6 es usm.",
-  "NotSupported": "javascript, python",
+  "NotSupported": "javascript, python, java",
   "Results": [
     {
       "Text": "300 mm",


### PR DESCRIPTION
This PR includes Number with Unit recognizers for the following languages:
- Portuguese
- French
- German

Also contains a fix to all RegExps so diatrics are considered within word boundaries (Pattern.UNICODE_CHARACTER_CLASS)