### PR TITLE
[Infra] Check if CommonAssemblyPath exists & escape path in BuildResources.cmd

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/BuildResources.cmd
+++ b/.NET/Microsoft.Recognizers.Definitions/BuildResources.cmd
@@ -2,12 +2,16 @@
 SETLOCAL EnableDelayedExpansion
 SET COMMONASSEMBLYPATH=%~dp0..\build\package\net462\Microsoft.Recognizers.Definitions.Common.dll
 
+IF NOT EXIST "%COMMONASSEMBLYPATH%" (
+	ECHO "%COMMONASSEMBLYPATH%" could not be found, build the Microsoft.Recognizers.Definitions solution first.
+	EXIT /B
+) 
 
 ECHO.
 ECHO # Transform All T4 Templates
 
 ECHO.
-FOR /R %%i IN (*.tt) DO (ECHO # Transform %%i to %%~dpni.cs & dotnet tt %%i -o %%~dpni.cs -r %COMMONASSEMBLYPATH%)
+FOR /R %%i IN (*.tt) DO (ECHO # Transform %%i to %%~dpni.cs & dotnet tt "%%i" -o "%%~dpni.cs" -r "%COMMONASSEMBLYPATH%")
 
 EXIT /b 0
 


### PR DESCRIPTION
- Escape the file path to prevent ["No input file specified."](
https://github.com/atifaziz/t5/blob/6f93925ad1ecbd676013e1c3abc3fbfc75f9ba39/src/TextTransform/TextTransform.cs#L78) errors being thrown, when a path contains spaces
- Add check if `CommonAssemblyPath` exists 