### PR TITLE
[Java][Datetime] Port BaseDurationParser from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/TimeTypeConstants.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/TimeTypeConstants.java
@@ -1,0 +1,18 @@
+package com.microsoft.recognizers.text.datetime;
+
+public class TimeTypeConstants {
+    public static final String DATE = "date";
+    public static final String DATETIME = "dateTime";
+    public static final String DATETIMEALT = "dateTimeAlt";
+    public static final String DURATION = "duration";
+    public static final String SET = "set";
+    public static final String TIME = "time";
+
+    // Internal SubType for Future/Past in DateTimeResolutionResult
+    public static final String START_DATE = "startDate";
+    public static final String END_DATE = "endDate";
+    public static final String START_DATETIME = "startDateTime";
+    public static final String END_DATETIME = "endDateTime";
+    public static final String START_TIME = "startTime";
+    public static final String END_TIME = "endTime";
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
@@ -1,0 +1,258 @@
+package com.microsoft.recognizers.text.datetime.english.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.*;
+import com.microsoft.recognizers.text.datetime.parsers.*;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.BaseDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.EnglishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.english.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.number.english.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.english.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.english.parsers.EnglishNumberParserConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.regex.Pattern;
+
+public class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConfiguration implements ICommonDateTimeParserConfiguration {
+
+    public static final Pattern AmbiguousMonthP0Regex = RegExpUtility.getSafeRegExp(EnglishDateTime.AmbiguousMonthP0Regex, Pattern.CASE_INSENSITIVE);
+
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfWeekMap;
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Double> doubleNumbers;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+    private final IExtractor cardinalExtractor;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser durationParser;
+    private final IDateTimeParser datePeriodParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser dateTimePeriodParser;
+    private final IDateTimeParser dateTimeAltParser;
+
+    public EnglishCommonDateTimeParserConfiguration(DateTimeOptions options) {
+        super(options);
+        utilityConfiguration = new EnglishDatetimeUtilityConfiguration();
+
+        unitMap = EnglishDateTime.UnitMap;
+        unitValueMap = EnglishDateTime.UnitValueMap;
+        seasonMap = EnglishDateTime.SeasonMap;
+        cardinalMap = EnglishDateTime.CardinalMap;
+        dayOfWeekMap = EnglishDateTime.DayOfWeek;
+        dayOfMonth = ImmutableMap.<String, Integer>builder().putAll(super.getDayOfMonth()).putAll(EnglishDateTime.DayOfMonth).build();
+        monthOfYear = EnglishDateTime.MonthOfYear;
+        numbers = EnglishDateTime.Numbers;
+        doubleNumbers = EnglishDateTime.DoubleNumbers;
+        writtenDecades = EnglishDateTime.WrittenDecades;
+        specialDecadeCases = EnglishDateTime.SpecialDecadeCases;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        integerExtractor = IntegerExtractor.getInstance();
+        ordinalExtractor = OrdinalExtractor.getInstance();
+        numberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
+
+        durationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
+        dateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration());
+        timeExtractor = new BaseTimeExtractor(null);
+        dateTimeExtractor = new BaseDateTimeExtractor(null);
+        datePeriodExtractor = new BaseDatePeriodExtractor(null);
+        timePeriodExtractor = new BaseTimePeriodExtractor(null);
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(null);
+
+        durationParser = new BaseDurationParser(new EnglishDurationParserConfiguration(this));
+        dateParser = new BaseDateParser(new EnglishDateParserConfiguration(this));
+        timeParser = new BaseTimeParser(null);
+        dateTimeParser = new BaseDateTimeParser(null);
+        datePeriodParser = new BaseDatePeriodParser(null);
+        timePeriodParser = new BaseTimePeriodParser(null);
+        dateTimePeriodParser = new BaseDateTimePeriodParser(null);
+        dateTimeAltParser = new BaseDateTimeAltParser(null);
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeAltParser() {
+        return dateTimeAltParser;
+    }
+
+    @Override
+    public Pattern getAmbiguousMonthP0Regex() {
+        return AmbiguousMonthP0Regex;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeekMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishCommonDateTimeParserConfiguration.java
@@ -84,16 +84,16 @@ public class EnglishCommonDateTimeParserConfiguration extends BaseDateParserConf
         dateTimeExtractor = new BaseDateTimeExtractor(null);
         datePeriodExtractor = new BaseDatePeriodExtractor(null);
         timePeriodExtractor = new BaseTimePeriodExtractor(null);
-        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(null);
+        dateTimePeriodExtractor = null;
 
         durationParser = new BaseDurationParser(new EnglishDurationParserConfiguration(this));
-        dateParser = new BaseDateParser(new EnglishDateParserConfiguration(this));
-        timeParser = new BaseTimeParser(null);
-        dateTimeParser = new BaseDateTimeParser(null);
-        datePeriodParser = new BaseDatePeriodParser(null);
-        timePeriodParser = new BaseTimePeriodParser(null);
-        dateTimePeriodParser = new BaseDateTimePeriodParser(null);
-        dateTimeAltParser = new BaseDateTimeAltParser(null);
+        dateParser = null;
+        timeParser = null;
+        dateTimeParser = null;
+        datePeriodParser = null;
+        timePeriodParser = null;
+        dateTimePeriodParser = null;
+        dateTimeAltParser = null;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDurationParserConfiguration.java
@@ -1,0 +1,139 @@
+package com.microsoft.recognizers.text.datetime.english.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.english.extractors.EnglishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
+
+import java.util.regex.Pattern;
+
+public class EnglishDurationParserConfiguration extends BaseOptionsConfiguration implements IDurationParserConfiguration {
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor durationExtractor;
+    private final IParser numberParser;
+    private final Pattern numberCombinedWithUnit;
+    private final Pattern anUnitRegex;
+    private final Pattern duringRegex;
+    private final Pattern allDateUnitRegex;
+    private final Pattern halfDateUnitRegex;
+    private final Pattern suffixAndRegex;
+    private final Pattern followedUnit;
+    private final Pattern conjunctionRegex;
+    private final Pattern inexactNumberRegex;
+    private final Pattern inexactNumberUnitRegex;
+    private final Pattern durationUnitRegex;
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, Double> doubleNumbers;
+
+    public EnglishDurationParserConfiguration(ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(), false);
+        numberCombinedWithUnit = EnglishDurationExtractorConfiguration.NumberCombinedWithDurationUnit;
+        anUnitRegex = EnglishDurationExtractorConfiguration.AnUnitRegex;
+        duringRegex = EnglishDurationExtractorConfiguration.DuringRegex;
+        allDateUnitRegex = EnglishDurationExtractorConfiguration.AllRegex;
+        halfDateUnitRegex = EnglishDurationExtractorConfiguration.HalfRegex;
+        suffixAndRegex = EnglishDurationExtractorConfiguration.SuffixAndRegex;
+        followedUnit = EnglishDurationExtractorConfiguration.DurationFollowedUnit;
+        conjunctionRegex = EnglishDurationExtractorConfiguration.ConjunctionRegex;
+        inexactNumberRegex = EnglishDurationExtractorConfiguration.InexactNumberRegex;
+        inexactNumberUnitRegex = EnglishDurationExtractorConfiguration.InexactNumberUnitRegex;
+        durationUnitRegex = EnglishDurationExtractorConfiguration.DurationUnitRegex;
+        unitMap = config.getUnitMap();
+        unitValueMap = config.getUnitValueMap();
+        doubleNumbers = config.getDoubleNumbers();
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return anUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return duringRegex;
+    }
+
+    @Override
+    public Pattern getAllDateUnitRegex() {
+        return allDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getHalfDateUnitRegex() {
+        return halfDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return suffixAndRegex;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return followedUnit;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return conjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return inexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return inexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return durationUnitRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDurationParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDurationParser.java
@@ -1,0 +1,396 @@
+package com.microsoft.recognizers.text.datetime.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.ExtractResult;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.ParseResult;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.TimeTypeConstants;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class BaseDurationParser implements IDateTimeParser {
+
+    private final IDurationParserConfiguration config;
+
+    public BaseDurationParser(IDurationParserConfiguration configuration) {
+        this.config = configuration;
+    }
+
+    @Override
+    public String getParserName() {
+        return Constants.SYS_DATETIME_DURATION;
+    }
+
+    @Override
+    public ParseResult parse(ExtractResult extractResult) {
+        return this.parse(extractResult, LocalDateTime.now());
+    }
+
+    @Override
+    public DateTimeParseResult parse(ExtractResult er, LocalDateTime reference) {
+
+        Object value = null;
+
+        if (er.type.equals(getParserName())) {
+            DateTimeResolutionResult innerResult;
+
+            innerResult = parseMergedDuration(er.text, reference);
+
+            if (!innerResult.getSuccess()) {
+                innerResult = parseNumberWithUnit(er.text, reference);
+            }
+
+            if (!innerResult.getSuccess()) {
+                innerResult = parseImplicitDuration(er.text, reference);
+            }
+
+            if (innerResult.getSuccess()) {
+                innerResult.setFutureResolution(ImmutableMap.<String, String>builder()
+                        .put(TimeTypeConstants.DURATION, StringUtility.format((Double)innerResult.getFutureValue()))
+                        .build());
+
+                innerResult.setPastResolution(ImmutableMap.<String, String>builder()
+                        .put(TimeTypeConstants.DURATION, StringUtility.format((Double)innerResult.getPastValue()))
+                        .build());
+
+                if (er.data != null) {
+                    if (er.data.equals(Constants.MORE_THAN_MOD)) {
+                        innerResult.setMod(Constants.MORE_THAN_MOD);
+                    } else if (er.data.equals(Constants.LESS_THAN_MOD)) {
+                        innerResult.setMod(Constants.LESS_THAN_MOD);
+                    }
+                }
+
+                value = innerResult;
+            }
+        }
+
+        DateTimeParseResult result = new DateTimeParseResult(
+                er.start,
+                er.length,
+                er.text,
+                er.type,
+                er.data,
+                value,
+                "",
+                value == null ? "" : ((DateTimeResolutionResult)value).getTimex()
+        );
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseMergedDuration(String text, LocalDateTime reference) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        IExtractor durationExtractor = config.getDurationExtractor();
+
+        // DurationExtractor without parameter will not extract merged duration
+        List<ExtractResult> ers = durationExtractor.extract(text);
+
+        // only handle merged duration cases like "1 month 21 days"
+        if (ers.size() <= 1) {
+            result.setSuccess(false);
+            return result;
+        }
+
+        int start = ers.get(0).start;
+        if (start != 0) {
+            String beforeStr = text.substring(0, start - 1);
+            if (!StringUtility.isNullOrWhiteSpace(beforeStr)) {
+                return result;
+            }
+        }
+
+        int end = ers.get(ers.size() - 1).start + ers.get(ers.size() - 1).length;
+        if (end != text.length()) {
+            String afterStr = text.substring(end);
+            if (!StringUtility.isNullOrWhiteSpace(afterStr)) {
+                return result;
+            }
+        }
+
+        List<DateTimeParseResult> prs = new ArrayList<>();
+        Map<String, String> timexMap = new HashMap<>();
+
+        // insert timex into a dictionary
+        for (ExtractResult er : ers) {
+            Pattern unitRegex = config.getDurationUnitRegex();
+            Optional<Match> unitMatch = Arrays.stream(RegExpUtility.getMatches(unitRegex, er.text)).findFirst();
+            if (unitMatch.isPresent()) {
+                DateTimeParseResult pr = (DateTimeParseResult) parse(er);
+                if (pr.value != null) {
+                    timexMap.put(unitMatch.get().getGroup("unit").value, pr.timexStr);
+                    prs.add(pr);
+                }
+            }
+        }
+
+        // sort the timex using the granularity of the duration, "P1M23D" for "1 month 23 days" and "23 days 1 month"
+        if (prs.size() == ers.size()) {
+            List<String> unitList = new ArrayList<>(timexMap.keySet());
+            unitList.sort((x, y) -> config.getUnitValueMap().get(x) < config.getUnitValueMap().get(y) ? 1 : -1);
+            StringBuilder timex = new StringBuilder("P");
+
+            for (String unit : unitList) {
+                timex.append(timexMap.get(unit).substring(1));
+            }
+
+            result.setTimex(timex.toString());
+
+            double value = 0;
+            for (DateTimeParseResult pr : prs) {
+                value += Double.parseDouble(((DateTimeResolutionResult)pr.value).getFutureValue().toString());
+            }
+
+            result.setFutureValue(value);
+            result.setPastValue(value);
+        }
+
+        result.setSuccess(true);
+        return result;
+    }
+
+    private DateTimeResolutionResult parseNumberWithUnit(String text, LocalDateTime reference) {
+        DateTimeResolutionResult result = parseNumberSpaceUnit(text);
+        if (!result.getSuccess()) {
+            result = parseNumberCombinedUnit(text);
+        }
+
+        if (!result.getSuccess()) {
+            result = parseAnUnit(text);
+        }
+
+        if (!result.getSuccess()) {
+            result = parseInexactNumberUnit(text);
+        }
+
+        return result;
+    }
+
+    // check {and} suffix after a {number} {unit}
+    private double parseNumberWithUnitAndSuffix(String text) {
+        double numVal = 0;
+
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getSuffixAndRegex(), text)).findFirst();
+        if (match.isPresent()) {
+            String numStr = match.get().getGroup("suffix_num").value.toLowerCase();
+
+            if (config.getDoubleNumbers().containsKey(numStr)) {
+                numVal = config.getDoubleNumbers().get(numStr);
+            }
+        }
+
+        return numVal;
+    }
+
+    private DateTimeResolutionResult parseNumberSpaceUnit(String text) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        // if there are spaces between nubmer and unit
+        List<ExtractResult> ers = config.getCardinalExtractor().extract(text);
+        if (ers.size() == 1) {
+            ExtractResult er = ers.get(0);
+            ParseResult pr = config.getNumberParser().parse(er);
+
+            // followed unit: {num} (<followed unit>and a half hours)
+            String srcUnit = "";
+            String noNum = text.substring(er.start + er.length).trim().toLowerCase();
+            String suffixStr = text;
+
+            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getFollowedUnit(), noNum)).findFirst();
+            if (match.isPresent()) {
+                srcUnit = match.get().getGroup("unit").value.toLowerCase();
+                suffixStr = match.get().getGroup(Constants.SuffixGroupName).value.toLowerCase();
+            }
+
+            if (config.getUnitMap().containsKey(srcUnit)) {
+                Double numVal = Double.parseDouble(pr.value.toString()) + parseNumberWithUnitAndSuffix(suffixStr);
+                String numStr = StringUtility.format(numVal);
+
+                String unitStr = config.getUnitMap().get(srcUnit);
+
+                String timex = String.format("P%s%s%c", isLessThanDay(unitStr) ? "T" : "", numStr, unitStr.charAt(0));
+                double timeValue = numVal * config.getUnitValueMap().get(srcUnit);
+
+                result.setTimex(timex);
+                result.setFutureValue(timeValue);
+                result.setPastValue(timeValue);
+
+                result.setSuccess(true);
+                return result;
+            }
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseNumberCombinedUnit(String text) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        String suffixStr = text;
+
+        // if there are NO spaces between number and unit
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getNumberCombinedWithUnit(), text)).findFirst();
+        if (match.isPresent()) {
+            Double numVal = Double.parseDouble(match.get().getGroup("num").value) + parseNumberWithUnitAndSuffix(suffixStr);
+            String numStr = StringUtility.format(numVal);
+
+            String srcUnit = match.get().getGroup("unit").value.toLowerCase();
+
+            if (config.getUnitMap().containsKey(srcUnit)) {
+                String unitStr = config.getUnitMap().get(srcUnit);
+
+                if ((numVal > 1000) && (unitStr.equals("Y") || unitStr.equals("MON") || unitStr.equals("W"))) {
+                    return  result;
+                }
+
+                String timex = String.format("P%s%s%c", isLessThanDay(unitStr) ? "T" : "", numStr, unitStr.charAt(0));
+                double timeValue = numVal * config.getUnitValueMap().get(srcUnit);
+
+                result.setTimex(timex);
+                result.setFutureValue(timeValue);
+                result.setPastValue(timeValue);
+
+                result.setSuccess(true);
+                return result;
+            }
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseAnUnit(String text) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        String suffixStr = text;
+
+        // if there are NO spaces between number and unit
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getAnUnitRegex(), text)).findFirst();
+        if (!match.isPresent()) {
+            match = Arrays.stream(RegExpUtility.getMatches(config.getHalfDateUnitRegex(), text)).findFirst();
+        }
+
+        if (match.isPresent()) {
+            Double numVal = StringUtility.isNullOrEmpty(match.get().getGroup("half").value) ? 1 : 0.5;
+            numVal += parseNumberWithUnitAndSuffix(suffixStr);
+            String numStr = StringUtility.format(numVal);
+
+            String srcUnit = match.get().getGroup("unit").value.toLowerCase();
+
+            if (config.getUnitMap().containsKey(srcUnit)) {
+                String unitStr = config.getUnitMap().get(srcUnit);
+
+                String timex = String.format("P%s%s%c", isLessThanDay(unitStr) ? "T" : "", numStr, unitStr.charAt(0));
+                double timeValue = numVal * config.getUnitValueMap().get(srcUnit);
+
+                result.setTimex(timex);
+                result.setFutureValue(timeValue);
+                result.setPastValue(timeValue);
+
+                result.setSuccess(true);
+                return result;
+            }
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseInexactNumberUnit(String text) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getInexactNumberUnitRegex(), text)).findFirst();
+        if (match.isPresent()) {
+            double numVal;
+
+            if (!StringUtility.isNullOrEmpty(match.get().getGroup("NumTwoTerm").value)) {
+                numVal = 2;
+            } else {
+                // set the inexact number "few", "some" to 3 for now
+                numVal = 3;
+            }
+
+            String numStr = StringUtility.format(numVal);
+
+            String srcUnit = match.get().getGroup("unit").value.toLowerCase();
+
+            if (config.getUnitMap().containsKey(srcUnit)) {
+                String unitStr = config.getUnitMap().get(srcUnit);
+
+                String timex = String.format("P%s%s%c", isLessThanDay(unitStr) ? "T" : "", numStr, unitStr.charAt(0));
+                double timeValue = numVal * config.getUnitValueMap().get(srcUnit);
+
+                result.setTimex(timex);
+                result.setFutureValue(timeValue);
+                result.setPastValue(timeValue);
+
+                result.setSuccess(true);
+                return result;
+            }
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseImplicitDuration(String text, LocalDateTime reference) {
+        // handle "all day" "all year"
+        DateTimeResolutionResult result = getResultFromRegex(config.getAllDateUnitRegex(), text, "1");
+
+        // handle "during/for the day/week/month/year"
+        if (config.getOptions().match(DateTimeOptions.CalendarMode) && !result.getSuccess()) {
+            result = getResultFromRegex(config.getDuringRegex(), text, "1");
+        }
+
+        // handle "half day", "half year"
+        if (!result.getSuccess()) {
+            result = getResultFromRegex(config.getHalfDateUnitRegex(), text, "0.5");
+        }
+
+        // handle single duration unit, it is filtered in the extraction that there is a relative word in advance
+        if (!result.getSuccess()) {
+            result = getResultFromRegex(config.getFollowedUnit(), text, "1");
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult getResultFromRegex(Pattern pattern, String text, String numStr) {
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(pattern, text)).findFirst();
+        if (match.isPresent()) {
+            String srcUnit = match.get().getGroup("unit").value.toLowerCase();
+            if (config.getUnitMap().containsKey(srcUnit)) {
+                String unitStr = config.getUnitMap().get(srcUnit);
+
+                String timex = String.format("P%s%s%c", isLessThanDay(unitStr) ? "T" : "", numStr, unitStr.charAt(0));
+                double timeValue = Double.parseDouble(numStr) * config.getUnitValueMap().get(srcUnit);
+
+                result.setTimex(timex);
+                result.setFutureValue(timeValue);
+                result.setPastValue(timeValue);
+
+                result.setSuccess(true);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isLessThanDay(String unit) {
+        return unit.equals("S") || unit.equals("M") || unit.equals("H");
+    }
+
+    @Override
+    public List<DateTimeParseResult> filterResults(String query, List<DateTimeParseResult> candidateResults) {
+        return candidateResults;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/BaseDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/BaseDateParserConfiguration.java
@@ -1,0 +1,17 @@
+package com.microsoft.recognizers.text.datetime.parsers.config;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
+
+public abstract class BaseDateParserConfiguration extends BaseOptionsConfiguration implements ICommonDateTimeParserConfiguration {
+    protected BaseDateParserConfiguration(DateTimeOptions options) {
+        super(options);
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return BaseDateTime.DayOfMonthDictionary;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/ICommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/ICommonDateTimeParserConfiguration.java
@@ -1,0 +1,46 @@
+package com.microsoft.recognizers.text.datetime.parsers.config;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+
+import java.util.regex.Pattern;
+
+public interface ICommonDateTimeParserConfiguration extends IOptionsConfiguration {
+    IExtractor getCardinalExtractor();
+    IExtractor getIntegerExtractor();
+    IExtractor getOrdinalExtractor();
+    IParser getNumberParser();
+    IDateTimeExtractor getDateExtractor();
+    IDateTimeExtractor getTimeExtractor();
+    IDateTimeExtractor getDateTimeExtractor();
+    IDateTimeExtractor getDurationExtractor();
+    IDateTimeExtractor getDatePeriodExtractor();
+    IDateTimeExtractor getTimePeriodExtractor();
+    IDateTimeExtractor getDateTimePeriodExtractor();
+    IDateTimeParser getDateParser();
+    IDateTimeParser getTimeParser();
+    IDateTimeParser getDateTimeParser();
+    IDateTimeParser getDurationParser();
+    IDateTimeParser getDatePeriodParser();
+    IDateTimeParser getTimePeriodParser();
+    IDateTimeParser getDateTimePeriodParser();
+    IDateTimeParser getDateTimeAltParser();
+    Pattern getAmbiguousMonthP0Regex();
+    ImmutableMap<String, Integer> getMonthOfYear();
+    ImmutableMap<String, Integer> getNumbers();
+    ImmutableMap<String, Long> getUnitValueMap();
+    ImmutableMap<String, String> getSeasonMap();
+    ImmutableMap<String, String> getUnitMap();
+    ImmutableMap<String, Integer> getCardinalMap();
+    ImmutableMap<String, Integer> getDayOfMonth();
+    ImmutableMap<String, Integer> getDayOfWeek();
+    ImmutableMap<String, Double> getDoubleNumbers();
+    ImmutableMap<String, Integer> getWrittenDecades();
+    ImmutableMap<String, Integer> getSpecialDecadeCases();
+    IDateTimeUtilityConfiguration getUtilityConfiguration();
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDurationParserConfiguration.java
@@ -1,0 +1,28 @@
+package com.microsoft.recognizers.text.datetime.parsers.config;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+
+import java.util.regex.Pattern;
+
+public interface IDurationParserConfiguration extends IOptionsConfiguration {
+    IExtractor getCardinalExtractor();
+    IExtractor getDurationExtractor();
+    IParser getNumberParser();
+    Pattern getNumberCombinedWithUnit();
+    Pattern getAnUnitRegex();
+    Pattern getDuringRegex();
+    Pattern getAllDateUnitRegex();
+    Pattern getHalfDateUnitRegex();
+    Pattern getSuffixAndRegex();
+    Pattern getFollowedUnit();
+    Pattern getConjunctionRegex();
+    Pattern getInexactNumberRegex();
+    Pattern getInexactNumberUnitRegex();
+    Pattern getDurationUnitRegex();
+    ImmutableMap<String, String> getUnitMap();
+    ImmutableMap<String, Long> getUnitValueMap();
+    ImmutableMap<String, Double> getDoubleNumbers();
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -1,0 +1,139 @@
+package com.microsoft.recognizers.text.tests.datetime;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.recognizers.text.Culture;
+import com.microsoft.recognizers.text.ExtractResult;
+import com.microsoft.recognizers.text.ModelResult;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.english.parsers.EnglishDurationParserConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.*;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
+import com.microsoft.recognizers.text.datetime.utilities.TimeZoneResolutionResult;
+import com.microsoft.recognizers.text.tests.AbstractTest;
+import com.microsoft.recognizers.text.tests.TestCase;
+import com.microsoft.recognizers.text.tests.helpers.DateTimeResolutionResultMixIn;
+import com.microsoft.recognizers.text.tests.helpers.TimeZoneResolutionResultMixIn;
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class DateTimeParserTest extends AbstractTest {
+
+	private static final String recognizerType = "DateTime";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<TestCase> testCases() {
+			return AbstractTest.enumerateTestCases(recognizerType, "Parser");
+	}
+
+	public DateTimeParserTest(TestCase currentCase) {
+		super(currentCase);
+	}
+
+	@Override
+	protected List<ModelResult> recognize(TestCase currentCase) {
+		return null;
+	}
+
+	protected List<DateTimeParseResult> parse(TestCase currentCase) {
+		IDateTimeExtractor extractor = getExtractor(currentCase);
+		IDateTimeParser parser = getParser(currentCase);
+		LocalDateTime referenceDateTime = currentCase.getReferenceDateTime();
+		List<ExtractResult> extractResult = extractor.extract(currentCase.input, referenceDateTime);
+		return extractResult.stream().map(er -> parser.parse(er, referenceDateTime)).collect(Collectors.toList());
+	}
+
+	@Override
+	protected void recognizeAndAssert(TestCase currentCase) {
+		List<DateTimeParseResult> results = parse(currentCase);
+		assertParseResults(currentCase, results);
+	}
+
+	public static void assertParseResults(TestCase currentCase, List<DateTimeParseResult> results) {
+		List<DateTimeParseResult> expectedResults = readExpectedDateTimeParseResults(DateTimeParseResult.class, currentCase.results);
+		Assert.assertEquals(getMessage(currentCase, "\"Result Count\""), expectedResults.size(), results.size());
+
+		IntStream.range(0, expectedResults.size())
+				.mapToObj(i -> Pair.with(expectedResults.get(i), results.get(i)))
+				.forEach(t -> {
+					DateTimeParseResult expected = t.getValue0();
+					DateTimeParseResult actual = t.getValue1();
+
+					Assert.assertEquals(getMessage(currentCase, "type"), expected.type, actual.type);
+					Assert.assertEquals(getMessage(currentCase, "text"), expected.text, actual.text);
+					Assert.assertEquals(getMessage(currentCase, "start"), expected.start, actual.start);
+					Assert.assertEquals(getMessage(currentCase, "length"), expected.length, actual.length);
+
+					if (expected.value != null) {
+						DateTimeResolutionResult expectedValue = parseDateTimeResolutionResult(DateTimeResolutionResult.class, expected.value);
+						DateTimeResolutionResult actualValue = (DateTimeResolutionResult) actual.value;
+
+						Assert.assertEquals(getMessage(currentCase, "timex"), expectedValue.getTimex(), actualValue.getTimex());
+						Assert.assertEquals(getMessage(currentCase, "futureResolution"), expectedValue.getFutureResolution(), actualValue.getFutureResolution());
+						Assert.assertEquals(getMessage(currentCase, "pastResolution"), expectedValue.getPastResolution(), actualValue.getPastResolution());
+					}
+				});
+	}
+
+  	private static IDateTimeParser getParser(TestCase currentCase) {
+		try {
+			String culture = getCultureCode(currentCase.language);
+			String name = currentCase.modelName;
+			switch (culture) {
+				case Culture.English:
+					return getEnglishParser(name);
+				default:
+					throw new AssumptionViolatedException("Parser Type/Name not supported.");
+			}
+		} catch (IllegalArgumentException ex) {
+			throw new AssumptionViolatedException(ex.getMessage(), ex);
+		}
+	}
+
+	private static IDateTimeParser getEnglishParser(String name) {
+		switch (name) {
+			case "DurationParser":
+				return new BaseDurationParser(new EnglishDurationParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+			default:
+				throw new AssumptionViolatedException("Parser Type/Name not supported.");
+		}
+	}
+
+	private IDateTimeExtractor getExtractor(TestCase currentCase) {
+		String extractorName = currentCase.modelName.replace("Parser", "Extractor");
+		return DateTimeExtractorTest.getExtractor(currentCase.language, extractorName);
+	}
+
+	public static <T extends DateTimeResolutionResult> T parseDateTimeResolutionResult(Class<T> dateTimeResolutionResultClass, Object result) {
+		// Deserializer
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+		mapper.addMixIn(DateTimeResolutionResult.class, DateTimeResolutionResultMixIn.class);
+		mapper.addMixIn(TimeZoneResolutionResult.class, TimeZoneResolutionResultMixIn.class);
+
+		try {
+			String json = mapper.writeValueAsString(result);
+			return mapper.readValue(json, dateTimeResolutionResultClass);
+
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+			return null;
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/helpers/TimeZoneResolutionResultMixIn.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/helpers/TimeZoneResolutionResultMixIn.java
@@ -1,0 +1,10 @@
+package com.microsoft.recognizers.text.tests.helpers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class TimeZoneResolutionResultMixIn {
+    TimeZoneResolutionResultMixIn(@JsonProperty("value") String value,
+                                  @JsonProperty("utcOffsetMins") Integer utcOffsetMins,
+                                  @JsonProperty("timeZoneText") String timeZoneText){
+    }
+}

--- a/Specs/DateTime/English/DurationParser.json
+++ b/Specs/DateTime/English/DurationParser.json
@@ -1232,7 +1232,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "python, javascript",
+    "NotSupported": "python, javascript, java",
     "Results": [
       {
         "Text": "another business day",


### PR DESCRIPTION
- setup main datetime parsers structure: test runner and folder structure
- In EnglishCommonDateTimeParserConfiguration.java included only those available extractors/parser. Will update incrementally as needed when port new parsers.
- Skipped one test added to C# after porting this class. We'll re-enable in another thread and PR.
