### PR TITLE
Fix override warnings build under .Net in PT/ES/FR/GE/IT

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             SuperfluousWordMatcher = FrenchMergedExtractorConfiguration.SuperfluousWordMatcher;
             SetParser = new BaseSetParser(new FrenchSetParserConfiguration(this));
             HolidayParser = new BaseHolidayParser(new FrenchHolidayParserConfiguration(this));
-            TimeZoneParser = new BaseTimeZoneParser();
+            TimeZoneParser = new DummyTimeZoneParser();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IDateTimeParser HolidayParser { get; }
 
-        public IDateTimeParser TimeZoneParser { get; }
-
         public StringMatcher SuperfluousWordMatcher { get; }
 
         public FrenchMergedParserConfiguration(IOptionsConfiguration config) : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             DateTimePeriodParser = new BaseDateTimePeriodParser(new GermanDateTimePeriodParserConfiguration(this));
             SetParser = new BaseSetParser(new GermanSetParserConfiguration(this));
             HolidayParser = new HolidayParserGer(new GermanHolidayParserConfiguration(this));
-            TimeZoneParser = new BaseTimeZoneParser();
+            TimeZoneParser = new DummyTimeZoneParser();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IDateTimeParser HolidayParser { get; }
 
-        public IDateTimeParser TimeZoneParser { get; }
-
         public StringMatcher SuperfluousWordMatcher { get; }
 
         public GermanMergedParserConfiguration(IOptionsConfiguration config) : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DateTimePeriodParser = new BaseDateTimePeriodParser(new ItalianDateTimePeriodParserConfiguration(this));
             SetParser = new BaseSetParser(new ItalianSetParserConfiguration(this));
             HolidayParser = new BaseHolidayParser(new ItalianHolidayParserConfiguration(this));
-            TimeZoneParser = new BaseTimeZoneParser();
+            TimeZoneParser = new DummyTimeZoneParser();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeParser HolidayParser { get; }
 
-        public IDateTimeParser TimeZoneParser { get; }
-
         public StringMatcher SuperfluousWordMatcher { get; }
 
         public ItalianMergedParserConfiguration(IOptionsConfiguration options) : base(options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Pop, restore the MOD string
-            if (hasBefore && pr.Value != null)
+            if (hasBefore && (pr != null && pr.Value != null))
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -178,7 +178,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if (hasAfter && pr.Value != null)
+            if (hasAfter && (pr != null && pr.Value != null))
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -197,7 +197,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if (hasSince && pr.Value != null)
+            if (hasSince && (pr != null && pr.Value != null))
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -207,7 +207,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if (hasAround && pr.Value != null)
+            if (hasAround && (pr != null && pr.Value != null))
             {
                 pr.Length += modStr.Length;
                 pr.Start -= modStr.Length;
@@ -217,7 +217,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Value = val;
             }
 
-            if (hasDateAfter && pr.Value != null)
+            if (hasDateAfter && (pr != null && pr.Value != null))
             {
                 pr.Length += modStr.Length;
                 pr.Text = pr.Text + modStr;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeParser.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     innerResult = InternalParse(er.Text.Substring(0, (int)(er.Text.Length - timezoneEr.Length)),
                         referenceTime);
 
-                    if (timezonePr.Value != null)
+                    if (timezonePr != null && timezonePr.Value != null)
                     {
                         innerResult.TimeZoneResolution = ((DateTimeResolutionResult)timezonePr.Value).TimeZoneResolution;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     innerResult = InternalParse(er.Text.Substring(0, (int)(er.Length - timezoneEr.Length)),
                         referenceTime);
-
-                    if (timezonePr.Value != null)
+                    
+                    if (timezonePr != null && timezonePr.Value != null)
                     {
                         innerResult.TimeZoneResolution = ((DateTimeResolutionResult)timezonePr.Value).TimeZoneResolution;
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+using DateObject = System.DateTime;
+
+
+namespace Microsoft.Recognizers.Text.DateTime{
+    
+
+    public class DummyTimeZoneParser : IDateTimeParser
+    {
+
+        public ParseResult Parse(ExtractResult result)
+        {
+            return Parse(result, DateObject.Now);
+        }
+
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
+        }
+
+        public DateTimeParseResult Parse(ExtractResult er, DateObject refDate)
+        {
+            return null;
+        }
+
+
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class DummyTimeZoneParser : IDateTimeParser
     {
-
         public ParseResult Parse(ExtractResult result)
         {
             return Parse(result, DateObject.Now);
@@ -19,7 +18,19 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public DateTimeParseResult Parse(ExtractResult er, DateObject refDate)
         {
-            return null;
+            var ret = new DateTimeParseResult
+            {
+                Text = er.Text,
+                Start = er.Start,
+                Length = er.Length,
+                Type = er.Type,
+                Data = er.Data,
+                Value = null,
+                TimexStr = null,
+                ResolutionStr = ""
+            };
+
+            return ret;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
@@ -18,19 +18,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public DateTimeParseResult Parse(ExtractResult er, DateObject refDate)
         {
-            var ret = new DateTimeParseResult
-            {
-                Text = er.Text,
-                Start = er.Start,
-                Length = er.Length,
-                Type = er.Type,
-                Data = er.Data,
-                Value = null,
-                TimexStr = null,
-                ResolutionStr = ""
-            };
-
-            return ret;
+            return null;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/DummyTimeZoneParser.cs
@@ -2,10 +2,8 @@ using System.Collections.Generic;
 
 using DateObject = System.DateTime;
 
-
-namespace Microsoft.Recognizers.Text.DateTime{
-    
-
+namespace Microsoft.Recognizers.Text.DateTime
+{
     public class DummyTimeZoneParser : IDateTimeParser
     {
 
@@ -23,7 +21,5 @@ namespace Microsoft.Recognizers.Text.DateTime{
         {
             return null;
         }
-
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeParser HolidayParser { get; }
 
-        IDateTimeParser TimeZoneParser { get; }
-
         StringMatcher SuperfluousWordMatcher { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             DateTimePeriodParser = new DateTimePeriodParser(new PortugueseDateTimePeriodParserConfiguration(this));
             SetParser = new BaseSetParser(new PortugueseSetParserConfiguration(this));
             HolidayParser = new BaseHolidayParser(new PortugueseHolidayParserConfiguration(this));
-            TimeZoneParser = new BaseTimeZoneParser();
+            TimeZoneParser = new DummyTimeZoneParser();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeParser HolidayParser { get; }
 
-        public IDateTimeParser TimeZoneParser { get; }
-
         public StringMatcher SuperfluousWordMatcher { get; }
 
         public PortugueseMergedParserConfiguration(IOptionsConfiguration config) : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DateTimePeriodParser = new DateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
             SetParser = new BaseSetParser(new SpanishSetParserConfiguration(this));
             HolidayParser = new BaseHolidayParser(new SpanishHolidayParserConfiguration(this));
-            TimeZoneParser = new BaseTimeZoneParser();
+            TimeZoneParser = new DummyTimeZoneParser();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeParser HolidayParser { get; }
 
-        public IDateTimeParser TimeZoneParser { get; }
-
         public StringMatcher SuperfluousWordMatcher { get; }
 
         public SpanishMergedParserConfiguration(IOptionsConfiguration config) : base(config)


### PR DESCRIPTION
Remove repeating TimeZoneParser in Portuguese, French, German, Spanish, and Italian. A DummyTimeZone file is added to avoid override warnings when build under .Net