### PR TITLE
Remove German word from dutch choices (nein is not a valid dutch word)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Dutch/ChoiceDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Dutch/ChoiceDefinitions.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Recognizers.Definitions.Dutch
 		public const string LangMarker = "Nl";
 		public const string TokenizerRegex = @"[^\w\d]";
 		public const string TrueRegex = @"\b(ja|jawel|jazeker|natuurlijk|prima|jep|yes|yep|y|ok|oke)\b|(\uD83D\uDC4D|\uD83D\uDC4C)";
-		public const string FalseRegex = @"\b(nee|neen|nope|nein|nop|no|niet)\b|(\uD83D\uDC4E|\u270B|\uD83D\uDD90)";
+		public const string FalseRegex = @"\b(nee|neen|nope|nop|no|niet)\b|(\uD83D\uDC4E|\u270B|\uD83D\uDD90)";
 	}
 }


### PR DESCRIPTION
I noticed the German word "nein" being part of the dutch choices for "no". Differently from "yes" and "no", "nein" is never really used.