### PR TITLE
Workaround for Java 8 not handling regexes with unbounded lookbehinds

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -66,16 +66,16 @@ public class EnglishDateTime {
             .replace("{BaseDateTime.FourDigitYearRegex}", BaseDateTime.FourDigitYearRegex)
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 
-    public static final String WeekDayRegex = "\\b(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tues|Tue|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|Sat|Sun)s?\\b";
+    public static final String WeekDayRegex = "\\b(?<weekday>sunday|monday|tuesday|wednesday|thursday|friday|saturday|mon|tues|tue|wedn|weds|wed|thurs|thur|thu|fri|sat|sun)s?\\b";
 
-    public static final String SingleWeekDayRegex = "\\b(?<weekday>Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Mon|Tue|Tues|Wedn|Weds|Wed|Thurs|Thur|Thu|Fri|((?<=on\\s+)(Sat|Sun)))\\b";
+    public static final String SingleWeekDayRegex = "\\b(?<weekday>sunday|monday|tuesday|wednesday|thursday|friday|saturday|mon|tue|tues|wedn|weds|wed|thurs|thur|thu|fri|((?<=on\\s+)(sat|sun)))\\b";
 
     public static final String RelativeMonthRegex = "(?<relmonth>(of\\s+)?{RelativeRegex}\\s+month)\\b"
             .replace("{RelativeRegex}", RelativeRegex);
 
-    public static final String WrittenMonthRegex = "(((the\\s+)?month of\\s+)?(?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sept|Sep))";
+    public static final String WrittenMonthRegex = "(((the\\s+)?month of\\s+)?(?<month>april|apr|august|aug|december|dec|february|feb|january|jan|july|jul|june|jun|march|mar|may|november|nov|october|oct|september|sept|sep))";
 
-    public static final String MonthSuffixRegex = "(?<msuf>(in\\s+|of\\s+|on\\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))"
+    public static final String MonthSuffixRegex = "(?<msuf>((in|of|on)\\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
             .replace("{WrittenMonthRegex}", WrittenMonthRegex);
 
@@ -113,11 +113,11 @@ public class EnglishDateTime {
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String MonthWithYear = "\\b(({WrittenMonthRegex}(\\.)?(\\s*),?(\\s+of)?(\\s*)({YearRegex}|(?<order>following|next|last|this)\\s+year))|(({YearRegex}|(?<order>following|next|last|this)\\s+year)(\\s*),?(\\s*){WrittenMonthRegex}))\\b"
+    public static final String MonthWithYear = "\\b(({WrittenMonthRegex}(\\.)?(\\s*)[/\\\\\\-\\.,]?(\\s+of)?(\\s*)({YearRegex}|(?<order>following|next|last|this)\\s+year))|(({YearRegex}|(?<order>following|next|last|this)\\s+year)(\\s*),?(\\s*){WrittenMonthRegex}))\\b"
             .replace("{WrittenMonthRegex}", WrittenMonthRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String OneWordPeriodRegex = "\\b((((the\\s+)?month of\\s+)?({StrictRelativeRegex}\\s+)?(?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sep|Sept))|(month|year) to date|({RelativeRegex}\\s+)?(my\\s+)?(weekend|week|month|year)(?!((\\s+of)?\\s+\\d+|\\s+to\\s+date))(\\s+{AfterNextSuffixRegex})?)\\b"
+    public static final String OneWordPeriodRegex = "\\b((((the\\s+)?month of\\s+)?({StrictRelativeRegex}\\s+)?(?<month>april|apr|august|aug|december|dec|february|feb|january|jan|july|jul|june|jun|march|mar|may|november|nov|october|oct|september|sept|sep))|(month|year) to date|({RelativeRegex}\\s+)?(my\\s+)?(weekend|week|month|year)(?!((\\s+of)?\\s+\\d+|\\s+to\\s+date))(\\s+{AfterNextSuffixRegex})?)\\b"
             .replace("{StrictRelativeRegex}", StrictRelativeRegex)
             .replace("{RelativeRegex}", RelativeRegex)
             .replace("{AfterNextSuffixRegex}", AfterNextSuffixRegex);
@@ -139,7 +139,7 @@ public class EnglishDateTime {
     public static final String NumberCombinedWithDateUnit = "\\b(?<num>\\d+(\\.\\d*)?){DateUnitRegex}"
             .replace("{DateUnitRegex}", DateUnitRegex);
 
-    public static final String QuarterTermRegex = "\\b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(Q(?<number>[1-4])))\\b";
+    public static final String QuarterTermRegex = "\\b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(q(?<number>[1-4])))\\b";
 
     public static final String QuarterRegex = "(the\\s+)?{QuarterTermRegex}((\\s+of|\\s*,\\s*)?\\s+({YearRegex}|{RelativeRegex}\\s+year))?"
             .replace("{YearRegex}", YearRegex)
@@ -153,10 +153,10 @@ public class EnglishDateTime {
 
     public static final String HalfYearTermRegex = "(?<cardinal>first|1st|second|2nd)\\s+half";
 
-    public static final String HalfYearFrontRegex = "(?<year>((1[5-9]|20)\\d{2})|2100)\\s*(the\\s+)?H(?<number>[1-2])"
+    public static final String HalfYearFrontRegex = "(?<year>((1[5-9]|20)\\d{2})|2100)\\s*(the\\s+)?h(?<number>[1-2])"
             .replace("{YearRegex}", YearRegex);
 
-    public static final String HalfYearBackRegex = "(the\\s+)?(H(?<number>[1-2])|({HalfYearTermRegex}))(\\s+of|\\s*,\\s*)?\\s+({YearRegex})"
+    public static final String HalfYearBackRegex = "(the\\s+)?(h(?<number>[1-2])|({HalfYearTermRegex}))(\\s+of|\\s*,\\s*)?\\s+({YearRegex})"
             .replace("{YearRegex}", YearRegex)
             .replace("{HalfYearTermRegex}", HalfYearTermRegex);
 
@@ -196,7 +196,7 @@ public class EnglishDateTime {
 
     public static final String MonthOfRegex = "(month)(\\s*)(of)";
 
-    public static final String MonthRegex = "(?<month>April|Apr|August|Aug|December|Dec|February|Feb|January|Jan|July|Jul|June|Jun|March|Mar|May|November|Nov|October|Oct|September|Sept|Sep)";
+    public static final String MonthRegex = "(?<month>april|apr|august|aug|december|dec|february|feb|january|jan|july|jul|june|jun|march|mar|may|november|nov|october|oct|september|sept|sep)";
 
     public static final String AmbiguousMonthP0Regex = "\\b((^may i)|(i|you|he|she|we|they)\\s+may|(may\\s+((((also|not|(also not)|well)\\s+)?(be|contain|constitute|email|e-mail|take|have|result|involve|get|work|reply))|(or may not))))\\b";
 
@@ -224,7 +224,7 @@ public class EnglishDateTime {
             .replace("{NextPrefixRegex}", NextPrefixRegex)
             .replace("{WeekDayRegex}", WeekDayRegex);
 
-    public static final String SpecialDayRegex = "\\b((the\\s+)?day before yesterday|(the\\s+)?day after (tomorrow|tmr)|((the\\s+)?({RelativeRegex}|my)\\s+day)|yesterday|tomorrow|tmr|today)\\b"
+    public static final String SpecialDayRegex = "\\b((the\\s+)?day before yesterday|(the\\s+)?day after (tomorrow|tmr)|the\\s+day\\s+(before|after)(?!=\\s+day)|((the\\s+)?({RelativeRegex}|my)\\s+day)|yesterday|tomorrow|tmr|today)\\b"
             .replace("{RelativeRegex}", RelativeRegex);
 
     public static final String SpecialDayWithNumRegex = "\\b((?<number>{WrittenNumRegex})\\s+days?\\s+from\\s+(?<day>yesterday|tomorrow|tmr|today))\\b"
@@ -233,7 +233,7 @@ public class EnglishDateTime {
     public static final String RelativeDayRegex = "\\b(((the\\s+)?{RelativeRegex}\\s+day))\\b"
             .replace("{RelativeRegex}", RelativeRegex);
 
-    public static final String SetWeekDayRegex = "\\b(?<prefix>on\\s+)?(?<weekday>morning|afternoon|evening|night|Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)s\\b";
+    public static final String SetWeekDayRegex = "\\b(?<prefix>on\\s+)?(?<weekday>morning|afternoon|evening|night|sunday|monday|tuesday|wednesday|thursday|friday|saturday)s\\b";
 
     public static final String WeekDayOfMonthRegex = "(?<wom>(the\\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\\s+{WeekDayRegex}\\s+{MonthSuffixRegex})"
             .replace("{WeekDayRegex}", WeekDayRegex)
@@ -415,7 +415,7 @@ public class EnglishDateTime {
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{DescRegex}", DescRegex);
 
-    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(T)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
+    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(t)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
             .replace("{TimePrefix}", TimePrefix)
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{BaseDateTime.MinuteRegex}", BaseDateTime.MinuteRegex)
@@ -605,7 +605,7 @@ public class EnglishDateTime {
 
     public static final String ConjunctionRegex = "\\b((and(\\s+for)?)|with)\\b";
 
-    public static final String HolidayRegex1 = "\\b(?<holiday>clean monday|good friday|ash wednesday|mardi gras|washington's birthday|mao's birthday|chinese new Year|new years' eve|new year's eve|new year 's eve|new years eve|new year eve|new years'|new year's|new year 's|new years|new year|may\\s*day|yuan dan|april fools|christmas eve|christmas|xmas|thanksgiving|halloween|yuandan|easter)(\\s+(of\\s+)?({YearRegex}|{RelativeRegex}\\s+year))?\\b"
+    public static final String HolidayRegex1 = "\\b(?<holiday>clean monday|good friday|ash wednesday|mardi gras|washington's birthday|mao's birthday|chinese new year|new years' eve|new year's eve|new year 's eve|new years eve|new year eve|new years'|new year's|new year 's|new years|new year|may\\s*day|yuan dan|april fools|christmas eve|christmas|xmas|thanksgiving|halloween|yuandan|easter)(\\s+(of\\s+)?({YearRegex}|{RelativeRegex}\\s+year))?\\b"
             .replace("{YearRegex}", YearRegex)
             .replace("{RelativeRegex}", RelativeRegex);
 
@@ -613,7 +613,7 @@ public class EnglishDateTime {
             .replace("{YearRegex}", YearRegex)
             .replace("{RelativeRegex}", RelativeRegex);
 
-    public static final String HolidayRegex3 = "(?<holiday>(independence|mlk|martin luther king|martin luther king jr|canberra|easter|columbus|thanks\\s*giving|christmas|xmas|labour|(international|int'l)\\s+workers'?|mother's|mother|mothers|father's|father|fathers|female|single|teacher's|youth|children|arbor|girls|chsmilbuild|lover|labor|inauguration|groundhog|valentine's|baptiste|bastille|halloween|veterans|memorial|mid(-| )autumn|moon|spring|lantern|qingming|dragon boat|new years'|new year's|new year 's|new years|new year)\\s+(day))(\\s+(of\\s+)?({YearRegex}|{RelativeRegex}\\s+year))?"
+    public static final String HolidayRegex3 = "(?<holiday>(independence|mlk|martin luther king|martin luther king jr|canberra|easter|columbus|thanks\\s*giving|christmas|xmas|labour|(international|int'l)\\s+workers'?|mother's|mother|mothers|father's|father|fathers|female|single|teacher's|youth|children|arbor|girls|chsmilbuild|lover|labor|inauguration|groundhog|valentine's|baptiste|bastille|halloween|veterans|memorial|mid[ \\-]autumn|moon|spring|lantern|qingming|dragon boat|new years'|new year's|new year 's|new years|new year)\\s+(day))(\\s+(of\\s+)?({YearRegex}|{RelativeRegex}\\s+year))?"
             .replace("{YearRegex}", YearRegex)
             .replace("{RelativeRegex}", RelativeRegex);
 
@@ -698,9 +698,9 @@ public class EnglishDateTime {
             .replace("{WeekDayRegex}", WeekDayRegex)
             .replace("{FlexibleDayRegex}", FlexibleDayRegex);
 
-    public static final String RestOfDateRegex = "\\bRest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<duration>week|month|year|decade)\\b";
+    public static final String RestOfDateRegex = "\\brest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<duration>week|month|year|decade)\\b";
 
-    public static final String RestOfDateTimeRegex = "\\bRest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<unit>day)\\b";
+    public static final String RestOfDateTimeRegex = "\\brest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<unit>day)\\b";
 
     public static final String MealTimeRegex = "\\b(at\\s+)?(?<mealTime>lunchtime)\\b";
 
@@ -729,7 +729,7 @@ public class EnglishDateTime {
 
     public static final String OrRegex = "\\s*((\\b|,\\s*)(or|and)\\b|,)\\s*";
 
-    public static final String YearPlusNumberRegex = "\\b(Year\\s+((?<year>(\\d{3,4}))|{FullTextYearRegex}))\\b"
+    public static final String YearPlusNumberRegex = "\\b(year\\s+((?<year>(\\d{3,4}))|{FullTextYearRegex}))\\b"
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 
     public static final String NumberAsTimeRegex = "\\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\\b"
@@ -1142,7 +1142,7 @@ public class EnglishDateTime {
     public static final List<String> DurationDateRestrictions = Arrays.asList("today", "now");
 
     public static final ImmutableMap<String, String> AmbiguityFiltersDict = ImmutableMap.<String, String>builder()
-        .put("\\bmorning|afternoon|evening|night|day\\b", "\\\\bgood\\\\s+(morning|afternoon|evening|night|day)\\\\b")
+        .put("\\bmorning|afternoon|evening|night|day\\b", "\\\\b(good\\\\s+(morning|afternoon|evening|night|day))|(nighty\\\\s+night)\\\\b")
         .put("\\bmay\\b", "\\\\b((^may i)|(i|you|he|she|we|they)\\\\s+may|(may\\\\s+((((also|not|(also not)|well)\\\\s+)?(be|contain|constitute|email|e-mail|take|have|result|involve|get|work|reply))|(or may not))))\\\\b")
         .build();
 
@@ -1155,4 +1155,14 @@ public class EnglishDateTime {
     public static final List<String> DaytimeTermList = Arrays.asList("daytime");
 
     public static final List<String> NightTermList = Arrays.asList("night");
+
+    public static final List<String> SameDayTerms = Arrays.asList("today");
+
+    public static final List<String> PlusOneDayTerms = Arrays.asList("tomorrow", "tmr", "day after");
+
+    public static final List<String> MinusOneDayTerms = Arrays.asList("yesterday", "day before");
+
+    public static final List<String> PlusTwoDayTerms = Arrays.asList("day after tomorrow", "day after tmr");
+
+    public static final List<String> MinusTwoDayTerms = Arrays.asList("day before yesterday");
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
@@ -50,14 +50,14 @@ public class FrenchDateTime {
             .replace("{BaseDateTime.FourDigitYearRegex}", BaseDateTime.FourDigitYearRegex)
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 
-    public static final String WeekDayRegex = "(?<weekday>Dimanche|Lundi|Mardi|Mercredi|Jeudi|Vendredi|Samedi|Lun|Mar|Mer|Jeu|Ven|Sam|Dim)\\b";
+    public static final String WeekDayRegex = "(?<weekday>dimanche|lundi|mardi|mercredi|jeudi|vendredi|samedi|lun|mar|mer|jeu|ven|sam|dim)\\b";
 
     public static final String RelativeMonthRegex = "(?<relmonth>({ThisPrefixRegex}\\s+mois)|(mois\\s+{PastSuffixRegex})|(mois\\s+{NextSuffixRegex}))\\b"
             .replace("{ThisPrefixRegex}", ThisPrefixRegex)
             .replace("{PastSuffixRegex}", PastSuffixRegex)
             .replace("{NextSuffixRegex}", NextSuffixRegex);
 
-    public static final String WrittenMonthRegex = "(?<month>Avril|Avr\\.|Avr|Août|D[eé]cembre|D[eé]c|D[eé]c\\.|F[eé]vrier|F[eé]v|F[eé]vr\\.|F[eé]vr|Javier|Jan|Janv\\.|Janv|Juillet|Jul|Juil|Juil\\.|Juin|Jun|Mars|Mar|Mai|Novembre|Nov|Nov\\.|Octobre|Oct|Oct\\.|Septembre|Sep|Sept|Sept\\.)";
+    public static final String WrittenMonthRegex = "(?<month>avril|avr\\.|avr|ao[uû]t|d[eé]cembre|d[eé]c\\.|d[eé]c|f[eé]vrier|f[eé]v|f[eé]vr\\.|f[eé]vr|janvier|janv\\.|janv|jan|juillet|jul|juil\\.|juil|juin|jun|mars|mar|mai|novembre|nov\\.|nov|octobre|oct\\.|oct|septembre|sept\\.|sept|sep)";
 
     public static final String MonthSuffixRegex = "(?<msuf>(en\\s*|le\\s*|de\\s*|dans\\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
@@ -91,13 +91,13 @@ public class FrenchDateTime {
 
     public static final String YearWordRegex = "\\b(?<year>l'ann[ée]e)\\b";
 
-    public static final String MonthWithYear = "\\b((?<month>Avril|Avr\\.|Avr|Août|Aout|D[ée]cembre|D[eé]c|Dec\\.|F[eé]v|F[eé]vr|Fev|F[eé]vrier|F[eé]v\\.|Janvier|Jan|Janv|Janv\\.|Jan\\.|Jul|Juillet|Juil\\.|Jun|Juin|Mar|Mars|Mai|Novembre|Nov|Nov\\.|Octobre|Oct|Oct\\.|Septembre|Sep|Sept|Sept\\.)(\\s*),?(\\s+de)?(\\s*)({YearRegex}|(?<order>cette)\\s*{YearWordRegex})|{YearWordRegex}\\s*({PastSuffixRegex}|{NextSuffixRegex}))"
+    public static final String MonthWithYear = "\\b((?<month>avril|avr\\.|avr|ao[uû]t|d[eé]cembre|d[eé]c\\.|d[eé]c|f[eé]vrier|f[eé]v|f[eé]vr\\.|f[eé]vr|janvier|janv\\.|janv|jan|juillet|jul|juil\\.|juil|juin|jun|mars|mar|mai|novembre|nov\\.|nov|octobre|oct\\.|oct|septembre|sept\\.|sept|sep)(\\s*),?(\\s+de)?(\\s*)({YearRegex}|(?<order>cette)\\s*{YearWordRegex})|{YearWordRegex}\\s*({PastSuffixRegex}|{NextSuffixRegex}))"
             .replace("{YearRegex}", YearRegex)
             .replace("{YearWordRegex}", YearWordRegex)
             .replace("{PastSuffixRegex}", PastSuffixRegex)
             .replace("{NextSuffixRegex}", NextSuffixRegex);
 
-    public static final String OneWordPeriodRegex = "\\b(({RelativeRegex}\\s+)?(?<month>Avril|Avr\\.|Avr|Août|Aout|D[eé]cembre|D[ée]c|D[eé]c\\.|F[eé]vrier|Fev|F[eé]v\\.|F[eé]vr|Janvier|Janv\\.|Janv|Jan|Jan\\.|Jul|Juillet|Juil\\.|Jun|Juin|Mar|Mars|Mai|Nov|Novembre|Nov\\.|Oct|Octobre|Oct\\.|Sep|Septembre|Sept\\.)|{RelativeRegex}\\s+(weekend|fin de semaine|week-end|semaine|mois|ans|l'année)|weekend|week-end|(mois|l'année))\\b"
+    public static final String OneWordPeriodRegex = "\\b(({RelativeRegex}\\s+)?(?<month>avril|avr\\.|avr|ao[uû]t|d[eé]cembre|d[eé]c\\.|d[eé]c|f[eé]vrier|f[eé]v|f[eé]vr\\.|f[eé]vr|janvier|janv\\.|janv|jan|juillet|jul|juil\\.|juil|juin|jun|mars|mar|mai|novembre|nov\\.|nov|octobre|oct\\.|oct|septembre|sept\\.|sept|sep)|{RelativeRegex}\\s+(weekend|fin de semaine|week-end|semaine|mois|ans|l'année)|weekend|week-end|(mois|l'année))\\b"
             .replace("{RelativeRegex}", RelativeRegex);
 
     public static final String MonthNumWithYear = "({YearRegex}(\\s*)[/\\-\\.](\\s*){MonthNumRegex})|({MonthNumRegex}(\\s*)[/\\-](\\s*){YearRegex})"
@@ -145,7 +145,7 @@ public class FrenchDateTime {
 
     public static final String MonthOfRegex = "(mois)(\\s*)(de)";
 
-    public static final String MonthRegex = "(?<month>Avril|Avr|Avr\\.|Août|Aout|D[ée]cembre|D[eé]c|Dec\\.|F[eé]vrier|F[eé]vr|Fev|F[eé]v|F[eé]v\\.|Janvier|Janv\\.|Janv|Jan|Jan\\.|Juillet|Juil|Juil\\.|Juin|Mars|Mai|Novembre|Nov|Nov\\.|Octobre|Oct|Oct\\.|Septembre|Sep|Sept|Sept\\.)";
+    public static final String MonthRegex = "(?<month>avril|avr\\.|avr|ao[uû]t|d[eé]cembre|d[eé]c\\.|d[eé]c|f[eé]vrier|f[eé]v|f[eé]vr\\.|f[eé]vr|janvier|janv\\.|janv|jan|juillet|jul|juil\\.|juil|juin|jun|mars|mar|mai|novembre|nov\\.|nov|octobre|oct\\.|oct|septembre|sept\\.|sept|sep)";
 
     public static final String OnRegex = "(?<=\\b(en|sur\\s*l[ea]|sur)\\s+)({DayRegex}s?)\\b"
             .replace("{DayRegex}", DayRegex);
@@ -167,9 +167,9 @@ public class FrenchDateTime {
 
     public static final String SpecialDayWithNumRegex = "^[.]";
 
-    public static final String StrictWeekDay = "\\b(?<weekday>Dimanche|Lundi|Mardi|Mercredi|Jeudi|Vendredi|Samedi|Lun|Mar|Mer|Jeu|Ven|Sam|Dim)s?\\b";
+    public static final String StrictWeekDay = "\\b(?<weekday>dimanche|lundi|mardi|mercredi|jeudi|vendredi|samedi|lun|mar|mer|jeu|ven|sam|dim)s?\\b";
 
-    public static final String SetWeekDayRegex = "\\b(?<prefix>le\\s+)?(?<weekday>matin|matin[ée]e|apres-midi|soir[ée]e|soir|Dimanche|Lundi|Mardi|Mercredi|Jeudi|Vendredi|Samedi)s\\b";
+    public static final String SetWeekDayRegex = "\\b(?<prefix>le\\s+)?(?<weekday>matin|matin[ée]e|apres-midi|soir[ée]e|soir|dimanche|lundi|mardi|mercredi|jeudi|vendredi|samedi)s\\b";
 
     public static final String WeekDayOfMonthRegex = "(?<wom>(le\\s+)?(?<cardinal>premier|1er|duexi[èe]me|2|troisi[èe]me|3|quatri[èe]me|4|cinqi[èe]me|5)\\s+{WeekDayRegex}\\s+{MonthSuffixRegex})"
             .replace("{WeekDayRegex}", WeekDayRegex)
@@ -334,7 +334,7 @@ public class FrenchDateTime {
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{DescRegex}", DescRegex);
 
-    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(T)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
+    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(t)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
             .replace("{TimePrefix}", TimePrefix)
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{BaseDateTime.MinuteRegex}", BaseDateTime.MinuteRegex)
@@ -504,7 +504,7 @@ public class FrenchDateTime {
 
     public static final String ConjunctionRegex = "\\b((et(\\s+de|pour)?)|avec)\\b";
 
-    public static final String HolidayRegex1 = "\\b(?<holiday>vendredi saint|mercredi des cendres|p[aâ]ques|l'action de gr[âa]ce|mardi gras|la saint-sylvestre|la saint sylvestre|la Saint-Valentin|la saint valentin|nouvel an chinois|nouvel an|r[eé]veillon de Nouvel an|jour de l'an|premier-mai|ler-mai|1-mai|poisson d'avril|r[eé]veillon de No[eë]l|veille de no[eë]l|noël|noel|thanksgiving|halloween|yuandan)(\\s+((d[ue]\\s+|d'))?({YearRegex}|({ThisPrefixRegex}\\s+)ann[eé]e|ann[eé]e\\s+({PastSuffixRegex}|{NextSuffixRegex})))?\\b"
+    public static final String HolidayRegex1 = "\\b(?<holiday>vendredi saint|mercredi des cendres|p[aâ]ques|l'action de gr[âa]ce|mardi gras|la saint-sylvestre|la saint sylvestre|la saint-valentin|la saint valentin|nouvel an chinois|nouvel an|r[eé]veillon de nouvel an|jour de l'an|premier-mai|ler-mai|1-mai|poisson d'avril|r[eé]veillon de no[eë]l|veille de no[eë]l|noël|noel|thanksgiving|halloween|yuandan)(\\s+((d[ue]\\s+|d'))?({YearRegex}|({ThisPrefixRegex}\\s+)ann[eé]e|ann[eé]e\\s+({PastSuffixRegex}|{NextSuffixRegex})))?\\b"
             .replace("{YearRegex}", YearRegex)
             .replace("{ThisPrefixRegex}", ThisPrefixRegex)
             .replace("{PastSuffixRegex}", PastSuffixRegex)
@@ -522,7 +522,7 @@ public class FrenchDateTime {
             .replace("{PastSuffixRegex}", PastSuffixRegex)
             .replace("{NextSuffixRegex}", NextSuffixRegex);
 
-    public static final String HolidayRegex4 = "(?<holiday>(F[eê]te\\s*(d[eu]|des)\\s*)(travail|m[eè]re|m[eè]res|p[eè]re|p[eè]res))(\\s+(de\\s+)?({YearRegex}|{ThisPrefixRegex}\\s+ann[eé]e|ann[eé]e\\s+({PastSuffixRegex}|{NextSuffixRegex})))?\\b"
+    public static final String HolidayRegex4 = "(?<holiday>(f[eê]te\\s*(d[eu]|des)\\s*)(travail|m[eè]re|m[eè]res|p[eè]re|p[eè]res))(\\s+(de\\s+)?({YearRegex}|{ThisPrefixRegex}\\s+ann[eé]e|ann[eé]e\\s+({PastSuffixRegex}|{NextSuffixRegex})))?\\b"
             .replace("{YearRegex}", YearRegex)
             .replace("{ThisPrefixRegex}", ThisPrefixRegex)
             .replace("{PastSuffixRegex}", PastSuffixRegex)
@@ -590,6 +590,12 @@ public class FrenchDateTime {
 
     public static final String ReferenceDatePeriodRegex = "^[.]";
 
+    public static final String NextPrefixRegex = "^[\\.]";
+
+    public static final String PastPrefixRegex = "^[\\.]";
+
+    public static final String RelativeDayRegex = "^[\\.]";
+
     public static final String ConnectorRegex = "^(,|pour|t|vers)$";
 
     public static final String ConnectorAndRegex = "\\b(et\\s*(le|la(s)?)?)\\b.+";
@@ -615,9 +621,9 @@ public class FrenchDateTime {
             .replace("{WeekDayRegex}", WeekDayRegex)
             .replace("{FlexibleDayRegex}", FlexibleDayRegex);
 
-    public static final String RestOfDateRegex = "\\b(Reste|fin)\\s+(d[eu]\\s+)?((le|cette|ce)\\s+)?(?<duration>semaine|mois|l'ann[ée]e)\\b";
+    public static final String RestOfDateRegex = "\\b(reste|fin)\\s+(d[eu]\\s+)?((le|cette|ce)\\s+)?(?<duration>semaine|mois|l'ann[ée]e)\\b";
 
-    public static final String RestOfDateTimeRegex = "\\b(Reste|fin)\\s+(d[eu]\\s+)?((le|cette|ce)\\s+)?(?<unit>jour)\\b";
+    public static final String RestOfDateTimeRegex = "\\b(reste|fin)\\s+(d[eu]\\s+)?((le|cette|ce)\\s+)?(?<unit>jour)\\b";
 
     public static final String LaterEarlyPeriodRegex = "^[.]";
 
@@ -1114,4 +1120,14 @@ public class FrenchDateTime {
     public static final List<String> DaytimeTermList = Arrays.asList("jour", "journee", "journée");
 
     public static final List<String> NightTermList = Arrays.asList("nuit");
+
+    public static final List<String> SameDayTerms = Arrays.asList("aujourd'hui", "auj");
+
+    public static final List<String> PlusOneDayTerms = Arrays.asList("demain", "a2m1", "lendemain", "jour suivant");
+
+    public static final List<String> MinusOneDayTerms = Arrays.asList("hier", "dernier");
+
+    public static final List<String> PlusTwoDayTerms = Arrays.asList("après demain", "après-demain", "apres-demain");
+
+    public static final List<String> MinusTwoDayTerms = Arrays.asList("avant-hier", "avant hier");
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/PortugueseDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/PortugueseDateTime.java
@@ -44,7 +44,7 @@ public class PortugueseDateTime {
 
     public static final String RelativeMonthRegex = "(?<relmonth>([nd]?es[st]e|pr[óo]ximo|passsado|[uú]ltimo)\\s+m[eê]s)\\b";
 
-    public static final String MonthRegex = "(?<month>Abril|Abr|Agosto|Ago|Dezembro|Dez|Fevereiro|Fev|Janeiro|Jan|Julho|Jul|Junho|Jun|Mar[çc]o|Mar|Maio|Mai|Novembro|Nov|Outubro|Out|Septembro|Setembro|Sept|Set)";
+    public static final String MonthRegex = "(?<month>abril|abr|agosto|ago|dezembro|dez|fevereiro|fev|janeiro|jan|julho|jul|junho|jun|mar[çc]o|mar|maio|mai|novembro|nov|outubro|out|septembro|setembro|sept|set)";
 
     public static final String MonthSuffixRegex = "(?<msuf>((em|no)\\s+|d[eo]\\s+)?({RelativeMonthRegex}|{MonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
@@ -80,9 +80,9 @@ public class PortugueseDateTime {
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\\s+)?(?<month>Abril|Abr|Agosto|Ago|Dezembro|Dez|Fevereiro|Fev|Janeiro|Jan|Julho|Jul|Junho|Jun|Mar[çc]o|Mar|Maio|Mai|Novembro|Nov|Outubro|Out|Septembro|Setembro|Sept|Set)|(?<=\\b(de|do|da|o|a)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\\b";
+    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\\s+)?(?<month>abril|abr|agosto|ago|dezembro|dez|fevereiro|fev|janeiro|jan|julho|jul|junho|jun|mar[çc]o|mar|maio|mai|novembro|nov|outubro|out|septembro|setembro|sept|set)|(?<=\\b(de|do|da|o|a)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\\b";
 
-    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|[nd]?es[st]e|aquele|[uú]ltim[oa]?|em)\\s+)?(?<month><month>Abril|Abr|Agosto|Ago|Dezembro|Dez|Fevereiro|Fev|Janeiro|Jan|Julho|Jul|Junho|Jun|Mar[çc]o|Mar|Maio|Mai|Novembro|Nov|Outubro|Out|Septembro|Setembro|Sept|Set)\\s+((de|do|da|o|a)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|[nd]?es[st]e)\\s+ano))\\b"
+    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|[nd]?es[st]e|aquele|[uú]ltim[oa]?|em)\\s+)?(?<month><month>abril|abr|agosto|ago|dezembro|dez|fevereiro|fev|janeiro|jan|julho|jul|junho|jun|mar[çc]o|mar|maio|mai|novembro|nov|outubro|out|septembro|setembro|sept|set)\\s+((de|do|da|o|a)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|[nd]?es[st]e)\\s+ano))\\b"
             .replace("{YearRegex}", YearRegex);
 
     public static final String MonthNumWithYearRegex = "({YearRegex}(\\s*?)[/\\-\\.](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-](\\s*?){YearRegex})"
@@ -136,7 +136,7 @@ public class PortugueseDateTime {
 
     public static final String BetweenRegex = "(entre\\s*([oa](s)?)?)";
 
-    public static final String WeekDayRegex = "\\b(?<weekday>Domingos?|Segundas?-feiras?|Segundas?\\s+feiras?|Segundas?|2a|Ter[çca]s?-feiras?|Ter[çc]as?\\s+feiras?|Ter[cça]s?|3a|Quartas?-feiras?|Quartas?\\s+feiras?|Quartas?|4a|Quintas?-feiras?|Quintas?\\s+feiras?|Quintas?|5a|Sextas?-feiras?|Sextas?\\s+feiras?|Sextas?|6a|S[aá]bados?|2ª|3ª|4ª|5ª|6ª|Dom|Seg|Ter|Qua|Qui|Sex|Sab|Seg\\.|Ter[cç]\\.|Qua\\.|Qui\\.|Sex\\.|S[aá]b\\.|Dom\\.)\\b";
+    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|segundas?-feiras?|segundas?\\s+feiras?|segundas?|2a|ter[çca]s?-feiras?|ter[çc]as?\\s+feiras?|ter[cça]s?|3a|quartas?-feiras?|quartas?\\s+feiras?|quartas?|4a|quintas?-feiras?|quintas?\\s+feiras?|quintas?|5a|sextas?-feiras?|sextas?\\s+feiras?|sextas?|6a|s[aá]bados?|2ª|3ª|4ª|5ª|6ª|dom|seg|ter|qua|qui|sex|sab|seg\\.|ter[cç]\\.|qua\\.|qui\\.|sex\\.|s[aá]b\\.|dom\\.)\\b";
 
     public static final String OnRegex = "(?<=\\b(em|no)\\s+)({DayRegex}s?)\\b"
             .replace("{DayRegex}", DayRegex);
@@ -298,7 +298,7 @@ public class PortugueseDateTime {
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{DescRegex}", DescRegex);
 
-    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(T)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
+    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(t)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
             .replace("{TimePrefix}", TimePrefix)
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{BaseDateTime.MinuteRegex}", BaseDateTime.MinuteRegex)
@@ -870,4 +870,14 @@ public class PortugueseDateTime {
     public static final List<String> EveningTermList = Arrays.asList("tarde");
 
     public static final List<String> NightTermList = Arrays.asList("noite");
+
+    public static final List<String> SameDayTerms = Arrays.asList("hoje", "este dia", "esse dia", "o dia");
+
+    public static final List<String> PlusOneDayTerms = Arrays.asList("amanha", "de amanha", "dia seguinte", "o dia de amanha", "proximo dia");
+
+    public static final List<String> MinusOneDayTerms = Arrays.asList("ontem", "ultimo dia");
+
+    public static final List<String> PlusTwoDayTerms = Arrays.asList("depois de amanha", "dia depois de amanha");
+
+    public static final List<String> MinusTwoDayTerms = Arrays.asList("anteontem", "dia antes de ontem");
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
@@ -44,7 +44,7 @@ public class SpanishDateTime {
 
     public static final String RelativeMonthRegex = "(?<relmonth>(este|pr[oó]ximo|[uú]ltimo)\\s+mes)\\b";
 
-    public static final String MonthRegex = "(?<month>Abril|Abr|Agosto|Ago|Diciembre|Dic|Febrero|Feb|Enero|Ene|Julio|Jul|Junio|Jun|Marzo|Mar|Mayo|May|Noviembre|Nov|Octubre|Oct|Septiembre|Setiembre|Sept|Set)";
+    public static final String MonthRegex = "(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)";
 
     public static final String MonthSuffixRegex = "(?<msuf>(en\\s+|del\\s+|de\\s+)?({RelativeMonthRegex}|{MonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
@@ -80,9 +80,9 @@ public class SpanishDateTime {
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en)\\s+)?(?<month>Abril|Abr|Agosto|Ago|Diciembre|Dic|Enero|Ene|Febrero|Feb|Julio|Jul|Junio|Jun|Marzo|Mar|Mayo|May|Noviembre|Nov|Octubre|Oct|Septiembre|Setiembre|Sept|Set)|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b";
+    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b";
 
-    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?|en)\\s+)?(?<month>Abril|Abr|Agosto|Ago|Diciembre|Dic|Enero|Ene|Febrero|Feb|Julio|Jul|Junio|Jun|Marzo|Mar|Mayo|May|Noviembre|Nov|Octubre|Oct|Septiembre|Setiembre|Sept|Set)\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
+    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
             .replace("{YearRegex}", YearRegex);
 
     public static final String MonthNumWithYearRegex = "({YearRegex}(\\s*?)[/\\-\\.](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-](\\s*?){YearRegex})"
@@ -136,7 +136,7 @@ public class SpanishDateTime {
 
     public static final String BetweenRegex = "(entre\\s*(la(s)?)?)";
 
-    public static final String WeekDayRegex = "\\b(?<weekday>Domingos?|Lunes|Martes|Mi[eé]rcoles|Jueves|Viernes|S[aá]bados?|Lu|Ma|Mi|Ju|Vi|Sa|Do)\\b";
+    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lu|ma|mi|ju|vi|sa|do)\\b";
 
     public static final String OnRegex = "(?<=\\ben\\s+)({DayRegex}s?)\\b"
             .replace("{DayRegex}", DayRegex);
@@ -294,7 +294,7 @@ public class SpanishDateTime {
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{DescRegex}", DescRegex);
 
-    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(T)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
+    public static final String TimeRegex2 = "(\\b{TimePrefix}\\s+)?(t)?{BaseDateTime.HourRegex}(\\s*)?:(\\s*)?{BaseDateTime.MinuteRegex}((\\s*)?:(\\s*)?{BaseDateTime.SecondRegex})?((\\s*{DescRegex})|\\b)"
             .replace("{TimePrefix}", TimePrefix)
             .replace("{BaseDateTime.HourRegex}", BaseDateTime.HourRegex)
             .replace("{BaseDateTime.MinuteRegex}", BaseDateTime.MinuteRegex)
@@ -842,4 +842,14 @@ public class SpanishDateTime {
     public static final List<String> EveningTermList = Arrays.asList("tarde");
 
     public static final List<String> NightTermList = Arrays.asList("noche");
+
+    public static final List<String> SameDayTerms = Arrays.asList("hoy", "el dia");
+
+    public static final List<String> PlusOneDayTerms = Arrays.asList("mañana", "dia siguiente", "el dia de mañana", "proximo dia");
+
+    public static final List<String> MinusOneDayTerms = Arrays.asList("ayer", "ultimo dia");
+
+    public static final List<String> PlusTwoDayTerms = Arrays.asList("pasado mañana", "dia despues de mañana");
+
+    public static final List<String> MinusTwoDayTerms = Arrays.asList("anteayer", "dia antes de ayer");
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/AgoLaterUtil.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/AgoLaterUtil.java
@@ -105,9 +105,9 @@ public class AgoLaterUtil {
 
         if (resultDateTime != referenceTime) {
             if (mode.equals(AgoLaterMode.DATE)) {
-                ret.setTimex(FormatUtil.luisDate(resultDateTime));
+                ret.setTimex(DateTimeFormatUtil.luisDate(resultDateTime));
             } else if (mode.equals(AgoLaterMode.DATETIME)) {
-                ret.setTimex(FormatUtil.luisDateTime(resultDateTime));
+                ret.setTimex(DateTimeFormatUtil.luisDateTime(resultDateTime));
             }
 
             ret.setFutureValue(resultDateTime);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DateTimeFormatUtil.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DateTimeFormatUtil.java
@@ -2,19 +2,18 @@ package com.microsoft.recognizers.text.datetime.utilities;
 
 import java.time.LocalDateTime;
 
-public class FormatUtil {
+public class DateTimeFormatUtil {
 
     private static final String dateDelimiter = "-";
     private static final String timeDelimiter = ":";
 
-    public static String luisDate(Integer year, Integer month, Integer day)
-    {
-        if (year == -1)
-        {
-            if (month == -1)
-            {
-                if (day == -1)
-                {
+    public static String luisDate(Integer year, Integer month, Integer day) {
+
+        if (year == -1) {
+
+            if (month == -1) {
+
+                if (day == -1) {
                     return String.join(dateDelimiter, "XXXX", "XX", "XX");
                 }
 
@@ -39,8 +38,7 @@ public class FormatUtil {
         return String.join(timeDelimiter, String.format("%02d", hour), String.format("%02d", min), String.format("%02d", second));
     }
 
-    public static String formatDate(LocalDateTime date)
-    {
-        return String.join(dateDelimiter, String.format("%04d", date.getYear()),  String.format("%02d", date.getMonthValue()),  String.format("%02d", date.getDayOfMonth()));
+    public static String formatDate(LocalDateTime date) {
+        return String.join(dateDelimiter, String.format("%04d", date.getYear()), String.format("%02d", date.getMonthValue()), String.format("%02d", date.getDayOfMonth()));
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DurationParsingUtil.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/DurationParsingUtil.java
@@ -1,122 +1,134 @@
 package com.microsoft.recognizers.text.datetime.utilities;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 
 public class DurationParsingUtil {
-  public static boolean isTimeDurationUnit(String unitStr) {
-    boolean result = false;
-    switch (unitStr) {
-      case "H":
-      result = true;
-      break;
-      case "M":
-      result = true;
-      break;
-      case "S":
-      result = true;
-      break;
-    }
-    return result;
-  }
-  
-  public static boolean isMultipleDuration(String timex) {
-    ImmutableMap<String, Double> map = resolveDurationTimex(timex);
-    return map.size() > 1;
-  }
-  
-  public static boolean isDateDuration(String timex) {
-    ImmutableMap<String, Double> map = resolveDurationTimex(timex);
-    
-    for (String unit : map.keySet()) {
-      if (isTimeDurationUnit(unit)) {
-        return false;
-      }
-    }
-    
-    return true;
-  }
-  
-  public static LocalDateTime shiftDateTime(String timex, LocalDateTime reference, boolean future) {
-    ImmutableMap<String, Double> timexUnitMap = resolveDurationTimex(timex);
-    
-    return getShiftResult(timexUnitMap, reference, future);
-  }
-  
-  public static LocalDateTime getShiftResult(ImmutableMap<String, Double> timexUnitMap, LocalDateTime reference, boolean future) {
-    LocalDateTime result = reference;
-    int futureOrPast = future ? 1 : -1;
-    for (Map.Entry<String, Double> pair : timexUnitMap.entrySet()) {
-      String unit = pair.getKey();
-      Double number = pair.getValue();
-      switch (unit) {
-        case "H":
-        result = result.plusHours(Math.round(number * futureOrPast));
-        break;
-        case "M":
-        result = result.plusMinutes(Math.round(number * futureOrPast));
-        break;
-        case "S":
-        result = result.plusSeconds(Math.round(number * futureOrPast));
-        break;
-        case "D":
-        result = result.plusDays(Math.round(number * futureOrPast));
-        break;
-        case "W":
-        result = result.plusWeeks(Math.round(number * futureOrPast));
-        break;
-        case "MON":
-        result = result.plusMonths(Math.round(number * futureOrPast));
-        break;
-        case "Y":
-        result = result.plusYears(Math.round(number * futureOrPast));
-        break;
-        
-        default:
-        return result;
-      }
-    }
-    return result;
-  }
-  
-  private static ImmutableMap<String, Double> resolveDurationTimex(String timex) {
-    Builder<String, Double> resultBuilder = ImmutableMap.builder();
-    
-    // resolve duration timex, such as P21DT2H(21 days 2 hours)
-    String durationStr = timex.replace('P', '\0');
-    int numberStart = 0;
-    boolean isTime = false;
-    
-    for (int i = 0; i < durationStr.length(); i++) {
-      if (Character.isLetter(durationStr.charAt(i))) {
-        if (durationStr.charAt(i) == 'T') {
-          isTime = true;
-        } else {
-          String numStr = durationStr.substring(numberStart, i);
-          
-          try {
-            Double number = Double.parseDouble(numStr);
-            String srcTimexUnit = durationStr.substring(i, i + 1);
-            
-            if (!isTime && srcTimexUnit.equals("M")) {
-              srcTimexUnit = "MON";
-            }
-            
-            resultBuilder.put(srcTimexUnit, number);
-            
-          } catch (NumberFormatException e) {
-            return resultBuilder.build();
-          }
-          
+
+    public static boolean isTimeDurationUnit(String unitStr) {
+
+        boolean result = false;
+
+        switch (unitStr) {
+            case "H":
+                result = true;
+                break;
+            case "M":
+                result = true;
+                break;
+            case "S":
+                result = true;
+                break;
         }
-        numberStart = i + 1;
-      }
+
+        return result;
     }
-    
-    return resultBuilder.build();
-  }
+
+    public static boolean isMultipleDuration(String timex) {
+        ImmutableMap<String, Double> map = resolveDurationTimex(timex);
+        return map.size() > 1;
+    }
+
+    public static boolean isDateDuration(String timex) {
+        ImmutableMap<String, Double> map = resolveDurationTimex(timex);
+
+        for (String unit : map.keySet()) {
+            if (isTimeDurationUnit(unit)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static LocalDateTime shiftDateTime(String timex, LocalDateTime reference, boolean future) {
+
+        ImmutableMap<String, Double> timexUnitMap = resolveDurationTimex(timex);
+
+        return getShiftResult(timexUnitMap, reference, future);
+    }
+
+    public static LocalDateTime getShiftResult(ImmutableMap<String, Double> timexUnitMap, LocalDateTime reference, boolean future) {
+
+        LocalDateTime result = reference;
+        int futureOrPast = future ? 1 : -1;
+
+        for (Map.Entry<String, Double> pair : timexUnitMap.entrySet()) {
+
+            String unit = pair.getKey();
+            Double number = pair.getValue();
+
+            switch (unit) {
+                case "H":
+                    result = result.plusHours(Math.round(number * futureOrPast));
+                    break;
+                case "M":
+                    result = result.plusMinutes(Math.round(number * futureOrPast));
+                    break;
+                case "S":
+                    result = result.plusSeconds(Math.round(number * futureOrPast));
+                    break;
+                case "D":
+                    result = result.plusDays(Math.round(number * futureOrPast));
+                    break;
+                case "W":
+                    result = result.plusWeeks(Math.round(number * futureOrPast));
+                    break;
+                case "MON":
+                    result = result.plusMonths(Math.round(number * futureOrPast));
+                    break;
+                case "Y":
+                    result = result.plusYears(Math.round(number * futureOrPast));
+                    break;
+
+                default:
+                    return result;
+            }
+        }
+
+        return result;
+    }
+
+    private static ImmutableMap<String, Double> resolveDurationTimex(String timex) {
+
+        Builder<String, Double> resultBuilder = ImmutableMap.builder();
+
+        // resolve duration timex, such as P21DT2H(21 days 2 hours)
+        String durationStr = timex.replace('P', '\0');
+        int numberStart = 0;
+        boolean isTime = false;
+
+        for (int i = 0; i < durationStr.length(); i++) {
+
+            if (Character.isLetter(durationStr.charAt(i))) {
+
+                if (durationStr.charAt(i) == 'T') {
+                    isTime = true;
+                } else {
+                    String numStr = durationStr.substring(numberStart, i);
+
+                    try {
+                        Double number = Double.parseDouble(numStr);
+                        String srcTimexUnit = durationStr.substring(i, i + 1);
+
+                        if (!isTime && srcTimexUnit.equals("M")) {
+                            srcTimexUnit = "MON";
+                        }
+
+                        resultBuilder.put(srcTimexUnit, number);
+
+                    } catch (NumberFormatException e) {
+                        return resultBuilder.build();
+                    }
+
+                }
+                numberStart = i + 1;
+            }
+        }
+
+        return resultBuilder.build();
+    }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/IDateTimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/IDateTimeUtilityConfiguration.java
@@ -3,15 +3,26 @@ package com.microsoft.recognizers.text.datetime.utilities;
 import java.util.regex.Pattern;
 
 public interface IDateTimeUtilityConfiguration {
+
     Pattern getAgoRegex();
+
     Pattern getLaterRegex();
+
     Pattern getInConnectorRegex();
+
     Pattern getWithinNextPrefixRegex();
+
     Pattern getRangeUnitRegex();
+
     Pattern getTimeUnitRegex();
+
     Pattern getDateUnitRegex();
+
     Pattern getAmDescRegex();
+
     Pattern getPmDescRegex();
+
     Pattern getAmPmDescRegex();
+
     Pattern getCommonDatePrefixRegex();
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimeZoneResolutionResult.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimeZoneResolutionResult.java
@@ -13,9 +13,15 @@ public class TimeZoneResolutionResult {
         this.timeZoneText = timeZoneText;
     }
 
-    public String getValue() { return this.value; }
+    public String getValue() {
+        return this.value;
+    }
 
-    public Integer getUtcOffsetMins() { return this.utcOffsetMins; }
+    public Integer getUtcOffsetMins() {
+        return this.utcOffsetMins;
+    }
 
-    public String getTimeZoneText() { return this.timeZoneText; }
+    public String getTimeZoneText() {
+        return this.timeZoneText;
+    }
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/FrenchNumericWithUnit.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/FrenchNumericWithUnit.java
@@ -16,14 +16,14 @@ import com.google.common.collect.ImmutableMap;
 
 public class FrenchNumericWithUnit {
 
-    public static final Map<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
         .put("Ans", "ans")
         .put("Mois", "mois d'âge|mois d'age|mois")
         .put("Semaines", "semaine|semaines|semaines d'âge|semaines d'age")
         .put("Jour", "jours|jour")
         .build();
 
-    public static final Map<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilomètre carré", "km2|km^2|km²|kilomètres carrés|kilomètre carré")
         .put("Hectomètre carré", "hm2|hm^2|hm²|hectomètre carré|hectomètres carrés")
         .put("Décamètre carré", "dam2|dam^2|dam²|décamètre carré|décamètres carrés")
@@ -37,7 +37,7 @@ public class FrenchNumericWithUnit {
         .put("Acre", "acre|acres")
         .build();
 
-    public static final Map<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
         .put("Abkhazie apsar", "abkhazie apsar|apsars")
         .put("Afghan afghani", "afghan afghani|؋|afn|afghanis|afghani")
         .put("Pul", "pul")
@@ -268,7 +268,7 @@ public class FrenchNumericWithUnit {
 
     public static final String CompoundUnitConnectorRegex = "(?<spacer>[^.])";
 
-    public static final Map<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
         .put("Dollar", "$")
         .put("Dollar États-Unis", "$us|usd|us$")
         .put("Dollar Caraïbes orientales", "xcd|$ec")
@@ -303,7 +303,7 @@ public class FrenchNumericWithUnit {
 
     public static final List<String> AmbiguousCurrencyUnitList = Arrays.asList("din.", "kina", "lari", "taka", "tala", "vatu", "yuan", "bob", "btn", "cop", "cup", "dop", "gip", "jod", "kgs", "lak", "mga", "mop", "nad", "omr", "sar", "sbd", "scr", "sdg", "sek", "sos", "std", "try", "yer");
 
-    public static final Map<String, String> InformationSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> InformationSuffixList = ImmutableMap.<String, String>builder()
         .put("Bit", "-bit|bit|bits")
         .put("Kilobit", "kilobit|kilobits|kb|kbit|kbits")
         .put("Megabit", "megabit|megabits|Mb|Mbit|mégabit|mégabits")
@@ -326,7 +326,7 @@ public class FrenchNumericWithUnit {
 
     public static final String ConnectorToken = "de";
 
-    public static final Map<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilomètres", "km|kilomètres|kilomètre|kilometres|kilometre|-km")
         .put("Hectomètre", "hm|hectomètre|hectomètres|hectometre|hectometres|-hm")
         .put("Décamètre", "dam|décamètre|décamètres|decametre|decametres|-dm")
@@ -347,7 +347,7 @@ public class FrenchNumericWithUnit {
 
     public static final List<String> AmbuguousLengthUnitList = Arrays.asList("m", "pouce", "pm");
 
-    public static final Map<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
         .put("Mètre par seconde", "m/s|metres/seconde|metres par seconde|metre par seconde|metres par secondes|mètre par seconde|mètres par seconde|mètres par secondes")
         .put("Kilomètre par heure", "km/h|kilomètre par heure|kilomètres par heure|kilomètres par heures|kilometres par heure|kilometre par heure")
         .put("Kilomètre par minute", "km/m|kilomètre par minute|kilomètres par minute|kilomètres par minutes|kilometre par minute|kilometre par minutes")
@@ -358,7 +358,7 @@ public class FrenchNumericWithUnit {
         .put("Pied par minute", "pieds/minute|pied/minute|ft/minute|ft/min|pied/min")
         .build();
 
-    public static final Map<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
         .put("Kelvin", "k|K|kelvin")
         .put("F", "°f|degres f|degrés f|deg f|° f|degrés fahrenheit|degres fahrenheit|fahrenheit")
         .put("R", "rankine|°r|° r")
@@ -366,7 +366,7 @@ public class FrenchNumericWithUnit {
         .put("Degré", "degrés|degres|deg.|°| °|degré|degre|deg")
         .build();
 
-    public static final Map<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
         .put("Mètre cube", "m3|m^3|m³|mètre cube|mètres cube|metre cube|metres cube")
         .put("Centimètre cube", "cm3|cm^3|cm³|centimètre cube|centimètres cube|centimetre cube|centimetres cube")
         .put("Millimètre cube", "mm3|mm^3|mm³|millimètre cube|millimètres cube|millimetre cube|millimetres cube")
@@ -385,7 +385,7 @@ public class FrenchNumericWithUnit {
 
     public static final List<String> AmbiguousVolumeUnitList = Arrays.asList("ounce", "oz", "l", "cup", "peck", "cord", "gill");
 
-    public static final Map<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilogramme", "kg|kilogramme|kilogrammes|kilo|kilos")
         .put("Gram", "g|gramme|grammes")
         .put("Milligramme", "mg|milligramme|milligrammes")
@@ -396,7 +396,7 @@ public class FrenchNumericWithUnit {
 
     public static final List<String> AmbiguousWeightUnitList = Arrays.asList("g", "oz", "stone", "dram");
 
-    public static final Map<String, String> AmbiguityFiltersDict = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AmbiguityFiltersDict = ImmutableMap.<String, String>builder()
         .put("\\bcent\\b", "\\\\bpour\\\\s+cent\\\\b")
         .build();
 }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/PortugueseNumericWithUnit.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/PortugueseNumericWithUnit.java
@@ -16,14 +16,14 @@ import com.google.common.collect.ImmutableMap;
 
 public class PortugueseNumericWithUnit {
 
-    public static final Map<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
         .put("Ano", "anos|ano")
         .put("Mês", "meses|mes|mês")
         .put("Semana", "semanas|semana")
         .put("Dia", "dias|dia")
         .build();
 
-    public static final Map<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
         .put("Quilômetro quadrado", "quilômetro quadrado|quilómetro quadrado|quilometro quadrado|quilômetros quadrados|quilómetros quadrados|quilomeros quadrados|km2|km^2|km²")
         .put("Hectare", "hectômetro quadrado|hectómetro quadrado|hectômetros quadrados|hectómetros cuadrados|hm2|hm^2|hm²|hectare|hectares")
         .put("Decâmetro quadrado", "decâmetro quadrado|decametro quadrado|decâmetros quadrados|decametro quadrado|dam2|dam^2|dam²|are|ares")
@@ -38,7 +38,7 @@ public class PortugueseNumericWithUnit {
         .put("Acre", "acre|acres")
         .build();
 
-    public static final Map<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
         .put("Dólar", "dólar|dolar|dólares|dolares")
         .put("Peso", "peso|pesos")
         .put("Coroa", "coroa|coroas")
@@ -348,7 +348,7 @@ public class PortugueseNumericWithUnit {
 
     public static final String CompoundUnitConnectorRegex = "(?<spacer>[^.])";
 
-    public static final Map<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
         .put("Dólar", "$")
         .put("Dólar estadunidense", "us$|u$d|usd$|usd")
         .put("Dólar do Caribe Oriental", "ec$|xcd")
@@ -384,7 +384,7 @@ public class PortugueseNumericWithUnit {
 
     public static final List<String> AmbiguousCurrencyUnitList = Arrays.asList("le");
 
-    public static final Map<String, String> InformationSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> InformationSuffixList = ImmutableMap.<String, String>builder()
         .put("bit", "bit|bits")
         .put("kilobit", "kilobit|kilobits|kb|kbit")
         .put("megabit", "megabit|megabits|Mb|Mbit")
@@ -417,7 +417,7 @@ public class PortugueseNumericWithUnit {
 
     public static final String ConnectorToken = "de";
 
-    public static final Map<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
         .put("Quilômetro", "km|quilometro|quilômetro|quilómetro|quilometros|quilômetros|quilómetros")
         .put("Hectômetro", "hm|hectometro|hectômetro|hectómetro|hectometros|hectômetros|hectómetros")
         .put("Decâmetro", "decametro|decâmetro|decámetro|decametros|decâmetro|decámetros|dam")
@@ -437,7 +437,7 @@ public class PortugueseNumericWithUnit {
 
     public static final List<String> AmbiguousLengthUnitList = Arrays.asList("mi", "milha", "milhas");
 
-    public static final Map<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
         .put("Metro por segundo", "metro/segundo|m/s|metro por segundo|metros por segundo|metros por segundos")
         .put("Quilômetro por hora", "km/h|quilômetro por hora|quilómetro por hora|quilometro por hora|quilômetros por hora|quilómetros por hora|quilometros por hora|quilômetro/hora|quilómetro/hora|quilometro/hora|quilômetros/hora|quilómetros/hora|quilometros/hora")
         .put("Quilômetro por minuto", "km/min|quilômetro por minuto|quilómetro por minuto|quilometro por minuto|quilômetros por minuto|quilómetros por minuto|quilometros por minuto|quilômetro/minuto|quilómetro/minuto|quilometro/minuto|quilômetros/minuto|quilómetros/minuto|quilometros/minuto")
@@ -452,7 +452,7 @@ public class PortugueseNumericWithUnit {
 
     public static final List<String> AmbiguousSpeedUnitList = Arrays.asList("nó", "no", "nós", "nos");
 
-    public static final Map<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
         .put("Kelvin", "k|K|kelvin")
         .put("Grau Rankine", "r|°r|°ra|grau rankine|graus rankine| rankine")
         .put("Grau Celsius", "°c|grau c|grau celsius|graus c|graus celsius|celsius|grau centígrado|grau centrigrado|graus centígrados|graus centigrados|centígrado|centígrados|centigrado|centigrados")
@@ -460,7 +460,7 @@ public class PortugueseNumericWithUnit {
         .put("Grau", "°|graus|grau")
         .build();
 
-    public static final Map<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
         .put("Quilômetro cúbico", "quilômetro cúbico|quilómetro cúbico|quilometro cubico|quilômetros cúbicos|quilómetros cúbicos|quilometros cubicos|km3|km^3|km³")
         .put("Hectômetro cúbico", "hectômetro cúbico|hectómetro cúbico|hectometro cubico|hectômetros cúbicos|hectómetros cúbicos|hectometros cubicos|hm3|hm^3|hm³")
         .put("Decâmetro cúbico", "decâmetro cúbico|decámetro cúbico|decametro cubico|decâmetros cúbicos|decámetros cúbicos|decametros cubicosdam3|dam^3|dam³")
@@ -480,7 +480,7 @@ public class PortugueseNumericWithUnit {
         .put("Onça líquida", "onça líquida|onca liquida|onças líquidas|oncas liquidas")
         .build();
 
-    public static final Map<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
         .put("Tonelada métrica", "tonelada métrica|tonelada metrica|toneladas métricas|toneladas metricas")
         .put("Tonelada", "ton|tonelada|toneladas")
         .put("Quilograma", "kg|quilograma|quilogramas|quilo|quilos|kilo|kilos")

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/SpanishNumericWithUnit.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/resources/SpanishNumericWithUnit.java
@@ -16,14 +16,14 @@ import com.google.common.collect.ImmutableMap;
 
 public class SpanishNumericWithUnit {
 
-    public static final Map<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AgeSuffixList = ImmutableMap.<String, String>builder()
         .put("Año", "años|año")
         .put("Mes", "meses|mes")
         .put("Semana", "semanas|semana")
         .put("Día", "dias|días|día|dia")
         .build();
 
-    public static final Map<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> AreaSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilómetro cuadrado", "kilómetro cuadrado|kilómetros cuadrados|km2|km^2|km²")
         .put("Hectómetro cuadrado", "hectómetro cuadrado|hectómetros cuadrados|hm2|hm^2|hm²|hectárea|hectáreas")
         .put("Decámetro cuadrado", "decámetro cuadrado|decámetros cuadrados|dam2|dam^2|dam²|área|áreas")
@@ -39,7 +39,7 @@ public class SpanishNumericWithUnit {
 
     public static final List<String> AreaAmbiguousValues = Arrays.asList("área", "áreas");
 
-    public static final Map<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencySuffixList = ImmutableMap.<String, String>builder()
         .put("Dólar", "dólar|dólares")
         .put("Peso", "peso|pesos")
         .put("Rublo", "rublo|rublos")
@@ -352,7 +352,7 @@ public class SpanishNumericWithUnit {
 
     public static final String CompoundUnitConnectorRegex = "(?<spacer>[^.])";
 
-    public static final Map<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> CurrencyPrefixList = ImmutableMap.<String, String>builder()
         .put("Dólar", "$")
         .put("Dólar estadounidense", "us$|u$d|usd")
         .put("Dólar del Caribe Oriental", "ec$|xcd")
@@ -388,7 +388,7 @@ public class SpanishNumericWithUnit {
 
     public static final List<String> AmbiguousCurrencyUnitList = Arrays.asList("le");
 
-    public static final Map<String, String> DimensionSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> DimensionSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilómetro", "km|kilometro|kilómetro|kilometros|kilómetros")
         .put("Hectómetro", "hm|hectometro|hectómetro|hectometros|hectómetros")
         .put("Decámetro", "decametro|decámetro|decametros|decámetros|dam")
@@ -484,7 +484,7 @@ public class SpanishNumericWithUnit {
 
     public static final List<String> AmbiguousDimensionUnitList = Arrays.asList("al", "mi", "área", "áreas", "pie", "pies");
 
-    public static final Map<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> LengthSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilómetro", "km|kilometro|kilómetro|kilometros|kilómetros")
         .put("Hectómetro", "hm|hectometro|hectómetro|hectometros|hectómetros")
         .put("Decámetro", "decametro|decámetro|decametros|decámetros|dam")
@@ -510,7 +510,7 @@ public class SpanishNumericWithUnit {
 
     public static final String ConnectorToken = "de";
 
-    public static final Map<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> SpeedSuffixList = ImmutableMap.<String, String>builder()
         .put("Metro por segundo", "metro/segundo|m/s|metro por segundo|metros por segundo|metros por segundos")
         .put("Kilómetro por hora", "km/h|kilómetro por hora|kilometro por hora|kilómetros por hora|kilometros por hora|kilómetro/hora|kilometro/hora|kilómetros/hora|kilometros/hora")
         .put("Kilómetro por minuto", "km/min|kilómetro por minuto|kilometro por minuto|kilómetros por minuto|kilometros por minuto|kilómetro/minuto|kilometro/minuto|kilómetros/minuto|kilometros/minuto")
@@ -525,7 +525,7 @@ public class SpanishNumericWithUnit {
 
     public static final List<String> AmbiguousSpeedUnitList = Arrays.asList("nudo", "nudos");
 
-    public static final Map<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> TemperatureSuffixList = ImmutableMap.<String, String>builder()
         .put("Kelvin", "k|K|kelvin")
         .put("Rankine", "r|rankine")
         .put("Grado Celsius", "°c|grados c|grado celsius|grados celsius|celsius|grado centígrado|grados centígrados|centígrado|centígrados")
@@ -535,7 +535,7 @@ public class SpanishNumericWithUnit {
         .put("Grado", "°|grados|grado")
         .build();
 
-    public static final Map<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> VolumeSuffixList = ImmutableMap.<String, String>builder()
         .put("Kilómetro cúbico", "kilómetro cúbico|kilómetros cúbico|km3|km^3|km³")
         .put("Hectómetro cúbico", "hectómetro cúbico|hectómetros cúbico|hm3|hm^3|hm³")
         .put("Decámetro cúbico", "decámetro cúbico|decámetros cúbico|dam3|dam^3|dam³")
@@ -555,7 +555,7 @@ public class SpanishNumericWithUnit {
         .put("Onza líquida", "onza líquida|onzas líquidas")
         .build();
 
-    public static final Map<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
+    public static final ImmutableMap<String, String> WeightSuffixList = ImmutableMap.<String, String>builder()
         .put("Tonelada métrica", "tonelada métrica|toneladas métricas")
         .put("Tonelada", "ton|tonelada|toneladas")
         .put("Kilogramo", "kg|kilogramo|kilogramos")

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/DoubleExtractor.java
@@ -27,21 +27,21 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(ChineseNumeric.DoubleSpecialsChars, Pattern.CASE_INSENSITIVE  | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleSpecialsChars, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         // (-)2.5, can avoid cases like ip address xx.xx.xx.xx
-        builder.put(Pattern.compile(ChineseNumeric.DoubleSpecialsCharsWithNegatives, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleSpecialsCharsWithNegatives, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         //(-).2
-        builder.put(Pattern.compile(ChineseNumeric.SimpleDoubleSpecialsChars, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleDoubleSpecialsChars, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         // 1.0 K
-        builder.put(Pattern.compile(ChineseNumeric.DoubleWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         //１５.２万
-        builder.put(Pattern.compile(ChineseNumeric.DoubleWithThousandsRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleChs");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleWithThousandsRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleChs");
         //四十五点三三
         builder.put(RegExpUtility.getSafeRegExp(ChineseNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleChs");
         // 2e6, 21.2e0
-        builder.put(Pattern.compile(ChineseNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         //2^5
-        builder.put(Pattern.compile(ChineseNumeric.DoubleScientificNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DoubleScientificNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/FractionExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.chinese.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.ChineseNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,11 +28,11 @@ public class FractionExtractor extends BaseNumberExtractor {
         HashMap<Pattern, String> builder = new HashMap<>();
 
         // -4 5/2,       ４ ６／３
-        builder.put(Pattern.compile(ChineseNumeric.FractionNotationSpecialsCharsRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FractionNotationSpecialsCharsRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
         // 8/3
-        builder.put(Pattern.compile(ChineseNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FractionNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
         //四分之六十五
-        builder.put(Pattern.compile(ChineseNumeric.AllFractionNumber, Pattern.UNICODE_CHARACTER_CLASS), "FracChs");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.AllFractionNumber, Pattern.UNICODE_CHARACTER_CLASS), "FracChs");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/IntegerExtractor.java
@@ -35,15 +35,15 @@ public class IntegerExtractor extends BaseNumberExtractor {
         HashMap<Pattern, String> builder = new HashMap<>();
 
         // 123456,  －１２３４５６
-        builder.put(Pattern.compile(ChineseNumeric.NumbersSpecialsChars, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersSpecialsChars, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         //15k,  16 G
-        builder.put(Pattern.compile(ChineseNumeric.NumbersSpecialsCharsWithSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersSpecialsCharsWithSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         //1,234,  ２，３３２，１１１
-        builder.put(Pattern.compile(ChineseNumeric.DottedNumbersSpecialsChar, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.DottedNumbersSpecialsChar, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         //半百  半打
-        builder.put(Pattern.compile(ChineseNumeric.NumbersWithHalfDozen, Pattern.UNICODE_CHARACTER_CLASS), "IntegerChs");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersWithHalfDozen, Pattern.UNICODE_CHARACTER_CLASS), "IntegerChs");
         //一打  五十打
-        builder.put(Pattern.compile(ChineseNumeric.NumbersWithDozen, Pattern.UNICODE_CHARACTER_CLASS), "IntegerChs");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersWithDozen, Pattern.UNICODE_CHARACTER_CLASS), "IntegerChs");
 
         switch (mode) {
             case Default:

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/PercentageExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/chinese/extractors/PercentageExtractor.java
@@ -28,71 +28,71 @@ public class PercentageExtractor extends BaseNumberExtractor {
     public PercentageExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        //二十个百分点,  四点五个百分点
+        //二十个百分点, 四点五个百分点
         builder.put(RegExpUtility.getSafeRegExp(ChineseNumeric.PercentagePointRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerChs");
 
         //百分之五十  百分之一点五
-        builder.put(Pattern.compile(ChineseNumeric.SimplePercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerChs");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimplePercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerChs");
 
         //百分之５６.２　百分之１２
-        builder.put(Pattern.compile(ChineseNumeric.NumbersPercentagePointRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersPercentagePointRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //百分之3,000  百分之１，１２３
-        builder.put(Pattern.compile(ChineseNumeric.NumbersPercentageWithSeparatorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersPercentageWithSeparatorRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //百分之3.2 k
-        builder.put(Pattern.compile(ChineseNumeric.NumbersPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //12.56个百分点  ０.４个百分点
-        builder.put(Pattern.compile(ChineseNumeric.FractionPercentagePointRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FractionPercentagePointRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //15,123个百分点  １１１，１１１个百分点
-        builder.put(Pattern.compile(ChineseNumeric.FractionPercentageWithSeparatorRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FractionPercentageWithSeparatorRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //12.1k个百分点  １５.1k个百分点
-        builder.put(Pattern.compile(ChineseNumeric.FractionPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FractionPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //百分之22  百分之１２０
-        builder.put(Pattern.compile(ChineseNumeric.SimpleNumbersPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleNumbersPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //百分之15k
-        builder.put(Pattern.compile(ChineseNumeric.SimpleNumbersPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleNumbersPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //百分之1,111  百分之９，９９９
-        builder.put(Pattern.compile(ChineseNumeric.SimpleNumbersPercentagePointRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleNumbersPercentagePointRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //12个百分点
-        builder.put(Pattern.compile(ChineseNumeric.IntegerPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.IntegerPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //12k个百分点
-        builder.put(Pattern.compile(ChineseNumeric.IntegerPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.IntegerPercentageWithMultiplierRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //2,123个百分点
-        builder.put(Pattern.compile(ChineseNumeric.NumbersFractionPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersFractionPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //32.5%
-        builder.put(Pattern.compile(ChineseNumeric.SimpleIntegerPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleIntegerPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerNum");
 
         //2折 ２.５折
-        builder.put(Pattern.compile(ChineseNumeric.NumbersFoldsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersFoldsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //三折 六点五折 七五折
-        builder.put(Pattern.compile(ChineseNumeric.FoldsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.FoldsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //5成 6成半 6成4
-        builder.put(Pattern.compile(ChineseNumeric.SimpleFoldsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleFoldsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //七成半 七成五
-        builder.put(Pattern.compile(ChineseNumeric.SpecialsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SpecialsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //2成 ２.５成
-        builder.put(Pattern.compile(ChineseNumeric.NumbersSpecialsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.NumbersSpecialsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //三成 六点五成
-        builder.put(Pattern.compile(ChineseNumeric.SimpleSpecialsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SimpleSpecialsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         //打对折 半成
-        builder.put(Pattern.compile(ChineseNumeric.SpecialsFoldsPercentageRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(ChineseNumeric.SpecialsFoldsPercentageRegex, Pattern.UNICODE_CHARACTER_CLASS), "PerSpe");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/DoubleExtractor.java
@@ -5,6 +5,7 @@ import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.NumberOptions;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.EnglishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +45,7 @@ public class DoubleExtractor extends BaseNumberExtractor {
     }
 
     public static DoubleExtractor getInstance(String placeholder) {
+
         if (!instances.containsKey(placeholder)) {
             DoubleExtractor instance = new DoubleExtractor(placeholder);
             instances.put(placeholder, instance);
@@ -58,15 +60,16 @@ public class DoubleExtractor extends BaseNumberExtractor {
     }
 
     private DoubleExtractor(String placeholder) {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(EnglishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
         builder.put(Pattern.compile(EnglishNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleEng");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
-        builder.put(Pattern.compile(EnglishNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumCommaDot, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumBlankDot, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceDot, placeholder), "DoubleNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/english/extractors/IntegerExtractor.java
@@ -5,6 +5,7 @@ import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.NumberOptions;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.EnglishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,10 +61,10 @@ public class IntegerExtractor extends BaseNumberExtractor {
     private IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(EnglishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(EnglishNumeric.NumbersWithSuffix), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(Pattern.compile(EnglishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(EnglishNumeric.NumbersWithDozenSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(EnglishNumeric.NumbersWithDozenSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
         builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerEng");
         builder.put(Pattern.compile(EnglishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerEng");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, placeholder), "IntegerNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/extractors/BaseNumberExtractor.java
@@ -24,6 +24,7 @@ public abstract class BaseNumberExtractor implements IExtractor {
     protected Optional<Pattern> getNegativeNumberTermsRegex() { return Optional.empty(); }
 
     public List<ExtractResult> extract(String source) {
+
         if (source == null || source.isEmpty()) {
             return Collections.emptyList();
         }
@@ -34,9 +35,12 @@ public abstract class BaseNumberExtractor implements IExtractor {
         Arrays.fill(matched, false);
 
         HashMap<Match, String> matchSource = new HashMap<>();
+
         getRegexes().forEach((k, value) -> {
+
             Match[] matches = RegExpUtility.getMatches(k, source);
-            for(Match m : matches) {
+
+            for (Match m : matches) {
                 int start = m.index;
                 int length = m.length;
                 for (int j = 0; j < length; j++) {
@@ -50,20 +54,26 @@ public abstract class BaseNumberExtractor implements IExtractor {
 
         int last = -1;
         for (int i = 0; i < source.length(); i++) {
+
             if (matched[i]) {
+
                 if (i + 1 == source.length() || !matched[i + 1]) {
+
                     int start = last + 1;
                     int length = i - last;
                     String subStr = source.substring(start, start + length);
 
                     int finalStart = start;
                     int finalLength = length;
+
                     Optional<Match> srcMatches = matchSource.keySet().stream().filter(o -> o.index == finalStart && o.length == finalLength).findFirst();
+
                     if (srcMatches.isPresent()) {
                         Match srcMatch = srcMatches.get();
 
                         // Extract negative numbers
                         if (getNegativeNumberTermsRegex().isPresent()) {
+
                             Matcher match = getNegativeNumberTermsRegex().get().matcher(source.substring(0, start));
                             if (match.find()) {
                                 start = match.start();
@@ -95,13 +105,14 @@ public abstract class BaseNumberExtractor implements IExtractor {
     }
 
     protected Pattern generateLongFormatNumberRegexes(LongFormatType type, String placeholder) {
+
         String thousandsMark = Pattern.quote(String.valueOf(type.thousandsMark));
         String decimalsMark = Pattern.quote(String.valueOf(type.decimalsMark));
 
-        String regexDefinition = type.decimalsMark == '\0'
-                ? BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark)
-                : BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
+        String regexDefinition = type.decimalsMark == '\0' ?
+                BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark) :
+                BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
 
-        return Pattern.compile(regexDefinition, Pattern.UNICODE_CHARACTER_CLASS);
+        return RegExpUtility.getSafeLookbehindRegExp(regexDefinition, Pattern.UNICODE_CHARACTER_CLASS);
     }
 }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/DoubleExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.FrenchNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,15 +30,16 @@ public class DoubleExtractor extends BaseNumberExtractor {
     }
 
     public DoubleExtractor(String placeholder) {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleFr");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
-        builder.put(Pattern.compile(FrenchNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleWithMultiplierRegex), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/FractionExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.french.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.FrenchNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,12 +24,15 @@ public class FractionExtractor extends BaseNumberExtractor {
     }
 
     public FractionExtractor() {
+
         HashMap<Pattern, String> builder = new HashMap<>();
-        builder.put(Pattern.compile(FrenchNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
-        builder.put(Pattern.compile(FrenchNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
-        builder.put(Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.FractionNotationWithSpacesRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.FractionNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.FractionNounRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.FractionNounWithArticleRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracFr");
+
         this.regexes = Collections.unmodifiableMap(builder);
     }
 }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/IntegerExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.FrenchNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,13 +32,13 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.NumbersWithSuffix), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.NumbersWithPlaceHolder(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
-        builder.put(Pattern.compile(FrenchNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.RoundNumberIntegerRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.NumbersWithDozenSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.AllIntRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerFr");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/extractors/OrdinalExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.french.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.FrenchNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,8 +27,8 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(FrenchNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
-        builder.put(Pattern.compile(FrenchNumeric.OrdinalFrenchRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdFr");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.OrdinalSuffixRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(FrenchNumeric.OrdinalFrenchRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdFr");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
@@ -28,6 +28,7 @@ public class FrenchNumberParserConfiguration extends BaseNumberParserConfigurati
                 FrenchNumeric.LangMarker,
                 cultureInfo,
                 options,
+
                 FrenchNumeric.NonDecimalSeparatorChar,
                 FrenchNumeric.DecimalSeparatorChar,
                 FrenchNumeric.FractionMarkerToken,
@@ -40,10 +41,11 @@ public class FrenchNumberParserConfiguration extends BaseNumberParserConfigurati
                 FrenchNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 FrenchNumeric.RoundNumberMap,
-                Pattern.compile(FrenchNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(FrenchNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(FrenchNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
+
+                Pattern.compile(FrenchNumeric.HalfADozenRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.DigitalNumberRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.NegativeNumberSignRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                Pattern.compile(FrenchNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     @Override

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/DoubleExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.GermanNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,15 +30,16 @@ public class DoubleExtractor extends BaseNumberExtractor {
     }
 
     public DoubleExtractor(String placeholder) {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
-        builder.put(Pattern.compile(GermanNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleGer");
-        builder.put(Pattern.compile(GermanNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
-        builder.put(Pattern.compile(GermanNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleWithMultiplierRegex), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS),"DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/FractionExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.german.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.GermanNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,13 +25,14 @@ public class FractionExtractor extends BaseNumberExtractor {
     }
 
     public FractionExtractor() {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(GermanNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(GermanNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
-        builder.put(Pattern.compile(GermanNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
-        builder.put(Pattern.compile(GermanNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.FractionNotationWithSpacesRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.FractionNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.FractionNounRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.FractionNounWithArticleRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracGer");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/IntegerExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.GermanNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,12 +32,12 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.NumbersWithSuffix), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.NumbersWithDozenSuffix,Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
-        builder.put(Pattern.compile(GermanNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.NumbersWithSuffix), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.NumbersWithDozenSuffix,Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerGer");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/german/extractors/OrdinalExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.german.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.GermanNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,10 +27,10 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(GermanNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalNumericRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalGermanRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
-        builder.put(Pattern.compile(GermanNumeric.OrdinalRoundNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.OrdinalSuffixRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.OrdinalNumericRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.OrdinalGermanRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(GermanNumeric.OrdinalRoundNumberRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdGer");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/DoubleExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.PortugueseNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,13 +32,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePor");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
-        builder.put(Pattern.compile(PortugueseNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleWithMultiplierRegex), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/FractionExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.portuguese.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.PortugueseNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,13 +25,14 @@ public class FractionExtractor extends BaseNumberExtractor {
     }
 
     public FractionExtractor() {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "FracNum");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "FracPor");
-        builder.put(Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionNotationWithSpacesRegex, Pattern.UNICODE_CHARACTER_CLASS) , "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionNounRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionNounWithArticleRegex, Pattern.UNICODE_CHARACTER_CLASS) , "FracPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/IntegerExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.PortugueseNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,16 +32,16 @@ public class IntegerExtractor extends BaseNumberExtractor {
     public IntegerExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithSuffix), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.NumbersWithPlaceHolder(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozen2Suffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
-        builder.put(Pattern.compile(PortugueseNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.RoundNumberIntegerRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.NumbersWithDozen2Suffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.NumbersWithDozenSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.AllIntRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/extractors/OrdinalExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.portuguese.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.PortugueseNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,8 +27,8 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     public OrdinalExtractor() {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(PortugueseNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
-        builder.put(Pattern.compile(PortugueseNumeric. OrdinalEnglishRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalPor");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.OrdinalSuffixRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric. OrdinalEnglishRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalPor");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/parsers/PortugueseNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/portuguese/parsers/PortugueseNumberParserConfiguration.java
@@ -8,6 +8,7 @@ import com.microsoft.recognizers.text.number.NumberOptions;
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParserConfiguration;
 import com.microsoft.recognizers.text.number.resources.PortugueseNumeric;
 import com.microsoft.recognizers.text.utilities.QueryProcessor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,7 @@ public class PortugueseNumberParserConfiguration extends BaseNumberParserConfigu
                 PortugueseNumeric.LangMarker,
                 cultureInfo,
                 options,
+
                 PortugueseNumeric.NonDecimalSeparatorChar,
                 PortugueseNumeric.DecimalSeparatorChar,
                 PortugueseNumeric.FractionMarkerToken,
@@ -41,10 +43,11 @@ public class PortugueseNumberParserConfiguration extends BaseNumberParserConfigu
                 PortugueseNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 PortugueseNumeric.RoundNumberMap,
-                Pattern.compile(PortugueseNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(PortugueseNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(PortugueseNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(PortugueseNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
+
+                RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.HalfADozenRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.DigitalNumberRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.NegativeNumberSignRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(PortugueseNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS));
     }
 
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/DoubleExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/DoubleExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.SpanishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,13 +32,13 @@ public class DoubleExtractor extends BaseNumberExtractor {
     public DoubleExtractor(String placeholder) {
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleWithRoundNumber, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleAllFloatRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoubleSpa");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
-        builder.put(Pattern.compile(SpanishNumeric.DoubleCaretExponentialNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleDecimalPointRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleWithoutIntegralRegex(placeholder), Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleWithMultiplierRegex), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleWithRoundNumber, Pattern.UNICODE_CHARACTER_CLASS), "DoubleNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleAllFloatRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoubleSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DoubleCaretExponentialNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "DoublePow");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumDotComma, placeholder), "DoubleNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder), "DoubleNum");
 

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/FractionExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/FractionExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.spanish.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.SpanishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,13 +25,14 @@ public class FractionExtractor extends BaseNumberExtractor {
     }
 
     public FractionExtractor() {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.FractionNotationRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNotationWithSpacesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
-        builder.put(Pattern.compile(SpanishNumeric.FractionNounWithArticleRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
-        builder.put(Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionNotationRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionNotationWithSpacesRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionNounRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionNounWithArticleRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS), "FracSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/IntegerExtractor.java
@@ -4,6 +4,7 @@ import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.LongFormatType;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.SpanishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,17 +30,18 @@ public class IntegerExtractor extends BaseNumberExtractor {
     }
 
     public IntegerExtractor(String placeholder) {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS) , "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.NumbersWithSuffix), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.NumbersWithPlaceHolder(placeholder), Pattern.UNICODE_CHARACTER_CLASS) , "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.NumbersWithSuffix), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumDot, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumBlank, placeholder), "IntegerNum");
         builder.put(generateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.NumbersWithDozenSuffix, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
-        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
-        builder.put(Pattern.compile(SpanishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.RoundNumberIntegerRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.NumbersWithDozenSuffix, Pattern.UNICODE_CHARACTER_CLASS), "IntegerNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.AllIntRegexWithLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.AllIntRegexWithDozenSuffixLocks, Pattern.UNICODE_CHARACTER_CLASS), "IntegerSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/OrdinalExtractor.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/extractors/OrdinalExtractor.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.number.spanish.extractors;
 import com.microsoft.recognizers.text.number.Constants;
 import com.microsoft.recognizers.text.number.extractors.BaseNumberExtractor;
 import com.microsoft.recognizers.text.number.resources.SpanishNumeric;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,10 +25,11 @@ public class OrdinalExtractor extends BaseNumberExtractor {
     }
 
     public OrdinalExtractor() {
+
         HashMap<Pattern, String> builder = new HashMap<>();
 
-        builder.put(Pattern.compile(SpanishNumeric.OrdinalSuffixRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
-        builder.put(Pattern.compile(SpanishNumeric.OrdinalNounRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS), "OrdinalSpa");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.OrdinalSuffixRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalNum");
+        builder.put(RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.OrdinalNounRegex, Pattern.UNICODE_CHARACTER_CLASS), "OrdinalSpa");
 
         this.regexes = Collections.unmodifiableMap(builder);
     }

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/parsers/SpanishNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/spanish/parsers/SpanishNumberParserConfiguration.java
@@ -8,6 +8,7 @@ import com.microsoft.recognizers.text.number.NumberOptions;
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParserConfiguration;
 import com.microsoft.recognizers.text.number.resources.SpanishNumeric;
 import com.microsoft.recognizers.text.utilities.QueryProcessor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +26,12 @@ public class SpanishNumberParserConfiguration extends BaseNumberParserConfigurat
     }
 
     public SpanishNumberParserConfiguration(CultureInfo cultureInfo, NumberOptions options) {
+
         super(
                 SpanishNumeric.LangMarker,
                 cultureInfo,
                 options,
+
                 SpanishNumeric.NonDecimalSeparatorChar,
                 SpanishNumeric.DecimalSeparatorChar,
                 SpanishNumeric.FractionMarkerToken,
@@ -41,14 +44,16 @@ public class SpanishNumberParserConfiguration extends BaseNumberParserConfigurat
                 SpanishNumeric.CardinalNumberMap,
                 buildOrdinalNumberMap(),
                 SpanishNumeric.RoundNumberMap,
-                Pattern.compile(SpanishNumeric.HalfADozenRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(SpanishNumeric.DigitalNumberRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(SpanishNumeric.NegativeNumberSignRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS),
-                Pattern.compile(SpanishNumeric.FractionPrepositionRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS));
+
+                RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.HalfADozenRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.DigitalNumberRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.NegativeNumberSignRegex, Pattern.UNICODE_CHARACTER_CLASS),
+                RegExpUtility.getSafeLookbehindRegExp(SpanishNumeric.FractionPrepositionRegex, Pattern.UNICODE_CHARACTER_CLASS));
     }
 
     @Override
     public List<String> normalizeTokenSet(List<String> tokens, ParseResult context) {
+
         List<String> result = new ArrayList<>();
 
         for (String token : tokens) {


### PR DESCRIPTION
- Java 8 doesn't support lookbehinds with no max length. Added method in RegExpUtility to make regexes safe for Java 8;
- Re-gen Java resources;
- Code formatting.