### PR TITLE
Fix cases like "Show sales in 2007 and 2009"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -236,8 +236,8 @@ namespace Microsoft.Recognizers.Definitions.English
 		public static readonly string DecadeWithCenturyRegex = $@"(the\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?s)|(({CenturyRegex}(\s+|-)(and\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(and\s+)?(?<decade>tens|hundreds)))";
 		public static readonly string RelativeDecadeRegex = $@"\b((the\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decades?)\b";
 		public const string YearAfterRegex = @"\b(or\s+(above|after))\b";
-		public static readonly string YearPeriodRegex = $@"(((from|during|in|between)\s+)?{YearRegex}\s*({TillRegex}|{RangeConnectorRegex})\s*{YearRegex})";
-		public static readonly string ComplexDatePeriodRegex = $@"((from|during|in|between)\s+)?(?<start>.+)\s*({TillRegex}|{RangeConnectorRegex})\s*(?<end>.+)";
+		public static readonly string YearPeriodRegex = $@"((((from|during|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((between)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
+		public static readonly string ComplexDatePeriodRegex = $@"(((from|during|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((between)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
 		public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
 		{
 			{ "years", "Y" },

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -549,10 +549,10 @@ RelativeDecadeRegex: !nestedRegex
 YearAfterRegex: !simpleRegex
   def: \b(or\s+(above|after))\b
 YearPeriodRegex: !nestedRegex
-  def: (((from|during|in|between)\s+)?{YearRegex}\s*({TillRegex}|{RangeConnectorRegex})\s*{YearRegex})
+  def: ((((from|during|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((between)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 ComplexDatePeriodRegex: !nestedRegex
-  def: ((from|during|in|between)\s+)?(?<start>.+)\s*({TillRegex}|{RangeConnectorRegex})\s*(?<end>.+)
+  def: (((from|during|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((between)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 UnitMap: !dictionary
   types: [ string, string ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -4337,4 +4337,68 @@
     }
   }]
 }
+,
+{
+  "Input": "Show sales in 2007 and 2009",
+  "Context": {
+    "ReferenceDateTime": "2018-06-26T00:00:00"
+  },
+  "NotSupported": "javascript,python,java",
+  "Results": [{
+    "Text": "2007",
+    "Start": 14,
+    "End": 17,
+    "TypeName": "datetimeV2.daterange",
+    "Resolution": {
+      "values": [
+        {
+          "timex": "2007",
+          "type": "daterange",
+          "start": "2007-01-01",
+          "end": "2008-01-01"
+        }
+      ]
+    }
+  },
+  {
+    "Text": "2009",
+    "Start": 23,
+    "End": 26,
+    "TypeName": "datetimeV2.daterange",
+    "Resolution": {
+      "values": [
+        {
+          "timex": "2009",
+          "type": "daterange",
+          "start": "2009-01-01",
+          "end": "2010-01-01"
+        }
+      ]
+    }
+  }]
+}
+,
+{
+  "Input": "Show sales between 2007 and 2009",
+  "Context": {
+    "ReferenceDateTime": "2018-06-26T00:00:00"
+  },
+  "NotSupported": "javascript,python,java",
+  "Results": [{
+    "Text": "between 2007 and 2009",
+    "Start": 11,
+    "End": 31,
+    "TypeName": "datetimeV2.daterange",
+    "Resolution": {
+      "values": [
+        {
+          "timex": "(2007-01-01,2009-01-01,P2Y)",
+          "type": "daterange",
+          "start": "2007-01-01",
+          "end": "2009-01-01"
+        }
+      ]
+    }
+  }]
+}
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -3847,4 +3847,75 @@
       }
     ]
   }
+  ,
+  {
+    "Input": "Show sales in 2007 and 2009",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "ParentText": "2007 and 2009",
+        "Text": "2007",
+        "Start": 14,
+        "End": 17,
+        "TypeName": "datetimeV2.datetimealt",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2007",
+              "type": "daterange",
+              "start": "2007-01-01",
+              "end": "2008-01-01"
+            }
+          ]
+        }
+      }
+      ,
+      {
+        "ParentText": "2007 and 2009",
+        "Text": "2009",
+        "Start": 23,
+        "End": 26,
+        "TypeName": "datetimeV2.datetimealt",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2009",
+              "type": "daterange",
+              "start": "2009-01-01",
+              "end": "2010-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  }
+  ,
+  {
+    "Input": "Show sales between 2007 and 2009",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "between 2007 and 2009",
+        "Start": 11,
+        "End": 31,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2007-01-01,2009-01-01,P2Y)",
+              "type": "daterange",
+              "start": "2007-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  }
 ]

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -3711,4 +3711,69 @@
     }
   ]
 }
+,
+{
+  "Input": "Show sales in 2007 and 2009",
+  "Context": {
+    "ReferenceDateTime": "2018-06-26T00:00:00"
+  },
+  "NotSupported": "javascript,java",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "2007",
+      "Type": "datetimeV2.daterange",
+      "Value":{
+        "values":[
+          {
+            "timex":"2007",
+            "type":"daterange",
+            "start":"2007-01-01",
+            "end":"2008-01-01"
+          }
+        ]
+      }
+    }
+    ,
+    {
+      "Text": "2009",
+      "Type": "datetimeV2.daterange",
+      "Value":{
+        "values":[
+          {
+            "timex":"2009",
+            "type":"daterange",
+            "start":"2009-01-01",
+            "end":"2010-01-01"
+          }          
+        ]
+      }
+    }
+  ]
+}
+,
+{
+  "Input": "Show sales between 2007 and 2009",
+  "Context": {
+    "ReferenceDateTime": "2018-06-26T00:00:00"
+  },
+  "NotSupported": "javascript,java",
+  "NotSupportedByDesign": "python",
+  "Results": [
+    {
+      "Text": "between 2007 and 2009",
+      "Type": "datetimeV2.daterange",
+      "Value":{
+        "values":[
+          {
+            "timex":"(2007-01-01,2009-01-01,P2Y)",
+            "type":"daterange",
+            "start":"2007-01-01",
+            "end":"2009-01-01"
+          }
+        ]
+      }
+    }
+  ]
+}
 ]


### PR DESCRIPTION
#667

When the connector is "RangeConnector" like "and", "between" is necessary, not optional.