### PR TITLE
Support cases like "today at 9a"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Recognizers.Definitions.English
 		public const string MidafternoonRegex = @"(?<midafternoon>midafternoon|mid-afternoon|mid afternoon)";
 		public const string MiddayRegex = @"(?<midday>midday|mid-day|mid day|((12\s)?noon))";
 		public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
-		public static readonly string AtRegex = $@"\b(((?<=\bat\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
+		public static readonly string AtRegex = $@"\b(((?<=\bat\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
 		public static readonly string IshRegex = $@"\b({BaseDateTime.HourRegex}(-|——)?ish|noonish|noon)\b";
 		public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>hours|hour|hrs|hr|h|minutes|minute|mins|min|seconds|second|secs|sec)\b";
 		public const string RestrictedTimeUnitRegex = @"(?<unit>hour|minute)\b";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimeParserChs.cs
@@ -162,13 +162,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var sec = time.Second;
 
             // handle morning, afternoon
-            if (SimplePmRegex.IsMatch(text) && hour < 12)
+            if (SimplePmRegex.IsMatch(text) && hour < Constants.HalfDayHourCount)
             {
-                hour += 12;
+                hour += Constants.HalfDayHourCount;
             }
-            else if (SimpleAmRegex.IsMatch(text) && hour >= 12)
+            else if (SimpleAmRegex.IsMatch(text) && hour >= Constants.HalfDayHourCount)
             {
-                hour -= 12;
+                hour -= Constants.HalfDayHourCount;
             }
 
             var timeStr = pr2.TimexStr;
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             var val = (DateTimeResolutionResult) pr2.Value;
 
-            if (hour <= 12 && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
+            if (hour <= Constants.HalfDayHourCount && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
                 //ret.Timex += "ampm";
@@ -228,38 +228,38 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 switch (matchStr)
                 {
                     case "今晚":
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            hour += 12;
+                            hour += Constants.HalfDayHourCount;
                         }
                         break;
                     case "今早":
                     case "今晨":
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            hour -= 12;
+                            hour -= Constants.HalfDayHourCount;
                         }
                         break;
                     case "明晚":
                         swift = 1;
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            hour += 12;
+                            hour += Constants.HalfDayHourCount;
                         }
                         break;
                     case "明早":
                     case "明晨":
                         swift = 1;
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            hour -= 12;
+                            hour -= Constants.HalfDayHourCount;
                         }
                         break;
                     case "昨晚":
                         swift = -1;
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            hour += 12;
+                            hour += Constants.HalfDayHourCount;
                         }
                         break;
                     default:

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/DateTimePeriodParserChs.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             if (rightResult.Comment != null && rightResult.Comment.Equals(Constants.Comment_AmPm) &&
                 leftResult.Comment == null && rightTime < leftTime)
             {
-                rightTime = rightTime.AddHours(12);
+                rightTime = rightTime.AddHours(Constants.HalfDayHourCount);
             }
 
             if (rightTime < leftTime)
@@ -356,7 +356,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         swift = 0;
                         timeStr = "TMO";
                         beginHour = 8;
-                        endHour = 12;
+                        endHour = Constants.HalfDayHourCount;
                         break;
                     case "明晚":
                         swift = 1;
@@ -369,7 +369,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         swift = 1;
                         timeStr = "TMO";
                         beginHour = 8;
-                        endHour = 12;
+                        endHour = Constants.HalfDayHourCount;
                         break;
                     case "昨晚":
                         swift = -1;
@@ -398,12 +398,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (AFRegex.IsMatch(trimedText))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (EVRegex.IsMatch(trimedText))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimeParserChs.cs
@@ -95,11 +95,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static TimeResult HandleLess(DateTimeExtra<TimeType> extra)
         {
-            var hour = MatchToValue(extra.NamedEntity["hour"].Value);
+            var hour = MatchToValue(extra.NamedEntity[Constants.HourGroupName].Value);
             var quarter = MatchToValue(extra.NamedEntity["quarter"].Value);
             var minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter * 15 : 0;
-            var second = MatchToValue(extra.NamedEntity["sec"].Value);
-            var less = MatchToValue(extra.NamedEntity["min"].Value);
+            var second = MatchToValue(extra.NamedEntity[Constants.SecondGroupName].Value);
+            var less = MatchToValue(extra.NamedEntity[Constants.MinuteGroupName].Value);
 
             var all = hour * 60 + minute - less;
             if (all < 0)
@@ -117,10 +117,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static TimeResult HandleChinese(DateTimeExtra<TimeType> extra)
         {
-            var hour = MatchToValue(extra.NamedEntity["hour"].Value);
+            var hour = MatchToValue(extra.NamedEntity[Constants.HourGroupName].Value);
             var quarter = MatchToValue(extra.NamedEntity["quarter"].Value);
-            var minute = MatchToValue(extra.NamedEntity["min"].Value);
-            var second = MatchToValue(extra.NamedEntity["sec"].Value);
+            var minute = MatchToValue(extra.NamedEntity[Constants.MinuteGroupName].Value);
+            var second = MatchToValue(extra.NamedEntity[Constants.SecondGroupName].Value);
             minute = !string.IsNullOrEmpty(extra.NamedEntity["half"].Value) ? 30 : quarter != -1 ? quarter * 15 : minute;
 
             return new TimeResult
@@ -135,9 +135,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var timeResult = new TimeResult
             {
-                Hour = MatchToValue(extra.NamedEntity["hour"].Value),
-                Minute = MatchToValue(extra.NamedEntity["min"].Value),
-                Second = MatchToValue(extra.NamedEntity["sec"].Value)
+                Hour = MatchToValue(extra.NamedEntity[Constants.HourGroupName].Value),
+                Minute = MatchToValue(extra.NamedEntity[Constants.MinuteGroupName].Value),
+                Second = MatchToValue(extra.NamedEntity[Constants.SecondGroupName].Value)
             };
             return timeResult;
         }
@@ -241,7 +241,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             if (LowBoundDesc.ContainsKey(dayDesc) && result.Hour < LowBoundDesc[dayDesc])
             {
-                result.Hour += 12;
+                result.Hour += Constants.HalfDayHourCount;
                 result.LowBound = LowBoundDesc[dayDesc];
             }
             else

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/TimePeriodParserChs.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             //the right side doesn't contain desc while the left side does
             if (rightResult.LowBound == -1 && leftResult.LowBound != -1 && rightResult.Hour <= leftResult.LowBound)
             {
-                rightResult.Hour += 12;
+                rightResult.Hour += Constants.HalfDayHourCount;
             }
 
             int day = refTime.Day,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -104,6 +104,17 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string DefaultLanguageFallback_MDY = "MDY";
         public const string DefaultLanguageFallback_DMY = "DMY";
 
-        public const string NextGroupNameForWithinRegex = "next";
+        // Groups' names for named groups in regexes
+        public const string NextGroupName = "next";
+        public const string AmGroupName = "am";
+        public const string PmGroupName = "pm";
+        public const string ImplicitAmGroupName = "iam";
+        public const string ImplicitPmGroupName = "ipm";
+        public const string PrefixGroupName = "prefix";
+        public const string SuffixGroupName = "suffix";
+        public const string DescGroupName = "desc";
+        public const string SecondGroupName = "sec";
+        public const string MinuteGroupName = "min";
+        public const string HourGroupName = "hour";
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
@@ -96,13 +96,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             var trimedText = text.Trim().ToLowerInvariant();
             int result = hour;
-            if (trimedText.EndsWith("morning") && hour >= 12)
+            if (trimedText.EndsWith("morning") && hour >= Constants.HalfDayHourCount)
             {
-                result -= 12;
+                result -= Constants.HalfDayHourCount;
             }
-            else if (!trimedText.EndsWith("morning") && hour < 12)
+            else if (!trimedText.EndsWith("morning") && hour < Constants.HalfDayHourCount)
             {
-                result += 12;
+                result += Constants.HalfDayHourCount;
             }
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -135,12 +135,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (AfternoonStartEndRegex.IsMatch(trimedText))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (EveningStartEndRegex.IsMatch(trimedText))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
@@ -104,12 +104,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
+                    var amStr = match.Groups[Constants.AmGroupName].Value;
                     if (!string.IsNullOrEmpty(amStr))
                     {
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            deltaHour = -12;
+                            deltaHour = -Constants.HalfDayHourCount;
                         }
                         else
                         {
@@ -117,21 +117,21 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                         }
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
+                    var pmStr = match.Groups[Constants.PmGroupName].Value;
                     if (!string.IsNullOrEmpty(pmStr))
                     {
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            deltaHour = 12;
+                            deltaHour = Constants.HalfDayHourCount;
                         }
 
                         if (LunchRegex.IsMatch(pmStr))
                         {
                             // for hour>=10, <12
-                            if (hour >=10 && hour <=12)
+                            if (hour >=10 && hour <=Constants.HalfDayHourCount)
                             {
                                 deltaHour = 0;
-                                if (hour == 12)
+                                if (hour == Constants.HalfDayHourCount)
                                 {
                                     hasPm = true;
                                 }
@@ -148,9 +148,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                         else if (NightRegex.IsMatch(pmStr))
                         {
                             //For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
-                            if (hour <= 3 || hour == 12)
+                            if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {
-                                if (hour == 12)
+                                if (hour == Constants.HalfDayHourCount)
                                 {
                                     hour = 0;
                                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
@@ -63,12 +63,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             {
                 timex = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.EndsWith("afternoon"))
             {
                 timex = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("evening"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/TimeParser.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             var match = EnglishTimeExtractorConfiguration.IshRegex.Match(trimedText);
             if (match.Success && match.Length == trimedText.Length)
             {
-                var hourStr = match.Groups["hour"].Value;
-                var hour = 12;
+                var hourStr = match.Groups[Constants.HourGroupName].Value;
+                var hour = Constants.HalfDayHourCount;
                 if (!string.IsNullOrEmpty(hourStr))
                 {
                     hour = int.Parse(hourStr);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var match = this.config.WithinNextPrefixRegex.Match(beforeString);
                             if (match.Success)
                             {
-                                var isNext = !string.IsNullOrEmpty(match.Groups[Constants.NextGroupNameForWithinRegex].Value);
+                                var isNext = !string.IsNullOrEmpty(match.Groups[Constants.NextGroupName].Value);
 
                                 // For "within" case
                                 // Cases like "within the next 5 days before today" is not acceptable

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
@@ -81,11 +81,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                 for (var idx = 0; idx < timeNumMatches.Count; idx++)
                 {
                     var match = timeNumMatches[idx];
-                    var node = new ExtractResult();
-                    node.Start = match.Index;
-                    node.Length = match.Length;
-                    node.Text = match.Value;
-                    node.Type = Number.Constants.SYS_NUM_INTEGER;
+                    var node = new ExtractResult
+                    {
+                        Start = match.Index,
+                        Length = match.Length,
+                        Text = match.Value,
+                        Type = Number.Constants.SYS_NUM_INTEGER
+                    };
                     numErs.Add(node);
                 }
                 ers.AddRange(numErs);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
@@ -145,9 +145,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (er.Start <= match.Index && er.Text.Contains(match.Groups["weekday"].Value))
                         {
                             var len = (er.Length ?? 0) + 1;
-                            if (match.Groups["prefix"].ToString() != string.Empty)
+                            if (match.Groups[Constants.PrefixGroupName].ToString() != string.Empty)
                             {
-                                len += match.Groups["prefix"].ToString().Length;
+                                len += match.Groups[Constants.PrefixGroupName].ToString().Length;
                             }
                             ret.Add(new Token(er.Start ?? 0, er.Start + len ?? 0));
                         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 foreach (Match match in matches)
                 {
                     // Cases like "from 10:30 to 11", don't necessarily need "am/pm"
-                    if (match.Groups["min"].Success || match.Groups["sec"].Success)
+                    if (match.Groups[Constants.MinuteGroupName].Success || match.Groups[Constants.SecondGroupName].Success)
                     {
                         // Cases like "from 3:30 to 4" should be supported
                         // Cases like "from 3:30 to 4 on 1/1/2015" should be supported
@@ -74,12 +74,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                     }
                     else
                     {
-                        // Is there "pm" or "am" ?
-                        var pmStr = match.Groups["pm"].Value;
-                        var amStr = match.Groups["am"].Value;
-                        var descStr = match.Groups["desc"].Value;
+                        // Is there Constants.PmGroupName or Constants.AmGroupName ?
+                        var pmStr = match.Groups[Constants.PmGroupName].Value;
+                        var amStr = match.Groups[Constants.AmGroupName].Value;
+                        var descStr = match.Groups[Constants.DescGroupName].Value;
 
-                        // Check "pm", "am"
+                        // Check Constants.PmGroupName, Constants.AmGroupName
                         if (!string.IsNullOrEmpty(pmStr) || !string.IsNullOrEmpty(amStr) || !string.IsNullOrEmpty(descStr))
                         {
                             ret.Add(new Token(match.Index, match.Index + match.Length));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
@@ -90,13 +90,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         {
             var trimedText = text.Trim().ToLowerInvariant();
             int result = hour;
-            if (trimedText.EndsWith("matin") && hour >= 12)
+            if (trimedText.EndsWith("matin") && hour >= Constants.HalfDayHourCount)
             {
-                result -= 12;
+                result -= Constants.HalfDayHourCount;
             }
-            else if (!trimedText.EndsWith("matin") && hour < 12)
+            else if (!trimedText.EndsWith("matin") && hour < Constants.HalfDayHourCount)
             {
-                result += 12;
+                result += Constants.HalfDayHourCount;
             }
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -134,12 +134,12 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (AfternoonStartEndRegex.IsMatch(trimedText))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (EveningStartEndRegex.IsMatch(trimedText))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
@@ -87,22 +87,22 @@ namespace Microsoft.Recognizers.Text.DateTime.French
                 var oclockStr = match.Groups["heures"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
+                    var amStr = match.Groups[Constants.AmGroupName].Value;
                     if (!string.IsNullOrEmpty(amStr))
                     {
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            deltaHour = -12;
+                            deltaHour = -Constants.HalfDayHourCount;
                         }
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
+                    var pmStr = match.Groups[Constants.PmGroupName].Value;
                     if (!string.IsNullOrEmpty(pmStr))
                     {
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            deltaHour = 12;
+                            deltaHour = Constants.HalfDayHourCount;
                         }
                         hasPm = true;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             {
                 timex = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.EndsWith("apres-midi")||trimedText.EndsWith("apres midi") 
                 || trimedText.EndsWith("après midi") || trimedText.EndsWith("après-midi"))
             {
                 timex = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             } 
             else if (trimedText.EndsWith("soir") || trimedText.EndsWith("soiree") || trimedText.EndsWith("soirée"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/TimeParser.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             var match = FrenchTimeExtractorConfiguration.IshRegex.Match(trimedText);
             if (match.Success && match.Length == trimedText.Length)
             {
-                var hourStr = match.Groups["hour"].Value;
-                var hour = 12;
+                var hourStr = match.Groups[Constants.HourGroupName].Value;
+                var hour = Constants.HalfDayHourCount;
                 if (!string.IsNullOrEmpty(hourStr))
                 {
                     hour = int.Parse(hourStr);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
@@ -91,13 +91,13 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             var trimedText = text.Trim().ToLowerInvariant();
             int result = hour;
-            if ((trimedText.EndsWith("morgen") || trimedText.EndsWith("morgens")) && hour >= 12)
+            if ((trimedText.EndsWith("morgen") || trimedText.EndsWith("morgens")) && hour >= Constants.HalfDayHourCount)
             {
-                result -= 12;
+                result -= Constants.HalfDayHourCount;
             }
-            else if (!(trimedText.EndsWith("morgen") || trimedText.EndsWith("morgens")) && hour < 12)
+            else if (!(trimedText.EndsWith("morgen") || trimedText.EndsWith("morgens")) && hour < Constants.HalfDayHourCount)
             {
-                result += 12;
+                result += Constants.HalfDayHourCount;
             }
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -136,12 +136,12 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (AfternoonStartEndRegex.IsMatch(trimedText))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (EveningStartEndRegex.IsMatch(trimedText))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -104,12 +104,12 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
+                    var amStr = match.Groups[Constants.AmGroupName].Value;
                     if (!string.IsNullOrEmpty(amStr))
                     {
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            deltaHour = -12;
+                            deltaHour = -Constants.HalfDayHourCount;
                         }
                         else
                         {
@@ -117,21 +117,21 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                         }
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
+                    var pmStr = match.Groups[Constants.PmGroupName].Value;
                     if (!string.IsNullOrEmpty(pmStr))
                     {
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            deltaHour = 12;
+                            deltaHour = Constants.HalfDayHourCount;
                         }
 
                         if (LunchRegex.IsMatch(pmStr))
                         {
                             // for hour>=10, <12
-                            if (hour >=10 && hour <=12)
+                            if (hour >=10 && hour <=Constants.HalfDayHourCount)
                             {
                                 deltaHour = 0;
-                                if (hour == 12)
+                                if (hour == Constants.HalfDayHourCount)
                                 {
                                     hasPm = true;
                                 }
@@ -148,9 +148,9 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                         else if (NightRegex.IsMatch(pmStr))
                         {
                             //For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
-                            if (hour <= 3 || hour == 12)
+                            if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {
-                                if (hour == 12)
+                                if (hour == Constants.HalfDayHourCount)
                                 {
                                     hour = 0;
                                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
@@ -63,12 +63,12 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 timex = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.EndsWith("nachmittag"))
             {
                 timex = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("abend"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/TimeParser.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             var match = GermanTimeExtractorConfiguration.IshRegex.Match(trimedText);
             if (match.Success && match.Length == trimedText.Length)
             {
-                var hourStr = match.Groups["hour"].Value;
-                var hour = 12;
+                var hourStr = match.Groups[Constants.HourGroupName].Value;
+                var hour = Constants.HalfDayHourCount;
                 if (!string.IsNullOrEmpty(hourStr))
                 {
                     hour = int.Parse(hourStr);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -653,19 +653,19 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (match.Groups["EarlyPrefix"].Success)
                 {
                     earlyPrefix = true;
-                    trimedText = match.Groups["suffix"].ToString();
+                    trimedText = match.Groups[Constants.SuffixGroupName].ToString();
                     ret.Mod = Constants.EARLY_MOD;
                 }
                 else if (match.Groups["LatePrefix"].Success)
                 {
                     latePrefix = true;
-                    trimedText = match.Groups["suffix"].ToString();
+                    trimedText = match.Groups[Constants.SuffixGroupName].ToString();
                     ret.Mod = Constants.LATE_MOD;
                 }
                 else if (match.Groups["MidPrefix"].Success)
                 {
                     midPrefix = true;
-                    trimedText = match.Groups["suffix"].ToString();
+                    trimedText = match.Groups[Constants.SuffixGroupName].ToString();
                     ret.Mod = Constants.MID_MOD;
                 }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -197,13 +197,13 @@ namespace Microsoft.Recognizers.Text.DateTime
             var sec = time.Second;
 
             // Handle morning, afternoon
-            if (this.config.PMTimeRegex.IsMatch(text) && hour < 12)
+            if (this.config.PMTimeRegex.IsMatch(text) && hour < Constants.HalfDayHourCount)
             {
-                hour += 12;
+                hour += Constants.HalfDayHourCount;
             }
-            else if (this.config.AMTimeRegex.IsMatch(text) && hour >= 12)
+            else if (this.config.AMTimeRegex.IsMatch(text) && hour >= Constants.HalfDayHourCount)
             {
-                hour -= 12;
+                hour -= Constants.HalfDayHourCount;
             }
 
             var timeStr = pr2.TimexStr;
@@ -215,7 +215,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             ret.Timex = pr1.TimexStr + timeStr;
 
             var val = (DateTimeResolutionResult) pr2.Value;
-            if (hour <= 12 && !this.config.PMTimeRegex.IsMatch(text) && !this.config.AMTimeRegex.IsMatch(text) &&
+            if (hour <= Constants.HalfDayHourCount && !this.config.PMTimeRegex.IsMatch(text) && !this.config.AMTimeRegex.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
                 ret.Comment = Constants.Comment_AmPm;
@@ -257,7 +257,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (wholeMatch.Success && wholeMatch.Length == trimedText.Length)
             {
-                var hourStr = wholeMatch.Groups["hour"].Value;
+                var hourStr = wholeMatch.Groups[Constants.HourGroupName].Value;
                 if (string.IsNullOrEmpty(hourStr))
                 {
                     hourStr = wholeMatch.Groups["hournum"].Value.ToLower();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             // AmPm comment is used for later SetParserResult to judge whether this parse result should have two parsing results
                             // Cases like "from 10:30 to 11 on 1/1/2015" should have AmPm comment, as it can be parsed to "10:30am to 11am" and also be parsed to "10:30pm to 11pm"
                             // Cases like "from 10:30 to 3 on 1/1/2015" should not have AmPm comment
-                            if (beginTime.Hour < 12 && endTime.Hour < 12)
+                            if (beginTime.Hour < Constants.HalfDayHourCount && endTime.Hour < Constants.HalfDayHourCount)
                             {
                                 ret.Comment = Constants.Comment_AmPm;
                             }
@@ -408,13 +408,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (match.Success && (match.Index == 0 || match.Index + match.Length == trimedText.Length))
             {
-                // This "from .. to .." pattern is valid if followed by a Date OR "pm"
+                // This "from .. to .." pattern is valid if followed by a Date OR Constants.PmGroupName
                 var hasAm = false;
                 var hasPm = false;
                 string dateStr;
 
                 // Get hours
-                var hourGroup = match.Groups["hour"];
+                var hourGroup = match.Groups[Constants.HourGroupName];
                 var hourStr = hourGroup.Captures[0].Value;
                 int beginHour;
 
@@ -468,50 +468,50 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
 
-                // Parse "pm" 
-                var pmStr = match.Groups["pm"].Value;
-                var amStr = match.Groups["am"].Value;
-                var descStr = match.Groups["desc"].Value;
+                // Parse Constants.PmGroupName 
+                var pmStr = match.Groups[Constants.PmGroupName].Value;
+                var amStr = match.Groups[Constants.AmGroupName].Value;
+                var descStr = match.Groups[Constants.DescGroupName].Value;
                 if (!string.IsNullOrEmpty(amStr) || !string.IsNullOrEmpty(descStr) && descStr.StartsWith("a"))
                 {
-                    if (beginHour >= 12)
+                    if (beginHour >= Constants.HalfDayHourCount)
                     {
-                        beginHour -= 12;
+                        beginHour -= Constants.HalfDayHourCount;
                     }
 
-                    if (endHour >= 12)
+                    if (endHour >= Constants.HalfDayHourCount)
                     {
-                        endHour -= 12;
+                        endHour -= Constants.HalfDayHourCount;
                     }
 
                     hasAm = true;
                 }
                 else if (!string.IsNullOrEmpty(pmStr) || !string.IsNullOrEmpty(descStr) && descStr.StartsWith("p"))
                 {
-                    if (beginHour < 12)
+                    if (beginHour < Constants.HalfDayHourCount)
                     {
-                        beginHour += 12;
+                        beginHour += Constants.HalfDayHourCount;
                     }
 
-                    if (endHour < 12)
+                    if (endHour < Constants.HalfDayHourCount)
                     {
-                        endHour += 12;
+                        endHour += Constants.HalfDayHourCount;
                     }
 
                     hasPm = true;
                 }
 
-                if (!hasAm && !hasPm && beginHour <= 12 && endHour <= 12)
+                if (!hasAm && !hasPm && beginHour <= Constants.HalfDayHourCount && endHour <= Constants.HalfDayHourCount)
                 {
                     if (beginHour > endHour)
                     {
-                        if (beginHour == 12)
+                        if (beginHour == Constants.HalfDayHourCount)
                         {
                             beginHour = 0;
                         }
                         else
                         {
-                            endHour += 12;
+                            endHour += Constants.HalfDayHourCount;
                         }
                     }
                     ret.Comment = Constants.Comment_AmPm;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (match.Success)
                 {
                     srcUnit = match.Groups["unit"].Value.ToLower();
-                    suffixStr = match.Groups["suffix"].Value.ToLower();
+                    suffixStr = match.Groups[Constants.SuffixGroupName].Value.ToLower();
                 }
 
                 if (this.config.UnitMap.ContainsKey(srcUnit))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -574,7 +574,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (resolution.ContainsKey(DateTimeResolutionKey.START))
                         {
                             var start = Convert.ToDateTime(resolution[DateTimeResolutionKey.START]);
-                            start = start.Hour == 12 ? start.AddHours(-12) : start.AddHours(12);
+                            start = start.Hour == Constants.HalfDayHourCount ? start.AddHours(-Constants.HalfDayHourCount) : start.AddHours(Constants.HalfDayHourCount);
 
                             resolutionPm[DateTimeResolutionKey.START] = FormatUtil.FormatDateTime(start);
                         }
@@ -582,7 +582,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (resolution.ContainsKey(DateTimeResolutionKey.END))
                         {
                             var end = Convert.ToDateTime(resolution[DateTimeResolutionKey.END]);
-                            end = end.Hour == 12 ? end.AddHours(-12) : end.AddHours(12);
+                            end = end.Hour == Constants.HalfDayHourCount ? end.AddHours(-Constants.HalfDayHourCount) : end.AddHours(Constants.HalfDayHourCount);
 
                             resolutionPm[DateTimeResolutionKey.END] = FormatUtil.FormatDateTime(end);
                         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -114,11 +114,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (match.Success && match.Index == 0)
             {
-                // this "from .. to .." pattern is valid if followed by a Date OR "pm"
+                // this "from .. to .." pattern is valid if followed by a Date OR Constants.PmGroupName
                 var isValid = false;
 
                 // get hours
-                var hourGroup = match.Groups["hour"];
+                var hourGroup = match.Groups[Constants.HourGroupName];
                 var hourStr = hourGroup.Captures[0].Value;
                 var afterHourIndex = hourGroup.Captures[0].Index + hourGroup.Captures[0].Length;
 
@@ -141,12 +141,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                             endHour = int.Parse(hourStr);
                         }
 
-                        // parse "pm" 
+                        // parse Constants.PmGroupName 
                         var leftDesc = match.Groups["leftDesc"].Value;
                         var rightDesc = match.Groups["rightDesc"].Value;
-                        var pmStr = match.Groups["pm"].Value;
-                        var amStr = match.Groups["am"].Value;
-                        var descStr = match.Groups["desc"].Value;
+                        var pmStr = match.Groups[Constants.PmGroupName].Value;
+                        var amStr = match.Groups[Constants.AmGroupName].Value;
+                        var descStr = match.Groups[Constants.DescGroupName].Value;
 
                         // The "ampm" only occurs in time, we don't have to consider it here
                         if (string.IsNullOrEmpty(leftDesc))
@@ -159,20 +159,20 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                             if (!string.IsNullOrEmpty(amStr) || rightAmValid)
                             {
-                                if (endHour >= 12)
+                                if (endHour >= Constants.HalfDayHourCount)
                                 {
-                                    endHour -= 12;
+                                    endHour -= Constants.HalfDayHourCount;
                                 }
 
-                                if (beginHour >= 12 && beginHour - 12 < endHour)
+                                if (beginHour >= Constants.HalfDayHourCount && beginHour - Constants.HalfDayHourCount < endHour)
                                 {
-                                    beginHour -= 12;
+                                    beginHour -= Constants.HalfDayHourCount;
                                 }
 
                                 // Resolve case like "11 to 3am"
-                                if (beginHour < 12 && beginHour > endHour)
+                                if (beginHour < Constants.HalfDayHourCount && beginHour > endHour)
                                 {
-                                    beginHour += 12;
+                                    beginHour += Constants.HalfDayHourCount;
                                 }
 
                                 isValid = true;
@@ -181,15 +181,15 @@ namespace Microsoft.Recognizers.Text.DateTime
                             else if (!string.IsNullOrEmpty(pmStr) || rightPmValid)
                             {
 
-                                if (endHour < 12)
+                                if (endHour < Constants.HalfDayHourCount)
                                 {
-                                    endHour += 12;
+                                    endHour += Constants.HalfDayHourCount;
                                 }
 
                                 // Resolve case like "11 to 3pm"
-                                if (beginHour + 12 < endHour)
+                                if (beginHour + Constants.HalfDayHourCount < endHour)
                                 {
-                                    beginHour += 12;
+                                    beginHour += Constants.HalfDayHourCount;
                                 }
 
                                 isValid = true;
@@ -243,7 +243,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (match.Success && match.Index == 0 && match.Index + match.Length == trimedText.Length)
             {
                 // Cases like "half past seven" are not handled here
-                if (match.Groups["prefix"].Success)
+                if (match.Groups[Constants.PrefixGroupName].Success)
                 {
                     return ret;
                 }
@@ -259,7 +259,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 int endSecond = invalidFlag;
 
                 // Get time1 and time2
-                var hourGroup = match.Groups["hour"];
+                var hourGroup = match.Groups[Constants.HourGroupName];
 
                 var hourStr = hourGroup.Captures[0].Value;
 
@@ -290,9 +290,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var time2EndIndex = time2StartIndex + match.Groups["time2"].Length;
 
                 // Get beginMinute (if exists) and endMinute (if exists)
-                for (int i = 0; i < match.Groups["min"].Captures.Count; i++)
+                for (int i = 0; i < match.Groups[Constants.MinuteGroupName].Captures.Count; i++)
                 {
-                    var minuteCapture = match.Groups["min"].Captures[i];
+                    var minuteCapture = match.Groups[Constants.MinuteGroupName].Captures[i];
                     if (minuteCapture.Index >= time1StartIndex && minuteCapture.Index + minuteCapture.Length <= time1EndIndex)
                     {
                         beginMinute = int.Parse(minuteCapture.Value);
@@ -304,9 +304,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // Get beginSecond (if exists) and endSecond (if exists)
-                for (int i = 0; i < match.Groups["sec"].Captures.Count; i++)
+                for (int i = 0; i < match.Groups[Constants.SecondGroupName].Captures.Count; i++)
                 {
-                    var secondCapture = match.Groups["sec"].Captures[i];
+                    var secondCapture = match.Groups[Constants.SecondGroupName].Captures[i];
                     if (secondCapture.Index >= time1StartIndex && secondCapture.Index + secondCapture.Length <= time1EndIndex)
                     {
                         beginSecond = int.Parse(secondCapture.Value);
@@ -322,9 +322,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var leftDesc = match.Groups["leftDesc"].Value;
                 var rightDesc = match.Groups["rightDesc"].Value;
 
-                for (int i = 0; i < match.Groups["desc"].Captures.Count; i++)
+                for (int i = 0; i < match.Groups[Constants.DescGroupName].Captures.Count; i++)
                 {
-                    var descCapture = match.Groups["desc"].Captures[i];
+                    var descCapture = match.Groups[Constants.DescGroupName].Captures[i];
                     if (descCapture.Index >= time1StartIndex && descCapture.Index + descCapture.Length <= time1EndIndex && string.IsNullOrEmpty(leftDesc))
                     {
                         leftDesc = descCapture.Value;
@@ -350,31 +350,31 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     if (hasLeftAm)
                     {
-                        if (beginHour >= 12)
+                        if (beginHour >= Constants.HalfDayHourCount)
                         {
-                            beginDateTime = beginDateTime.AddHours(-12);
+                            beginDateTime = beginDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
                     }
                     else if (hasLeftPm)
                     {
-                        if (beginHour < 12)
+                        if (beginHour < Constants.HalfDayHourCount)
                         {
-                            beginDateTime = beginDateTime.AddHours(12);
+                            beginDateTime = beginDateTime.AddHours(Constants.HalfDayHourCount);
                         }
                     }
 
                     if (hasRightAm)
                     {
-                        if (endHour >= 12)
+                        if (endHour >= Constants.HalfDayHourCount)
                         {
-                            endDateTime = endDateTime.AddHours(-12);
+                            endDateTime = endDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
                     }
                     else if (hasRightPm)
                     {
-                        if (endHour < 12)
+                        if (endHour < Constants.HalfDayHourCount)
                         {
-                            endDateTime = endDateTime.AddHours(12);
+                            endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                         }
                     }
                 }
@@ -383,38 +383,38 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     if (hasLeftAm)
                     {
-                        if (beginHour >= 12)
+                        if (beginHour >= Constants.HalfDayHourCount)
                         {
-                            beginDateTime = beginDateTime.AddHours(-12);
+                            beginDateTime = beginDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
 
-                        if (endHour < 12)
+                        if (endHour < Constants.HalfDayHourCount)
                         {
                             if (endDateTime < beginDateTime)
                             {
-                                endDateTime = endDateTime.AddHours(12);
+                                endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                             }
                         }
                     }
                     else if (hasLeftPm)
                     {
-                        if (beginHour < 12)
+                        if (beginHour < Constants.HalfDayHourCount)
                         {
-                            beginDateTime = beginDateTime.AddHours(12);
+                            beginDateTime = beginDateTime.AddHours(Constants.HalfDayHourCount);
                         }
 
-                        if (endHour < 12)
+                        if (endHour < Constants.HalfDayHourCount)
                         {
                             if (endDateTime < beginDateTime)
                             {
                                 var span = beginDateTime - endDateTime;
-                                if (span.TotalHours >= 12)
+                                if (span.TotalHours >= Constants.HalfDayHourCount)
                                 {
                                     endDateTime = endDateTime.AddHours(24);
                                 }
                                 else
                                 {
-                                    endDateTime = endDateTime.AddHours(12);
+                                    endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                                 }
                             }
                         }
@@ -422,55 +422,55 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     if (hasRightAm)
                     {
-                        if (endHour >= 12)
+                        if (endHour >= Constants.HalfDayHourCount)
                         {
-                            endDateTime = endDateTime.AddHours(-12);
+                            endDateTime = endDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
 
-                        if (beginHour < 12)
+                        if (beginHour < Constants.HalfDayHourCount)
                         {
                             if (endDateTime < beginDateTime)
                             {
-                                beginDateTime = beginDateTime.AddHours(-12);
+                                beginDateTime = beginDateTime.AddHours(-Constants.HalfDayHourCount);
                             }
                         }
                     }
                     else if (hasRightPm)
                     {
-                        if (endHour < 12)
+                        if (endHour < Constants.HalfDayHourCount)
                         {
-                            endDateTime = endDateTime.AddHours(12);
+                            endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                         }
 
-                        if (beginHour < 12)
+                        if (beginHour < Constants.HalfDayHourCount)
                         {
                             if (endDateTime < beginDateTime)
                             {
-                                beginDateTime = beginDateTime.AddHours(-12);
+                                beginDateTime = beginDateTime.AddHours(-Constants.HalfDayHourCount);
                             }
                             else
                             {
                                 var span = endDateTime - beginDateTime;
-                                if (span.TotalHours > 12)
+                                if (span.TotalHours > Constants.HalfDayHourCount)
                                 {
-                                    beginDateTime = beginDateTime.AddHours(12);
+                                    beginDateTime = beginDateTime.AddHours(Constants.HalfDayHourCount);
                                 }
                             }
                         }
                     }
                 }
                 // No 'am' or 'pm' indicator
-                else if (!hasLeft && !hasRight && beginHour <= 12 && endHour <= 12)
+                else if (!hasLeft && !hasRight && beginHour <= Constants.HalfDayHourCount && endHour <= Constants.HalfDayHourCount)
                 {
                     if (beginHour > endHour)
                     {
-                        if (beginHour == 12)
+                        if (beginHour == Constants.HalfDayHourCount)
                         {
-                            beginDateTime = beginDateTime.AddHours(-12);
+                            beginDateTime = beginDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
                         else
                         {
-                            endDateTime = endDateTime.AddHours(12);
+                            endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                         }
                     }
                     ret.Comment = Constants.Comment_AmPm;
@@ -595,9 +595,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             var beginTime = (DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue;
             var endTime = (DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue;
 
-            if (!string.IsNullOrEmpty(ampmStr2) && ampmStr2.EndsWith(Constants.Comment_AmPm) && endTime <= beginTime && endTime.AddHours(12) > beginTime)
+            if (!string.IsNullOrEmpty(ampmStr2) && ampmStr2.EndsWith(Constants.Comment_AmPm) && endTime <= beginTime && endTime.AddHours(Constants.HalfDayHourCount) > beginTime)
             {
-                endTime = endTime.AddHours(12);
+                endTime = endTime.AddHours(Constants.HalfDayHourCount);
                 ((DateTimeResolutionResult)pr2.Value).FutureValue = endTime;
                 pr2.TimexStr = $"T{endTime.Hour}";
                 if (endTime.Minute > 0)
@@ -606,9 +606,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            if (!string.IsNullOrEmpty(ampmStr1) && ampmStr1.EndsWith(Constants.Comment_AmPm) && endTime > beginTime.AddHours(12))
+            if (!string.IsNullOrEmpty(ampmStr1) && ampmStr1.EndsWith(Constants.Comment_AmPm) && endTime > beginTime.AddHours(Constants.HalfDayHourCount))
             {
-                beginTime = beginTime.AddHours(12);
+                beginTime = beginTime.AddHours(Constants.HalfDayHourCount);
                 ((DateTimeResolutionResult)pr1.Value).FutureValue = beginTime;
                 pr1.TimexStr = $"T{beginTime.Hour}";
                 if (beginTime.Minute > 0)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 minutes = 0;
             }
 
-            if (hours > 12)
+            if (hours > Constants.HalfDayHourCount)
             {
                 return Constants.InvalidOffsetValue;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -88,13 +88,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             int result = hour;
 
             //TODO: Replace with a regex
-            if ((trimedText.EndsWith("manha") || trimedText.EndsWith("madrugada")) && hour >= 12)
+            if ((trimedText.EndsWith("manha") || trimedText.EndsWith("madrugada")) && hour >= Constants.HalfDayHourCount)
             {
-                result -= 12;
+                result -= Constants.HalfDayHourCount;
             }
-            else if (!(trimedText.EndsWith("manha") || trimedText.EndsWith("madrugada")) && hour < 12)
+            else if (!(trimedText.EndsWith("manha") || trimedText.EndsWith("madrugada")) && hour < Constants.HalfDayHourCount)
             {
-                result += 12;
+                result += Constants.HalfDayHourCount;
             }
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.Contains("passado o meio dia") || trimedText.Contains("depois do meio dia"))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("tarde"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -101,22 +101,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
+                    var amStr = match.Groups[Constants.AmGroupName].Value;
                     if (!string.IsNullOrEmpty(amStr))
                     {
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            deltaHour = -12;
+                            deltaHour = -Constants.HalfDayHourCount;
                         }
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
+                    var pmStr = match.Groups[Constants.PmGroupName].Value;
                     if (!string.IsNullOrEmpty(pmStr))
                     {
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            deltaHour = 12;
+                            deltaHour = Constants.HalfDayHourCount;
                         }
                         hasPm = true;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
@@ -66,12 +66,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             {
                 timex = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.Contains("passado o meio dia") || trimedText.Contains("depois do meio dia"))
             {
                 timex = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("tarde"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -91,13 +91,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             int result = hour;
 
             //TODO: Replace with a regex
-            if ((trimedText.EndsWith("mañana") || trimedText.EndsWith("madrugada")) && hour >= 12)
+            if ((trimedText.EndsWith("mañana") || trimedText.EndsWith("madrugada")) && hour >= Constants.HalfDayHourCount)
             {
-                result -= 12;
+                result -= Constants.HalfDayHourCount;
             }
-            else if (!(trimedText.EndsWith("mañana") || trimedText.EndsWith("madrugada")) && hour < 12)
+            else if (!(trimedText.EndsWith("mañana") || trimedText.EndsWith("madrugada")) && hour < Constants.HalfDayHourCount)
             {
-                result += 12;
+                result += Constants.HalfDayHourCount;
             }
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             {
                 timeStr = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.Contains("pasado mediodia") || trimedText.Contains("pasado el mediodia"))
             {
                 timeStr = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("tarde"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -99,22 +99,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 var oclockStr = match.Groups["oclock"].Value;
                 if (string.IsNullOrEmpty(oclockStr))
                 {
-                    var amStr = match.Groups["am"].Value;
+                    var amStr = match.Groups[Constants.AmGroupName].Value;
                     if (!string.IsNullOrEmpty(amStr))
                     {
-                        if (hour >= 12)
+                        if (hour >= Constants.HalfDayHourCount)
                         {
-                            deltaHour = -12;
+                            deltaHour = -Constants.HalfDayHourCount;
                         }
                         hasAm = true;
                     }
 
-                    var pmStr = match.Groups["pm"].Value;
+                    var pmStr = match.Groups[Constants.PmGroupName].Value;
                     if (!string.IsNullOrEmpty(pmStr))
                     {
-                        if (hour < 12)
+                        if (hour < Constants.HalfDayHourCount)
                         {
-                            deltaHour = 12;
+                            deltaHour = Constants.HalfDayHourCount;
                         }
                         hasPm = true;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
@@ -66,12 +66,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             {
                 timex = "TMO";
                 beginHour = 8;
-                endHour = 12;
+                endHour = Constants.HalfDayHourCount;
             }
             else if (trimedText.Contains("pasado mediodia") || trimedText.Contains("pasado el mediodia"))
             {
                 timex = "TAF";
-                beginHour = 12;
+                beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
             else if (trimedText.EndsWith("tarde"))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/FormatUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/FormatUtil.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             var splited = timeStr.Split(':');
             var hour = int.Parse(splited[0]);
-            hour = hour >= 12 ? hour - 12: hour + 12;
+            hour = hour >= Constants.HalfDayHourCount ? hour - Constants.HalfDayHourCount: hour + Constants.HalfDayHourCount;
             splited[0] = hour.ToString("D2");
 
             return hasT ? "T" + string.Join(":", splited) : string.Join(":", splited);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseTime.ts
@@ -270,22 +270,26 @@ export class BaseTimeExtractor implements IDateTimeExtractor {
 
                     // adjust by desc string
                     let descStr = match.groups('desc').value.toLowerCase();
-                    if (!StringUtility.isNullOrWhitespace(descStr)) {
-                        if (RegExpUtility.getMatches(this.config.utilityConfiguration.amDescRegex, descStr).length > 0
-                         || RegExpUtility.getMatches(this.config.utilityConfiguration.amPmDescRegex, descStr).length > 0) {
-                            if (hour >= 12) {
-                                hour -= 12;
-                            }
-                            if (RegExpUtility.getMatches(this.config.utilityConfiguration.amPmDescRegex, descStr).length === 0) {
-                                hasAm = true;
-                            }
-                         }
-                        else if (RegExpUtility.getMatches(this.config.utilityConfiguration.pmDescRegex, descStr).length > 0) {
-                            if (hour < 12) {
-                                hour += 12;
-                            }
-                            hasPm = true;
+                    if (RegExpUtility.getMatches(this.config.utilityConfiguration.amDescRegex, descStr).length > 0
+                        || RegExpUtility.getMatches(this.config.utilityConfiguration.amPmDescRegex, descStr).length > 0
+                        || !StringUtility.isNullOrEmpty(match.groups('iam').value)) {
+
+                        if (hour >= 12) {
+                            hour -= 12;
                         }
+
+                        if (RegExpUtility.getMatches(this.config.utilityConfiguration.amPmDescRegex, descStr).length === 0) {
+                            hasAm = true;
+                        }
+                    }
+                    else if (RegExpUtility.getMatches(this.config.utilityConfiguration.pmDescRegex, descStr).length > 0
+                        || !StringUtility.isNullOrEmpty(match.groups('ipm').value)) {
+
+                        if (hour < 12) {
+                            hour += 12;
+                        }
+
+                        hasPm = true;
                     }
 
                     // adjust min by prefix

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -115,7 +115,7 @@ export namespace EnglishDateTime {
 	export const MidafternoonRegex = `(?<midafternoon>midafternoon|mid-afternoon|mid afternoon)`;
 	export const MiddayRegex = `(?<midday>midday|mid-day|mid day|((12\\s)?noon))`;
 	export const MidTimeRegex = `(?<mid>(${MidnightRegex}|${MidmorningRegex}|${MidafternoonRegex}|${MiddayRegex}))`;
-	export const AtRegex = `\\b(((?<=\\bat\\s+)(${WrittenTimeRegex}|${HourNumRegex}|${BaseDateTime.HourRegex}|${MidTimeRegex}))|${MidTimeRegex})\\b`;
+	export const AtRegex = `\\b(((?<=\\bat\\s+)(${WrittenTimeRegex}|${HourNumRegex}|${BaseDateTime.HourRegex}(\\s*((?<iam>a)|(?<ipm>p)))?|${MidTimeRegex}))|${MidTimeRegex})\\b`;
 	export const IshRegex = `\\b(${BaseDateTime.HourRegex}(-|——)?ish|noonish|noon)\\b`;
 	export const TimeUnitRegex = `([^A-Za-z]{1,}|\\b)(?<unit>hours|hour|hrs|hr|h|minutes|minute|mins|min|seconds|second|secs|sec)\\b`;
 	export const RestrictedTimeUnitRegex = `(?<unit>hour|minute)\\b`;
@@ -227,8 +227,8 @@ export namespace EnglishDateTime {
 	export const DecadeWithCenturyRegex = `(the\\s+)?(((?<century>\\d|1\\d|2\\d)?(')?(?<decade>\\d0)(')?s)|((${CenturyRegex}(\\s+|-)(and\\s+)?)?${DecadeRegex})|(${CenturyRegex}(\\s+|-)(and\\s+)?(?<decade>tens|hundreds)))`;
 	export const RelativeDecadeRegex = `\\b((the\\s+)?${RelativeRegex}\\s+((?<number>[\\w,]+)\\s+)?decades?)\\b`;
 	export const YearAfterRegex = `\\b(or\\s+(above|after))\\b`;
-	export const YearPeriodRegex = `(((from|during|in|between)\\s+)?${YearRegex}\\s*(${TillRegex}|${RangeConnectorRegex})\\s*${YearRegex})`;
-	export const ComplexDatePeriodRegex = `((from|during|in|between)\\s+)?(?<start>.+)\\s*(${TillRegex}|${RangeConnectorRegex})\\s*(?<end>.+)`;
+	export const YearPeriodRegex = `((((from|during|in)\\s+)?${YearRegex}\\s*(${TillRegex})\\s*${YearRegex})|(((between)\\s+)${YearRegex}\\s*(${RangeConnectorRegex})\\s*${YearRegex}))`;
+	export const ComplexDatePeriodRegex = `(((from|during|in)\\s+)?(?<start>.+)\\s*(${TillRegex})\\s*(?<end>.+)|((between)\\s+)(?<start>.+)\\s*(${RangeConnectorRegex})\\s*(?<end>.+))`;
 	export const UnitMap: ReadonlyMap<string, string> = new Map<string, string>([["years", "Y"],["year", "Y"],["months", "MON"],["month", "MON"],["weeks", "W"],["week", "W"],["days", "D"],["day", "D"],["hours", "H"],["hour", "H"],["hrs", "H"],["hr", "H"],["h", "H"],["minutes", "M"],["minute", "M"],["mins", "M"],["min", "M"],["seconds", "S"],["second", "S"],["secs", "S"],["sec", "S"]]);
 	export const UnitValueMap: ReadonlyMap<string, number> = new Map<string, number>([["years", 31536000],["year", 31536000],["months", 2592000],["month", 2592000],["weeks", 604800],["week", 604800],["days", 86400],["day", 86400],["hours", 3600],["hour", 3600],["hrs", 3600],["hr", 3600],["h", 3600],["minutes", 60],["minute", 60],["mins", 60],["min", 60],["seconds", 1],["second", 1],["secs", 1],["sec", 1]]);
 	export const SeasonMap: ReadonlyMap<string, string> = new Map<string, string>([["spring", "SP"],["summer", "SU"],["fall", "FA"],["autumn", "FA"],["winter", "WI"]]);

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -273,7 +273,7 @@ MidTimeRegex: !nestedRegex
   def: (?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))
   references: [ MidnightRegex, MidmorningRegex, MidafternoonRegex, MiddayRegex ]
 AtRegex: !nestedRegex
-  def: \b(((?<=\bat\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b
+  def: \b(((?<=\bat\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, MidTimeRegex ]
 IshRegex: !nestedRegex
   def: '\b({BaseDateTime.HourRegex}(-|——)?ish|noonish|noon)\b'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_time.py
@@ -260,20 +260,22 @@ class BaseTimeParser(DateTimeParser):
             if sec_str.strip():
                 second = int(sec_str)
                 has_seconds = True
+
         #adjust by desc string
-        desc_str = RegExpUtility.get_group(match, 'desc')
-        desc_str = desc_str.lower()
-        if desc_str.strip():
-            if any([regex.search(self.config.utility_configuration.am_desc_regex, desc_str),
-                    regex.search(self.config.utility_configuration.am_pm_desc_regex, desc_str)]):
-                if hour >= 12:
-                    hour -= 12
-                if regex.search(self.config.utility_configuration.am_pm_desc_regex, desc_str) is None:
-                    has_am = True
-            elif regex.search(self.config.utility_configuration.pm_desc__regex, desc_str) is not None:
-                if hour < 12:
-                    hour += 12
-                has_pm = True
+        desc_str = RegExpUtility.get_group(match, 'desc').lower()
+
+        if any([regex.search(self.config.utility_configuration.am_desc_regex, desc_str),
+                regex.search(self.config.utility_configuration.am_pm_desc_regex, desc_str)]) or RegExpUtility.get_group(
+                match, 'iam'):
+            if hour >= 12:
+                hour -= 12
+            if regex.search(self.config.utility_configuration.am_pm_desc_regex, desc_str) is None:
+                has_am = True
+        elif regex.search(self.config.utility_configuration.pm_desc__regex,
+                          desc_str) is not None or RegExpUtility.get_group(match, 'ipm'):
+            if hour < 12:
+                hour += 12
+            has_pm = True
 
         #adjust min by prefix
         time_prefix = RegExpUtility.get_group(match, 'prefix')

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -116,7 +116,7 @@ class EnglishDateTime:
     MidafternoonRegex = f'(?<midafternoon>midafternoon|mid-afternoon|mid afternoon)'
     MiddayRegex = f'(?<midday>midday|mid-day|mid day|((12\\s)?noon))'
     MidTimeRegex = f'(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))'
-    AtRegex = f'\\b(((?<=\\bat\\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\\b'
+    AtRegex = f'\\b(((?<=\\bat\\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(\\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\\b'
     IshRegex = f'\\b({BaseDateTime.HourRegex}(-|——)?ish|noonish|noon)\\b'
     TimeUnitRegex = f'([^A-Za-z]{{1,}}|\\b)(?<unit>hours|hour|hrs|hr|h|minutes|minute|mins|min|seconds|second|secs|sec)\\b'
     RestrictedTimeUnitRegex = f'(?<unit>hour|minute)\\b'
@@ -228,8 +228,8 @@ class EnglishDateTime:
     DecadeWithCenturyRegex = f'(the\\s+)?(((?<century>\\d|1\\d|2\\d)?(\')?(?<decade>\\d0)(\')?s)|(({CenturyRegex}(\\s+|-)(and\\s+)?)?{DecadeRegex})|({CenturyRegex}(\\s+|-)(and\\s+)?(?<decade>tens|hundreds)))'
     RelativeDecadeRegex = f'\\b((the\\s+)?{RelativeRegex}\\s+((?<number>[\\w,]+)\\s+)?decades?)\\b'
     YearAfterRegex = f'\\b(or\\s+(above|after))\\b'
-    YearPeriodRegex = f'(((from|during|in|between)\\s+)?{YearRegex}\\s*({TillRegex}|{RangeConnectorRegex})\\s*{YearRegex})'
-    ComplexDatePeriodRegex = f'((from|during|in|between)\\s+)?(?<start>.+)\\s*({TillRegex}|{RangeConnectorRegex})\\s*(?<end>.+)'
+    YearPeriodRegex = f'((((from|during|in)\\s+)?{YearRegex}\\s*({TillRegex})\\s*{YearRegex})|(((between)\\s+){YearRegex}\\s*({RangeConnectorRegex})\\s*{YearRegex}))'
+    ComplexDatePeriodRegex = f'(((from|during|in)\\s+)?(?<start>.+)\\s*({TillRegex})\\s*(?<end>.+)|((between)\\s+)(?<start>.+)\\s*({RangeConnectorRegex})\\s*(?<end>.+))'
     UnitMap = dict([('years', 'Y'),
                     ('year', 'Y'),
                     ('months', 'MON'),

--- a/Specs/DateTime/English/DateTimeExtractor.json
+++ b/Specs/DateTime/English/DateTimeExtractor.json
@@ -805,5 +805,27 @@
         "Length": 12
       }
     ]
+  },
+  {
+    "Input": "Please book Skype call today at 9a.",
+    "Results": [
+      {
+        "Text": "today at 9a",
+        "Type": "datetime",
+        "Start": 23,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Please book Skype call today at 9p.",
+    "Results": [
+      {
+        "Text": "today at 9p",
+        "Type": "datetime",
+        "Start": 23,
+        "Length": 11
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -4562,5 +4562,53 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Please book Skype call today at 9a.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-28T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "today at 9a",
+        "Start": 23,
+        "End": 33,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-28T09",
+              "type": "datetime",
+              "value": "2018-06-28 09:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Please book Skype call today at 9p.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-28T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "today at 9p",
+        "Start": 23,
+        "End": 33,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-28T21",
+              "type": "datetime",
+              "value": "2018-06-28 21:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -3986,5 +3986,53 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Please book Skype call today at 9a.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-28T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "today at 9a",
+        "Start": 23,
+        "End": 33,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-28T09",
+              "type": "datetime",
+              "value": "2018-06-28 09:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Please book Skype call today at 9p.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-28T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "today at 9p",
+        "Start": 23,
+        "End": 33,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-28T21",
+              "type": "datetime",
+              "value": "2018-06-28 21:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/TimeExtractor.json
+++ b/Specs/DateTime/English/TimeExtractor.json
@@ -846,5 +846,42 @@
   {
     "Input": "Cortana, schedule a meeting for next week.\nBentonville, AR 72716 P: 479.277",
     "Results": []
+  },
+  {
+    "Input": "9p is suitable for me.",
+    "Results": [
+      {
+        "Text": "9p",
+        "Type": "time",
+        "Start": 0,
+        "Length": 2
+      }
+    ]
+  },
+  {
+    "Input": "9a is suitable for me.",
+    "Results": []
+  },
+  {
+    "Input": "I'll be back at 9p.",
+    "Results": [
+      {
+        "Text": "9p",
+        "Type": "time",
+        "Start": 16,
+        "Length": 2
+      }
+    ]
+  },
+  {
+    "Input": "I'll be back at 9a.",
+    "Results": [
+      {
+        "Text": "9a",
+        "Type": "time",
+        "Start": 16,
+        "Length": 2
+      }
+    ]
   }
 ]


### PR DESCRIPTION
As discussed offline, this PR address time entity extracted from "at 9a" and keep the original behavior of "9p".

- replace HalfDayHourCount constant in datetime
- replace some named group's names to constants