### PR TITLE
[DO NOT MERGE] Update 'ava' dependency to v1.0.0

### DIFF
--- a/JavaScript/.babelrc
+++ b/JavaScript/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     [
-      "es2015",
+      "@ava/stage-4",
       {
         "modules": false
       }

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -46,7 +46,7 @@
 		"@types/lodash.trimend": "^4.5.1",
 		"@types/node": "^8.0.20",
 		"@types/npm": "^2.0.29",
-		"ava": "^0.22.0",
+		"ava": "^1.0.0",
 		"ava-spec": "^1.1.0",
 		"babel-plugin-external-helpers": "^6.22.0",
 		"cached-path-relative": ">=1.0.2",

--- a/JavaScript/test/.babelrc
+++ b/JavaScript/test/.babelrc
@@ -1,7 +1,6 @@
 {
     "presets": [
-        "es2015",
-        "stage-0"
+        "@ava/stage-4"
     ],
     "plugins": []
 }

--- a/JavaScript/test/runner.js
+++ b/JavaScript/test/runner.js
@@ -9,6 +9,9 @@ module.exports = function (describe, specs) {
         describe(`${suite.config.type} - ${suite.config.language} - ${suite.config.subType} -`, it => {
             suite.specs.forEach(testCase => {
                 var caseName = `"${testCase.Input}"`;
+                if(suite.config.type === "DateTime" && testCase.Context){
+                    caseName += ` - "${testCase.Context.ReferenceDateTime}"`;
+                }   
 
                 // Not Supported by Design - right now we don't care about implementing it
                 var notSupportedByDesign = (testCase.NotSupportedByDesign || '').split(',').map(s => s.trim());


### PR DESCRIPTION
Depends on #1080 being merged before, or tests won't pass. This is due to ava v1.0.0 failing when encountering duplicated test titles.

# Proposed changes
  - Update '[ava](https://github.com/avajs/ava)' dependency to v1.0.0 for [recent major release](https://blog.sindresorhus.com/ava-1-0-861d780b2d81).
  - **Modify title structure for DateTime tests**; right now, title is formed with test `Input`, but different tests with different `ReferenceDateTime` have identical `Input`, so [adding the `ReferenceDateTime`](https://github.com/Microsoft/Recognizers-Text/compare/master...southworkscom:feature/southworks/update-ava-dependency#diff-f4d950b7c5709d0830a08de72c79e3d6R12) to the title for making them unique.