### PR TITLE
[StyleCop] Fix all StyleCop warnings in GermanDatePeriodParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -7,74 +7,8 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDatePeriodParserConfiguration : BaseOptionsConfiguration,IDatePeriodParserConfiguration
+    public class GermanDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
     {
-        public int MinYearNum { get; }
-
-        public int MaxYearNum { get; }
-
-        public string TokenBeforeDate { get; }
-
-        #region internalParsers
-
-        public IDateExtractor DateExtractor { get; }
-
-        public IExtractor CardinalExtractor { get; }
-
-        public IExtractor OrdinalExtractor { get; }
-
-        public IDateTimeExtractor DurationExtractor { get; }
-
-        public IExtractor IntegerExtractor { get; }
-
-        public IParser NumberParser { get; }
-
-        public IDateTimeParser DateParser { get; }
-
-        public IDateTimeParser DurationParser { get; }
-
-        #endregion
-
-        #region Regexes
-
-        public Regex MonthFrontBetweenRegex { get; }
-        public Regex BetweenRegex { get; }
-        public Regex MonthFrontSimpleCasesRegex { get; }
-        public Regex SimpleCasesRegex { get; }
-        public Regex OneWordPeriodRegex { get; }
-        public Regex MonthWithYear { get; }
-        public Regex MonthNumWithYear { get; }
-        public Regex YearRegex { get; }
-        public Regex PastRegex { get; }
-        public Regex FutureRegex { get; }
-        public Regex FutureSuffixRegex { get; }
-        public Regex NumberCombinedWithUnit { get; }
-        public Regex WeekOfMonthRegex { get; }
-        public Regex WeekOfYearRegex { get; }
-        public Regex QuarterRegex { get; }
-        public Regex QuarterRegexYearFront { get; }
-        public Regex AllHalfYearRegex { get; }
-        public Regex SeasonRegex { get; }
-        public Regex WhichWeekRegex { get; }
-        public Regex WeekOfRegex { get; }
-        public Regex MonthOfRegex { get; }
-        public Regex InConnectorRegex { get; }
-        public Regex WithinNextPrefixRegex { get; }
-        public Regex RestOfDateRegex { get; }
-        public Regex LaterEarlyPeriodRegex { get; }
-        public Regex WeekWithWeekDayRangeRegex { get; }
-        public Regex YearPlusNumberRegex { get; }
-        public Regex DecadeWithCenturyRegex { get; }
-        public Regex YearPeriodRegex { get; }
-        public Regex ComplexDatePeriodRegex { get; }
-        public Regex RelativeDecadeRegex { get; }
-        public Regex ReferenceDatePeriodRegex { get; }
-        public Regex AgoRegex { get; }
-        public Regex LaterRegex { get; }
-        public Regex LessThanRegex { get; }
-        public Regex MoreThanRegex { get; }
-        public Regex CenturySuffixRegex { get; }
-
         public static readonly Regex NextPrefixRegex =
             new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
 
@@ -90,36 +24,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex UnspecificEndOfRangeRegex =
             new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexOptions.Singleline);
 
-        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
-        Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
-        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
-        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
-        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
-
-        #endregion
-
-        #region Dictionaries
-        public IImmutableDictionary<string, string> UnitMap { get; }
-
-        public IImmutableDictionary<string, int> CardinalMap { get; }
-
-        public IImmutableDictionary<string, int> DayOfMonth { get; }
-
-        public IImmutableDictionary<string, int> MonthOfYear { get; }
-
-        public IImmutableDictionary<string, string> SeasonMap { get; }
-
-        public IImmutableDictionary<string, int> WrittenDecades { get; }
-
-        public IImmutableDictionary<string, int> Numbers { get; }
-
-        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
-
-        #endregion
-
-        public IImmutableList<string> InStringList { get; }
-
-        public GermanDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
+        public GermanDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+    : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             CardinalExtractor = config.CardinalExtractor;
@@ -149,7 +55,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             AllHalfYearRegex = GermanDatePeriodExtractorConfiguration.AllHalfYearRegex;
             SeasonRegex = GermanDatePeriodExtractorConfiguration.SeasonRegex;
             WhichWeekRegex = GermanDatePeriodExtractorConfiguration.WhichWeekRegex;
-            WeekOfRegex= GermanDatePeriodExtractorConfiguration.WeekOfRegex;
+            WeekOfRegex = GermanDatePeriodExtractorConfiguration.WeekOfRegex;
             MonthOfRegex = GermanDatePeriodExtractorConfiguration.MonthOfRegex;
             RestOfDateRegex = GermanDatePeriodExtractorConfiguration.RestOfDateRegex;
             LaterEarlyPeriodRegex = GermanDatePeriodExtractorConfiguration.LaterEarlyPeriodRegex;
@@ -177,6 +83,130 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             SpecialDecadeCases = config.SpecialDecadeCases;
         }
 
+        public int MinYearNum { get; }
+
+        public int MaxYearNum { get; }
+
+        public string TokenBeforeDate { get; }
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IExtractor CardinalExtractor { get; }
+
+        public IExtractor OrdinalExtractor { get; }
+
+        public IDateTimeExtractor DurationExtractor { get; }
+
+        public IExtractor IntegerExtractor { get; }
+
+        public IParser NumberParser { get; }
+
+        public IDateTimeParser DateParser { get; }
+
+        public IDateTimeParser DurationParser { get; }
+
+        public Regex MonthFrontBetweenRegex { get; }
+
+        public Regex BetweenRegex { get; }
+
+        public Regex MonthFrontSimpleCasesRegex { get; }
+
+        public Regex SimpleCasesRegex { get; }
+
+        public Regex OneWordPeriodRegex { get; }
+
+        public Regex MonthWithYear { get; }
+
+        public Regex MonthNumWithYear { get; }
+
+        public Regex YearRegex { get; }
+
+        public Regex PastRegex { get; }
+
+        public Regex FutureRegex { get; }
+
+        public Regex FutureSuffixRegex { get; }
+
+        public Regex NumberCombinedWithUnit { get; }
+
+        public Regex WeekOfMonthRegex { get; }
+
+        public Regex WeekOfYearRegex { get; }
+
+        public Regex QuarterRegex { get; }
+
+        public Regex QuarterRegexYearFront { get; }
+
+        public Regex AllHalfYearRegex { get; }
+
+        public Regex SeasonRegex { get; }
+
+        public Regex WhichWeekRegex { get; }
+
+        public Regex WeekOfRegex { get; }
+
+        public Regex MonthOfRegex { get; }
+
+        public Regex InConnectorRegex { get; }
+
+        public Regex WithinNextPrefixRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
+
+        public Regex LaterEarlyPeriodRegex { get; }
+
+        public Regex WeekWithWeekDayRangeRegex { get; }
+
+        public Regex YearPlusNumberRegex { get; }
+
+        public Regex DecadeWithCenturyRegex { get; }
+
+        public Regex YearPeriodRegex { get; }
+
+        public Regex ComplexDatePeriodRegex { get; }
+
+        public Regex RelativeDecadeRegex { get; }
+
+        public Regex ReferenceDatePeriodRegex { get; }
+
+        public Regex AgoRegex { get; }
+
+        public Regex LaterRegex { get; }
+
+        public Regex LessThanRegex { get; }
+
+        public Regex MoreThanRegex { get; }
+
+        public Regex CenturySuffixRegex { get; }
+
+        Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.PastPrefixRegex => PastPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.ThisPrefixRegex => ThisPrefixRegex;
+
+        Regex IDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex IDatePeriodParserConfiguration.UnspecificEndOfRangeRegex => UnspecificEndOfRangeRegex;
+
+        public IImmutableDictionary<string, string> UnitMap { get; }
+
+        public IImmutableDictionary<string, int> CardinalMap { get; }
+
+        public IImmutableDictionary<string, int> DayOfMonth { get; }
+
+        public IImmutableDictionary<string, int> MonthOfYear { get; }
+
+        public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, int> WrittenDecades { get; }
+
+        public IImmutableDictionary<string, int> Numbers { get; }
+
+        public IImmutableDictionary<string, int> SpecialDecadeCases { get; }
+
+        public IImmutableList<string> InStringList { get; }
+
         public int GetSwiftDayOrMonth(string text)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -189,6 +219,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 swift = -1;
             }
+
             return swift;
         }
 
@@ -208,6 +239,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 swift = 0;
             }
+
             return swift;
         }
 


### PR DESCRIPTION
- Reordered fields, properties and methods. Public before private and static before non-static.
- Removed regions
- Added spaces when needed