### PR TITLE
Normalize existing testcases for Dutch language

### DIFF
--- a/Specs/Choice/Dutch/BooleanModel.json
+++ b/Specs/Choice/Dutch/BooleanModel.json
@@ -1,23 +1,23 @@
 [
   {
     "Input": "Prima!",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Prima",
         "TypeName": "boolean",
         "Resolution": {
           "value": true,
-          "score": 1.0
+          "score": 1
         }
       }
     ]
   },
   {
     "Input": "Ik denk het niet.",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "niet",
@@ -31,23 +31,23 @@
   },
   {
     "Input": "Ik denk dat het wel gaat werken, dus ja ik zal het doen.",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "ja",
         "TypeName": "boolean",
         "Resolution": {
           "value": true,
-          "score": 0.44615384615384618
+          "score": 0.4461538461538462
         }
       }
     ]
   },
   {
     "Input": "Nee, ik zei 4 juli.",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Nee",
@@ -61,8 +61,8 @@
   },
   {
     "Input": "Ja... Ik heb dat nooit gezegd",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Ja",
@@ -76,23 +76,23 @@
   },
   {
     "Input": "Ik zei NEE in plaats van ja!",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "NEE",
         "TypeName": "boolean",
         "Resolution": {
           "value": false,
-          "score": 0.48571428571428571
+          "score": 0.4857142857142857
         }
       }
     ]
   },
   {
     "Input": "Ja. Ik zei nee",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Ja",
@@ -106,8 +106,8 @@
   },
   {
     "Input": "👌 Dat is ok",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "👌",
@@ -121,8 +121,8 @@
   },
   {
     "Input": "👌👌👌",
-    "NotSupportedByDesign": "python",
-    "NotSupported": "javascript",
+    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "👌",

--- a/Specs/Number/Dutch/NumberModel.json
+++ b/Specs/Number/Dutch/NumberModel.json
@@ -1,1617 +1,1738 @@
 [
-    {
-        "Input": "192.",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "192",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "192"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "192.168.1.2",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "192",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "192"
-                }
-            },
-            {
-                "Text": "168",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "168"
-                }
-            },
-            {
-                "Text": "1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1"
-                }
-            },
-            {
-                "Text": "2",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "180,25ml vloeistof",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": "180ml vloeistof",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": " 29km weg ",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": " 4 mei ",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": ",25ml vloeistof",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": ",08",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": ",08",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,08"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "en",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": ",23456000",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": ",23456000",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,23456"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "4,800",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "4,800",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "4,8"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderddrie en twee derde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderddrie en twee derde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "103,666666666667"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderdendrie en twee derde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderdendrie en twee derde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "103,666666666667"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "zestien",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "zestien",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "16"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "twee derde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "twee derde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,666666666666667"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderdzestien",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderdzestien",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "116"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderdzes",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderdzes",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "106"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderdeenenzestig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderdeenenzestig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "161"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een half  dozijn",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een half dozijn",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " 3 dozijn",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "3 dozijn",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "36"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een dozijn",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een dozijn",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "12"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " drie dozijnen ",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie dozijnen",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "36"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " driehonderd en twee dozijn",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "driehonderd en twee dozijn",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "324"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1.234,567",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1.234,567",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1234,567"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1, 234, 567",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1"
-                }
-            },
-            {
-                "Text": "234",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "234"
-                }
-            },
-            {
-                "Text": "567",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "567"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "9,2321312",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "9,2321312",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "9,2321312"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " -9,2321312",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-9,2321312",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-9,2321312"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " -1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-1"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-4/5",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-4/5",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-0,8"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "- 1 4/5",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "- 1 4/5",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-1,8"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drie",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "3"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " 123456789101231",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "123456789101231",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "123456789101231"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-123456789101231",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-123456789101231",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-123456789101231"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " -123456789101231",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-123456789101231",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-123456789101231"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "10k",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "10k",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "10000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "10G",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "10G",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "10000000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "- 10  k",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "- 10  k",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-10000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "2 miljoen",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "2 miljoen",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 biljoen",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 biljoen",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1000000000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " drie ",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "3"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een biljoen",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een biljoen",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1000000000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "eenentwintig biljoen",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "eenentwintig biljoen",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "21000000000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "fifty - two",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "fifty - two",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "52"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeënvijftig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeënvijftig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "52"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeenvijftig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeenvijftig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "52"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeduizend tweehonderd",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeduizend tweehonderd",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2200"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeduizend tweehonderdtwintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeduizend tweehonderdtwintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2220"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeëntwintighonderd",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeëntwintighonderd",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2200"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " 2,33 k",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "2,33 k",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2330"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1e10",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1e10",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "10000000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1,1^23",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1,1^23",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "8,95430243255239"
-                }
-            }
-        ]
-    },
-    {
-        "Input": " tweeendertigduizend tweehonderd  ",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeendertigduizend tweehonderd ",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "32200"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "zeventig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "zeventig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "70"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeenvijftig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeenvijftig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "52"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "2  1/4",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "2  1/4",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2,25"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "3/4",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "3/4",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,75"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een achtste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een achtste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,125"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "vijf achtste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "vijf achtste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,625"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een halve",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een halve",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,5"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drie kwart",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie kwart",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,75"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "twintig drie vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "twintig drie vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "20,6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drieëntwintig vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drieëntwintig vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "4,6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drieëntwintig en drie vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drieëntwintig en drie vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "23,6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een miljoen tweeduizend tweehonderd drie vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een miljoen tweeduizend tweehonderd drie vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "200440,6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "anderhalf",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "anderhalf",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1,5"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een en een vierde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een en een vierde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1,25"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "vijf en een kwart",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "vijf en een kwart",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "5,25"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderd driekwart",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderd driekwart",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "100,75"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een honderdste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een honderdste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,01"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1,1^+23",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1,1^+23",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "8,95430243255239"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "2,5^-1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "2,5^-1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,4"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-2500^-1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-2500^-1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-0,0004"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-1,1^+23",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-1,1^+23",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-8,95430243255239"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-2,5^-1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-2,5^-1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-0,4"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-1,1^--23",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-1,1^--23",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-8,95430243255239"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-127,32e13",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-127,32e13",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-1,2732E+15"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "12,32e+14",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "12,32e+14",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1,232E+15"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "-12e-1",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "-12e-1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-1,2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1,2b",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1,2b",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1200000000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderdduizend biljoensten",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderdduizend biljoensten",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1E-07"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drie vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,6"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "twintig vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "twintig vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "4"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drie een vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie een vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "3,2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "eenentwintig vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "eenentwintig vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "4,2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een eenentwintigste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een eenentwintigste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,0476190476190476"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een vijfentwintigste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een vijfentwintigste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,04"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "drie eenentwintigste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "drie eenentwintigste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,142857142857143"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "twintig vijventwintigste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "twintig vijventwintigste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,8"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "honderd en dertig vijfde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "honderd en dertig vijfde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "35"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een van de drie",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een van de drie",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,333333333333333"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 uit eenentwintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 uit eenentwintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,0476190476190476"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 uit drie",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 uit drie",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,333333333333333"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 op de 3",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 op de 3",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,333333333333333"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 van de 3",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 van de 3",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0.333333333333333"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "één uit de 20",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "één uit de 20",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,05"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "één van de twintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "één van de twintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,05"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Boek een eerste klas ticket naar Amsterdam",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": []
-    },
-    {
-        "Input": "Het antwoord is min een",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "min een",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-1"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Een op de twintig is hier niet tevreden mee",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "Een op de twintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-0.05"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Het antwoord is vijf en een half",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "vijf en een half",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "5,5"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Het antwoord is min 5 punt vijf",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "min 5 punt vijf",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-5,5"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Het antwoord is min 5",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "min 5",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "-5"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een - vierde",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een - vierde",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,25"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een-achtste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een-achtste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,125"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "vijf / achtste",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "vijf / achtste",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,625"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "een van de drie",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "een van de drie",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,333333333333333"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 van de eenentwintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 van de eenentwintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,0476190476190476"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "vijf achtsten van",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "vijf achtsten",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0,625"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 234 567",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 234 567",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1234567"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "40 000 is hetzelfde als 40 000",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "40 000",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "40000"
-                }
-            },
-            {
-                "Text": "40 000",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "40000"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Op dit moment de populatie van China is 1 414 021 100.",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 414 021 100",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1414021100"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "423 0000 zal worden herkend als twee nummers.",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "423",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "423"
-                }
-            },
-            {
-                "Text": "0000",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0"
-                }
-            },
-            {
-                "Text": "twee",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "1 234 567,89 is een geldig nummer.",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1 234 567,89",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1234567,89"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Nul is hetzelfde als 0",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "nul",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0"
-                }
-            },
-            {
-                "Text": "0",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "0"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Heb je op 17/5/2018 tijd om af te spreken?",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "17",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "17"
-                }
-            },
-            {
-                "Text": "5",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "5"
-                }
-            },
-            {
-                "Text": "2018",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2018"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "Mijn telefoonnummer is +1-222-2222/2222",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "1",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1"
-                }
-            },
-            {
-                "Text": "222",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "222"
-                }
-            },
-            {
-                "Text": "2222",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2222"
-                }
-            },
-            {
-                "Text": "2222",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "2222"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeentwintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeentwintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "22"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "tweeëntwintig",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "tweeëntwintig",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "22"
-                }
-            }
-        ]
-    },
-    {
-        "Input": "één",
-        "NotSupported": "dotNet,javascript,python",
-        "Results": [
-            {
-                "Text": "één",
-                "TypeName": "number",
-                "Resolution": {
-                    "value": "1"
-                }
-            }
-        ]
-    }
+  {
+    "Input": "192.",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "192",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "192"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "192.168.1.2",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "192",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "192"
+        }
+      },
+      {
+        "Text": "168",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "168"
+        }
+      },
+      {
+        "Text": "1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        }
+      },
+      {
+        "Text": "2",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "180,25ml vloeistof",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": "180ml vloeistof",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": " 29km weg ",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": " 4 mei ",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": ",25ml vloeistof",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": ",08",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": ",08",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,08"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "en",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": ",23456000",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": ",23456000",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,23456"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "4,800",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "4,800",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4,8"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderddrie en twee derde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderddrie en twee derde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "103,666666666667"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdendrie en twee derde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderdendrie en twee derde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "103,666666666667"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "zestien",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "zestien",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "16"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "twee derde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "twee derde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,666666666666667"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdzestien",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderdzestien",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "116"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdzes",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderdzes",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "106"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdeenenzestig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderdeenenzestig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "161"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een half  dozijn",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een half dozijn",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " 3 dozijn",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "3 dozijn",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "36"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een dozijn",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een dozijn",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "12"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " drie dozijnen ",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie dozijnen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "36"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " driehonderd en twee dozijn",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "driehonderd en twee dozijn",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "324"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1.234,567",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1.234,567",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1234,567"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1, 234, 567",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        }
+      },
+      {
+        "Text": "234",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "234"
+        }
+      },
+      {
+        "Text": "567",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "567"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "9,2321312",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "9,2321312",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "9,2321312"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " -9,2321312",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-9,2321312",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-9,2321312"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " -1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-4/5",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-4/5",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-0,8"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "- 1 4/5",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "- 1 4/5",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1,8"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drie",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " 123456789101231",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "123456789101231",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "123456789101231"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-123456789101231",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-123456789101231",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-123456789101231"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " -123456789101231",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-123456789101231",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-123456789101231"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "10k",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "10k",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "10G",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "10G",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "- 10  k",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "- 10  k",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-10000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "2 miljoen",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "2 miljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 biljoen",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 biljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1000000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " drie ",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een biljoen",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een biljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1000000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "eenentwintig biljoen",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "eenentwintig biljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "21000000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "fifty - two",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "fifty - two",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "52"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeënvijftig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeënvijftig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "52"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeenvijftig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeenvijftig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "52"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeduizend tweehonderd",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeduizend tweehonderd",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2200"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeduizend tweehonderdtwintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeduizend tweehonderdtwintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2220"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeëntwintighonderd",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeëntwintighonderd",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2200"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " 2,33 k",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "2,33 k",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2330"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1e10",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1e10",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1,1^23",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1,1^23",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "8,95430243255239"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": " tweeendertigduizend tweehonderd  ",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeendertigduizend tweehonderd ",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "32200"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "zeventig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "zeventig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "70"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeenvijftig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeenvijftig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "52"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "2  1/4",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "2  1/4",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2,25"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "3/4",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "3/4",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,75"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een achtste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een achtste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,125"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "vijf achtste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "vijf achtste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,625"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een halve",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een halve",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,5"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drie kwart",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie kwart",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,75"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "twintig drie vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "twintig drie vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "20,6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drieëntwintig vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drieëntwintig vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4,6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drieëntwintig en drie vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drieëntwintig en drie vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "23,6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een miljoen tweeduizend tweehonderd drie vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een miljoen tweeduizend tweehonderd drie vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "200440,6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "anderhalf",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "anderhalf",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1,5"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een en een vierde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een en een vierde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1,25"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "vijf en een kwart",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "vijf en een kwart",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "5,25"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderd driekwart",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderd driekwart",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "100,75"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een honderdste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een honderdste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,01"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1,1^+23",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1,1^+23",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "8,95430243255239"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "2,5^-1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "2,5^-1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,4"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-2500^-1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-2500^-1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-0,0004"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-1,1^+23",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-1,1^+23",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-8,95430243255239"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-2,5^-1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-2,5^-1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-0,4"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-1,1^--23",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-1,1^--23",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-8,95430243255239"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-127,32e13",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-127,32e13",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1,2732E+15"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "12,32e+14",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "12,32e+14",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1,232E+15"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "-12e-1",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "-12e-1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1,2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1,2b",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1,2b",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1200000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdduizend biljoensten",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderdduizend biljoensten",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1E-07"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drie vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,6"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "twintig vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "twintig vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drie een vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie een vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3,2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "eenentwintig vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "eenentwintig vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4,2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een eenentwintigste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een eenentwintigste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,0476190476190476"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een vijfentwintigste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een vijfentwintigste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,04"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "drie eenentwintigste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "drie eenentwintigste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,142857142857143"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "twintig vijventwintigste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "twintig vijventwintigste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,8"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderd en dertig vijfde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "honderd en dertig vijfde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "35"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een van de drie",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een van de drie",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,333333333333333"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 uit eenentwintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 uit eenentwintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,0476190476190476"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 uit drie",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 uit drie",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,333333333333333"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 op de 3",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 op de 3",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,333333333333333"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 van de 3",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 van de 3",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0.333333333333333"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "één uit de 20",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "één uit de 20",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,05"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "één van de twintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "één van de twintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,05"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Boek een eerste klas ticket naar Amsterdam",
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
+  },
+  {
+    "Input": "Het antwoord is min een",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "min een",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Een op de twintig is hier niet tevreden mee",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "Een op de twintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-0.05"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Het antwoord is vijf en een half",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "vijf en een half",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "5,5"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Het antwoord is min 5 punt vijf",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "min 5 punt vijf",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-5,5"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Het antwoord is min 5",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "min 5",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-5"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een - vierde",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een - vierde",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,25"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een-achtste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een-achtste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,125"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "vijf / achtste",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "vijf / achtste",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,625"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "een van de drie",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "een van de drie",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,333333333333333"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 van de eenentwintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 van de eenentwintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,0476190476190476"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "vijf achtsten van",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "vijf achtsten",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,625"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 234 567",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 234 567",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1234567"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "40 000 is hetzelfde als 40 000",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "40 000",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "40000"
+        }
+      },
+      {
+        "Text": "40 000",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "40000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Op dit moment de populatie van China is 1 414 021 100.",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 414 021 100",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1414021100"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "423 0000 zal worden herkend als twee nummers.",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "423",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "423"
+        }
+      },
+      {
+        "Text": "0000",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        }
+      },
+      {
+        "Text": "twee",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "1 234 567,89 is een geldig nummer.",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1 234 567,89",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1234567,89"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Nul is hetzelfde als 0",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "nul",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        }
+      },
+      {
+        "Text": "0",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Heb je op 17/5/2018 tijd om af te spreken?",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "17",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "17"
+        }
+      },
+      {
+        "Text": "5",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "5"
+        }
+      },
+      {
+        "Text": "2018",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2018"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Mijn telefoonnummer is +1-222-2222/2222",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        }
+      },
+      {
+        "Text": "222",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "222"
+        }
+      },
+      {
+        "Text": "2222",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2222"
+        }
+      },
+      {
+        "Text": "2222",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2222"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeentwintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeentwintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "22"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "tweeëntwintig",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "tweeëntwintig",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "22"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "één",
+    "NotSupported": "dotNet",
+    "Results": [
+      {
+        "Text": "één",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  }
 ]

--- a/Specs/Number/Dutch/NumberModelPercentMode.json
+++ b/Specs/Number/Dutch/NumberModelPercentMode.json
@@ -1,7 +1,7 @@
 [
   {
     "Input": "één van de drie",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "één",
@@ -17,11 +17,12 @@
           "value": "3"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "1 in eenentwintig",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1",
@@ -37,6 +38,7 @@
           "value": "21"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]

--- a/Specs/Number/Dutch/NumberRangeModel.json
+++ b/Specs/Number/Dutch/NumberRangeModel.json
@@ -1,12 +1,13 @@
 [
   {
     "Input": "10-1995",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "Dit nummer is hoger dan twintig en kleiner of gelijk dan vijfendertig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "hoger dan twintig en kleiner of gelijk dan vijfendertig",
@@ -15,11 +16,12 @@
           "value": "(20,35]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het nummer ligt tussen de 20 en 30.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tussen de 20 en 30",
@@ -28,11 +30,12 @@
           "value": "(20,30)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hij is geëindigd tussen de tiende en de vijftiende.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tussen de tiende en de vijftiende",
@@ -41,11 +44,12 @@
           "value": "(10,15)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hij scoort tussen min tien en vijftien.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tussen min tien en vijftien",
@@ -54,11 +58,12 @@
           "value": "(-10,15)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hij staat hoger dan de tiende maar lager dan de vijftiende.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "hoger dan de tiende maar lager dan de vijftiende",
@@ -67,11 +72,12 @@
           "value": "(10,15)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Dit is een getal wat groter is dan 100, maar kleiner als 300",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "groter is dan 100, maar kleiner als 300",
@@ -80,11 +86,12 @@
           "value": "(100,300)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Dit aantal is hoger of gelijk aan honderd, maar lager of gelijk aan driehonderd",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "hoger of gelijk aan honderd, maar lager of gelijk aan driehonderd",
@@ -93,11 +100,12 @@
           "value": "[100,300]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Er zijn maximum 100 appels en op zijn minst 20 appels.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "maximum 100 appels en op zijn minst 20",
@@ -106,11 +114,12 @@
           "value": "[20,100]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Deze appels zijn ongeveer 20~100 gram",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "20~100",
@@ -119,11 +128,12 @@
           "value": "[20,100)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het bereik van de getallen is 20 tot 100",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "20 tot 100",
@@ -132,11 +142,12 @@
           "value": "[20,100)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het bereik van de getallen is 20 tot en met 100",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "20 tot en met 100",
@@ -145,11 +156,12 @@
           "value": "[20,100]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het bereik van de getallen gaat van duizend tot vijftienhonderd.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "van duizend tot vijftienhonderd",
@@ -158,11 +170,12 @@
           "value": "[1000,1500)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het nummer ligt boven de 1000 en onder de 1500",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "boven de 1000 en onder de 1500",
@@ -171,11 +184,12 @@
           "value": "(1000,1500)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het getal is hoger dan een kwart maar lager als de helft.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "hoger dan een kwart maar lager als de helft",
@@ -184,11 +198,12 @@
           "value": "(0.25,0.5)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Dit getal is groter of gelijk aan drieduizendnegenhonderdvijfenzestig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "groter of gelijk aan drieduizendnegenhonderdvijfenzestig",
@@ -197,11 +212,12 @@
           "value": "[3965,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Dit getal is groter als 4.565",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "groter als 4.565",
@@ -210,11 +226,12 @@
           "value": "(4565,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hij is meer dan dertig jaren oud.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "meer dan dertig",
@@ -223,11 +240,12 @@
           "value": "(30,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn leeftijd is niet minder dan dertig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "niet minder dan dertig",
@@ -236,11 +254,12 @@
           "value": "[30,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "There're about five hundred and more in these products.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "five hundred and more",
@@ -249,11 +268,12 @@
           "value": "[500,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Er zijn ongeveer vijfhonderd of meer van deze producten.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "vijfhonderd of meer",
@@ -262,11 +282,12 @@
           "value": "[500,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Meer dan de helft van de mensen is aanwezig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Meer dan de helft",
@@ -275,11 +296,12 @@
           "value": "(0.5,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Meer dan 1/2 van de mensen is aanwezig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Meer dan 1/2",
@@ -288,11 +310,12 @@
           "value": "(0.5,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zoek de priemgetallen die kleiner of gelijk aan 100 zijn",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "kleiner of gelijk aan 100",
@@ -301,11 +324,12 @@
           "value": "(,100]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Er zijn ongeveer vijfhonderd of minder van deze producten.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "vijfhonderd of minder",
@@ -314,11 +338,12 @@
           "value": "(,500]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Vind de priemgetallen die < = 100 zijn",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "< = 100",
@@ -327,11 +352,12 @@
           "value": "(,100]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn lengte is onder de 170.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "onder de 170",
@@ -340,11 +366,12 @@
           "value": "(,170)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn lengte is kleiner dan 170.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "kleiner dan 170",
@@ -353,11 +380,12 @@
           "value": "(,170)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Minder dan duizend reuzenpanda's leven nog steeds in het wild.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Minder dan duizend",
@@ -366,11 +394,12 @@
           "value": "(,1000)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "x is gelijk aan honderdzeventig.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan honderdzeventig",
@@ -379,11 +408,12 @@
           "value": "[170,170]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "x>10 en y<20",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": ">10",
@@ -399,11 +429,12 @@
           "value": "(,20)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "x is groter dan 10 en kleiner dan 20. y is niet meer als 50 en niet kleiner als 20.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "groter dan 10 en kleiner dan 20",
@@ -419,16 +450,18 @@
           "value": "[20,50]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Een vierde is een breuk",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "Het getal is gelijk aan 20.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 20",
@@ -437,11 +470,12 @@
           "value": "[20,20]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Gelijk aan 20, is het aantal studenten in onze klas niet significant.",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "Gelijk aan 20",
@@ -450,26 +484,30 @@
           "value": "[20,20]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "0612345678 is een telefoonnummer.",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "+31612345678 is een telefoonnummer.",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "+31 6 12 34 56 78 is een telefoonnummer.",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "Zojn resultaat is 200 of meer",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "200 of meer",
@@ -478,11 +516,12 @@
           "value": "[200,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn resultaat is 200 of hoger dan 190",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "hoger dan 190",
@@ -491,11 +530,12 @@
           "value": "(190,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het resultaat is 200 of hoger",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "200 of hoger",
@@ -504,11 +544,12 @@
           "value": "[200,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is minder dan of gelijk aan 30",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "minder dan of gelijk aan 30",
@@ -517,11 +558,12 @@
           "value": "(,30]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is gelijk aan of minder dan 30",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan of minder dan 30",
@@ -530,11 +572,12 @@
           "value": "(,30]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is minstens of gelijk aan 30",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "minstens of gelijk aan 30",
@@ -543,11 +586,12 @@
           "value": "[30,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is gelijk of meer dan 30",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk of meer dan 30",
@@ -556,11 +600,12 @@
           "value": "[30,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is gelijk aan 5000 of minder",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 5000 of minder",
@@ -569,11 +614,12 @@
           "value": "(,5000]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn score is gelijk aan 5000 of minder dan 6000",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 5000",
@@ -589,11 +635,12 @@
           "value": "(,6000)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn resultaat is gelijk aan 5000 of meer dan dat",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 5000 of meer dan",
@@ -602,11 +649,12 @@
           "value": "[5000,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het resultaat is gelijk aan 5000 of meer dan 4500",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 5000",
@@ -622,11 +670,12 @@
           "value": "(4500,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het resultaat is minder dan 5000 of gelijk aan",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "minder dan 5000 of gelijk aan",
@@ -635,11 +684,12 @@
           "value": "(,5000]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het kost meer dan 5000 of evenveel",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "meer dan 5000 of evenveel",
@@ -648,11 +698,12 @@
           "value": "[5000,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zijn resultaat is meer dan 5000 of gelijk aan",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "meer dan 5000 of gelijk aan",
@@ -661,11 +712,12 @@
           "value": "[5000,)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het resultaat is meer dan 5000 of gelijk aan 6000",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "meer dan 5000",
@@ -681,11 +733,12 @@
           "value": "[6000,6000]"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het resultaat is gelijk aan 5000 of minder dan 5000",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "gelijk aan 5000",
@@ -701,6 +754,7 @@
           "value": "(,5000)"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]

--- a/Specs/Number/Dutch/OrdinalModel.json
+++ b/Specs/Number/Dutch/OrdinalModel.json
@@ -1,7 +1,7 @@
 [
   {
     "Input": "drie biljoenste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "drie biljoenste",
@@ -10,16 +10,18 @@
           "value": "3000000000000"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een biljoenste",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "honderd biljoenste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "honderd biljoenste",
@@ -28,11 +30,12 @@
           "value": "100000000000000"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "11e",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "11e",
@@ -41,11 +44,12 @@
           "value": "11"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "derde",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "derde",
@@ -54,11 +58,12 @@
           "value": "3"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "30ste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "30ste",
@@ -67,11 +72,12 @@
           "value": "30"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "tweede",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tweede",
@@ -80,11 +86,12 @@
           "value": "2"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "elfde",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "elfde",
@@ -93,11 +100,12 @@
           "value": "11"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "nulde",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "nulde",
@@ -106,11 +114,12 @@
           "value": "0"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "twintigste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "twintigste",
@@ -119,11 +128,12 @@
           "value": "20"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "vijfentwintigste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "vijfentwintigste",
@@ -132,11 +142,12 @@
           "value": "25"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "eenentwintigste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "eenentwintigste",
@@ -145,11 +156,12 @@
           "value": "21"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "honderdvijfentwintigste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "honderdvijfentwintigste",
@@ -158,11 +170,12 @@
           "value": "125"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "biljoenste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "biljoenste",
@@ -171,11 +184,12 @@
           "value": "1000000000000"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "eerste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "eerste",
@@ -184,11 +198,12 @@
           "value": "1"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "tweehonderdste",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tweehonderdste",
@@ -197,11 +212,12 @@
           "value": "200"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Boek een eerste klas ticket naar Amsterdam",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "eerste",
@@ -210,6 +226,7 @@
           "value": "1"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]

--- a/Specs/Number/Dutch/PercentModel.json
+++ b/Specs/Number/Dutch/PercentModel.json
@@ -1,7 +1,7 @@
 [
   {
     "Input": "100%",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "100%",
@@ -10,11 +10,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " 100% ",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "100%",
@@ -23,11 +24,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " 100 procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "100 procent",
@@ -36,11 +38,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " percentage van 100",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "percentage van 100",
@@ -49,11 +52,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "240 procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "240 procent",
@@ -62,11 +66,12 @@
           "value": "240%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "twintig procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "twenty percent",
@@ -75,11 +80,12 @@
           "value": "20%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "percentage van 30 procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "30 procent",
@@ -88,11 +94,12 @@
           "value": "30%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "honderd procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "honderd procent",
@@ -101,11 +108,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "210 percent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "210 percent",
@@ -114,11 +122,12 @@
           "value": "210%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "10 percent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "10 percent",
@@ -127,11 +136,12 @@
           "value": "10%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "dit is een korting van min vijf procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "min vijf procent",
@@ -140,16 +150,19 @@
           "value": "-5%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Bezoek http://proquest.umi.com/pqdweb?RQT=305&SQ=issn%280024%2D9114%29%20and%20%28ti%28Using%203D%20CAD%20to%20design%20a%20dog%29%20or%20startpage%28158%29%29%20and%20volume%2872%29%20and%20issue%289%29%20and%20pdn%28%3E01%2F01%2F2000%20AND%20%3C12%2F31%2F2000%29&clientId=17859 voor meer informatie.",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   },
   {
     "Input": "Bezoek https://www.test.com/search?q=30%25%2020%",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   }
 ]

--- a/Specs/Number/Dutch/PercentModelPercentMode.json
+++ b/Specs/Number/Dutch/PercentModelPercentMode.json
@@ -1,7 +1,7 @@
 [
   {
     "Input": "100%",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "100%",
@@ -10,11 +10,12 @@
           "value": "100%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "twintig procent",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "twintig procent",
@@ -23,11 +24,12 @@
           "value": "20%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "percents of twenty",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "percents of twenty",
@@ -36,11 +38,12 @@
           "value": "20%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een van de drie",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "een van de drie",
@@ -49,11 +52,12 @@
           "value": "33,3333333333333%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een uit twee",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "een uit twee",
@@ -62,11 +66,12 @@
           "value": "50%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "1/4 van",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1/4 van",
@@ -75,11 +80,12 @@
           "value": "25%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een vierde van",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "een vierde van",
@@ -88,11 +94,12 @@
           "value": "25%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "de helft van",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "de helft van",
@@ -101,11 +108,12 @@
           "value": "50%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een kwart van",
-    "NotSupported": "dotNet,javascript,python",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "een kwart van",
@@ -114,11 +122,13 @@
           "value": "25%"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een derde",
-    "NotSupported": "dotNet,javascript,python",
-    "Results": []
+    "NotSupported": "",
+    "Results": [],
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   }
 ]

--- a/Specs/NumberWithUnit/Dutch/AgeModel.json
+++ b/Specs/NumberWithUnit/Dutch/AgeModel.json
@@ -11,7 +11,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Dit verhaal is 10 jaar oud.",
@@ -25,7 +26,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben pas 29 jaar.",
@@ -39,7 +41,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Nu, op 95-jarige leeftijd, inzichten veranderen.",
@@ -53,7 +56,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "De Chinese Muur is meer dan 500 jaar oud en is langer dan 5000 mijl.",
@@ -67,7 +71,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zij is 60; zij is geboren op 8 mei 1945.",
@@ -81,7 +86,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "25% van de gevallen zijn niet gediagnostiseerd tot een leeftijd van 3 jaar.",
@@ -95,7 +101,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Wanneer komt er druk om een afspraak van 1 jaar na te komen?",
@@ -109,7 +116,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het gebeurde toen de baby pas 10 maanden was.",
@@ -123,7 +131,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het bestuursvoorstel is 8 maanden.",
@@ -137,7 +146,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ongeveer 50% van de gevallen worden gediagnostiseerd wanneer ze 18 maanden oud zijn.",
@@ -151,7 +161,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het is mogelijk, maar in 2006 was 95% jonger dan drie maanden.",
@@ -165,7 +176,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Als we doorgaan in december, is het project 3 weken oud.",
@@ -179,7 +191,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Op 6-jarige leeftijd kun je al Kerst vieren.",
@@ -193,7 +206,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Een energie factuur van 90 dagen is erg oud",
@@ -207,11 +221,12 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hij is tussen de 40 en 50 jaar.",
-    "NotSupported": "dotNet,javascript,python,java,",
+    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "50 jaar",
@@ -221,6 +236,7 @@
           "value": "50"
         }
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]

--- a/Specs/NumberWithUnit/Dutch/DimensionModel.json
+++ b/Specs/NumberWithUnit/Dutch/DimensionModel.json
@@ -11,7 +11,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het grootste nadeel is de dikte van 3 inch, groot genoeg voor een consultant om het beschrijven als plomp.",
@@ -25,7 +26,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "een tornado woekerde door een gebied van tien kilometer lang, waardoor ten minste veertien mensen om het leven zijn gekomen en tientallen huizen verwoest zijn.",
@@ -39,7 +41,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Er is meer dan 10 1/2 kilometer kabel en snoer nodig om het allemaal aan te sluiten, en 23 computers.",
@@ -53,7 +56,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "de reis van 6 kilometer naar mijn vliegveld hotel dat eerder op de dag 20 minuten duurde, duurde nu meer dan drie uur.",
@@ -67,7 +71,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " In de gehele industrie daalde de olieproductie in dit land met 500.000 vaten per dag naar vaten in de eerste acht maanden van dit jaar. ",
@@ -81,7 +86,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " het is wat 1) verklaart waarom we zijn als, nou ja, onszelf in plaats van bo jackson; 2) waarschuwt dat het mogelijk is om te verdrinken in een meer dat gemiddeld twee voet diep is; en 3) voorspelt dat 10.000 apen die vóór 10.000 worden geplaatst, 1, 118 publiceerbare rock 'n' roll-tunes produceren.",
@@ -95,7 +101,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " op 19 mei begon de fda met het vasthouden van Chinese paddestoelen in 68 ons blikken nadat meer dan 100 mensen in Mississippi, New York en Pennsylvania ziek werden door het eten van bedorven champignons.",
@@ -109,7 +116,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Dhr. Hulings gnoof dat hij al zijn aandelen verkocht een week voor de markt 190 punten kelderde op 13 oktober, en hij gebruikt het geld om een 45-hectare groot paardenbedrijf te kopen.",
@@ -123,7 +131,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "dan, om van deze tuintjes vrij letterlijk kamers te maken, had mvr. Bartlett raamloze wanden (baksteen, traliewerk, haag) van acht tot tien voet hoog gemaakt, waardoor haar interieurs in dag-lange stygische schaduwen worden geworpen",
@@ -137,7 +146,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "'management wil geen verrassingen', merkt jack zaves op, die als brandstofservicedirecteur bij American Airlines jaarlijks ongeveer 2,4 miljard liter vliegtuigbrandstof koopt.",
@@ -151,7 +161,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " een 10-liter waterkoeler was op de vloer gevallen en bedrenkte de rode vloerbedekking. ",
@@ -165,7 +176,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " in de buurt, dartelen zes dolfijnen in een zeewateraquarium van 1,5 miljoen liter. ",
@@ -179,7 +191,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " en deze baby is meer dan twee pond.",
@@ -193,7 +206,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "ik vertrouw mensen die niet eten, niet, zei ms. Volokh, hoewel ze zelf een paar jaar geleden stopte met het eten van lunch om 25 pond te laten vallen. ",
@@ -207,7 +221,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Shell, een dochteronderneming van Royal Dutch / Shell Group, mag 0,9 biljoen kubieke voet exporteren, en Golf, een afdeling van Olympia & York Developments ltd. zal worden toegestaan om te exporteren ",
@@ -221,7 +236,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " De belangrijkste elementen van de wetgeving, zoals die momenteel worden weergegeven, zijn: - een beperking van de hoeveelheid onroerend goed die een gezin kan bezitten, tot 660 vierkante meter in de zes grootste steden van de natie, maar meer in kleinere steden en plattelandsgebieden.",
@@ -235,7 +251,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Tigrische legers zijn nu 200 mijl ten noorden van Addis Ababa en bedreigen de stad Dese, die de heer Mengistu 's hoofdstad zou afsnijden van de haven van Assab, via welke alle brandstof en andere benodigdheden Addis Ababa bereiken.",
@@ -249,7 +266,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " hij zei dat een van de computers drie meter over de vloer gleed. ",
@@ -263,7 +281,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de kern van het bezit is 190.000 vierkante meter ongelooflijk duur vastgoed in de wijk Marunouchi, het zakelijke en financiële centrum van Tokio, vaak gekscherend 'Mitsubishi-dorp' genoemd. ''",
@@ -277,7 +296,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de satelliet, gebouwd door hughes voor de internationale telecommunicatiesatellietorganisatie, maakt deel uit van een contract van 700 miljoen dollar dat in 1982 aan Hughes werd toegekend om vijf van de drie ton-satellieten te ontwikkelen.",
@@ -291,7 +311,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " in een rapport uit 1996 over biologische wapens, waarschuwde het centrum voor strategische en internationale studies, een onderzoeksinstelling voor overheidsbeleid in Washington, dat het voor potentiële terroristen gemakkelijk was om biologische wapens te verzamelen _ met behulp van commerciële apparatuur met een capaciteit van 130 liter. ",
@@ -305,7 +326,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " uit de gegevens van de handelsgroep over de gegevens van de handelsafdeling bleek dat de invoer in augustus, het op een na grootste maandelijkse totaal van het jaar, met 5% steeg ten opzichte van 1.488.000 ton in juli, maar onder het niveau van vorig jaar in juni 1988.",
@@ -319,7 +341,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " bij nummer 1, sloeg Singh een 9-ijzeren naderingsschot tot op zes voet van de beker.",
@@ -333,7 +356,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " dus wanneer het psylliumgewas van volgend jaar in maart wordt geoogst, kan het kleiner zijn dan de 16.000 ton van de afgelopen paar jaar - precies op de top van de psylliumboom.",
@@ -347,7 +371,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de 486 is de afstammeling van een lange reeks intel-chips die de markt begon te domineren sinds IBM de 16-bit 8088-chip koos voor zijn eerste personal computer. ",
@@ -361,7 +386,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de `` jiotto caspita '' kan op meer dan 188 mijl per uur rennen, aldus een woordvoerder van het bedrijf.",
@@ -375,7 +401,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "de marine heeft een helikopterlandingszone opgezet op slechts 100 meter van een mobiele operatiekamer, net aan de rand van Bagdad.",
@@ -389,7 +416,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Caltran is van plan om een tweede dek toe te voegen voor bussen en carpools boven de mediaan van een 2,5 mijl lang stuk van de havenfiet net ten zuiden van Los Angeles, in de buurt van het gedenkteken Coliseum. ",
@@ -403,7 +431,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " op mijn rit van vier mijl naar het hoofdkwartier van de boerderij elke ochtend, rijd ik langs nog vier lege huizen.",
@@ -417,7 +446,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " we zijn beledigd, zei Langa van het Grieks-katholieke hoofdkwartier, zo'n 325 kilometer ten noordwesten van Boekarest. ",
@@ -431,7 +461,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Rotich is een kleine (5 voet",
@@ -445,7 +476,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "4 inch) 28 - jarige die pas drie jaar geleden serieus begon te rennen en tot deze maand niet binnen competitie had gedaan. ",
@@ -459,7 +491,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " racebaan park (minnesota) in shakopee is een verharde ovaal van 1/4 mijl. ",
@@ -473,7 +506,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Castlecrag Mountain ligt ten zuiden van Moat Lake, 1,6 km ten westen van Mount Frink langs dezelfde rand lijn.",
@@ -487,7 +521,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de javadi-heuvels liggen op ongeveer 17 km van Ambur.",
@@ -501,7 +536,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Na meer dan twee uur rond het meer in Michigan in de buurt van de expositie te hebben gevlogen, heeft commandant hugo eckener het 776-voet luchtschip geland op de nabijgelegen curtiss-wright luchthaven in glenview. ",
@@ -515,7 +551,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "het knooppunt met snelweg 35 en snelweg 115 naar Lindsay en Peterborough (afrit 436) ligt 500 meter ten oosten van Bennett Road. ",
@@ -529,7 +566,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " in 1995 introduceerde Canon de eerste commercieel verkrijgbare SLR-lens met interne beeldstabilisatie, bijv. 75 - 300 mm f / 4 - 5. 6 is usm. ",
@@ -543,7 +581,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " Sterling Armaments uit Dagenham, Essex produceerde een conversiekit bestaande uit een nieuwe 7,62 mm vat, magazijn, afzuigkap en uitwerper voor commerciële verkoop. ",
@@ -557,7 +596,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " het project kost $46.8 miljoen, en is bedoeld om de productiecapaciteit van het bedrijf met 25% te verhogen tot 34.500 metrische ton koperkathodes per jaar. ",
@@ -571,7 +611,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " de productie van canadese staal - ingots bedroeg 291.890 ton in de week eindigend op 7 oktober, 14. 8% meer dan het totaal van de vorige week, zei een Federaal agentschap. ",
@@ -585,7 +626,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "De floridapanters hebben leefgebieden tussen de 190 km2.",
@@ -599,7 +641,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": " een metrische ton is gelijk aan 2,204.62 pond. ",
@@ -621,11 +664,13 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben een man",
     "Results": [],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "",
+    "NotSupportedByDesign": "dotNet,javascript,python,java"
   }
 ]

--- a/Specs/NumberWithUnit/Dutch/TemperatureModel.json
+++ b/Specs/NumberWithUnit/Dutch/TemperatureModel.json
@@ -11,7 +11,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "het is 90 Fahrenheit in Texas",
@@ -25,7 +26,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "-5 graden Fahrenheit",
@@ -39,7 +41,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "6 gr. C",
@@ -53,7 +56,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "98,6 graden F is de normale temperatuur",
@@ -67,7 +71,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Zet de temperatuur op 30 graden Celsius",
@@ -81,7 +86,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "normale temperatuur is 98,6 graden Fahrenheit",
@@ -95,7 +101,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "100 graden F",
@@ -109,7 +116,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "20 graden C",
@@ -123,7 +131,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "100,2 graden Farenheit is laag",
@@ -137,7 +146,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "10,5 Celcius",
@@ -151,7 +161,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "20 graden Celsius",
@@ -165,7 +176,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "20,3 Celsius",
@@ -179,7 +191,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "34,5 Celcius",
@@ -193,7 +206,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "de temperatuur buiten is 30 graden",
@@ -207,7 +221,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "zet de thermostaat op 85°",
@@ -221,7 +236,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "verhoog de temperatuur met 5 graden",
@@ -235,7 +251,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "zet de temperatuur op 70 graden F",
@@ -249,7 +266,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "verhoog de temperatuur met 20 graden",
@@ -263,7 +281,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "zet de temperatuur op 100 graden",
@@ -277,7 +296,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "hou de temperatuur op 75 graden F",
@@ -291,7 +311,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laat de temperatuur 40 Celsius zijn",
@@ -305,7 +326,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laat de temperatuur 50 graden zijn",
@@ -319,7 +341,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "converteer 10 graden Celsius to Fahrenheit",
@@ -341,7 +364,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "34,9 graden Celsius naar Fahrenheit",
@@ -363,7 +387,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "converteer 200 graden Celsius naar Fahrenheit",
@@ -393,7 +418,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Fahrenheit naar Celsius: 101 Fahrenheit is hoe veel graden Celsius",
@@ -431,7 +457,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "50 graden Celsius naar Fahrenheit",
@@ -461,7 +488,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "zou je 51 Fahrenheit naar graden Celsius kunnen converteren?",
@@ -483,7 +511,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "converteer 106 graden Fahrenheit naar graden Celsius",
@@ -505,7 +534,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "converteer 45 graden Fahrenheit naar Celsius",
@@ -527,7 +557,8 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "hoe converteer je - 20 graden Fahrenheit naar Celsius",
@@ -549,6 +580,7 @@
         }
       }
     ],
-    "NotSupported": "dotNet,javascript,python,java,"
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]


### PR DESCRIPTION
Changed ```NotSupported``` to ```NotSupportedByDesign``` for javascript, python and java. 

I kept the dotNet on NotSupported for now, should I also change them to NotSupportedByDesign since there is no implementation yet? Or keep them on NotSupported since implementation is planned.