### PR TITLE
[Java] Fix failed unit tests count in summary table

### DIFF
--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/AbstractTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/AbstractTest.java
@@ -55,7 +55,10 @@ public abstract class AbstractTest {
     public static void after(){
         Map<String, String> counter = new LinkedHashMap<>();
         for (Map.Entry<String, Integer> entry : testCounter.entrySet()) {
-            counter.put(entry.getKey(), entry.getValue().toString());
+            int skipped = skipCounter.getOrDefault(entry.getKey(), 0);
+            if (entry.getValue() > skipped) {
+                counter.put(entry.getKey(), entry.getValue().toString());
+            }
         }
         for (Map.Entry<String, String> entry : counter.entrySet()) {
             Integer passValue = passCounter.getOrDefault(entry.getKey(), 0);
@@ -116,9 +119,9 @@ public abstract class AbstractTest {
         } catch (AssumptionViolatedException ex) {
             countSkip(currentCase);
             throw ex;
-        } catch (Exception ex) {
+        } catch (Throwable err) {
             countFail(currentCase);
-            throw ex;
+            throw err;
         }
     }
 


### PR DESCRIPTION
- We found the failed count in the summary table for Java unit tests might not be counting failed tests properly. However, it does mark the build as failed and it is showing the error details.
