### PR TITLE
[Java][Recognizers-Text] Linting rules update

### DIFF
--- a/Java/linting-rules.xml
+++ b/Java/linting-rules.xml
@@ -102,18 +102,18 @@
              value="Member name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="CatchParameterName">
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
-            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <property name="format" value="^([a-z][a-zA-Z0-9]*|[A-Z][A-Z0-9_]*)$"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -157,7 +157,7 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance">
-            <property name="allowedDistance" value="5"/>
+            <property name="allowedDistance" value="10"/>
         </module>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
@@ -168,7 +168,11 @@
         <module name="ParenPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LE, LITERAL_INSTANCEOF, LT, MINUS, MOD, NOT_EQUAL, PLUS, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="EOL"/>
+            <property name="tokens" value="LAND, LOR, QUESTION"/>
         </module>
         <module name="AnnotationLocation">
             <property name="id" value="AnnotationLocationMostCases"/>

--- a/Java/linting-rules.xml
+++ b/Java/linting-rules.xml
@@ -195,5 +195,8 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="TYPECAST"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
Linting rules update:
* Parameter and catch parameter name must match the regex `^[a-z][a-zA-Z0-9]*$`, which allow variables name with the format `variableName`, `varName01`, `vName01`, `vNAME` and `v01`.
* Local variable name must match the regex `^([a-z][a-zA-Z0-9]*|[A-Z][A-Z0-9_]*)$`, which allow variables name with the format `variableName`, `varName01`, `vName01`, `vNAME`, **`VAR_NAME`** and `v01`.
* Variable declaration distance change from 5 to 10.
* The operators `&&`, `||` and `?` must be at the end of the line when the line is split into multiple lines.
* Add a new rule for "No white spaces after typecast".