### PR TITLE
Fix regex in appveyor.yml file

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,9 @@ clone_depth: 1
 branches:
   only:
   - master
-  - feature/*
+  - /[Ff]eature\/.+/
+  - /[Ff]ix\/.+/
+  - /[Hh]otfix\/.+/
 
 build:
   parallel: true


### PR DESCRIPTION
## Description
Fix the appveyor.yml file to start running builds/tests over the `feature/[anything]` branches. The reason is that the `.yml` file needs a regular expression instead of a wildcard ([more info here](https://www.appveyor.com/docs/branches/#white--and-blacklisting)).

Also, add the `fix/[anything]` and `hotfix/[anything]` regexes.

## Evidence

AppVeyor successfully run after the `.yml` file modification

![image](https://user-images.githubusercontent.com/43762887/50363257-a4f85380-0549-11e9-810c-24c828841d4a.png)
