### PR TITLE
[StyleCop] Fix all StyleCop warnings in FrenchDatePeriodParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -8,72 +8,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
-        public int MinYearNum { get; }
-
-        public int MaxYearNum { get; }
-
-        public string TokenBeforeDate { get; }
-
-        #region internalParsers
-
-        public IDateExtractor DateExtractor { get; }
-
-        public IExtractor CardinalExtractor { get; }
-
-        public IExtractor OrdinalExtractor { get; }
-
-        public IDateTimeExtractor DurationExtractor { get; }
-
-        public IExtractor IntegerExtractor { get; }
-
-        public IParser NumberParser { get; }
-
-        public IDateTimeParser DateParser { get; }
-
-        public IDateTimeParser DurationParser { get; }
-
-        #endregion
-
-        #region Regexes
-
-        public Regex MonthFrontBetweenRegex { get; }
-        public Regex BetweenRegex { get; }
-        public Regex MonthFrontSimpleCasesRegex { get; }
-        public Regex SimpleCasesRegex { get; }
-        public Regex OneWordPeriodRegex { get; }
-        public Regex MonthWithYear { get; }
-        public Regex MonthNumWithYear { get; }
-        public Regex YearRegex { get; }
-        public Regex PastRegex { get; }
-        public Regex FutureRegex { get; }
-        public Regex FutureSuffixRegex { get; }
-        public Regex NumberCombinedWithUnit { get; }
-        public Regex WeekOfMonthRegex { get; }
-        public Regex WeekOfYearRegex { get; }
-        public Regex QuarterRegex { get; }
-        public Regex QuarterRegexYearFront { get; }
-        public Regex AllHalfYearRegex { get; }
-        public Regex SeasonRegex { get; }
-        public Regex WhichWeekRegex { get; }
-        public Regex WeekOfRegex { get; }
-        public Regex MonthOfRegex { get; }
-        public Regex InConnectorRegex { get; }
-        public Regex WithinNextPrefixRegex { get; }
-        public Regex RestOfDateRegex { get; }
-        public Regex LaterEarlyPeriodRegex { get; }
-        public Regex WeekWithWeekDayRangeRegex { get; }
-        public Regex YearPlusNumberRegex { get; }
-        public Regex DecadeWithCenturyRegex { get; }
-        public Regex YearPeriodRegex { get; }
-        public Regex ComplexDatePeriodRegex { get; }
-        public Regex RelativeDecadeRegex { get; }
-        public Regex ReferenceDatePeriodRegex { get; }
-        public Regex AgoRegex { get; }
-        public Regex LaterRegex { get; }
-        public Regex LessThanRegex { get; }
-        public Regex MoreThanRegex { get; }
-        public Regex CenturySuffixRegex { get; }
-
         // @TODO move to resources - French - relative
         public static readonly Regex NextPrefixRegex =
             new Regex(@"(prochain|prochaine)\b", RegexOptions.Singleline);
@@ -90,37 +24,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex UnspecificEndOfRangeRegex =
             new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexOptions.Singleline);
 
-        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
-        Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
-        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
-        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
-        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
-
-        #endregion
-
-        #region Dictionaries
-
-        public IImmutableDictionary<string, string> UnitMap { get; }
-
-        public IImmutableDictionary<string, int> CardinalMap { get; }
-
-        public IImmutableDictionary<string, int> DayOfMonth { get; }
-
-        public IImmutableDictionary<string, int> MonthOfYear { get; }
-
-        public IImmutableDictionary<string, string> SeasonMap { get; }
-
-        public IImmutableDictionary<string, int> WrittenDecades { get; }
-
-        public IImmutableDictionary<string, int> Numbers { get; }
-
-        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
-
-        #endregion
-
-        public IImmutableList<string> InStringList { get; }
-
-        public FrenchDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
+        public FrenchDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
 
@@ -181,26 +86,150 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             SpecialDecadeCases = config.SpecialDecadeCases;
         }
 
+        public int MinYearNum { get; }
+
+        public int MaxYearNum { get; }
+
+        public string TokenBeforeDate { get; }
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IExtractor CardinalExtractor { get; }
+
+        public IExtractor OrdinalExtractor { get; }
+
+        public IDateTimeExtractor DurationExtractor { get; }
+
+        public IExtractor IntegerExtractor { get; }
+
+        public IParser NumberParser { get; }
+
+        public IDateTimeParser DateParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
+
+        public Regex MonthFrontBetweenRegex { get; }
+
+        public Regex BetweenRegex { get; }
+
+        public Regex MonthFrontSimpleCasesRegex { get; }
+
+        public Regex SimpleCasesRegex { get; }
+
+        public Regex OneWordPeriodRegex { get; }
+
+        public Regex MonthWithYear { get; }
+
+        public Regex MonthNumWithYear { get; }
+
+        public Regex YearRegex { get; }
+
+        public Regex PastRegex { get; }
+
+        public Regex FutureRegex { get; }
+
+        public Regex FutureSuffixRegex { get; }
+
+        public Regex NumberCombinedWithUnit { get; }
+
+        public Regex WeekOfMonthRegex { get; }
+
+        public Regex WeekOfYearRegex { get; }
+
+        public Regex QuarterRegex { get; }
+
+        public Regex QuarterRegexYearFront { get; }
+
+        public Regex AllHalfYearRegex { get; }
+
+        public Regex SeasonRegex { get; }
+
+        public Regex WhichWeekRegex { get; }
+
+        public Regex WeekOfRegex { get; }
+
+        public Regex MonthOfRegex { get; }
+
+        public Regex InConnectorRegex { get; }
+
+        public Regex WithinNextPrefixRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
+
+        public Regex LaterEarlyPeriodRegex { get; }
+
+        public Regex WeekWithWeekDayRangeRegex { get; }
+
+        public Regex YearPlusNumberRegex { get; }
+
+        public Regex DecadeWithCenturyRegex { get; }
+
+        public Regex YearPeriodRegex { get; }
+
+        public Regex ComplexDatePeriodRegex { get; }
+
+        public Regex RelativeDecadeRegex { get; }
+
+        public Regex ReferenceDatePeriodRegex { get; }
+
+        public Regex AgoRegex { get; }
+
+        public Regex LaterRegex { get; }
+
+        public Regex LessThanRegex { get; }
+
+        public Regex MoreThanRegex { get; }
+
+        public Regex CenturySuffixRegex { get; }
+
+        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
+
+        public IImmutableDictionary<string, string> UnitMap { get; }
+
+        public IImmutableDictionary<string, int> CardinalMap { get; }
+
+        public IImmutableDictionary<string, int> DayOfMonth { get; }
+
+        public IImmutableDictionary<string, int> MonthOfYear { get; }
+
+        public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, int> WrittenDecades { get; }
+
+        public IImmutableDictionary<string, int> Numbers { get; }
+
+        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
+
+        public IImmutableList<string> InStringList { get; }
+
         public int GetSwiftDayOrMonth(string text)
         {
             var swift = 0;
 
             var trimmedText = text.Trim().ToLowerInvariant();
 
-            //TODO: Replace with a regex
-            //TODO: Add 'upcoming' key word
-            
+            // TODO: Replace with a regex
+            // TODO: Add 'upcoming' key word
+
             // example: "nous serons ensemble cette fois la semaine prochaine" - "We'll be together this time next week"
             if (trimmedText.EndsWith("prochain") || trimmedText.EndsWith("prochaine"))
             {
                 swift = 1;
             }
 
-            //TODO: Replace with a regex
+            // TODO: Replace with a regex
 
-            // example: Je l'ai vue pas plus tard que la semaine derniere - "I saw her only last week" 
+            // example: Je l'ai vue pas plus tard que la semaine derniere - "I saw her only last week"
             if (trimmedText.EndsWith("dernière") || trimmedText.EndsWith("dernières") ||
-                trimmedText.EndsWith("derniere") || trimmedText.EndsWith("dernieres")) 
+                trimmedText.EndsWith("derniere") || trimmedText.EndsWith("dernieres"))
             {
                 swift = -1;
             }
@@ -213,7 +242,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             var swift = -10;
 
             var trimmedText = text.Trim().ToLowerInvariant();
-            
+
             if (trimmedText.EndsWith("prochain") || trimmedText.EndsWith("prochaine"))
             {
                 swift = 1;
@@ -242,7 +271,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public bool IsLastCardinal(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
-            return DateTimeDefinitions.LastCardinalTerms.Any(o => trimmedText.Equals(o));            
+            return DateTimeDefinitions.LastCardinalTerms.Any(o => trimmedText.Equals(o));
         }
 
         public bool IsMonthOnly(string text)
@@ -266,7 +295,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
-            return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o)) && 
+            return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o)) &&
                    !DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o));
         }
 


### PR DESCRIPTION
- Reordered fields, properties and methods. Public before private and static before non-static.
- Removed regions
- Added spaces when needed