### PR TITLE
[StyleCop] Fix all StyleCop warnings in PortugueseHolidayParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
@@ -1,51 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using DateObject = System.DateTime;
-
 using Microsoft.Recognizers.Definitions.Portuguese;
+using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public PortugueseHolidayParserConfiguration(IOptionsConfiguration config) : base(config)
+        public PortugueseHolidayParserConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             this.HolidayRegexList = PortugueseHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
             this.VariableHolidaysTimexDictionary = DateTimeDefinitions.VariableHolidaysTimexDictionary.ToImmutableDictionary();
         }
-
-        protected override IDictionary<string, Func<int, DateObject>> InitHolidayFuncs()
-        {
-            return new Dictionary<string, Func<int, DateObject>>(base.InitHolidayFuncs())
-            {
-                {"pai", FathersDay},
-                {"mae", MothersDay},
-                {"acaodegracas", ThanksgivingDay},
-                {"trabalho", LabourDay},
-                {"pascoa", Easter},
-                {"natal", ChristmasDay},
-                {"vesperadenatal", ChristmasEve},
-                {"anonovo", NewYear},
-                {"versperadeanonovo", NewYearEve},
-                {"yuandan", NewYear},
-                {"professor", TeacherDay},
-                {"todosossantos", HalloweenDay},
-                {"crianca", ChildrenDay},
-                {"mulher", FemaleDay}
-            };
-        }
-
-        private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
-        private static DateObject NewYearEve(int year) => new DateObject(year, 12, 31);
-        private static DateObject ChristmasDay(int year) => new DateObject(year, 12, 25);
-        private static DateObject ChristmasEve(int year) => new DateObject(year, 12, 24);
-        private static DateObject FemaleDay(int year) => new DateObject(year, 3, 8);
-        private static DateObject ChildrenDay(int year) => new DateObject(year, 6, 1);
-        private static DateObject HalloweenDay(int year) => new DateObject(year, 10, 31);
-        private static DateObject TeacherDay(int year) => new DateObject(year, 9, 11);
-        private static DateObject Easter(int year) => DateObject.MinValue;
 
         public override int GetSwiftYear(string text)
         {
@@ -72,7 +41,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public override string SanitizeHolidayToken(string holiday)
         {
             return holiday
-                .Replace(" ", "")
+                .Replace(" ", string.Empty)
                 .Replace("á", "a")
                 .Replace("é", "e")
                 .Replace("í", "i")
@@ -85,5 +54,44 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 .Replace("õ", "o")
                 .Replace("ç", "c");
         }
+
+        protected override IDictionary<string, Func<int, DateObject>> InitHolidayFuncs()
+        {
+            return new Dictionary<string, Func<int, DateObject>>(base.InitHolidayFuncs())
+            {
+                { "pai", FathersDay },
+                { "mae", MothersDay },
+                { "acaodegracas", ThanksgivingDay },
+                { "trabalho", LabourDay },
+                { "pascoa", Easter },
+                { "natal", ChristmasDay },
+                { "vesperadenatal", ChristmasEve },
+                { "anonovo", NewYear },
+                { "versperadeanonovo", NewYearEve },
+                { "yuandan", NewYear },
+                { "professor", TeacherDay },
+                { "todosossantos", HalloweenDay },
+                { "crianca", ChildrenDay },
+                { "mulher", FemaleDay },
+            };
+        }
+
+        private static DateObject NewYear(int year) => new DateObject(year, 1, 1);
+
+        private static DateObject NewYearEve(int year) => new DateObject(year, 12, 31);
+
+        private static DateObject ChristmasDay(int year) => new DateObject(year, 12, 25);
+
+        private static DateObject ChristmasEve(int year) => new DateObject(year, 12, 24);
+
+        private static DateObject FemaleDay(int year) => new DateObject(year, 3, 8);
+
+        private static DateObject ChildrenDay(int year) => new DateObject(year, 6, 1);
+
+        private static DateObject HalloweenDay(int year) => new DateObject(year, 10, 31);
+
+        private static DateObject TeacherDay(int year) => new DateObject(year, 9, 11);
+
+        private static DateObject Easter(int year) => DateObject.MinValue;
     }
 }


### PR DESCRIPTION
- Reordered fields, properties and methods. Public before private and static before non-static.
- Removed regions
- Added spaces when needed