### PR TITLE
[NL NumberModel] Fix ‘honderduizend’ and ‘honderd duizend’

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Dutch/NumberDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Dutch/NumberDefinitions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
 		public const string AnIntRegex = @"(een|één)(?=\s)";
 		public const string TenToNineteenIntegerRegex = @"(zeventien|dertien|veertien|achttien|negentien|vijftien|zestien|elf|twaalf|tien)";
 		public const string TensNumberIntegerRegex = @"(zeventig|twintig|dertig|tachtig|negentig|veertig|vijftig|zestig)";
-		public static readonly string SeparaIntRegex = $@"((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}?(\s*{RoundNumberIntegerRegex})+))";
+		public static readonly string SeparaIntRegex = $@"((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}(\s*{RoundNumberIntegerRegex})+))";
 		public static readonly string AllIntRegex = $@"(((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*(en\s*)?)*{SeparaIntRegex})";
 		public const string PlaceHolderPureNumber = @"\b";
 		public const string PlaceHolderDefault = @"\D|\b";

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -17,7 +17,7 @@ TenToNineteenIntegerRegex: !simpleRegex
 TensNumberIntegerRegex: !simpleRegex
   def: (zeventig|twintig|dertig|tachtig|negentig|veertig|vijftig|zestig)
 SeparaIntRegex: !nestedRegex
-  def: ((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}?(\s*{RoundNumberIntegerRegex})+))
+  def: ((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}(\s*{RoundNumberIntegerRegex})+))
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex, AnIntRegex ]
 AllIntRegex: !nestedRegex
   def: (((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*(en\s*)?)*{SeparaIntRegex})

--- a/Specs/Number/Dutch/NumberModel.json
+++ b/Specs/Number/Dutch/NumberModel.json
@@ -2048,6 +2048,19 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
+    "Input": "honderd duizend",
+    "Results": [
+      {
+        "Text": "honderd duizend",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "100000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
     "Input": "honderdduizend",
     "Results": [
       {
@@ -2058,7 +2071,32 @@
         }
       }
     ],
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "honderdduizend miljoen",
+    "Results": [
+      {
+        "Text": "honderdduizend miljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "100000000000"
+        }
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "vijf miljard tweehonderd miljoen",
+    "Results": [
+      {
+        "Text": "vijf miljard tweehonderd miljoen",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "5200000000"
+        }
+      }
+    ],
     "NotSupportedByDesign": "javascript,python,java"
   },
   {


### PR DESCRIPTION
- Fix ‘honderduizend’ and ‘honderd duizend’
- Enable testcases for .NET and add missing testcases