### PR TITLE
[Java][Choice] Enable tests, port base recognizer and English extractor from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/ChoiceRecognizer.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/ChoiceRecognizer.java
@@ -1,15 +1,19 @@
 package com.microsoft.recognizers.text.choice;
 
+import com.microsoft.recognizers.text.Culture;
 import com.microsoft.recognizers.text.IModel;
 import com.microsoft.recognizers.text.ModelResult;
 import com.microsoft.recognizers.text.Recognizer;
+import com.microsoft.recognizers.text.choice.english.extractors.EnglishBooleanExtractorConfiguration;
+import com.microsoft.recognizers.text.choice.extractors.BooleanExtractor;
+import com.microsoft.recognizers.text.choice.models.BooleanModel;
+import com.microsoft.recognizers.text.choice.parsers.BooleanParser;
 
 import java.util.List;
 
 public class ChoiceRecognizer extends Recognizer<ChoiceOptions> {
 
-    public ChoiceRecognizer(String targetCulture, ChoiceOptions options,
-            boolean lazyInitialization) {
+    public ChoiceRecognizer(String targetCulture, ChoiceOptions options, boolean lazyInitialization) {
         super(targetCulture, options, lazyInitialization);
     }
 
@@ -41,13 +45,16 @@ public class ChoiceRecognizer extends Recognizer<ChoiceOptions> {
         this(null, ChoiceOptions.None, true);
     }
 
-    public IModel getBooleanModel(String culture, boolean fallbackToDefaultCulture) {
-        throw new UnsupportedOperationException();
-        // return GetModel<BooleanModel>(culture, fallbackToDefaultCulture);
+    public BooleanModel getBooleanModel(String culture, boolean fallbackToDefaultCulture) {
+        return getModel(BooleanModel.class, culture, fallbackToDefaultCulture);
     }
 
     public static List<ModelResult> recognizeBoolean(String query, String culture, ChoiceOptions options, boolean fallbackToDefaultCulture) {
-        throw new UnsupportedOperationException();
+        
+        ChoiceRecognizer recognizer = new ChoiceRecognizer(options);
+        IModel model = recognizer.getBooleanModel(culture, fallbackToDefaultCulture);
+
+        return model.parse(query);
     }
 
     public static List<ModelResult> recognizeBoolean(String query, String culture, ChoiceOptions options) {
@@ -60,6 +67,8 @@ public class ChoiceRecognizer extends Recognizer<ChoiceOptions> {
 
     @Override
     protected void initializeConfiguration() {
-        throw new UnsupportedOperationException();
+
+        //English
+        registerModel(BooleanModel.class, Culture.English, (options) -> new BooleanModel(new BooleanParser(), new BooleanExtractor(new EnglishBooleanExtractorConfiguration())));
     }
 }

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/config/BooleanParserConfiguration.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/config/BooleanParserConfiguration.java
@@ -1,14 +1,19 @@
 package com.microsoft.recognizers.text.choice.config;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.choice.Constants;
+
 import java.util.Map;
 
 public class BooleanParserConfiguration implements IChoiceParserConfiguration<Boolean> {
 
-    public Map<String,Boolean> resolutions = new HashMap<String, Boolean>();
+    public static Map<String, Boolean> Resolutions = ImmutableMap.<String, Boolean>builder()
+            .put(Constants.SYS_BOOLEAN_TRUE, true)
+            .put(Constants.SYS_BOOLEAN_FALSE, false)
+            .build();
 
     @Override
-    public Map<String,Boolean> getResolutions() {
-        return this.resolutions;
+    public Map<String, Boolean> getResolutions() {
+        return Resolutions;
     }
 }

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/config/BooleanParserConfiguration.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/config/BooleanParserConfiguration.java
@@ -1,10 +1,11 @@
 package com.microsoft.recognizers.text.choice.config;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class BooleanParserConfiguration implements IChoiceParserConfiguration<Boolean> {
 
-    public Map<String,Boolean> resolutions;
+    public Map<String,Boolean> resolutions = new HashMap<String, Boolean>();
 
     @Override
     public Map<String,Boolean> getResolutions() {

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/english/extractors/EnglishBooleanExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/english/extractors/EnglishBooleanExtractorConfiguration.java
@@ -1,0 +1,70 @@
+package com.microsoft.recognizers.text.choice.english.extractors;
+
+import com.microsoft.recognizers.text.choice.Constants;
+import com.microsoft.recognizers.text.choice.extractors.IBooleanExtractorConfiguration;
+import com.microsoft.recognizers.text.choice.resources.EnglishChoice;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class EnglishBooleanExtractorConfiguration implements IBooleanExtractorConfiguration {
+    public static final Pattern  trueRegex = RegExpUtility.getSafeRegExp(EnglishChoice.TrueRegex);
+    public static final Pattern falseRegex = RegExpUtility.getSafeRegExp(EnglishChoice.FalseRegex);
+    public static final Pattern tokenRegex = RegExpUtility.getSafeRegExp(EnglishChoice.TokenizerRegex);
+    public static final Map<Pattern, String> mapRegexes;
+
+    static {
+        mapRegexes = new HashMap<Pattern, String>();
+        mapRegexes.put(trueRegex, Constants.SYS_BOOLEAN_TRUE);
+        mapRegexes.put(falseRegex, Constants.SYS_BOOLEAN_FALSE);
+    }
+
+    public boolean allowPartialMatch = false;
+    public int maxDistance = 2;
+    public boolean onlyTopMatch;
+
+    public EnglishBooleanExtractorConfiguration(boolean topMatch) {
+        onlyTopMatch = topMatch;
+    }
+
+    public EnglishBooleanExtractorConfiguration() {
+        this(true);
+    }
+
+    @Override
+    public Map<Pattern, String> getMapRegexes() {
+        return mapRegexes;
+    }
+
+    @Override
+    public Pattern getTrueRegex() {
+        return trueRegex;
+    }
+
+    @Override
+    public Pattern getFalseRegex() {
+        return falseRegex;
+    }
+
+    @Override
+    public Pattern getTokenRegex() {
+        return tokenRegex;
+    }
+
+    @Override
+    public boolean getAllowPartialMatch() {
+        return allowPartialMatch;
+    }
+
+    @Override
+    public int getMaxDistance() {
+        return maxDistance;
+    }
+
+    @Override
+    public boolean getOnlyTopMatch() {
+        return onlyTopMatch;
+    }
+}

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
@@ -54,7 +54,13 @@ public class ChoiceExtractor implements IExtractor {
                     int start = match.index;
                     int length = match.length;
                     partialResults.add(
-                        new ExtractResult(start, length, text.substring(start, length).trim(), constantValue, new ChoiceExtractDataResult(text, topScore, new ArrayList<>()))
+                        new ExtractResult(
+                            start,
+                            length,
+                            text.substring(start, length+start),
+                            constantValue,
+                            new ChoiceExtractDataResult(text, topScore, new ArrayList<>())
+                        )
                     );
                 }
 

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/extractors/ChoiceExtractor.java
@@ -7,12 +7,7 @@ import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class ChoiceExtractor implements IExtractor {
@@ -71,7 +66,7 @@ public class ChoiceExtractor implements IExtractor {
             return results;
         }
 
-        Collections.sort(partialResults, (ExtractResult extractResult1, ExtractResult extractResult2) -> (extractResult1.start < extractResult2.start) ? 1 : -1);
+        partialResults.sort(Comparator.comparingInt(er -> er.start));
 
         if (this.config.getOnlyTopMatch()) {
 

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/BooleanModel.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/BooleanModel.java
@@ -1,24 +1,44 @@
 package com.microsoft.recognizers.text.choice.models;
 
-import java.util.Map;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
 import com.microsoft.recognizers.text.ParseResult;
 import com.microsoft.recognizers.text.choice.Constants;
+import com.microsoft.recognizers.text.choice.parsers.OptionsOtherMatchParseResult;
+import com.microsoft.recognizers.text.choice.parsers.OptionsParseDataResult;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class BooleanModel extends ChoiceModel {
 
-	public BooleanModel(IParser parser, IExtractor extractor) {
-		super(parser, extractor);
-		throw new UnsupportedOperationException();
-	}
+    public BooleanModel(IParser parser, IExtractor extractor) {
+        super(parser, extractor);
+    }
 
-	public String getModelTypeName() {
-		return Constants.MODEL_BOOLEAN;
-	}
+    public String getModelTypeName() {
+        return Constants.MODEL_BOOLEAN;
+    }
 
-	protected Map<String, Object> GetResolution(ParseResult parseResult) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    protected SortedMap<String, Object> getResolution(ParseResult parseResult) {
+
+        OptionsParseDataResult parseResultData = (OptionsParseDataResult) parseResult.data;
+        SortedMap<String, Object> results = new TreeMap<String, Object>();
+        SortedMap<String, Object> otherMatchesMap = new TreeMap<String, Object>();
+
+        results.put("value", parseResult.value);
+        results.put("score", parseResultData.score);
+
+        for (OptionsOtherMatchParseResult otherMatchParseRes : parseResultData.otherMatches) {
+            otherMatchesMap.put("text", otherMatchParseRes.text);
+            otherMatchesMap.put("value", otherMatchParseRes.value);
+            otherMatchesMap.put("score", otherMatchParseRes.score);
+        }
+
+        results.put("otherResults", otherMatchesMap);
+        
+
+        return results;
+    }
 }

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/ChoiceModel.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/models/ChoiceModel.java
@@ -1,8 +1,6 @@
 package com.microsoft.recognizers.text.choice.models;
 
-import java.util.List;
-import java.util.Map;
-
+import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IModel;
 import com.microsoft.recognizers.text.IParser;
@@ -10,26 +8,36 @@ import com.microsoft.recognizers.text.ModelResult;
 import com.microsoft.recognizers.text.ParseResult;
 import com.microsoft.recognizers.text.choice.Constants;
 
-public class ChoiceModel implements IModel {
-	protected IExtractor Extractor;
-	protected IParser Parser;
-	
-	public ChoiceModel(IParser parser, IExtractor extractor) {
-		this.Parser = parser;
-		this.Extractor = extractor;
-	}
+import java.util.List;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
 
-	@Override
-	public String getModelTypeName() {
-		return Constants.MODEL_BOOLEAN;
-	}
+public abstract class ChoiceModel implements IModel {
+    protected IExtractor extractor;
+    protected IParser parser;
+        
+    public ChoiceModel(IParser choiceParser, IExtractor choiceExtractor) {
+        parser = choiceParser;
+        extractor = choiceExtractor;
+    }
 
-	@Override
-	public List<ModelResult> parse(String query) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public String getModelTypeName() {
+        return Constants.MODEL_BOOLEAN;
+    }
 
-	protected Map<String, Object> GetResolution(ParseResult parseResult) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public List<ModelResult> parse(String query) {
+
+        List<ExtractResult> extractResults = extractor.extract(query);
+        List<ParseResult> parseResults = extractResults.stream().map(exRes -> parser.parse(exRes)).collect(Collectors.toList());
+        
+        List<ModelResult> modelResults = parseResults.stream().map(
+            parseRes -> new ModelResult(parseRes.text, parseRes.start, parseRes.start + parseRes.length - 1, getModelTypeName(), getResolution(parseRes))
+        ).collect(Collectors.toList());
+         
+        return modelResults;
+    }
+
+    protected abstract SortedMap<String, Object> getResolution(ParseResult parseResult);
 }

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/parsers/ChoiceParser.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/parsers/ChoiceParser.java
@@ -26,7 +26,7 @@ public class ChoiceParser<T> implements IParser {
         List<OptionsOtherMatchParseResult> matches = data.otherMatches.stream().map(match -> getOptionsOtherMatchResult(match)).collect(Collectors.toList());
 
         parseResult = parseResult.withData(new OptionsParseDataResult(data.score, matches));
-        parseResult = parseResult.withValue((boolean) resolutions.get(parseResult.type));
+        parseResult = parseResult.withValue(resolutions.getOrDefault(parseResult.type, false));
 
         return parseResult;
     }

--- a/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/utilities/UnicodeUtils.java
+++ b/Java/libraries/recognizers-text-choice/src/main/java/com/microsoft/recognizers/text/choice/utilities/UnicodeUtils.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class UnicodeUtils {
     public static boolean isEmoji(String letter) {
         final int WhereEmojiLive = 0xFFFF; // Supplementary Unicode Plane. This is where emoji live
-        return Character.isHighSurrogate(letter.charAt(0)) && (letter.codePointAt(0) > WhereEmojiLive);
+        return Character.isHighSurrogate(letter.charAt(0)) && (letter.codePoints().sum() > WhereEmojiLive);
     }
 
     public static List<String> letters(String text) {
@@ -16,7 +16,7 @@ public class UnicodeUtils {
         for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
             if (codePoint != 0) {
-                result.add(Character.toString(codePoint));
+                result.add(new String(Character.toChars(codePoint + c)));
                 codePoint = 0;
             } else if (!Character.isHighSurrogate(c)) {
                 result.add(Character.toString(c));

--- a/Java/tests/pom.xml
+++ b/Java/tests/pom.xml
@@ -76,6 +76,12 @@
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.recognizers.text.choice</groupId>
+            <artifactId>recognizers-text-choice</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/choice/BooleanModelTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/choice/BooleanModelTest.java
@@ -1,0 +1,67 @@
+package com.microsoft.recognizers.text.tests.choice;
+
+import com.microsoft.recognizers.text.ModelResult;
+import com.microsoft.recognizers.text.ResolutionKey;
+import com.microsoft.recognizers.text.choice.ChoiceOptions;
+import com.microsoft.recognizers.text.choice.ChoiceRecognizer;
+import com.microsoft.recognizers.text.tests.AbstractTest;
+import com.microsoft.recognizers.text.tests.TestCase;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.runners.Parameterized;
+
+public class BooleanModelTest extends AbstractTest {
+
+    private static final String recognizerType = "Choice";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<TestCase> testCases() {
+        return AbstractTest.enumerateTestCases(recognizerType, "Model");
+    }
+
+    public BooleanModelTest(TestCase currentCase) {
+        super(currentCase);
+    }
+
+    @Override
+    protected void recognizeAndAssert(TestCase currentCase) {
+        // parse
+        List<ModelResult> results = recognize(currentCase);
+        // assert
+        assertResultsWithKeys(currentCase, results, getKeysToTest(currentCase));
+    }
+
+    private List<String> getKeysToTest(TestCase currentCase) {
+        switch (currentCase.modelName) {
+            case "BooleanModel":
+                return Arrays.asList(ResolutionKey.Value, ResolutionKey.Score);
+            default:
+                return Arrays.asList(ResolutionKey.Value, ResolutionKey.Score);
+        }
+    }
+
+    @Override
+    protected List<ModelResult> recognize(TestCase currentCase) {
+        try {
+
+            String culture = getCultureCode(currentCase.language);
+            switch (currentCase.modelName) {
+
+                case "BooleanModel": {
+                    return ChoiceRecognizer.recognizeBoolean(currentCase.input, culture, ChoiceOptions.None, false);
+                }
+
+                default: {
+                    throw new AssumptionViolatedException("Model Type/Name not supported.");
+                }
+            }
+
+        } catch (IllegalArgumentException ex) {
+            throw new AssumptionViolatedException(ex.getMessage(), ex);
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
- Add `english/extractors/EnglishBooleanExtractorConfiguration.java`
- Add models logic
- Add `ChoiceRecognizer.java` logic
- Fix various implementation errors
- Enable tests for `BooleanModel`
  - Add `choice/BooleanModelTest.java` to test suite
  - Modify `pom.xml` in tests project to include the `recognizers-text-choice` package

## Tests
Tests are passing (14 of 14 for **English**)
<img width="800" alt="image" src="https://user-images.githubusercontent.com/2738891/48630320-c2f6f500-e99a-11e8-9aef-5f602f5a71d9.png">

This is a successor of PR #971 and will be preceded with follow up PRs for the remaining languages