### PR TITLE
Fix wrong recognition for "10/1 - 11/7"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/BaseDateTime.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/BaseDateTime.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Recognizers.Definitions
 		public const string SecondRegex = @"(?<sec>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";
 		public const string FourDigitYearRegex = @"\b(?<![$])(?<year>((1\d|20)\d{2})|2100)(?!\.0\b)\b";
 		public static readonly string IllegalYearRegex = $@"([-])({FourDigitYearRegex})([-])";
+		public const string RangeConnectorSymbolRegex = @"(--|-|—|——|~|–)";
 		public const string MinYearNum = "1500";
 		public const string MaxYearNum = "2100";
 		public const string MaxTwoDigitYearFutureNum = "30";

--- a/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/English/DateTimeDefinitions.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Recognizers.Definitions.English
 
 	public static class DateTimeDefinitions
 	{
-		public const string TillRegex = @"(?<till>\b(to|till|til|until|thru|through)\b|(--|-|—|——|~|–))";
-		public const string RangeConnectorRegex = @"(?<and>\b(and|through|to)\b|(--|-|—|——|~|–))";
+		public static readonly string TillRegex = $@"(?<till>\b(to|till|til|until|thru|through)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+		public static readonly string RangeConnectorRegex = $@"(?<and>\b(and|through|to)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
 		public const string RelativeRegex = @"\b(?<order>following|next|coming|upcoming|this|last|past|previous|current|the)\b";
 		public const string StrictRelativeRegex = @"\b(?<order>following|next|coming|upcoming|this|last|past|previous|current)\b";
 		public const string NextPrefixRegex = @"\b(following|next|upcoming|coming)\b";
@@ -103,7 +103,7 @@ namespace Microsoft.Recognizers.Definitions.English
 		public static readonly string DateExtractor7 = $@"\b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}((\s+|\s*,\s*|\s+of\s+){DateYearRegex})?(?![%])\b";
 		public static readonly string DateExtractor8 = $@"(?<={DatePreposition}\s+)({WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}(?![%])\b";
 		public static readonly string DateExtractor9 = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+of\s+){DateYearRegex})?(?![%])\b";
-		public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?{DateYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}";
+		public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}";
 		public static readonly string OfMonth = $@"^\s*of\s*{MonthRegex}";
 		public static readonly string MonthEnd = $@"{MonthRegex}\s*(the)?\s*$";
 		public static readonly string WeekDayEnd = $@"(this\s+)?{WeekDayRegex}\s*,?\s*$";

--- a/.NET/Microsoft.Recognizers.Definitions/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Portuguese/DateTimeDefinitions.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
 		public const string InConnectorRegex = @"\b(em)\b";
 		public const string WithinNextPrefixRegex = @"^[.]";
 		public const string CenturySuffixRegex = @"^[.]";
+		public const string RelativeRegex = @"^[.]";
 		public const string FromRegex = @"((desde|de)(\s*a(s)?)?)$";
 		public const string ConnectorAndRegex = @"(e\s*([àa](s)?)?)$";
 		public const string BetweenRegex = @"(entre\s*([oa](s)?)?)";

--- a/.NET/Microsoft.Recognizers.Definitions/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Spanish/DateTimeDefinitions.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string AllHalfYearRegex = @"^[.]";
 		public const string PrefixDayRegex = @"^[.]";
 		public const string CenturySuffixRegex = @"^[.]";
+		public const string RelativeRegex = @"^[.]";
 		public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
 		public const string WhichWeekRegex = @"(semana)(\s*)(?<number>\d\d|\d|0\d)";
 		public const string WeekOfRegex = @"(semana)(\s*)((do|da|de))";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -104,6 +104,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -227,5 +229,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DatePeriodExtractor = new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
         public IDateTimeExtractor DatePeriodExtractor { get; }
 
         private static readonly Regex OrRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public Regex LaterRegex { get; }
         public Regex LessThanRegex { get; }
         public Regex MoreThanRegex { get; }
-
         public Regex CenturySuffixRegex { get; }
 
         public static readonly Regex NextPrefixRegex =
@@ -91,11 +90,17 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             new Regex(
                 DateTimeDefinitions.AfterNextSuffixRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex =
+            new Regex(
+                DateTimeDefinitions.RelativeRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
-        
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
+
+
         #endregion
 
         #region Dictionaries

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     {
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/AbstractYearExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/AbstractYearExtractor.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Recognizers.Text.DateTime
+{
+    public abstract class AbstractYearExtractor : IDateExtractor
+    {
+        protected readonly IDateExtractorConfiguration config;
+
+        public AbstractYearExtractor(IDateExtractorConfiguration config)
+        {
+            this.config = config;
+        }
+
+        public abstract List<ExtractResult> Extract(string input);
+
+        public abstract List<ExtractResult> Extract(string input, System.DateTime reference);
+
+        public int GetYearFromText(Match match)
+        {
+            int year = Constants.InvalidYear;
+
+            var yearStr = match.Groups["year"].Value;
+            if (!string.IsNullOrEmpty(yearStr))
+            {
+                year = int.Parse(yearStr);
+                if (year < 100 && year >= Constants.MinTwoDigitYearPastNum)
+                {
+                    year += 1900;
+                }
+                else if (year >= 0 && year < Constants.MaxTwoDigitYearFutureNum)
+                {
+                    year += 2000;
+                }
+            }
+            else
+            {
+                var firstTwoYearNumStr = match.Groups["firsttwoyearnum"].Value;
+                if (!string.IsNullOrEmpty(firstTwoYearNumStr))
+                {
+                    var er = new ExtractResult
+                    {
+                        Text = firstTwoYearNumStr,
+                        Start = match.Groups["firsttwoyearnum"].Index,
+                        Length = match.Groups["firsttwoyearnum"].Length
+                    };
+
+                    var firstTwoYearNum = Convert.ToInt32((double)(this.config.NumberParser.Parse(er).Value ?? 0));
+
+                    var lastTwoYearNum = 0;
+                    var lastTwoYearNumStr = match.Groups["lasttwoyearnum"].Value;
+                    if (!string.IsNullOrEmpty(lastTwoYearNumStr))
+                    {
+                        er.Text = lastTwoYearNumStr;
+                        er.Start = match.Groups["lasttwoyearnum"].Index;
+                        er.Length = match.Groups["lasttwoyearnum"].Length;
+
+                        lastTwoYearNum = Convert.ToInt32((double)(this.config.NumberParser.Parse(er).Value ?? 0));
+                    }
+
+                    // Exclude pure number like "nineteen", "twenty four"
+                    if (firstTwoYearNum < 100 && lastTwoYearNum == 0 || firstTwoYearNum < 100 && firstTwoYearNum % 10 == 0 && lastTwoYearNumStr.Trim().Split(' ').Length == 1)
+                    {
+                        year = Constants.InvalidYear;
+                        return year;
+                    }
+
+                    if (firstTwoYearNum >= 100)
+                    {
+                        year = firstTwoYearNum + lastTwoYearNum;
+                    }
+                    else
+                    {
+                        year = firstTwoYearNum * 100 + lastTwoYearNum;
+                    }
+                }
+            }
+
+            return year;
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -7,23 +7,20 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public class BaseDateExtractor : IDateTimeExtractor
+    public class BaseDateExtractor : AbstractYearExtractor, IDateExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
-        private readonly IDateExtractorConfiguration config;
-
-        public BaseDateExtractor(IDateExtractorConfiguration config)
+        public BaseDateExtractor(IDateExtractorConfiguration config) : base(config)
         {
-            this.config = config;
         }
 
-        public List<ExtractResult> Extract(string text)
+        public override List<ExtractResult> Extract(string text)
         {
             return Extract(text, DateObject.Now);
         }
 
-        public List<ExtractResult> Extract(string text, DateObject reference)
+        public override List<ExtractResult> Extract(string text, DateObject reference)
         {
             var tokens = new List<Token>();
             tokens.AddRange(BasicRegexMatch(text));
@@ -32,69 +29,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             tokens.AddRange(ExtractRelativeDurationDate(text, reference));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
-        }
-
-        public int GetYearFromText(Match match)
-        {
-            int year = Constants.InvalidYear;
-
-            var yearStr = match.Groups["year"].Value;
-            if (!string.IsNullOrEmpty(yearStr))
-            {
-                year = int.Parse(yearStr);
-                if (year < 100 && year >= Constants.MinTwoDigitYearPastNum)
-                {
-                    year += 1900;
-                }
-                else if (year >= 0 && year < Constants.MaxTwoDigitYearFutureNum)
-                {
-                    year += 2000;
-                }
-            }
-            else
-            {
-                var firstTwoYearNumStr = match.Groups["firsttwoyearnum"].Value;
-                if (!string.IsNullOrEmpty(firstTwoYearNumStr))
-                {
-                    var er = new ExtractResult
-                    {
-                        Text = firstTwoYearNumStr,
-                        Start = match.Groups["firsttwoyearnum"].Index,
-                        Length = match.Groups["firsttwoyearnum"].Length
-                    };
-
-                    var firstTwoYearNum = Convert.ToInt32((double)(this.config.NumberParser.Parse(er).Value ?? 0));
-
-                    var lastTwoYearNum = 0;
-                    var lastTwoYearNumStr = match.Groups["lasttwoyearnum"].Value;
-                    if (!string.IsNullOrEmpty(lastTwoYearNumStr))
-                    {
-                        er.Text = lastTwoYearNumStr;
-                        er.Start = match.Groups["lasttwoyearnum"].Index;
-                        er.Length = match.Groups["lasttwoyearnum"].Length;
-
-                        lastTwoYearNum = Convert.ToInt32((double)(this.config.NumberParser.Parse(er).Value ?? 0));
-                    }
-
-                    // Exclude pure number like "nineteen", "twenty four"
-                    if (firstTwoYearNum < 100 && lastTwoYearNum == 0 || firstTwoYearNum < 100 && firstTwoYearNum % 10 == 0 && lastTwoYearNumStr.Trim().Split(' ').Length == 1)
-                    {
-                        year = Constants.InvalidYear;
-                        return year;
-                    }
-
-                    if (firstTwoYearNum >= 100)
-                    {
-                        year = firstTwoYearNum + lastTwoYearNum;
-                    }
-                    else
-                    {
-                        year = firstTwoYearNum * 100 + lastTwoYearNum;
-                    }
-                }
-            }
-
-            return year;
         }
 
         // match basic patterns in DateRegexList
@@ -156,6 +90,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return isValidMatch;
         }
 
+        // TODO: Simplify this method to improve the performance
         private string TrimStartRangeConnectorSymbols(string text)
         {
             var rangeConnectorSymbolMatches = config.RangeConnectorSymbolRegex.Matches(text);
@@ -178,6 +113,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return text.Trim();
         }
 
+        // TODO: Simplify this method to improve the performance
         private bool StartsWithBasicDate(string text)
         {
             foreach (var regex in this.config.DateRegexList)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 // Single year cases like "1998"
                 if (matchYear.Success && matchYear.Length == match.Value.Length)
                 {
-                    var year = ((BaseDateExtractor)this.config.DatePointExtractor).GetYearFromText(matchYear);
+                    var year = config.DatePointExtractor.GetYearFromText(matchYear);
                     if (!(year >= Constants.MinYearNum && year <= Constants.MaxYearNum))
                     {
                         continue;
@@ -113,7 +113,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     var matchYear = this.config.YearRegex.Match(match.Value);
                     if (matchYear.Success && matchYear.Length == match.Value.Length)
                     {
-                        var year = ((BaseDateExtractor)this.config.DatePointExtractor).GetYearFromText(matchYear);
+                        var year = config.DatePointExtractor.GetYearFromText(matchYear);
                         if (!(year >= Constants.MinYearNum && year <= Constants.MaxYearNum))
                         {
                             continue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractor.cs
@@ -1,0 +1,11 @@
+﻿// Enable GetYearFromText method
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Recognizers.Text.DateTime
+{
+    public interface IDateExtractor : IDateTimeExtractor
+    {
+        int GetYearFromText(Match match);
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex RangeUnitRegex { get; }
 
+        Regex RangeConnectorSymbolRegex { get; }
+
         IExtractor IntegerExtractor { get; }
 
         IExtractor OrdinalExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex CenturySuffixRegex { get; }
 
-        IDateTimeExtractor DatePointExtractor { get; }
+        IDateExtractor DatePointExtractor { get; }
 
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeAltExtractorConfiguration.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public interface IDateTimeAltExtractorConfiguration
     {
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor DatePeriodExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor DurationExtractor { get; }
 
-        IDateTimeExtractor DatePointExtractor { get; }
+        IDateExtractor DatePointExtractor { get; }
 
         IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.DateTime
     public interface IMergedExtractorConfiguration : IOptionsConfiguration
     {
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor TimeExtractor { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -257,5 +259,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         Regex IDateExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DatePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DatePeriodExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -85,10 +85,15 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             new Regex(
                 @"(ce|cette)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex =
+            new Regex(
+                DateTimeDefinitions.RelativeRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
         #endregion
 
         #region Dictionaries

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     {
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -110,6 +110,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek = 
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -217,5 +219,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         Regex IDateExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             DatePeriodExtractor = new BaseDatePeriodExtractor(new GermanDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DatePeriodExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             new Regex(DateTimeDefinitions.OneOnOneRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline),
         };
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -87,10 +87,15 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             new Regex(
                 DateTimeDefinitions.ThisPrefixRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex =
+            new Regex(
+                DateTimeDefinitions.RelativeRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
         #endregion
 
         #region Dictionaries

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     {
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -256,5 +258,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         Regex IDateExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DatePeriodExtractor = new BaseDatePeriodExtractor(new ItalianDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DatePeriodExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -85,10 +85,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             new Regex(
                 @"(ce|cette)\b",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex =
+            new Regex(
+                DateTimeDefinitions.RelativeRegex,
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
         #endregion
 
         #region Dictionaries

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public virtual IParser NumberParser { get; protected set; }
 
-        public virtual IDateTimeExtractor DateExtractor { get; protected set; }
+        public virtual IDateExtractor DateExtractor { get; protected set; }
 
         public virtual IDateTimeExtractor TimeExtractor { get; protected set; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -543,7 +543,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 endDay = this.config.DayOfMonth[days.Captures[1].Value.ToLower()];
 
                 // parse year
-                year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                year = config.DateExtractor.GetYearFromText(match);
                 if (year != Constants.InvalidYear)
                 {
                     noYear = false;
@@ -961,7 +961,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 var month = this.config.MonthOfYear[monthStr.ToLower()];
 
-                var year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                var year = config.DateExtractor.GetYearFromText(match);
                 if (year == Constants.InvalidYear)
                 {
                     var swift = this.config.GetSwiftYear(orderStr);
@@ -1042,7 +1042,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 match = this.config.YearRegex.Match(text);
                 if (match.Success && match.Length == text.Trim().Length)
                 {
-                    year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                    year = config.DateExtractor.GetYearFromText(match);
                     if (!(year >= Constants.MinYearNum && year <= Constants.MaxYearNum))
                     {
                         year = Constants.InvalidYear;
@@ -1053,7 +1053,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     match = this.config.YearPlusNumberRegex.Match(text);
                     if (match.Success && match.Length == text.Trim().Length)
                     {
-                        year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                        year = config.DateExtractor.GetYearFromText(match);
                     }
                 }
 
@@ -1407,7 +1407,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var cardinalStr = match.Groups["cardinal"].Value;
             var orderStr = match.Groups["order"].Value.ToLower();
 
-            var year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+            var year = config.DateExtractor.GetYearFromText(match);
             if (year == Constants.InvalidYear)
             {
                 var swift = this.config.GetSwiftYear(orderStr);
@@ -1479,7 +1479,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var orderStr = match.Groups["order"].Value.ToLower();
             var numberStr = match.Groups["number"].Value;
 
-            int year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+            int year = config.DateExtractor.GetYearFromText(match);
 
             if (year == Constants.InvalidYear)
             {
@@ -1530,7 +1530,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var numberStr = match.Groups["number"].Value;
 
             bool noSpecificYear = false;
-            int year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+            int year = config.DateExtractor.GetYearFromText(match);
 
             if (year == Constants.InvalidYear)
             {
@@ -1611,7 +1611,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Mod = Constants.LATE_MOD;
                 }
 
-                var year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                var year = config.DateExtractor.GetYearFromText(match);
                 if (year == Constants.InvalidYear)
                 {
                     var swift = this.config.GetSwiftYear(text);
@@ -1975,7 +1975,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 foreach (Match match in config.YearRegex.Matches(text))
                 {
-                    var year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(match);
+                    var year = config.DateExtractor.GetYearFromText(match);
 
                     if (year != Constants.InvalidYear)
                     {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IParser NumberParser { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor DurationExtractor { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         string TokenBeforeDate { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex CenturySuffixRegex { get; }
 
+        Regex RelativeRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> CardinalMap { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         string TokenBeforeTime { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         string TokenBeforeDate { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeParser TimeParser { get; }
 
-        IDateTimeExtractor DateExtractor { get; }
+        IDateExtractor DateExtractor { get; }
 
         IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -61,19 +61,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex RelativeWeekDayRegex =
             new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex ForTheRegex = new Regex(DateTimeDefinitions.ForTheRegex,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex ForTheRegex = 
+            new Regex(DateTimeDefinitions.ForTheRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex WeekDayAndDayOfMothRegex = new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex WeekDayAndDayOfMothRegex = 
+            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex,
-            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeMonthRegex = 
+            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex PrefixArticleRegex = new Regex(DateTimeDefinitions.PrefixArticleRegex,
-                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex PrefixArticleRegex = 
+            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RangeConnectorSymbolRegex = 
+            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -81,13 +82,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             WeekDayRegex, WeekDayOfMonthRegex, SpecialDateRegex
         };
 
-        public static readonly Regex OfMonth = new Regex(DateTimeDefinitions.OfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex OfMonth = 
+            new Regex(DateTimeDefinitions.OfMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex MonthEnd = new Regex(DateTimeDefinitions.MonthEndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex MonthEnd = 
+            new Regex(DateTimeDefinitions.MonthEndRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex WeekDayEnd = new Regex(DateTimeDefinitions.WeekDayEnd, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex WeekDayEnd = 
+            new Regex(DateTimeDefinitions.WeekDayEnd, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex YearSuffix = new Regex(DateTimeDefinitions.YearSuffix, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex YearSuffix = 
+            new Regex(DateTimeDefinitions.YearSuffix, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex LessThanRegex =
             new Regex(DateTimeDefinitions.LessThanRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -70,10 +70,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex,
             RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex PrefixArticleRegex =
-            new Regex(
-                DateTimeDefinitions.PrefixArticleRegex,
+        public static readonly Regex PrefixArticleRegex = new Regex(DateTimeDefinitions.PrefixArticleRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -206,5 +206,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         Regex IDateExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             DatePeriodExtractor = new BaseDatePeriodExtractor(new PortugueseDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
         public IDateTimeExtractor DatePeriodExtractor { get; }
 
         private static readonly Regex OrRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
         };
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -79,10 +79,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 
         #endregion
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     {
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-        public static readonly Regex PrefixArticleRegex =
-            new Regex(
-                DateTimeDefinitions.PrefixArticleRegex,
+        public static readonly Regex PrefixArticleRegex = new Regex(DateTimeDefinitions.PrefixArticleRegex,
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        public static readonly Regex RangeConnectorSymbolRegex = new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -200,5 +200,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IDateExtractorConfiguration.InConnectorRegex => InConnectorRegex;
 
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
+
+        Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
         }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DatePeriodExtractor = new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(this));
         }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
         public IDateTimeExtractor DatePeriodExtractor { get; }
 
         private static readonly Regex OrRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IExtractor IntegerExtractor { get; }
 
-        public IDateTimeExtractor DatePointExtractor { get; }
+        public IDateExtractor DatePointExtractor { get; }
 
         public IDateTimeExtractor TimePointExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeExtractor TimeExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor DateTimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeExtractor DurationExtractor { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         #region internalParsers
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -79,10 +79,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
         public static readonly Regex ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
         Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
         Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 
         #endregion
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public string TokenBeforeTime { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     {
         public string TokenBeforeDate { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeParser TimeParser { get; }
 
-        public IDateTimeExtractor DateExtractor { get; }
+        public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DateParser { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using DateObject = System.DateTime;
 
-namespace Microsoft.Recognizers.Text.DateTime.Utilities
+namespace Microsoft.Recognizers.Text.DateTime
 {
     // Currently only Year is enabled as context, we may support Month or Week in the future
     public class DateContext
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         {
             if (!IsEmpty())
             {
-                originalResult.TimexStr = SetTimexWithContext(originalResult.TimexStr);
+                originalResult.TimexStr = TimexUtility.SetTimexWithContext(originalResult.TimexStr, this);
                 originalResult.Value = ProcessDateEntityResolution((DateTimeResolutionResult)originalResult.Value);
             }
 
@@ -23,7 +23,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         {
             if (!IsEmpty())
             {
-                resolutionResult.Timex = SetTimexWithContext(resolutionResult.Timex);
+                resolutionResult.Timex = TimexUtility.SetTimexWithContext(resolutionResult.Timex, this);
                 resolutionResult.FutureValue = SetDateWithContext((DateObject)resolutionResult.FutureValue);
                 resolutionResult.PastValue = SetDateWithContext((DateObject)resolutionResult.PastValue);
             }
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         {
             if (!IsEmpty())
             {
-                resolutionResult.Timex = SetTimexWithContext(resolutionResult.Timex);
+                resolutionResult.Timex = TimexUtility.SetTimexWithContext(resolutionResult.Timex, this);
                 resolutionResult.FutureValue = SetDateRangeWithContext((Tuple<DateObject, DateObject>)resolutionResult.FutureValue);
                 resolutionResult.PastValue = SetDateRangeWithContext((Tuple<DateObject, DateObject>)resolutionResult.PastValue);
             }
@@ -71,11 +71,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             var endDate = SetDateWithContext(originalDateRange.Item2);
 
             return new Tuple<DateObject, DateObject>(startDate, endDate);
-        }
-
-        private string SetTimexWithContext(string originalTimex)
-        {
-            return originalTimex.Replace(Constants.TimexFuzzyYear, Year.ToString("D4"));
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DateTime.Utilities
+{
+    // Currently only Year is enabled as context, we may support Month or Week in the future
+    public class DateContext
+    {
+        public int Year { get; set; } = Constants.InvalidYear;
+
+        public DateTimeParseResult ProcessDateEntityParsingResult(DateTimeParseResult originalResult)
+        {
+            if (!IsEmpty())
+            {
+                originalResult.TimexStr = SetTimexWithContext(originalResult.TimexStr);
+                originalResult.Value = ProcessDateEntityResolution((DateTimeResolutionResult)originalResult.Value);
+            }
+
+            return originalResult;
+        }
+
+        public DateTimeResolutionResult ProcessDateEntityResolution(DateTimeResolutionResult resolutionResult)
+        {
+            if (!IsEmpty())
+            {
+                resolutionResult.Timex = SetTimexWithContext(resolutionResult.Timex);
+                resolutionResult.FutureValue = SetDateWithContext((DateObject)resolutionResult.FutureValue);
+                resolutionResult.PastValue = SetDateWithContext((DateObject)resolutionResult.PastValue);
+            }
+
+            return resolutionResult;
+        }
+
+        public DateTimeResolutionResult ProcessDatePeriodEntityResolution(DateTimeResolutionResult resolutionResult)
+        {
+            if (!IsEmpty())
+            {
+                resolutionResult.Timex = SetTimexWithContext(resolutionResult.Timex);
+                resolutionResult.FutureValue = SetDateRangeWithContext((Tuple<DateObject, DateObject>)resolutionResult.FutureValue);
+                resolutionResult.PastValue = SetDateRangeWithContext((Tuple<DateObject, DateObject>)resolutionResult.PastValue);
+            }
+
+            return resolutionResult;
+        }
+
+        public bool IsEmpty()
+        {
+            return this.Year == Constants.InvalidYear;
+        }
+
+        // This method is to ensure the begin date is less than the end date
+        // As DateContext only support common Year as context, so decrease year part of begin date to ensure the begin date is less than end date
+        public DateObject SwiftDateObject(DateObject beginDate, DateObject endDate)
+        {
+            if (beginDate > endDate)
+            {
+                beginDate = beginDate.AddYears(-1);
+            }
+
+            return beginDate;
+        }
+
+        private DateObject SetDateWithContext(DateObject originalDate)
+        {
+            return new DateObject(Year, originalDate.Month, originalDate.Day);
+        }
+
+        private Tuple<DateObject, DateObject> SetDateRangeWithContext(Tuple<DateObject, DateObject> originalDateRange)
+        {
+            var startDate = SetDateWithContext(originalDateRange.Item1);
+            var endDate = SetDateWithContext(originalDateRange.Item2);
+
+            return new Tuple<DateObject, DateObject>(startDate, endDate);
+        }
+
+        private string SetTimexWithContext(string originalTimex)
+        {
+            return originalTimex.Replace(Constants.TimexFuzzyYear, Year.ToString("D4"));
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -254,5 +254,10 @@ namespace Microsoft.Recognizers.Text.DateTime
          
             return result;
         }
+
+        public static string SetTimexWithContext(string timex, DateContext context)
+        {
+            return timex.Replace(Constants.TimexFuzzyYear, context.Year.ToString("D4"));
+        }
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/resources/baseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/baseDateTime.ts
@@ -13,6 +13,7 @@ export namespace BaseDateTime {
 	export const SecondRegex = `(?<sec>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)`;
 	export const FourDigitYearRegex = `\\b(?<![$])(?<year>((1\\d|20)\\d{2})|2100)(?!\\.0\\b)\\b`;
 	export const IllegalYearRegex = `([-])(${FourDigitYearRegex})([-])`;
+	export const RangeConnectorSymbolRegex = `(--|-|—|——|~|–)`;
 	export const MinYearNum = '1500';
 	export const MaxYearNum = '2100';
 	export const MaxTwoDigitYearFutureNum = '30';

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -8,8 +8,8 @@
 
 import { BaseDateTime } from "./baseDateTime";
 export namespace EnglishDateTime {
-	export const TillRegex = `(?<till>\\b(to|till|til|until|thru|through)\\b|(--|-|—|——|~|–))`;
-	export const RangeConnectorRegex = `(?<and>\\b(and|through|to)\\b|(--|-|—|——|~|–))`;
+	export const TillRegex = `(?<till>\\b(to|till|til|until|thru|through)\\b|${BaseDateTime.RangeConnectorSymbolRegex})`;
+	export const RangeConnectorRegex = `(?<and>\\b(and|through|to)\\b|${BaseDateTime.RangeConnectorSymbolRegex})`;
 	export const RelativeRegex = `\\b(?<order>following|next|coming|upcoming|this|last|past|previous|current|the)\\b`;
 	export const StrictRelativeRegex = `\\b(?<order>following|next|coming|upcoming|this|last|past|previous|current)\\b`;
 	export const NextPrefixRegex = `\\b(following|next|upcoming|coming)\\b`;
@@ -94,7 +94,7 @@ export namespace EnglishDateTime {
 	export const DateExtractor7 = `\\b(${WeekDayRegex}\\s+)?${MonthNumRegex}\\s*/\\s*${DayRegex}((\\s+|\\s*,\\s*|\\s+of\\s+)${DateYearRegex})?(?![%])\\b`;
 	export const DateExtractor8 = `(?<=${DatePreposition}\\s+)(${WeekDayRegex}\\s+)?${DayRegex}[\\\\\\-]${MonthNumRegex}(?![%])\\b`;
 	export const DateExtractor9 = `\\b(${WeekDayRegex}\\s+)?${DayRegex}\\s*/\\s*${MonthNumRegex}((\\s+|\\s*,\\s*|\\s+of\\s+)${DateYearRegex})?(?![%])\\b`;
-	export const DateExtractorA = `\\b(${WeekDayRegex}\\s+)?${DateYearRegex}\\s*[/\\\\\\-\\.]\\s*${MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*${DayRegex}`;
+	export const DateExtractorA = `\\b(${WeekDayRegex}\\s+)?${BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*${MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*${DayRegex}`;
 	export const OfMonth = `^\\s*of\\s*${MonthRegex}`;
 	export const MonthEnd = `${MonthRegex}\\s*(the)?\\s*$`;
 	export const WeekDayEnd = `(this\\s+)?${WeekDayRegex}\\s*,?\\s*$`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/portugueseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/portugueseDateTime.ts
@@ -48,6 +48,7 @@ export namespace PortugueseDateTime {
 	export const InConnectorRegex = `\\b(em)\\b`;
 	export const WithinNextPrefixRegex = `^[.]`;
 	export const CenturySuffixRegex = `^[.]`;
+	export const RelativeRegex = `^[.]`;
 	export const FromRegex = `((desde|de)(\\s*a(s)?)?)$`;
 	export const ConnectorAndRegex = `(e\\s*([àa](s)?)?)$`;
 	export const BetweenRegex = `(entre\\s*([oa](s)?)?)`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
@@ -41,6 +41,7 @@ export namespace SpanishDateTime {
 	export const AllHalfYearRegex = `^[.]`;
 	export const PrefixDayRegex = `^[.]`;
 	export const CenturySuffixRegex = `^[.]`;
+	export const RelativeRegex = `^[.]`;
 	export const SeasonRegex = `\\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\\s+)?(?<seas>primavera|verano|otoño|invierno)((\\s+del?|\\s*,\\s*)?\\s+(${YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\\s+año))?)\\b`;
 	export const WhichWeekRegex = `(semana)(\\s*)(?<number>\\d\\d|\\d|0\\d)`;
 	export const WeekOfRegex = `(semana)(\\s*)((do|da|de))`;

--- a/Patterns/Base-DateTime.yaml
+++ b/Patterns/Base-DateTime.yaml
@@ -1,4 +1,4 @@
-HourRegex: !simpleRegex
+﻿HourRegex: !simpleRegex
   def: (?<hour>00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)(h)?
 MinuteRegex: !simpleRegex
   def: (?<min>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)(?!\d)
@@ -11,6 +11,8 @@ FourDigitYearRegex: !simpleRegex
 IllegalYearRegex: !nestedRegex
   def: ([-])({FourDigitYearRegex})([-])
   references: [ FourDigitYearRegex ]
+RangeConnectorSymbolRegex: !simpleRegex
+  def: (--|-|—|——|~|–)
 MinYearNum: 1500
 MaxYearNum: 2100
 MaxTwoDigitYearFutureNum: 30

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -1,8 +1,10 @@
 ---
-TillRegex: !simpleRegex
-  def: (?<till>\b(to|till|til|until|thru|through)\b|(--|-|—|——|~|–))
-RangeConnectorRegex : !simpleRegex
-  def: (?<and>\b(and|through|to)\b|(--|-|—|——|~|–))
+TillRegex: !nestedRegex
+  def: (?<till>\b(to|till|til|until|thru|through)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  references: [ BaseDateTime.RangeConnectorSymbolRegex ]
+RangeConnectorRegex : !nestedRegex
+  def: (?<and>\b(and|through|to)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RelativeRegex: !simpleRegex
   def: \b(?<order>following|next|coming|upcoming|this|last|past|previous|current|the)\b
 StrictRelativeRegex: !simpleRegex
@@ -217,8 +219,8 @@ DateExtractor9: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+of\s+){DateYearRegex})?(?![%])\b
   references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex ]
 DateExtractorA: !nestedRegex
-  def: \b({WeekDayRegex}\s+)?{DateYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}
-  references: [ DateYearRegex, MonthNumRegex, DayRegex, WeekDayRegex ]
+  def: \b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}
+  references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex, DayRegex, WeekDayRegex ]
 OfMonth: !nestedRegex
   def: ^\s*of\s*{MonthRegex}
   references: [ MonthRegex ]

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -101,6 +101,9 @@ WithinNextPrefixRegex: !simpleRegex
 CenturySuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+RelativeRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 FromRegex: !simpleRegex
   def: ((desde|de)(\s*a(s)?)?)$
 ConnectorAndRegex: !simpleRegex

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -85,6 +85,9 @@ PrefixDayRegex: !simpleRegex
 CenturySuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+RelativeRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 SeasonRegex: !nestedRegex
   def: \b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b
   references: [ YearRegex ]

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/base_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/base_date_time.py
@@ -14,6 +14,7 @@ class BaseDateTime:
     SecondRegex = f'(?<sec>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)'
     FourDigitYearRegex = f'\\b(?<![$])(?<year>((1\\d|20)\\d{{2}})|2100)(?!\\.0\\b)\\b'
     IllegalYearRegex = f'([-])({FourDigitYearRegex})([-])'
+    RangeConnectorSymbolRegex = f'(--|-|—|——|~|–)'
     MinYearNum = '1500'
     MaxYearNum = '2100'
     MaxTwoDigitYearFutureNum = '30'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -9,8 +9,8 @@
 from .base_date_time import BaseDateTime
 # pylint: disable=line-too-long
 class EnglishDateTime:
-    TillRegex = f'(?<till>\\b(to|till|til|until|thru|through)\\b|(--|-|—|——|~|–))'
-    RangeConnectorRegex = f'(?<and>\\b(and|through|to)\\b|(--|-|—|——|~|–))'
+    TillRegex = f'(?<till>\\b(to|till|til|until|thru|through)\\b|{BaseDateTime.RangeConnectorSymbolRegex})'
+    RangeConnectorRegex = f'(?<and>\\b(and|through|to)\\b|{BaseDateTime.RangeConnectorSymbolRegex})'
     RelativeRegex = f'\\b(?<order>following|next|coming|upcoming|this|last|past|previous|current|the)\\b'
     StrictRelativeRegex = f'\\b(?<order>following|next|coming|upcoming|this|last|past|previous|current)\\b'
     NextPrefixRegex = f'\\b(following|next|upcoming|coming)\\b'
@@ -95,7 +95,7 @@ class EnglishDateTime:
     DateExtractor7 = f'\\b({WeekDayRegex}\\s+)?{MonthNumRegex}\\s*/\\s*{DayRegex}((\\s+|\\s*,\\s*|\\s+of\\s+){DateYearRegex})?(?![%])\\b'
     DateExtractor8 = f'(?<={DatePreposition}\\s+)({WeekDayRegex}\\s+)?{DayRegex}[\\\\\\-]{MonthNumRegex}(?![%])\\b'
     DateExtractor9 = f'\\b({WeekDayRegex}\\s+)?{DayRegex}\\s*/\\s*{MonthNumRegex}((\\s+|\\s*,\\s*|\\s+of\\s+){DateYearRegex})?(?![%])\\b'
-    DateExtractorA = f'\\b({WeekDayRegex}\\s+)?{DateYearRegex}\\s*[/\\\\\\-\\.]\\s*{MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*{DayRegex}'
+    DateExtractorA = f'\\b({WeekDayRegex}\\s+)?{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*{MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*{DayRegex}'
     OfMonth = f'^\\s*of\\s*{MonthRegex}'
     MonthEnd = f'{MonthRegex}\\s*(the)?\\s*$'
     WeekDayEnd = f'(this\\s+)?{WeekDayRegex}\\s*,?\\s*$'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/portuguese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/portuguese_date_time.py
@@ -49,6 +49,7 @@ class PortugueseDateTime:
     InConnectorRegex = f'\\b(em)\\b'
     WithinNextPrefixRegex = f'^[.]'
     CenturySuffixRegex = f'^[.]'
+    RelativeRegex = f'^[.]'
     FromRegex = f'((desde|de)(\\s*a(s)?)?)$'
     ConnectorAndRegex = f'(e\\s*([àa](s)?)?)$'
     BetweenRegex = f'(entre\\s*([oa](s)?)?)'
@@ -433,4 +434,5 @@ class PortugueseDateTime:
     SpecialDecadeCases = dict([('', 0)])
     DefaultLanguageFallback = 'DMY'
     DurationDateRestrictions = []
+    AmbiguityFiltersDict = dict([('null', 'null')])
 # pylint: enable=line-too-long

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
@@ -42,6 +42,7 @@ class SpanishDateTime:
     AllHalfYearRegex = f'^[.]'
     PrefixDayRegex = f'^[.]'
     CenturySuffixRegex = f'^[.]'
+    RelativeRegex = f'^[.]'
     SeasonRegex = f'\\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\\s+)?(?<seas>primavera|verano|otoño|invierno)((\\s+del?|\\s*,\\s*)?\\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\\s+año))?)\\b'
     WhichWeekRegex = f'(semana)(\\s*)(?<number>\\d\\d|\\d|0\\d)'
     WeekOfRegex = f'(semana)(\\s*)((do|da|de))'

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/resources/french_numeric_with_unit.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/resources/french_numeric_with_unit.py
@@ -349,4 +349,5 @@ class FrenchNumericWithUnit:
                              ('Tonne', 'tonne|tonnes|-tonnes|-tonne'),
                              ('Livre', 'livre|livres')])
     AmbiguousWeightUnitList = ['g', 'oz', 'stone', 'dram']
+    AmbiguityFiltersDict = dict([('\\bcent\\b', '\\bpour\\s+cent\\b')])
 # pylint: enable=line-too-long

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -4640,13 +4640,13 @@
         "Text": "from Feb 1st to March 2019",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-02-01,2019-03-01,PXXD)",
+          "Timex": "(2019-02-01,2019-03-01,P28D)",
           "FutureResolution": {
             "startDate": "2019-02-01",
             "endDate": "2019-03-01"
           },
           "PastResolution": {
-            "startDate": "2018-02-01",
+            "startDate": "2019-02-01",
             "endDate": "2019-03-01"
           }
         },
@@ -4666,13 +4666,13 @@
         "Text": "between Feb 1st and March 2019",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-02-01,2019-03-01,PXXD)",
+          "Timex": "(2019-02-01,2019-03-01,P28D)",
           "FutureResolution": {
             "startDate": "2019-02-01",
             "endDate": "2019-03-01"
           },
           "PastResolution": {
-            "startDate": "2018-02-01",
+            "startDate": "2019-02-01",
             "endDate": "2019-03-01"
           }
         },

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -7468,5 +7468,461 @@
         }
       }
     ]
+  },
+  {
+    "Input": "My vacation is from 10-1-2018-10-7-2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10-1-2018-10-7-2018",
+        "Start": 15,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "My vacation is from 10/1/2018 - 10/7/2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10/1/2018 - 10/7/2018",
+        "Start": 15,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "My vacation is from 10/1/2018-10/7/2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10/1/2018-10/7/2018",
+        "Start": 15,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will have a long vacation between 10/1-11/7",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between 10/1-11/7",
+        "Start": 28,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-10-01,XXXX-11-07,P37D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will have a long vacation between 10/1-11/7",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between 10/1-11/7",
+        "Start": 28,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-10-01,XXXX-11-07,P37D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Jan-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "jan-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2017-01-01,2017-02-01,P1M)",
+              "type": "daterange",
+              "start": "2017-01-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Jan-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "jan-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2017-01-01,2017-02-01,P1M)",
+              "type": "daterange",
+              "start": "2017-01-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-01,2017-02-01,P3M)",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov-Feb 5th, 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov-feb 5th, 2017",
+        "Start": 26,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-01,2017-02-05,P96D)",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2017-02-05"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18-Dec 19, 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18-dec 19, 2015",
+        "Start": 26,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-11-18,2015-12-19,P31D)",
+              "type": "daterange",
+              "start": "2015-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18 2014-Dec 19 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18 2014-dec 19 2015",
+        "Start": 26,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2014-11-18,2015-12-19,P396D)",
+              "type": "daterange",
+              "start": "2014-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18 2014-Dec 19 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18 2014-dec 19 2015",
+        "Start": 26,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2014-11-18,2015-12-19,P396D)",
+              "type": "daterange",
+              "start": "2014-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea on November 18-19",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "on november 18-19",
+        "Start": 26,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-11-18,XXXX-11-19,P1D)",
+              "type": "daterange",
+              "start": "2017-11-18",
+              "end": "2017-11-19"
+            },
+            {
+              "timex": "(XXXX-11-18,XXXX-11-19,P1D)",
+              "type": "daterange",
+              "start": "2018-11-18",
+              "end": "2018-11-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from this May to Oct 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from this may to oct 2020",
+        "Start": 13,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-05-01,2020-10-01,P29M)",
+              "type": "daterange",
+              "start": "2018-05-01",
+              "end": "2020-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from May to Oct 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from may to oct 2020",
+        "Start": 13,
+        "End": 32,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-10-01,P5M)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1-5/7, 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1-5/7, 2020",
+        "Start": 13,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-05-07,P6D)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1-5/7/2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1-5/7/2020",
+        "Start": 13,
+        "End": 29,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-05-07,P6D)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2019-5/7/2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2019-5/7/2020",
+        "Start": 13,
+        "End": 34,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-05-01,2020-05-07,P372D)",
+              "type": "daterange",
+              "start": "2019-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -6404,5 +6404,461 @@
         }
       }
     ]
+  },
+  {
+    "Input": "My vacation is from 10-1-2018-10-7-2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10-1-2018-10-7-2018",
+        "Start": 15,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "My vacation is from 10/1/2018 - 10/7/2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10/1/2018 - 10/7/2018",
+        "Start": 15,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "My vacation is from 10/1/2018-10/7/2018",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 10/1/2018-10/7/2018",
+        "Start": 15,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-10-01,2018-10-07,P6D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-10-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will have a long vacation between 10/1-11/7",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between 10/1-11/7",
+        "Start": 28,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-10-01,XXXX-11-07,P37D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will have a long vacation between 10/1-11/7",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between 10/1-11/7",
+        "Start": 28,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-10-01,XXXX-11-07,P37D)",
+              "type": "daterange",
+              "start": "2018-10-01",
+              "end": "2018-11-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Jan-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "jan-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2017-01-01,2017-02-01,P1M)",
+              "type": "daterange",
+              "start": "2017-01-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Jan-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "jan-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2017-01-01,2017-02-01,P1M)",
+              "type": "daterange",
+              "start": "2017-01-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov-Feb 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov-feb 2017",
+        "Start": 26,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-01,2017-02-01,P3M)",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2017-02-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov-Feb 5th, 2017",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov-feb 5th, 2017",
+        "Start": 26,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-01,2017-02-05,P96D)",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2017-02-05"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18-Dec 19, 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18-dec 19, 2015",
+        "Start": 26,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-11-18,2015-12-19,P31D)",
+              "type": "daterange",
+              "start": "2015-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18 2014-Dec 19 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18 2014-dec 19 2015",
+        "Start": 26,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2014-11-18,2015-12-19,P396D)",
+              "type": "daterange",
+              "start": "2014-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea Nov 18 2014-Dec 19 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nov 18 2014-dec 19 2015",
+        "Start": 26,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2014-11-18,2015-12-19,P396D)",
+              "type": "daterange",
+              "start": "2014-11-18",
+              "end": "2015-12-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "APEC will happen in Korea on November 18-19",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "on november 18-19",
+        "Start": 26,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-11-18,XXXX-11-19,P1D)",
+              "type": "daterange",
+              "start": "2017-11-18",
+              "end": "2017-11-19"
+            },
+            {
+              "timex": "(XXXX-11-18,XXXX-11-19,P1D)",
+              "type": "daterange",
+              "start": "2018-11-18",
+              "end": "2018-11-19"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from this May to Oct 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from this may to oct 2020",
+        "Start": 13,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-05-01,2020-10-01,P29M)",
+              "type": "daterange",
+              "start": "2018-05-01",
+              "end": "2020-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from May to Oct 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from may to oct 2020",
+        "Start": 13,
+        "End": 32,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-10-01,P5M)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1-5/7, 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1-5/7, 2020",
+        "Start": 13,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-05-07,P6D)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1-5/7/2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1-5/7/2020",
+        "Start": 13,
+        "End": 29,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-05-01,2020-05-07,P6D)",
+              "type": "daterange",
+              "start": "2020-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2019-5/7/2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2019-5/7/2020",
+        "Start": 13,
+        "End": 34,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-05-01,2020-05-07,P372D)",
+              "type": "daterange",
+              "start": "2019-05-01",
+              "end": "2020-05-07"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
#819 
The main cases handle in this PR includes:
1. Wrong splitting of DateRange entity, like "10/1-11/5", the original design would extract "10/1-11" as a date, which is wrong
2. Shared date context missing, like "Jan - March 2015", where "2015" should be the context of year.

Besides, there are some known issues:
1. "Dec/2018-Dec/2019", this still fails as we don't support recognizing "Dec/2018" for now #944
2. "10/1-10/2/2017", this still fails as after the Regex match "10/1-10", it will skip the "10/2/2017" as there is some overlapping #945
3. The Javascript and Python support is not in this PR, specs for other languages are also not in this PR as time is limited #946