### PR TITLE
Fix wrong extraction for '2015 or later than 2018' in JavaScript

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -140,7 +140,7 @@ export class BaseMergedExtractor implements IDateTimeExtractor {
                     }
                 }
 
-                // insert at the first overlap occurence to keep the order
+                // insert at the first overlap occurrence to keep the order
                 tempDst.splice(firstIndex, 0, value);
                 destination.length = 0;
                 destination.push.apply(destination, tempDst);
@@ -570,8 +570,21 @@ export class BaseMergedParser implements IDateTimeParser {
                 return;
             }
 
+            // For the 'after' mod
+            // 1. Cases like "After January". the end of the period should be the start of the new period, not the end
+            // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
             if (mod === TimeTypeConstants.afterMod) {
-                result[TimeTypeConstants.START] = end;
+                // For cases like "After January" or "After 2018"
+                // The "end" of the period is not inclusive by default ("January", the end should be "XXXX-02-01" / "2018", the end should be "2019-01-01")
+                // Mod "after" is also not inclusive the "start" ("After January", the start should be "XXXX-01-31" / "After 2018", the start should be "2017-12-31")
+                // So here the START day should be the inclusive end of the period, which is one day previous to the default end (exclusive end)
+                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end)) {
+                    var dateObj = new Date(end);
+                    dateObj.setDate(dateObj.getDate() - 1);
+                    result[TimeTypeConstants.START] = FormatUtil.formatDate(dateObj);
+                } else {
+                    result[TimeTypeConstants.START] = start;
+                }
                 return;
             }
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -229,7 +229,7 @@ export namespace EnglishDateTime {
 	export const DecadeRegex = `(?<decade>noughties|twenties|thirties|forties|fifties|sixties|seventies|eighties|nineties|two thousands)`;
 	export const DecadeWithCenturyRegex = `(the\\s+)?(((?<century>\\d|1\\d|2\\d)?(')?(?<decade>\\d0)(')?s)|((${CenturyRegex}(\\s+|-)(and\\s+)?)?${DecadeRegex})|(${CenturyRegex}(\\s+|-)(and\\s+)?(?<decade>tens|hundreds)))`;
 	export const RelativeDecadeRegex = `\\b((the\\s+)?${RelativeRegex}\\s+((?<number>[\\w,]+)\\s+)?decades?)\\b`;
-	export const DateAfterRegex = `\\b((or|and)\\s+(above|after|later|greater))\\b`;
+	export const DateAfterRegex = `\\b((or|and)\\s+(above|after|later|greater)(?!\\s+than))\\b`;
 	export const YearPeriodRegex = `((((from|during|in)\\s+)?${YearRegex}\\s*(${TillRegex})\\s*${YearRegex})|(((between)\\s+)${YearRegex}\\s*(${RangeConnectorRegex})\\s*${YearRegex}))`;
 	export const ComplexDatePeriodRegex = `(((from|during|in)\\s+)?(?<start>.+)\\s*(${TillRegex})\\s*(?<end>.+)|((between)\\s+)(?<start>.+)\\s*(${RangeConnectorRegex})\\s*(?<end>.+))`;
 	export const UnitMap: ReadonlyMap<string, string> = new Map<string, string>([["decades", "10Y"],["decade", "10Y"],["years", "Y"],["year", "Y"],["months", "MON"],["month", "MON"],["weeks", "W"],["week", "W"],["days", "D"],["day", "D"],["hours", "H"],["hour", "H"],["hrs", "H"],["hr", "H"],["h", "H"],["minutes", "M"],["minute", "M"],["mins", "M"],["min", "M"],["seconds", "S"],["second", "S"],["secs", "S"],["sec", "S"]]);

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -6931,5 +6931,46 @@
         }
       }
     ]
+  },
+  {
+    "Input": "2015 or later than 2018",
+    "Context": {
+      "ReferenceDateTime": "2018-09-21T16:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "2015",
+        "Start": 0,
+        "End": 3,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "later than 2018",
+        "Start": 8,
+        "End": 22,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-12-31"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -5923,5 +5923,46 @@
         }
       }
     ]
+  },
+  {
+    "Input": "2015 or later than 2018",
+    "Context": {
+      "ReferenceDateTime": "2018-09-21T16:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "2015",
+        "Start": 0,
+        "End": 3,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "later than 2018",
+        "Start": 8,
+        "End": 22,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-12-31"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -5741,5 +5741,46 @@
         }
       }
     ]
+  },
+  {
+    "Input": "2015 or later than 2018",
+    "Context": {
+      "ReferenceDateTime": "2018-09-21T16:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "2015",
+        "Start": 0,
+        "End": 3,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "later than 2018",
+        "Start": 8,
+        "End": 22,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-12-31"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Github Issue #872 