### PR TITLE
Add bignumber.js missing dependency

### DIFF
--- a/JavaScript/packages/recognizers-number/package-lock.json
+++ b/JavaScript/packages/recognizers-number/package-lock.json
@@ -1,7 +1,14 @@
 {
-	"requires": true,
+	"name": "@microsoft/recognizers-text-number",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"bignumber.js": {
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -17,6 +24,5 @@
 			"resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
 			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
 		}
-	},
-	"version": "1.1.0"
+	}
 }

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -31,9 +31,10 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
+    "@microsoft/recognizers-text": "~1.1.0",
+    "bignumber.js": "^7.2.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.sortby": "^4.7.0",
-    "lodash.trimend": "^4.5.1",
-    "@microsoft/recognizers-text": "~1.1.0"
+    "lodash.trimend": "^4.5.1"
   }
 }


### PR DESCRIPTION
Add missing `bignumber.js` dependency in `JavaScript/packages/recognizers-number/package.json`.
This dependency was updated and incorrectly _moved_ to root's package.json.
It is correct to update in root since it is used by lerna, however since removed from `recognizers-number/package.json` is is no longer installed alongside which causes issues in dependant packages like [`botbuilder-dialogs`](https://github.com/Microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/package.json#L25-L28)