### PR TITLE
 [CN DateTime] Extend the recognition for traditional Chinese

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Chinese/DateTimeDefinitions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string SpecialDate = $@"(?<thisyear>({DateThisRe}|{DateLastRe}|{DateNextRe})年)?(?<thismonth>({DateThisRe}|{DateLastRe}|{DateNextRe})月)?{DateDayRegexInChinese}";
 		public const string DateUnitRegex = @"(?<unit>年|个月|周|日|天)";
 		public const string BeforeRegex = @"以前|之前|前";
-		public const string AfterRegex = @"以后|之后|后";
+		public const string AfterRegex = @"以后|以後|之后|之後|后|後";
 		public static readonly string DateRegexList1 = $@"({LunarRegex}(\s*))?((({YearRegex}|{DateYearInChineseRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInChinese}((\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?";
 		public static readonly string DateRegexList2 = $@"((({YearRegex}|{DateYearInChineseRegex})年)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*){DateDayRegexInChinese}((\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?";
 		public static readonly string DateRegexList3 = $@"((({YearRegex}|{DateYearInChineseRegex})年)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*)({DayRegexNumInChinese}|{DayRegex})((\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?";
@@ -71,12 +71,12 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string FollowedUnit = $@"^\s*{UnitRegex}";
 		public static readonly string NumberCombinedWithUnit = $@"(?<num>\d+(\.\d*)?){UnitRegex}";
 		public const string DateRangePrepositions = @"((从|在|自)\s*)?";
-		public static readonly string YearToYear = $@"({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|之后)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?";
+		public static readonly string YearToYear = $@"({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|後|之后|之後)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?";
 		public static readonly string YearToYearSuffixRequired = $@"({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillSuffixRequiredRegex})\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*(之间|之内|期间|中间|间)";
 		public static readonly string MonthToMonth = $@"({DateRangePrepositions})({MonthRegex}){DatePeriodTillRegex}({MonthRegex})";
 		public static readonly string MonthToMonthSuffixRequired = $@"({DateRangePrepositions})({MonthRegex}){DatePeriodTillSuffixRequiredRegex}({MonthRegex})\s*(之间|之内|期间|中间|间)";
 		public const string PastRegex = @"(?<past>(前|上|之前|近|过去))";
-		public const string FutureRegex = @"(?<future>(后|(?<![一两几]\s*)下|之后|未来(的)?))";
+		public const string FutureRegex = @"(?<future>(后|後|(?<![一两几]\s*)下|之后|之後|未来(的)?))";
 		public const string SeasonRegex = @"(?<season>春|夏|秋|冬)(天|季)?";
 		public static readonly string SeasonWithYear = $@"(({DatePeriodYearRegex}|{DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?{SeasonRegex}";
 		public static readonly string QuarterRegex = $@"(({DatePeriodYearRegex}|{DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?(第(?<cardinal>1|2|3|4|一|二|三|四)季度)";
@@ -156,7 +156,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?";
 		public const string TimeDayDescRegex = @"(?<daydesc>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|午夜|夜间|深夜|傍晚|晚)";
 		public const string TimeApproximateDescPreffixRegex = @"(大[约概]|差不多|可能|也许|约|不超过|不多[于过]|最[多长少]|少于|[超短长多]过|几乎要|将近|差点|快要|接近|至少|起码|超出|不到)";
-		public const string TimeApproximateDescSuffixRegex = @"(之前|以前|以后|之后|前|后|左右)";
+		public const string TimeApproximateDescSuffixRegex = @"(之前|以前|以后|以後|之后|之後|前|后|後|左右)";
 		public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?{TimeDayDescRegex}?{TimeChineseTimeRegex}{TimeApproximateDescSuffixRegex}?";
 		public static readonly string TimeRegexes2 = $@"{TimeApproximateDescPreffixRegex}?{TimeDayDescRegex}?{TimeDigitTimeRegex}{TimeApproximateDescSuffixRegex}?";
 		public static readonly string TimeRegexes3 = $@"差{TimeMinuteRegex}{TimeChineseTimeRegex}";
@@ -170,7 +170,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string TimePeriodRegexes1 = $@"({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftChsTimeRegex}{TimePeriodRightChsTimeRegex})";
 		public static readonly string TimePeriodRegexes2 = $@"({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftChsTimeRegex}{TimePeriodRightChsTimeRegex})";
 		public const string ParserConfigurationBefore = @"(之前|以前|前)";
-		public const string ParserConfigurationAfter = @"(之后|以后|后)";
+		public const string ParserConfigurationAfter = @"(之后|以后|后|之後|以後|後)";
 		public const string ParserConfigurationUntil = @"(直到|直至|截至|截止(到)?)";
 		public const string ParserConfigurationSincePrefix = @"(自从|自|自打|打)";
 		public const string ParserConfigurationSinceSuffix = @"(以来|开始)";
@@ -579,7 +579,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 			{ "感恩节", "-11-WXX-4-4" }
 		};
 		public const string MergedBeforeRegex = @"(前|之前)$";
-		public const string MergedAfterRegex = @"(后|之后|後|之後)$";
+		public const string MergedAfterRegex = @"(后|後|之后|之後)$";
 		public static readonly Dictionary<char, int> TimeNumberDictionary = new Dictionary<char, int>
 		{
 			{ '零', 0 },

--- a/.NET/Samples/SimpleConsole/Program.cs
+++ b/.NET/Samples/SimpleConsole/Program.cs
@@ -15,7 +15,7 @@ namespace SimpleConsole
     class Program
     {
         // Use English for the Recognizers culture
-        private const string DefaultCulture = Culture.English;
+        private const string DefaultCulture = Culture.Chinese;
 
         static void Main(string[] args)
         {

--- a/.NET/Samples/SimpleConsole/Program.cs
+++ b/.NET/Samples/SimpleConsole/Program.cs
@@ -15,7 +15,7 @@ namespace SimpleConsole
     class Program
     {
         // Use English for the Recognizers culture
-        private const string DefaultCulture = Culture.Chinese;
+        private const string DefaultCulture = Culture.English;
 
         static void Main(string[] args)
         {

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /packages
 /.idea
 Python/.cache/v/cache/lastfailed
+/.vs

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -32,7 +32,7 @@ export namespace ChineseDateTime {
 	export const SpecialDate = `(?<thisyear>(${DateThisRe}|${DateLastRe}|${DateNextRe})年)?(?<thismonth>(${DateThisRe}|${DateLastRe}|${DateNextRe})月)?${DateDayRegexInChinese}`;
 	export const DateUnitRegex = `(?<unit>年|个月|周|日|天)`;
 	export const BeforeRegex = `以前|之前|前`;
-    export const AfterRegex = `以后|以後|之后|之後|后|後`;
+	export const AfterRegex = `以后|以後|之后|之後|后|後`;
 	export const DateRegexList1 = `(${LunarRegex}(\\s*))?(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?${MonthRegex}(\\s*)${DateDayRegexInChinese}((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
 	export const DateRegexList2 = `(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?(${LunarRegex}(\\s*))?${MonthRegex}(\\s*)${DateDayRegexInChinese}((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
 	export const DateRegexList3 = `(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?(${LunarRegex}(\\s*))?${MonthRegex}(\\s*)(${DayRegexNumInChinese}|${DayRegex})((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
@@ -164,7 +164,7 @@ export namespace ChineseDateTime {
 	export const DurationUnitValueMap: ReadonlyMap<string, number> = new Map<string, number>([["Y", 31536000],["Mon", 2592000],["W", 604800],["D", 86400],["H", 3600],["M", 60],["S", 1]]);
 	export const HolidayNoFixedTimex: ReadonlyMap<string, string> = new Map<string, string>([["父亲节", "-06-WXX-6-3"],["母亲节", "-05-WXX-7-2"],["感恩节", "-11-WXX-4-4"]]);
 	export const MergedBeforeRegex = `(前|之前)$`;
-    export const MergedAfterRegex = `(后|後|之后|之後)$`;
+	export const MergedAfterRegex = `(后|後|之后|之後)$`;
 	export const TimeNumberDictionary: ReadonlyMap<string, number> = new Map<string, number>([["零", 0],["一", 1],["二", 2],["三", 3],["四", 4],["五", 5],["六", 6],["七", 7],["八", 8],["九", 9],["〇", 0],["两", 2],["十", 10]]);
 	export const TimeLowBoundDesc: ReadonlyMap<string, number> = new Map<string, number>([["中午", 11],["下午", 12],["午后", 12],["晚上", 18],["夜里", 18],["夜晚", 18],["夜间", 18],["深夜", 18],["傍晚", 18],["晚", 18]]);
 	export const DefaultLanguageFallback = 'DMY';

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -32,7 +32,7 @@ export namespace ChineseDateTime {
 	export const SpecialDate = `(?<thisyear>(${DateThisRe}|${DateLastRe}|${DateNextRe})年)?(?<thismonth>(${DateThisRe}|${DateLastRe}|${DateNextRe})月)?${DateDayRegexInChinese}`;
 	export const DateUnitRegex = `(?<unit>年|个月|周|日|天)`;
 	export const BeforeRegex = `以前|之前|前`;
-	export const AfterRegex = `以后|之后|后`;
+    export const AfterRegex = `以后|以後|之后|之後|后|後`;
 	export const DateRegexList1 = `(${LunarRegex}(\\s*))?(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?${MonthRegex}(\\s*)${DateDayRegexInChinese}((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
 	export const DateRegexList2 = `(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?(${LunarRegex}(\\s*))?${MonthRegex}(\\s*)${DateDayRegexInChinese}((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
 	export const DateRegexList3 = `(((${YearRegex}|${DateYearInChineseRegex})年)(\\s*))?(${LunarRegex}(\\s*))?${MonthRegex}(\\s*)(${DayRegexNumInChinese}|${DayRegex})((\\s*|,|，)${WeekDayRegex})?(${BeforeRegex}|${AfterRegex})?`;
@@ -62,12 +62,12 @@ export namespace ChineseDateTime {
 	export const FollowedUnit = `^\\s*${UnitRegex}`;
 	export const NumberCombinedWithUnit = `(?<num>\\d+(\\.\\d*)?)${UnitRegex}`;
 	export const DateRangePrepositions = `((从|在|自)\\s*)?`;
-	export const YearToYear = `(${DateRangePrepositions})(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})\\s*(${DatePeriodTillRegex}|后|之后)\\s*(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?`;
+	export const YearToYear = `(${DateRangePrepositions})(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})\\s*(${DatePeriodTillRegex}|后|後|之后|之後)\\s*(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?`;
 	export const YearToYearSuffixRequired = `(${DateRangePrepositions})(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})\\s*(${DatePeriodTillSuffixRequiredRegex})\\s*(${DatePeriodYearInChineseRegex}|${DatePeriodYearRegex})\\s*(之间|之内|期间|中间|间)`;
 	export const MonthToMonth = `(${DateRangePrepositions})(${MonthRegex})${DatePeriodTillRegex}(${MonthRegex})`;
 	export const MonthToMonthSuffixRequired = `(${DateRangePrepositions})(${MonthRegex})${DatePeriodTillSuffixRequiredRegex}(${MonthRegex})\\s*(之间|之内|期间|中间|间)`;
 	export const PastRegex = `(?<past>(前|上|之前|近|过去))`;
-	export const FutureRegex = `(?<future>(后|(?<![一两几]\\s*)下|之后|未来(的)?))`;
+	export const FutureRegex = `(?<future>(后|後|(?<![一两几]\\s*)下|之后|之後|未来(的)?))`;
 	export const SeasonRegex = `(?<season>春|夏|秋|冬)(天|季)?`;
 	export const SeasonWithYear = `((${DatePeriodYearRegex}|${DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?${SeasonRegex}`;
 	export const QuarterRegex = `((${DatePeriodYearRegex}|${DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?(第(?<cardinal>1|2|3|4|一|二|三|四)季度)`;
@@ -125,7 +125,7 @@ export namespace ChineseDateTime {
 	export const TimeDigitTimeRegex = `(?<hour>${TimeHourNumRegex}):(?<min>${TimeMinuteNumRegex})(:(?<sec>${TimeSecondNumRegex}))?`;
 	export const TimeDayDescRegex = `(?<daydesc>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|午夜|夜间|深夜|傍晚|晚)`;
 	export const TimeApproximateDescPreffixRegex = `(大[约概]|差不多|可能|也许|约|不超过|不多[于过]|最[多长少]|少于|[超短长多]过|几乎要|将近|差点|快要|接近|至少|起码|超出|不到)`;
-	export const TimeApproximateDescSuffixRegex = `(之前|以前|以后|之后|前|后|左右)`;
+	export const TimeApproximateDescSuffixRegex = `(之前|以前|以后|以後|之后|之後|前|后|後|左右)`;
 	export const TimeRegexes1 = `${TimeApproximateDescPreffixRegex}?${TimeDayDescRegex}?${TimeChineseTimeRegex}${TimeApproximateDescSuffixRegex}?`;
 	export const TimeRegexes2 = `${TimeApproximateDescPreffixRegex}?${TimeDayDescRegex}?${TimeDigitTimeRegex}${TimeApproximateDescSuffixRegex}?`;
 	export const TimeRegexes3 = `差${TimeMinuteRegex}${TimeChineseTimeRegex}`;
@@ -139,7 +139,7 @@ export namespace ChineseDateTime {
 	export const TimePeriodRegexes1 = `(${TimePeriodLeftDigitTimeRegex}${TimePeriodRightDigitTimeRegex}|${TimePeriodLeftChsTimeRegex}${TimePeriodRightChsTimeRegex})`;
 	export const TimePeriodRegexes2 = `(${TimePeriodShortLeftDigitTimeRegex}${TimePeriodRightDigitTimeRegex}|${TimePeriodShortLeftChsTimeRegex}${TimePeriodRightChsTimeRegex})`;
 	export const ParserConfigurationBefore = `(之前|以前|前)`;
-	export const ParserConfigurationAfter = `(之后|以后|后)`;
+	export const ParserConfigurationAfter = `(之后|之後|以后|以後|后|後)`;
 	export const ParserConfigurationUntil = `(直到|直至|截至|截止(到)?)`;
 	export const ParserConfigurationSincePrefix = `(自从|自|自打|打)`;
 	export const ParserConfigurationSinceSuffix = `(以来|开始)`;
@@ -164,7 +164,7 @@ export namespace ChineseDateTime {
 	export const DurationUnitValueMap: ReadonlyMap<string, number> = new Map<string, number>([["Y", 31536000],["Mon", 2592000],["W", 604800],["D", 86400],["H", 3600],["M", 60],["S", 1]]);
 	export const HolidayNoFixedTimex: ReadonlyMap<string, string> = new Map<string, string>([["父亲节", "-06-WXX-6-3"],["母亲节", "-05-WXX-7-2"],["感恩节", "-11-WXX-4-4"]]);
 	export const MergedBeforeRegex = `(前|之前)$`;
-	export const MergedAfterRegex = `(后|之后|後|之後)$`;
+    export const MergedAfterRegex = `(后|後|之后|之後)$`;
 	export const TimeNumberDictionary: ReadonlyMap<string, number> = new Map<string, number>([["零", 0],["一", 1],["二", 2],["三", 3],["四", 4],["五", 5],["六", 6],["七", 7],["八", 8],["九", 9],["〇", 0],["两", 2],["十", 10]]);
 	export const TimeLowBoundDesc: ReadonlyMap<string, number> = new Map<string, number>([["中午", 11],["下午", 12],["午后", 12],["晚上", 18],["夜里", 18],["夜晚", 18],["夜间", 18],["深夜", 18],["傍晚", 18],["晚", 18]]);
 	export const DefaultLanguageFallback = 'DMY';

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -147,7 +147,7 @@ NumberCombinedWithUnit: !nestedRegex
 DateRangePrepositions: !simpleRegex
   def: ((从|在|自)\s*)?
 YearToYear: !nestedRegex
-  def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|後|之后)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?
+  def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|後|之后|之後)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?
   references: [DatePeriodYearInChineseRegex, DatePeriodYearRegex, DatePeriodTillRegex, DateRangePrepositions]
 YearToYearSuffixRequired: !nestedRegex
   def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillSuffixRequiredRegex})\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*(之间|之内|期间|中间|间)
@@ -161,7 +161,7 @@ MonthToMonthSuffixRequired: !nestedRegex
 PastRegex: !simpleRegex
   def: (?<past>(前|上|之前|近|过去))
 FutureRegex: !simpleRegex
-  def: (?<future>(后|後(?<![一两几]\s*)下|之后|之後|未来(的)?))
+  def: (?<future>(后|後|(?<![一两几]\s*)下|之后|之後|未来(的)?))
 SeasonRegex: !simpleRegex
   def: (?<season>春|夏|秋|冬)(天|季)?
 SeasonWithYear: !nestedRegex
@@ -364,7 +364,7 @@ TimePeriodRegexes2: !nestedRegex
 ParserConfigurationBefore: !simpleRegex
   def: (之前|以前|前)
 ParserConfigurationAfter: !simpleRegex
-  def: (之后|之後|以后|以後|后)
+  def: (之后|之後|以后|以後|后|後)
 ParserConfigurationUntil: !simpleRegex
   def: (直到|直至|截至|截止(到)?)
 ParserConfigurationSincePrefix: !simpleRegex

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -55,7 +55,7 @@ DateUnitRegex: !simpleRegex
 BeforeRegex: !simpleRegex
   def: 以前|之前|前
 AfterRegex: !simpleRegex
-  def: 以后|之后|后
+  def: 以后|以後|之后|之後|后|後
 # (农历)?(2016年)?一月三日(星期三)?
 DateRegexList1: !nestedRegex
   def: ({LunarRegex}(\s*))?((({YearRegex}|{DateYearInChineseRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInChinese}((\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?
@@ -147,7 +147,7 @@ NumberCombinedWithUnit: !nestedRegex
 DateRangePrepositions: !simpleRegex
   def: ((从|在|自)\s*)?
 YearToYear: !nestedRegex
-  def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|之后)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?
+  def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillRegex}|后|後|之后)\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\s*((之间|之内|期间|中间|间)|前|之前))?
   references: [DatePeriodYearInChineseRegex, DatePeriodYearRegex, DatePeriodTillRegex, DateRangePrepositions]
 YearToYearSuffixRequired: !nestedRegex
   def: ({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*({DatePeriodTillSuffixRequiredRegex})\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\s*(之间|之内|期间|中间|间)
@@ -161,7 +161,7 @@ MonthToMonthSuffixRequired: !nestedRegex
 PastRegex: !simpleRegex
   def: (?<past>(前|上|之前|近|过去))
 FutureRegex: !simpleRegex
-  def: (?<future>(后|(?<![一两几]\s*)下|之后|未来(的)?))
+  def: (?<future>(后|後(?<![一两几]\s*)下|之后|之後|未来(的)?))
 SeasonRegex: !simpleRegex
   def: (?<season>春|夏|秋|冬)(天|季)?
 SeasonWithYear: !nestedRegex
@@ -323,7 +323,7 @@ TimeDayDescRegex: !simpleRegex
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (大[约概]|差不多|可能|也许|约|不超过|不多[于过]|最[多长少]|少于|[超短长多]过|几乎要|将近|差点|快要|接近|至少|起码|超出|不到)
 TimeApproximateDescSuffixRegex: !simpleRegex
-  def: (之前|以前|以后|之后|前|后|左右)
+  def: (之前|以前|以后|以後|之后|之後|前|后|後|左右)
 TimeRegexes1: !nestedRegex
   def: '{TimeApproximateDescPreffixRegex}?{TimeDayDescRegex}?{TimeChineseTimeRegex}{TimeApproximateDescSuffixRegex}?'
   references: [TimeApproximateDescPreffixRegex, TimeDayDescRegex, TimeChineseTimeRegex, TimeApproximateDescSuffixRegex]
@@ -364,7 +364,7 @@ TimePeriodRegexes2: !nestedRegex
 ParserConfigurationBefore: !simpleRegex
   def: (之前|以前|前)
 ParserConfigurationAfter: !simpleRegex
-  def: (之后|以后|后)
+  def: (之后|之後|以后|以後|后)
 ParserConfigurationUntil: !simpleRegex
   def: (直到|直至|截至|截止(到)?)
 ParserConfigurationSincePrefix: !simpleRegex
@@ -784,7 +784,7 @@ HolidayNoFixedTimex: !dictionary
 MergedBeforeRegex: !simpleRegex
   def: (前|之前)$
 MergedAfterRegex: !simpleRegex
-  def: (后|之后|後|之後)$
+  def: (后|後|之后|之後)$
 TimeNumberDictionary: !dictionary
   types: [char, int]
   entries:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
@@ -63,7 +63,7 @@ class ChineseDateTime:
     FollowedUnit = f'^\\s*{UnitRegex}'
     NumberCombinedWithUnit = f'(?<num>\\d+(\\.\\d*)?){UnitRegex}'
     DateRangePrepositions = f'((从|在|自)\\s*)?'
-    YearToYear = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillRegex}|后|後|之后)\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?'
+    YearToYear = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillRegex}|后|後|之后|之後)\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?'
     YearToYearSuffixRequired = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillSuffixRequiredRegex})\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*(之间|之内|期间|中间|间)'
     MonthToMonth = f'({DateRangePrepositions})({MonthRegex}){DatePeriodTillRegex}({MonthRegex})'
     MonthToMonthSuffixRequired = f'({DateRangePrepositions})({MonthRegex}){DatePeriodTillSuffixRequiredRegex}({MonthRegex})\\s*(之间|之内|期间|中间|间)'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
@@ -33,7 +33,7 @@ class ChineseDateTime:
     SpecialDate = f'(?<thisyear>({DateThisRe}|{DateLastRe}|{DateNextRe})年)?(?<thismonth>({DateThisRe}|{DateLastRe}|{DateNextRe})月)?{DateDayRegexInChinese}'
     DateUnitRegex = f'(?<unit>年|个月|周|日|天)'
     BeforeRegex = f'以前|之前|前'
-    AfterRegex = f'以后|之后|后'
+    AfterRegex = f'以后|以後|之后|之後|后|後'
     DateRegexList1 = f'({LunarRegex}(\\s*))?((({YearRegex}|{DateYearInChineseRegex})年)(\\s*))?{MonthRegex}(\\s*){DateDayRegexInChinese}((\\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?'
     DateRegexList2 = f'((({YearRegex}|{DateYearInChineseRegex})年)(\\s*))?({LunarRegex}(\\s*))?{MonthRegex}(\\s*){DateDayRegexInChinese}((\\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?'
     DateRegexList3 = f'((({YearRegex}|{DateYearInChineseRegex})年)(\\s*))?({LunarRegex}(\\s*))?{MonthRegex}(\\s*)({DayRegexNumInChinese}|{DayRegex})((\\s*|,|，){WeekDayRegex})?({BeforeRegex}|{AfterRegex})?'
@@ -63,12 +63,12 @@ class ChineseDateTime:
     FollowedUnit = f'^\\s*{UnitRegex}'
     NumberCombinedWithUnit = f'(?<num>\\d+(\\.\\d*)?){UnitRegex}'
     DateRangePrepositions = f'((从|在|自)\\s*)?'
-    YearToYear = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillRegex}|后|之后)\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?'
+    YearToYear = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillRegex}|后|後|之后)\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})(\\s*((之间|之内|期间|中间|间)|前|之前))?'
     YearToYearSuffixRequired = f'({DateRangePrepositions})({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*({DatePeriodTillSuffixRequiredRegex})\\s*({DatePeriodYearInChineseRegex}|{DatePeriodYearRegex})\\s*(之间|之内|期间|中间|间)'
     MonthToMonth = f'({DateRangePrepositions})({MonthRegex}){DatePeriodTillRegex}({MonthRegex})'
     MonthToMonthSuffixRequired = f'({DateRangePrepositions})({MonthRegex}){DatePeriodTillSuffixRequiredRegex}({MonthRegex})\\s*(之间|之内|期间|中间|间)'
     PastRegex = f'(?<past>(前|上|之前|近|过去))'
-    FutureRegex = f'(?<future>(后|(?<![一两几]\\s*)下|之后|未来(的)?))'
+    FutureRegex = f'(?<future>(后|後|(?<![一两几]\\s*)下|之后|之後|未来(的)?))'
     SeasonRegex = f'(?<season>春|夏|秋|冬)(天|季)?'
     SeasonWithYear = f'(({DatePeriodYearRegex}|{DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?{SeasonRegex}'
     QuarterRegex = f'(({DatePeriodYearRegex}|{DatePeriodYearInChineseRegex}|(?<yearrel>明年|今年|去年))(的)?)?(第(?<cardinal>1|2|3|4|一|二|三|四)季度)'
@@ -132,7 +132,7 @@ class ChineseDateTime:
     TimeDigitTimeRegex = f'(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?'
     TimeDayDescRegex = f'(?<daydesc>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|午夜|夜间|深夜|傍晚|晚)'
     TimeApproximateDescPreffixRegex = f'(大[约概]|差不多|可能|也许|约|不超过|不多[于过]|最[多长少]|少于|[超短长多]过|几乎要|将近|差点|快要|接近|至少|起码|超出|不到)'
-    TimeApproximateDescSuffixRegex = f'(之前|以前|以后|之后|前|后|左右)'
+    TimeApproximateDescSuffixRegex = f'(之前|以前|以后|以後|之后|之後|前|后|後|左右)'
     TimeRegexes1 = f'{TimeApproximateDescPreffixRegex}?{TimeDayDescRegex}?{TimeChineseTimeRegex}{TimeApproximateDescSuffixRegex}?'
     TimeRegexes2 = f'{TimeApproximateDescPreffixRegex}?{TimeDayDescRegex}?{TimeDigitTimeRegex}{TimeApproximateDescSuffixRegex}?'
     TimeRegexes3 = f'差{TimeMinuteRegex}{TimeChineseTimeRegex}'
@@ -146,7 +146,7 @@ class ChineseDateTime:
     TimePeriodRegexes1 = f'({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftChsTimeRegex}{TimePeriodRightChsTimeRegex})'
     TimePeriodRegexes2 = f'({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftChsTimeRegex}{TimePeriodRightChsTimeRegex})'
     ParserConfigurationBefore = f'(之前|以前|前)'
-    ParserConfigurationAfter = f'(之后|以后|后)'
+    ParserConfigurationAfter = f'(之后|之後|以后|以後|后|後)'
     ParserConfigurationUntil = f'(直到|直至|截至|截止(到)?)'
     ParserConfigurationSincePrefix = f'(自从|自|自打|打)'
     ParserConfigurationSinceSuffix = f'(以来|开始)'
@@ -525,7 +525,7 @@ class ChineseDateTime:
                                 ('母亲节', '-05-WXX-7-2'),
                                 ('感恩节', '-11-WXX-4-4')])
     MergedBeforeRegex = f'(前|之前)$'
-    MergedAfterRegex = f'(后|之后|後|之後)$'
+    MergedAfterRegex = f'(后|後|之后|之後)$'
     TimeNumberDictionary = dict([('零', 0),
                                  ('一', 1),
                                  ('二', 2),


### PR DESCRIPTION
Revised direction 
1. 后=>后|後
2. 之后=>之后|之後
3. 以后=>以后|以後