### PR TITLE
Fix "半小时" cannot be recognized, add specs for "twenty-six"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Chinese/NumbersDefinitions.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
 		public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[多几余]?[万亿萬億]{{1,2}}";
 		public const string FracSplitRegex = @"又|分\s*之";
 		public const string ZeroToNineIntegerRegex = @"[一二三四五六七八九零壹贰貳叁肆伍陆陸柒捌玖〇两兩俩倆仨]";
+		public const string HalfUnitRegex = @"半";
 		public const string NegativeNumberTermsRegex = @"[负負]";
 		public const string NegativeNumberTermsRegexNum = @"((?<!(\d+\s*)|[-－])[-－])";
 		public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*";

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.NumbersWithHalfDozen, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
                 {
+                    //半
+                    new Regex(NumbersDefinitions.HalfUnitRegex, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
+                },
+                {
                     //一打  五十打
                     new Regex(NumbersDefinitions.NumbersWithDozen, RegexOptions.Singleline), RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 }

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -23,9 +23,15 @@ export namespace EnglishDateTime {
 	export const DayRegex = `(the\\s*)?(?<day>01|02|03|04|05|06|07|08|09|10th|10|11th|11st|11|12nd|12th|12|13rd|13th|13|14th|14|15th|15|16th|16|17th|17|18th|18|19th|19|1st|1|20th|20|21st|21th|21|22nd|22th|22|23rd|23th|23|24th|24|25th|25|26th|26|27th|27|28th|28|29th|29|2nd|2|30th|30|31st|31|3rd|3|4th|4|5th|5|6th|6|7th|7|8th|8|9th|9)(?=\\b|t)`;
 	export const ImplicitDayRegex = `(the\\s*)?(?<day>10th|11th|11st|12nd|12th|13rd|13th|14th|15th|16th|17th|18th|19th|1st|20th|21st|21th|22nd|22th|23rd|23th|24th|25th|26th|27th|28th|29th|2nd|30th|31st|3rd|4th|5th|6th|7th|8th|9th)\\b`;
 	export const MonthNumRegex = `(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\\b`;
-	export const CenturyRegex = `\\b(?<century>((one|two)\\s+thousand(\\s+and)?(\\s+(one|two|three|four|five|six|seven|eight|nine)\\s+hundred(\\s+and)?)?)|((twenty one|twenty two|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)(\\s+hundred)?(\\s+and)?))\\b`;
-	export const WrittenNumRegex = `(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fourty|fifty|sixty|seventy|eighty|ninety)`;
-	export const FullTextYearRegex = `\\b((?<firsttwoyearnum>${CenturyRegex})\\s+(?<lasttwoyearnum>((zero|twenty|thirty|forty|fourty|fifty|sixty|seventy|eighty|ninety)\\s+${WrittenNumRegex})|${WrittenNumRegex}))\\b|\\b(?<firsttwoyearnum>${CenturyRegex})\\b`;
+	export const WrittenOneToNineRegex = `(one|two|three|four|five|six|seven|eight|nine)`;
+	export const WrittenElevenToNineteenRegex = `(eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen)`;
+	export const WrittenTensRegex = `(ten|twenty|thirty|forty|fourty|fifty|sixty|seventy|eighty|ninety)`;
+	export const WrittenNumRegex = `(${WrittenOneToNineRegex}|${WrittenElevenToNineteenRegex}|${WrittenTensRegex}(\\s+${WrittenOneToNineRegex})?)`;
+	export const WrittenCenturyFullYearRegex = `((one|two)\\s+thousand(\\s+and)?(\\s+${WrittenOneToNineRegex}\\s+hundred(\\s+and)?)?)`;
+	export const WrittenCenturyOrdinalYearRegex = `(twenty one|twenty two|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)`;
+	export const CenturyRegex = `\\b(?<century>${WrittenCenturyFullYearRegex}|${WrittenCenturyOrdinalYearRegex}(\\s+hundred)?(\\s+and)?)\\b`;
+	export const LastTwoYearNumRegex = `(zero\\s+${WrittenOneToNineRegex}|${WrittenElevenToNineteenRegex}|${WrittenTensRegex}(\\s+${WrittenOneToNineRegex})?)`;
+	export const FullTextYearRegex = `\\b((?<firsttwoyearnum>${CenturyRegex})\\s+(?<lasttwoyearnum>${LastTwoYearNumRegex})\\b|\\b(?<firsttwoyearnum>${WrittenCenturyFullYearRegex}|${WrittenCenturyOrdinalYearRegex}\\s+hundred(\\s+and)?))\\b`;
 	export const OclockRegex = `(?<oclock>o\\s*’\\s*clock|o\\s*‘\\s*clock|o\\s*'\\s*clock|o\\s*clock)`;
 	export const SpecialDescRegex = `(p\\b)`;
 	export const AmDescRegex = `(${BaseDateTime.BaseAmDescRegex})`;

--- a/JavaScript/packages/recognizers-number/src/number/chinese/extractors.ts
+++ b/JavaScript/packages/recognizers-number/src/number/chinese/extractors.ts
@@ -72,6 +72,10 @@ export class ChineseIntegerExtractor extends BaseNumberExtractor {
                 regExp: RegExpUtility.getSafeRegExp(ChineseNumeric.NumbersWithHalfDozen, "gis"),
                 value: "IntegerChs"
             },
+            { // 半
+                regExp: RegExpUtility.getSafeRegExp(ChineseNumeric.HalfUnitRegex, "gis"),
+                value: "IntegerChs"
+            },
             { // 一打  五十打
                 regExp: RegExpUtility.getSafeRegExp(ChineseNumeric.NumbersWithDozen, "gis"),
                 value: "IntegerChs"

--- a/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
+++ b/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
@@ -29,6 +29,7 @@ export namespace ChineseNumeric {
 	export const DoubleAndRoundRegex = `${ZeroToNineFullHalfRegex}+(\\.${ZeroToNineFullHalfRegex}+)?\\s*[多几余]?[万亿萬億]{1,2}`;
 	export const FracSplitRegex = `又|分\\s*之`;
 	export const ZeroToNineIntegerRegex = `[一二三四五六七八九零壹贰貳叁肆伍陆陸柒捌玖〇两兩俩倆仨]`;
+	export const HalfUnitRegex = `半`;
 	export const NegativeNumberTermsRegex = `[负負]`;
 	export const NegativeNumberTermsRegexNum = `((?<!(\\d+\\s*)|[-－])[-－])`;
 	export const NegativeNumberSignRegex = `^${NegativeNumberTermsRegex}.*|^${NegativeNumberTermsRegexNum}.*`;

--- a/Patterns/Chinese/Chinese-Numbers.yaml
+++ b/Patterns/Chinese/Chinese-Numbers.yaml
@@ -149,6 +149,8 @@ FracSplitRegex: !simpleRegex
   def: 又|分\s*之
 ZeroToNineIntegerRegex: !simpleRegex
   def: '[一二三四五六七八九零壹贰貳叁肆伍陆陸柒捌玖〇两兩俩倆仨]'
+HalfUnitRegex: !simpleRegex
+  def: 半
 NegativeNumberTermsRegex: !simpleRegex
   def: '[负負]'
 NegativeNumberTermsRegexNum: !simpleRegex

--- a/Python/libraries/recognizers-number/recognizers_number/number/chinese/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/chinese/extractors.py
@@ -71,6 +71,9 @@ class ChineseIntegerExtractor(BaseNumberExtractor):
                 val='IntegerChs'),
             ReVal(
                 re=RegExpUtility.get_safe_reg_exp(ChineseNumeric.NumbersWithDozen),
+                val='IntegerChs'),
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(ChineseNumeric.HalfUnitRegex),
                 val='IntegerChs')
         ]
         if mode == ChineseNumberExtractorMode.DEFAULT:

--- a/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
@@ -122,6 +122,7 @@ class ChineseNumeric:
     DoubleAndRoundRegex = f'{ZeroToNineFullHalfRegex}+(\\.{ZeroToNineFullHalfRegex}+)?\\s*[多几余]?[万亿萬億]{{1,2}}'
     FracSplitRegex = f'又|分\\s*之'
     ZeroToNineIntegerRegex = f'[一二三四五六七八九零壹贰貳叁肆伍陆陸柒捌玖〇两兩俩倆仨]'
+    HalfUnitRegex = f'半'
     NegativeNumberTermsRegex = f'[负負]'
     NegativeNumberTermsRegexNum = f'((?<!(\\d+\\s*)|[-－])[-－])'
     NegativeNumberSignRegex = f'^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*'

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -2641,5 +2641,77 @@
         }
       }
     ]
+  },
+  {
+    "Input": "还有半小时饭就做好了",
+    "Context": {
+      "ReferenceDateTime": "2018-12-14T12:00:00"
+    },
+    "NotSupportedByDesign": "Java",
+    "Results": [
+      {
+        "Text": "半小时",
+        "Start": 2,
+        "End": 4,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT0.5H",
+              "type": "duration",
+              "value": "1800"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "他在希腊旅游了半个月",
+    "Context": {
+      "ReferenceDateTime": "2018-12-14T12:00:00"
+    },
+    "NotSupportedByDesign": "Java",
+    "Results": [
+      {
+        "Text": "半个月",
+        "Start": 7,
+        "End": 9,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P0.5M",
+              "type": "duration",
+              "value": "1296000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "这个饭店已经营业半年了",
+    "Context": {
+      "ReferenceDateTime": "2018-12-14T12:00:00"
+    },
+    "NotSupportedByDesign": "Java",
+    "Results": [
+      {
+        "Text": "半年",
+        "Start": 8,
+        "End": 9,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P0.5Y",
+              "type": "duration",
+              "value": "15768000"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -9550,5 +9550,13 @@
     "NotSupported": "javascript, python, java",
     "Comment": "Not extracted may as a datetime range is not supported for now",
     "Results": []
+  },
+  {
+    "Input": "Twenty-six people die in accident at Techiman",
+    "Context": {
+      "ReferenceDateTime": "2018-12-13T12:00:00"
+    },
+    "NotSupportedByDesign": "java",
+    "Results": []
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8379,5 +8379,13 @@
     "NotSupported": "javascript, python, java",
     "Comment": "Not extracted may as a datetime range is not supported for now",
     "Results": []
+  },
+  {
+    "Input": "Twenty-six people die in accident at Techiman",
+    "Context": {
+      "ReferenceDateTime": "2018-12-13T12:00:00"
+    },
+    "NotSupportedByDesign": "java",
+    "Results": []
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -7308,5 +7308,13 @@
     "NotSupported": "javascript, python, java",
     "Comment": "Not extracted may as a datetime range is not supported for now",
     "Results": []
+  },
+  {
+    "Input": "Twenty-six people die in accident at Techiman",
+    "Context": {
+      "ReferenceDateTime": "2018-12-13T12:00:00"
+    },
+    "NotSupportedByDesign": "java",
+    "Results": []
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2467,5 +2467,21 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Twenty-six people die in accident at Techiman",
+    "NotSupportedByDesign": "java",
+    "Results": [
+      {
+        "Text": "twenty-six",
+        "Start": 0,
+        "End": 9,
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "26"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
#1054 

A HalfUnitRegex is added to fix datetime duration like "半小时", "半个月", and "半年", etc. The specs for "twenty-six" is added.