### PR TITLE
Filter out certain German ein/1 ambiguity, correct incorrect spec

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/German/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/German/NumbersDefinitions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Definitions.German
 	public static class NumbersDefinitions
 	{
 		public const string LangMarker = @"Ger";
-		public const string ZeroToNineIntegerRegex = @"(drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|ein|eine|einer|einen|zwei|zwo|sechs)";
+		public const string ZeroToNineIntegerRegex = @"(drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|(ein(?!($|\.|,|!|\?)))|eine|einer|einen|zwei|zwo|sechs)";
 		public const string RoundNumberIntegerRegex = @"(hundert|einhundert|tausend|(\s*million\s*)|(\s*millionen\s*)|(\s*mio\s*)|(\s*milliarde\s*)|(\s*milliarden\s*)|(\s*mrd\s*)|(\s*billion\s*)|(\s*billionen\s*))";
 		public const string AnIntRegex = @"(eine|ein)(?=\s)";
 		public const string TenToNineteenIntegerRegex = @"(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)";

--- a/Patterns/German/German-Numbers.yaml
+++ b/Patterns/German/German-Numbers.yaml
@@ -2,7 +2,7 @@
 LangMarker: Ger
 #Integer Regex
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|ein|eine|einer|einen|zwei|zwo|sechs)
+  def: (drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|(ein(?!($|\.|,|!|\?)))|eine|einer|einen|zwei|zwo|sechs)
 RoundNumberIntegerRegex: !simpleRegex
   def: (hundert|einhundert|tausend|(\s*million\s*)|(\s*millionen\s*)|(\s*mio\s*)|(\s*milliarde\s*)|(\s*milliarden\s*)|(\s*mrd\s*)|(\s*billion\s*)|(\s*billionen\s*))
 AnIntRegex: !simpleRegex

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -15,17 +15,17 @@
     ]
   },
   {
-    "Input": "ein",
+    "Input": "eins",
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "ein",
+        "Text": "eins",
         "TypeName": "number",
         "Resolution": {
           "value": "1"
         },
         "Start": 0,
-        "End": 2
+        "End": 3
       }
     ]
   },


### PR DESCRIPTION
Filter out certain cases of ein/1 ambiguity in German where "ein" is incorrectly parsed as a number at the end of a phrase or sentence. This will improve behaviour especially with smart home use cases.

Examples:

- "Schalte das Radio ein"
- "Ein"
- "Mir fällt nichts ein"
- "Schalte die Heizung ein"