### PR TITLE
Enable explicit priority order of regexes in BaseNumberExtractor

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Japanese/NumbersDefinitions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 		public const string WhiteListRegex = @"(。|，|、|（|）|”｜国|週間|時間|時|匹|キロ|トン|年|個|足|本|\s|$)";
 		public static readonly string NotSingleRegex = $@"(?<!(第|だい))(({RoundNumberIntegerRegex}+({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*))|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*({RoundNumberIntegerRegex}\s*){{1,2}})\s*(([零]?({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*{RoundNumberIntegerRegex}{{0,1}})\s*)*\s*(\s*(以上)?)";
 		public static readonly string SingleRegex = $@"(({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|十)(?={WhiteListRegex}))";
-		public static readonly string AllIntRegex = $@"(({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|[十百千])\s*{RoundNumberIntegerRegex}*){{1,2}}\s*(\s*[以上]?)";
+		public static readonly string AllIntRegex = $@"(((({ZeroToNineIntegerRegex}|[十百千])\s*{RoundNumberIntegerRegex}*)|({ZeroToNineFullHalfRegex}\s*{RoundNumberIntegerRegex})){{1,2}}(\s*[以上])?)";
 		public static readonly string NumbersSpecialsChars = $@"(({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?{ZeroToNineFullHalfRegex}+";
 		public static readonly string NumbersSpecialsCharsWithSuffix = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)";
 		public static readonly string DottedNumbersSpecialsChar = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{{1,3}}([,，、]{ZeroToNineFullHalfRegex}{{3}})+";
@@ -141,7 +141,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 		public static readonly string FractionNotationSpecialsCharsRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+\s+{ZeroToNineFullHalfRegex}+[/／]{ZeroToNineFullHalfRegex}+";
 		public static readonly string FractionNotationRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[/／]{ZeroToNineFullHalfRegex}+";
 		public static readonly string PercentagePointRegex = $@"(?<!{AllIntRegex})({AllFloatRegex}|{AllIntRegex})\s*パ\s*ー\s*セ\s*ン\s*ト";
-		public static readonly string SimplePercentageRegex = $@"({AllFloatRegex}|{AllIntRegex}|{ZeroToNineIntegerRegex}|[百])\s*パ\s*ー\s*セ\s*ン\s*ト";
+		public static readonly string SimplePercentageRegex = $@"({AllFloatRegex}|{AllIntRegex}|[百])\s*パ\s*ー\s*セ\s*ン\s*ト";
 		public static readonly string NumbersPercentagePointRegex = $@"({ZeroToNineFullHalfRegex})+([\.．]({ZeroToNineFullHalfRegex})+)?\s*パ\s*ー\s*セ\s*ン\s*ト";
 		public static readonly string NumbersPercentageWithSeparatorRegex = $@"({ZeroToNineFullHalfRegex}{{1,3}}[,，、]{ZeroToNineFullHalfRegex}{{3}})+([\.．]{ZeroToNineFullHalfRegex}+)*\s*パ\s*ー\s*セ\s*ン\s*ト";
 		public static readonly string NumbersPercentageWithMultiplierRegex = $@"(?<!{ZeroToNineIntegerRegex}){ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)\s*パ\s*ー\s*セ\s*ン\s*ト";

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
 
         // CardinalExtractor = Int + Double
         public CardinalExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             var intExtractChs = new IntegerExtractor(mode);
             builder.AddRange(intExtractChs.Regexes);

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
 
         public DoubleExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
         
         public FractionExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     // -4 5/2,       ４ ６／３

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
         
         public IntegerExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>()
             {
                 {
                     // 123456,  －１２３４５６

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
 
         public NumberExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Cardinal
             var cardExtractChs = new CardinalExtractor(mode);

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
 
         public OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     //第一百五十四

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class PercentageExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
 
         public PercentageExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     //二十个百分点,  四点五个百分点

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/CardinalExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             //Add Integer Regexes
             var intExtract = IntegerExtractor.GetInstance(placeholder);

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string> {
+            var regexes = new Dictionary<Regex, TypeTag> {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder),
                               RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/FractionExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override NumberOptions Options { get; }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.Number.English
         {
             Options = options;
 
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex,

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
 
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string> {
+            var regexes = new Dictionary<Regex, TypeTag> {
                 {
                     new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder),
                               RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override NumberOptions Options { get; }
 
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 
             Options = options;
 
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
             
             //Add Cardinal
             CardinalExtractor cardExtract = null;

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/OrdinalExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.English
 
         private OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number
 {
     public abstract class BaseNumberExtractor : IExtractor
     {
-        internal abstract ImmutableDictionary<Regex, string> Regexes { get; }
+        internal abstract ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected virtual string ExtractType { get; } = "";
 
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             var result = new List<ExtractResult>();
-            var matchSource = new Dictionary<Match, string>();
+            var matchSource = new Dictionary<Match, TypeTag>();
             var matched = new bool[source.Length];
 
             var collections = Regexes.ToDictionary(o => o.Key.Matches(source), p => p.Value);
@@ -56,7 +56,8 @@ namespace Microsoft.Recognizers.Text.Number
 
                         if (matchSource.Keys.Any(o => o.Index == start && o.Length == length))
                         {
-                            var srcMatch = matchSource.Keys.First(o => o.Index == start && o.Length == length);
+                            var type = matchSource.Where(p => p.Key.Index == start && p.Key.Length == length)
+                                .Select(p => (p.Value.Priority, p.Value.Name)).Min().Item2;
 
                             // Extract negative numbers
                             if (NegativeNumberTermsRegex != null) {
@@ -75,7 +76,7 @@ namespace Microsoft.Recognizers.Text.Number
                                 Length = length,
                                 Text = substr,
                                 Type = ExtractType,
-                                Data = matchSource.ContainsKey(srcMatch) ? matchSource[srcMatch] : null
+                                Data = type
                             };
                             result.Add(er);
                         }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Recognizers.Text.Number
         {
             foreach (var er in ers)
             {
-                if (er.Data != null && er.Data.ToString() == RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH))
+                if (er.Data != null && er.Data.ToString() == RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH).Name)
                 {
                     var match = AmbiguousFractionConnectorsRegex.Match(er.Text);
 

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/CardinalExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number.French
 
         public CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Integer Regexes
             var intExtract = new IntegerExtractor(placeholder);

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/DoubleExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
 
         public DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            this.Regexes = new Dictionary<Regex, string>
+            this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexOptions.IgnoreCase | RegexOptions.Singleline),

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/FractionExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
 
         public FractionExtractor()
         {
-            this.Regexes = new Dictionary<Regex, string>
+            this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline)

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/IntegerExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
 
         public IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            this.Regexes = new Dictionary<Regex, string>
+            this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexOptions.IgnoreCase | RegexOptions.Singleline)

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/NumberExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
 
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.French
 
         public NumberExtractor(NumberMode mode = NumberMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             CardinalExtractor cardExtract = null;
             switch(mode)

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/OrdinalExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.French
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
 
         public OrdinalExtractor()
         {
-            this.Regexes = new Dictionary<Regex, string>
+            this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/CardinalExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             //Add Integer Regexes
             var intExtract = IntegerExtractor.GetInstance(placeholder);

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string> {
+            var regexes = new Dictionary<Regex, TypeTag> {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder),
                               RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private FractionExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex,

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
 
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string> {
+            var regexes = new Dictionary<Regex, TypeTag> {
                 {
                     new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder),
                               RegexOptions.IgnoreCase | RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
 
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private NumberExtractor(NumberMode mode = NumberMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
             
             //Add Cardinal
             CardinalExtractor cardExtract = null;

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline),

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/PercentageExtractor.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         protected override ImmutableHashSet<Regex> InitRegexes()
         {
-            HashSet<string> regexStrs = new HashSet<string>
+            var regexStrs = new HashSet<string>
             {
                 NumbersDefinitions.NumberWithSuffixPercentage,
                 NumbersDefinitions.NumberWithPrefixPercentage

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
@@ -5,14 +5,14 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
 
         // CardinalExtractor = Int + Double
         public CardinalExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             var intExtract = new IntegerExtractor(mode);
             builder.AddRange(intExtract.Regexes);

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
 
         public DoubleExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexOptions.IgnoreCase | RegexOptions.Singleline)

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
 
         public FractionExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     // -4 5/2,       ４ ６／３

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
 
         public IntegerExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     // 123456,  －１２３４５６

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
@@ -5,13 +5,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
 
         public NumberExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Cardinal
             var cardExtract = new CardinalExtractor(mode);

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
         public NumberRangeExtractor() : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new JapaneseNumberParserConfiguration()))
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, string>
             {
                 {
                     // ...と...の間

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
 
         public OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     //だい一百五十四

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class PercentageExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_PERCENTAGE;
 
         public PercentageExtractor()
         {
-            var regexes = new Dictionary<Regex, string>()
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     //百パーセント 十五パーセント

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/CardinalExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class CardinalExtractor : BaseNumberExtractor // Same as Spanish.
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Integer Regexes
             var intExtract = new IntegerExtractor(placeholder);

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
 
         public DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexOptions.IgnoreCase | RegexOptions.Singleline),

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
 
         public FractionExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.FractionNotationRegex,

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
 
         public IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder),

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/NumberExtractor.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
 
         public NumberExtractor(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             //Add Cardinal
             CardinalExtractor cardExtract = null;

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
 
         public OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(

--- a/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
@@ -1,14 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Microsoft.Recognizers.Text.Number
+﻿namespace Microsoft.Recognizers.Text.Number
 {
-    public class RegexTagGenerator
+    public static class RegexTagGenerator
     {
-        public static string GenerateRegexTag(string extractorType, string suffix)
+        private static int _priority;
+        public static TypeTag GenerateRegexTag(string extractorType, string suffix)
         {
-            return $"{extractorType}{suffix}";
+            return new TypeTag($"{extractorType}{suffix}", ++_priority);
+        }
+    }
+
+    public class TypeTag
+    {
+        public string Name { get; }
+        public int Priority { get; }
+
+        public TypeTag(string name, int priority)
+        {
+            Name = name;
+            Priority = priority;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
@@ -2,10 +2,10 @@
 {
     public static class RegexTagGenerator
     {
-        private static int _priority;
+        private static int priority;
         public static TypeTag GenerateRegexTag(string extractorType, string suffix)
         {
-            return new TypeTag($"{extractorType}{suffix}", ++_priority);
+            return new TypeTag($"{extractorType}{suffix}", ++priority);
         }
     }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/CardinalExtractor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
 
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             //Add Integer Regexes
             var intExtract = new IntegerExtractor(placeholder);

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
         
         public DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string> {
+            var regexes = new Dictionary<Regex, TypeTag> {
                 {
                     new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder),
                               RegexOptions.IgnoreCase | RegexOptions.Singleline),

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
 
         public FractionExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.FractionNotationRegex,

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
         
         public IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder),

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
 
         public NumberExtractor(NumberMode mode = NumberMode.Default, NumberOptions options = NumberOptions.None)
         {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, string>();
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             //Add Cardinal
             CardinalExtractor cardExtract = null;
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     break;
                 case NumberMode.Currency:
                     builder.Add(new Regex(NumbersDefinitions.CurrencyRegex, RegexOptions.Singleline),
-                        "IntegerNum");
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
                     break;
                 case NumberMode.Default:
                     break;
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             var fracExtract = new FractionExtractor();
             builder.AddRange(fracExtract.Regexes);
 
-            this.Regexes = builder.ToImmutable();
+            Regexes = builder.ToImmutable();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
         
         public OrdinalExtractor()
         {
-            var regexes = new Dictionary<Regex, string>
+            var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
                     new Regex(

--- a/JavaScript/packages/recognizers-number/src/resources/japaneseNumeric.ts
+++ b/JavaScript/packages/recognizers-number/src/resources/japaneseNumeric.ts
@@ -37,7 +37,7 @@ export namespace JapaneseNumeric {
 	export const WhiteListRegex = `(。|，|、|（|）|”｜国|週間|時間|時|匹|キロ|トン|年|個|足|本|\\s|$)`;
 	export const NotSingleRegex = `(?<!(第|だい))((${RoundNumberIntegerRegex}+(${ZeroToNineIntegerRegex}+|${ZeroToNineFullHalfRegex}+|十)\\s*))|((${ZeroToNineIntegerRegex}+|${ZeroToNineFullHalfRegex}+|十)\\s*(${RoundNumberIntegerRegex}\\s*){1,2})\\s*(([零]?(${ZeroToNineIntegerRegex}+|${ZeroToNineFullHalfRegex}+|十)\\s*${RoundNumberIntegerRegex}{0,1})\\s*)*\\s*(\\s*(以上)?)`;
 	export const SingleRegex = `((${ZeroToNineIntegerRegex}|${ZeroToNineFullHalfRegex}|十)(?=${WhiteListRegex}))`;
-	export const AllIntRegex = `((${ZeroToNineIntegerRegex}|${ZeroToNineFullHalfRegex}|[十百千])\\s*${RoundNumberIntegerRegex}*){1,2}\\s*(\\s*[以上]?)`;
+	export const AllIntRegex = `((((${ZeroToNineIntegerRegex}|[十百千])\\s*${RoundNumberIntegerRegex}*)|(${ZeroToNineFullHalfRegex}\\s*${RoundNumberIntegerRegex})){1,2}(\\s*[以上])?)`;
 	export const NumbersSpecialsChars = `((${NegativeNumberTermsRegexNum}|${NegativeNumberTermsRegex})\\s*)?${ZeroToNineFullHalfRegex}+`;
 	export const NumbersSpecialsCharsWithSuffix = `${NegativeNumberTermsRegexNum}?${ZeroToNineFullHalfRegex}+\\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)`;
 	export const DottedNumbersSpecialsChar = `${NegativeNumberTermsRegexNum}?${ZeroToNineFullHalfRegex}{1,3}([,，、]${ZeroToNineFullHalfRegex}{3})+`;
@@ -62,7 +62,7 @@ export namespace JapaneseNumeric {
 	export const FractionNotationSpecialsCharsRegex = `(${NegativeNumberTermsRegexNum}\\s*)?${ZeroToNineFullHalfRegex}+\\s+${ZeroToNineFullHalfRegex}+[/／]${ZeroToNineFullHalfRegex}+`;
 	export const FractionNotationRegex = `(${NegativeNumberTermsRegexNum}\\s*)?${ZeroToNineFullHalfRegex}+[/／]${ZeroToNineFullHalfRegex}+`;
 	export const PercentagePointRegex = `(?<!${AllIntRegex})(${AllFloatRegex}|${AllIntRegex})\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;
-	export const SimplePercentageRegex = `(${AllFloatRegex}|${AllIntRegex}|${ZeroToNineIntegerRegex}|[百])\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;
+	export const SimplePercentageRegex = `(${AllFloatRegex}|${AllIntRegex}|[百])\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;
 	export const NumbersPercentagePointRegex = `(${ZeroToNineFullHalfRegex})+([\\.．](${ZeroToNineFullHalfRegex})+)?\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;
 	export const NumbersPercentageWithSeparatorRegex = `(${ZeroToNineFullHalfRegex}{1,3}[,，、]${ZeroToNineFullHalfRegex}{3})+([\\.．]${ZeroToNineFullHalfRegex}+)*\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;
 	export const NumbersPercentageWithMultiplierRegex = `(?<!${ZeroToNineIntegerRegex})${ZeroToNineFullHalfRegex}+[\\.．]${ZeroToNineFullHalfRegex}+\\s*(K|k|M|G|T|Ｍ|Ｋ|ｋ|Ｇ|Ｔ)\\s*パ\\s*ー\\s*セ\\s*ン\\s*ト`;

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -123,7 +123,7 @@ SingleRegex: !nestedRegex
   def: (({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|十)(?={WhiteListRegex}))
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, WhiteListRegex]
 AllIntRegex: !nestedRegex
-  def: (({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|[十百千])\s*{RoundNumberIntegerRegex}*){1,2}\s*(\s*[以上]?)
+  def: (((({ZeroToNineIntegerRegex}|[十百千])\s*{RoundNumberIntegerRegex}*)|({ZeroToNineFullHalfRegex}\s*{RoundNumberIntegerRegex})){1,2}(\s*[以上])?)
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 NumbersSpecialsChars: !nestedRegex
   def: (({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?{ZeroToNineFullHalfRegex}+
@@ -201,7 +201,7 @@ PercentagePointRegex: !nestedRegex
   def: (?<!{AllIntRegex})({AllFloatRegex}|{AllIntRegex})\s*パ\s*ー\s*セ\s*ン\s*ト
   references: [AllIntRegex, AllFloatRegex]
 SimplePercentageRegex: !nestedRegex
-  def: ({AllFloatRegex}|{AllIntRegex}|{ZeroToNineIntegerRegex}|[百])\s*パ\s*ー\s*セ\s*ン\s*ト
+  def: ({AllFloatRegex}|{AllIntRegex}|[百])\s*パ\s*ー\s*セ\s*ン\s*ト
   references: [ZeroToNineIntegerRegex, AllFloatRegex, AllIntRegex]
 NumbersPercentagePointRegex: !nestedRegex
   def: ({ZeroToNineFullHalfRegex})+([\.．]({ZeroToNineFullHalfRegex})+)?\s*パ\s*ー\s*セ\s*ン\s*ト


### PR DESCRIPTION
This PR address the implicit priority order issue which mentioned in #766 and #736.

Note that the first commit of this PR is expected to fail in order to reproduce the test cases failing mentioned in #736.

![image](https://user-images.githubusercontent.com/18565449/43633089-c36dc430-973a-11e8-8617-8c9a15a81202.png)
