### PR TITLE
Replace 'RegExp.test()' with RegExpUtility.isMatch()'

### DIFF
--- a/JavaScript/packages/recognizers-number/src/number/cjkParsers.ts
+++ b/JavaScript/packages/recognizers-number/src/number/cjkParsers.ts
@@ -61,7 +61,7 @@ export class BaseCJKNumberParser extends BaseNumberParser {
         } else if (extra.includes("Num")) {
             getExtResult.text = this.replaceFullWithHalf(getExtResult.text);
             result = this.digitNumberParse(getExtResult);
-            if(this.config.negativeNumberSignRegex.test(getExtResult.text) && result.value > 0){
+            if(RegExpUtility.isMatch(this.config.negativeNumberSignRegex, getExtResult.text) && result.value > 0){
                 result.value = - result.value;
             }
             result.resolutionStr = this.toString(result.value);


### PR DESCRIPTION
Depends on #1065 
# Proposed Changes
  - Replace `regExp.test()` with `RegExpUtility.isMatch()` in `recognizers-number` for **Chinese**. When executing the same Regex method in a single scope, the starting index in the Regex is modified and results may be affected ([more info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#Description))

# Testing
  - Run all `JavaScript` tests at once.