### PR TITLE
Fix wrong parse result for '从二零一六年至二零一八年' in Python and JavaScript

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
@@ -475,13 +475,14 @@ export class ChineseDatePeriodParser extends BaseDatePeriodParser {
             if (yearNum < 10) {
                 yearNum = 0;
                 for (let index = 0; index < yearStr.length; index++) {
-                    let char = yearStr.charAt[index];
+                    let char = yearStr.charAt(index);
                     yearNum *= 10;
                     er = this.integerExtractor.extract(char).pop();
                     if (er && er.type === NumberConstants.SYS_NUM_INTEGER) {
                         yearNum += Number.parseInt(this.numberParser.parse(er).value);
                     }
                 }
+                year = yearNum;
             } else {
                 year = yearNum;
             }
@@ -781,8 +782,8 @@ export class ChineseDatePeriodParser extends BaseDatePeriodParser {
             beginYear = this.convertChineseToNumber(yearMatches[0].groups('year').value);
             endYear = this.convertChineseToNumber(yearMatches[1].groups('year').value);
         } else if (chineseYearMatches.length === 2) {
-            beginYear = this.convertChineseToNumber(chineseYearMatches[0].groups('yearchs').value);
-            endYear = this.convertChineseToNumber(chineseYearMatches[1].groups('yearchs').value);
+            beginYear = this.convertYear(chineseYearMatches[0].groups('yearchs').value, true);
+            endYear = this.convertYear(chineseYearMatches[1].groups('yearchs').value, true);
         } else if (yearMatches.length === 1 && chineseYearMatches.length === 1) {
             if (yearMatches[0].index < chineseYearMatches[0].index) {
                 beginYear = this.convertChineseToNumber(yearMatches[0].groups('year').value);

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_parser.py
@@ -324,8 +324,8 @@ class ChineseDatePeriodParser(BaseDatePeriodParser):
             begin_year = self.__convert_chinese_to_number(RegExpUtility.get_group(year_matches[0], 'year'))
             end_year = self.__convert_chinese_to_number(RegExpUtility.get_group(year_matches[1], 'year'))
         elif len(chinese_year_matches) == 2:
-            begin_year = self.__convert_chinese_to_number(RegExpUtility.get_group(chinese_year_matches[0], 'yearchs'))
-            end_year = self.__convert_chinese_to_number(RegExpUtility.get_group(chinese_year_matches[1], 'yearchs'))
+            begin_year = self._convert_year(RegExpUtility.get_group(chinese_year_matches[0], 'yearchs'), True)
+            end_year = self._convert_year(RegExpUtility.get_group(chinese_year_matches[1], 'yearchs'), True)
         elif len(year_matches) == 1 and len(chinese_year_matches) == 1:
             if year_matches[0].start() < chinese_year_matches[0].start():
                 begin_year = self.__convert_chinese_to_number(RegExpUtility.get_group(year_matches[0], 'year'))
@@ -406,6 +406,7 @@ class ChineseDatePeriodParser(BaseDatePeriodParser):
                     er = next(iter(self.integer_extractor.extract(char)), None)
                     if er and er.type == NumberConstants.SYS_NUM_INTEGER:
                         year_num += int(self.number_parser.parse(er).value)
+                year = year_num
             else:
                 year = year_num
         else:

--- a/Specs/DateTime/Chinese/DatePeriodParser.json
+++ b/Specs/DateTime/Chinese/DatePeriodParser.json
@@ -573,7 +573,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "从二零一六年至二零一八年",

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -2220,5 +2220,29 @@
         }
       }
     ]
+  },
+  {
+    "Input": "时间从二零一六年至二零一八年",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "从二零一六年至二零一八年",
+        "Start": 2,
+        "End": 13,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-01-01,2018-01-01,P2Y)",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Github issue #747 