### PR TITLE
[Java][DateTime] Enable and Fix DateTime parser unit tests

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimeExtractorConfiguration.java
@@ -29,7 +29,8 @@ public class EnglishDateTimeExtractorConfiguration extends BaseOptionsConfigurat
     public static final Pattern TimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeOfTodayBeforeRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern SimpleTimeOfTodayAfterRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayAfterRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern SimpleTimeOfTodayBeforeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SimpleTimeOfTodayBeforeRegex, Pattern.CASE_INSENSITIVE);
-    public static final Pattern TheEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificEndOfRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern SpecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.SpecificEndOfRegex, Pattern.CASE_INSENSITIVE);
+    public static final Pattern UnspecificEndOfRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.UnspecificEndOfRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.TimeUnitRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern ConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.ConnectorRegex, Pattern.CASE_INSENSITIVE);
     public static final Pattern NumberAsTimeRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.NumberAsTimeRegex, Pattern.CASE_INSENSITIVE);
@@ -93,8 +94,13 @@ public class EnglishDateTimeExtractorConfiguration extends BaseOptionsConfigurat
     }
 
     @Override
-    public Pattern getTheEndOfRegex() {
-        return TheEndOfRegex;
+    public Pattern getSpecificEndOfRegex() {
+        return SpecificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnspecificEndOfRegex() {
+        return UnspecificEndOfRegex;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/EnglishDateTimeParserConfiguration.java
@@ -39,7 +39,8 @@ public class EnglishDateTimeParserConfiguration extends BaseOptionsConfiguration
     private final Pattern simpleTimeOfTodayAfterRegex;
     private final Pattern simpleTimeOfTodayBeforeRegex;
     private final Pattern specificTimeOfDayRegex;
-    private final Pattern theEndOfRegex;
+    private final Pattern specificEndOfRegex;
+    private final Pattern unspecificEndOfRegex;
     private final Pattern unitRegex;
     private final Pattern dateNumberConnectorRegex;
 
@@ -72,7 +73,8 @@ public class EnglishDateTimeParserConfiguration extends BaseOptionsConfiguration
         simpleTimeOfTodayAfterRegex = EnglishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
         simpleTimeOfTodayBeforeRegex = EnglishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
         specificTimeOfDayRegex = EnglishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-        theEndOfRegex = EnglishDateTimeExtractorConfiguration.TheEndOfRegex;
+        specificEndOfRegex = EnglishDateTimeExtractorConfiguration.SpecificEndOfRegex;
+        unspecificEndOfRegex = EnglishDateTimeExtractorConfiguration.UnspecificEndOfRegex;
         unitRegex = EnglishTimeExtractorConfiguration.TimeUnitRegex;
         dateNumberConnectorRegex = EnglishDateTimeExtractorConfiguration.DateNumberConnectorRegex;
 
@@ -167,8 +169,13 @@ public class EnglishDateTimeParserConfiguration extends BaseOptionsConfiguration
     }
 
     @Override
-    public Pattern getTheEndOfRegex() {
-        return theEndOfRegex;
+    public Pattern getSpecificEndOfRegex() {
+        return specificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnspecificEndOfRegex() {
+        return unspecificEndOfRegex;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
@@ -54,7 +54,7 @@ public class BaseDateTimeExtractor implements IDateTimeExtractor {
     // Special case for 'the end of today'
     public List<Token> specialTimeOfDay(String input, LocalDateTime reference) {
         List<Token> ret = new ArrayList<>();
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getTheEndOfRegex(), input)).findFirst();
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getSpecificEndOfRegex(), input)).findFirst();
         if (match.isPresent()) {
             ret.add(new Token(match.get().index, input.length()));
         }
@@ -91,17 +91,23 @@ public class BaseDateTimeExtractor implements IDateTimeExtractor {
         for (ExtractResult er : ers) {
             String beforeStr = input.substring(0, (er != null) ? er.start : 0);
 
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getTheEndOfRegex(), beforeStr)).findFirst();
+            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getSpecificEndOfRegex(), beforeStr)).findFirst();
             if (match.isPresent()) {
                 ret.add(new Token(match.get().index, (er != null) ? er.start + er.length : 0));
             } else {
                 String afterStr = input.substring((er != null) ? er.start + er.length : 0);
 
-                match = Arrays.stream(RegExpUtility.getMatches(this.config.getTheEndOfRegex(), afterStr)).findFirst();
+                match = Arrays.stream(RegExpUtility.getMatches(this.config.getSpecificEndOfRegex(), afterStr)).findFirst();
                 if (match.isPresent()) {
                     ret.add(new Token((er != null) ? er.start : 0, ((er != null) ? er.start + er.length : 0) + ((match != null) ? match.get().index + match.get().length : 0)));
                 }
             }
+        }
+
+        // Handle "eod, end of day"
+        Match[] matches = RegExpUtility.getMatches(config.getUnspecificEndOfRegex(), input);
+        for (Match match : matches) {
+            ret.add(new Token(match.index, match.index + match.length));
         }
 
         return ret;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/IDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/config/IDateTimeExtractorConfiguration.java
@@ -22,7 +22,9 @@ public interface IDateTimeExtractorConfiguration extends IOptionsConfiguration {
 
     Pattern getTimeOfDayRegex();
 
-    Pattern getTheEndOfRegex();
+    Pattern getSpecificEndOfRegex();
+
+    Pattern getUnspecificEndOfRegex();
 
     Pattern getUnitRegex();
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDateTimeParser.java
@@ -8,6 +8,7 @@ import com.microsoft.recognizers.text.datetime.TimeTypeConstants;
 import com.microsoft.recognizers.text.datetime.extractors.config.ResultTimex;
 import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.AgoLaterUtil;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeFormatUtil;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
 import com.microsoft.recognizers.text.datetime.utilities.FormatUtil;
@@ -16,6 +17,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -327,7 +329,11 @@ public class BaseDateTimeParser implements IDateTimeParser {
     }
 
     private DateTimeResolutionResult parseSpecialTimeOfDate(String text, LocalDateTime reference) {
-        DateTimeResolutionResult result = new DateTimeResolutionResult();
+        DateTimeResolutionResult result = parseUnspecificTimeOfDate(text, reference);
+
+        if (result.getSuccess()) {
+            return result;
+        }
 
         List<ExtractResult> ers = config.getDateExtractor().extract(text, reference);
         if (ers.size() != 1) {
@@ -335,16 +341,40 @@ public class BaseDateTimeParser implements IDateTimeParser {
         }
 
         String beforeStr = text.substring(0, ers.get(0).start);
-        if (RegExpUtility.getMatches(config.getTheEndOfRegex(), beforeStr).length != 0) {
+        if (RegExpUtility.getMatches(config.getSpecificEndOfRegex(), beforeStr).length != 0) {
             DateTimeParseResult pr = config.getDateParser().parse(ers.get(0), reference);
             LocalDateTime futureDate = (LocalDateTime)((DateTimeResolutionResult)pr.value).getFutureValue();
             LocalDateTime pastDate = (LocalDateTime)((DateTimeResolutionResult)pr.value).getPastValue();
 
-            result.setTimex(pr.timexStr + "T23:59");
-            result.setFutureValue(futureDate.plusDays(1).minusMinutes(1));
-            result.setPastValue(pastDate.plusDays(1).minusMinutes(1));
-            result.setSuccess(true);
+            result = resolveEndOfDay(pr.timexStr, futureDate, pastDate);
         }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult parseUnspecificTimeOfDate(String text, LocalDateTime reference) {
+        // Handle 'eod', 'end of day'
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        Optional<Match> eod = Arrays.stream(RegExpUtility.getMatches(config.getUnspecificEndOfRegex(), text)).findFirst();
+
+        if (eod.isPresent()) {
+            result = resolveEndOfDay(DateTimeFormatUtil.formatDate(reference), reference, reference);
+        }
+
+        return result;
+    }
+
+    private DateTimeResolutionResult resolveEndOfDay(String timexPrefix, LocalDateTime futureDate, LocalDateTime pastDate) {
+        String timex = String.format("%sT23:59:59", timexPrefix);
+        LocalDateTime futureValue = LocalDateTime.of(futureDate.toLocalDate(), LocalTime.MIDNIGHT).plusDays(1).minusSeconds(1);
+        LocalDateTime pastValue = LocalDateTime.of(pastDate.toLocalDate(), LocalTime.MIDNIGHT).plusDays(1).minusSeconds(1);
+
+        DateTimeResolutionResult result = new DateTimeResolutionResult();
+        result.setTimex(timex);
+        result.setFutureValue(futureValue);
+        result.setPastValue(pastValue);
+        result.setSuccess(true);
 
         return result;
     }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/config/IDateTimeParserConfiguration.java
@@ -46,7 +46,9 @@ public interface IDateTimeParserConfiguration extends IOptionsConfiguration {
 
     Pattern getSpecificTimeOfDayRegex();
 
-    Pattern getTheEndOfRegex();
+    Pattern getSpecificEndOfRegex();
+
+    Pattern getUnspecificEndOfRegex();
 
     Pattern getUnitRegex();
 

--- a/Specs/DateTime/English/DateTimeParser.json
+++ b/Specs/DateTime/English/DateTimeParser.json
@@ -809,7 +809,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "the end of the day",
@@ -833,7 +832,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "end of tomorrow",
@@ -857,7 +855,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "end of the sunday",
@@ -1180,7 +1177,7 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T19:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "1 day 2 hours later",
@@ -1204,7 +1201,7 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T19:15:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "1 month 2 days 2 hours 30 mins ago",
@@ -1277,7 +1274,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "end of the day",
@@ -1301,7 +1297,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "end of day",
@@ -1325,7 +1320,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupportedByDesign": "java",
     "Results": [
       {
         "Text": "the eod",


### PR DESCRIPTION
- Enable 8 tests skipped in previous versions.
- Fix an issue related to `DateTime` parse method.