### PR TITLE
[StyleCop] Fix all StyleCop warnings in JapaneseDateTimeParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateTimePeriodExtractorChs.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Chinese;
 using DateObject = System.DateTime;
-using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
@@ -116,8 +116,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         idx += 2;
                         continue;
                     }
+
                     idx++;
                 }
+
                 idx++;
             }
 
@@ -171,7 +173,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 var middleEnd = timePoints[idx + 1].Start ?? 0;
 
                 var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
-                
+
                 // handle "{TimePoint} to {TimePoint}"
                 if (TillRegex.IsExactMatch(middleStr, trim: true))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -8,26 +8,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
-        public string TokenBeforeDate { get; }
-
-        private static readonly Regex[] SimpleCases =
-        {
-            EnglishTimePeriodExtractorConfiguration.PureNumFromTo,
-            EnglishTimePeriodExtractorConfiguration.PureNumBetweenAnd
-        };
-
-        private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexOptions.Singleline);
-
-        private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
-
-        private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
         public static readonly Regex TimeNumberCombinedWithUnit =
             new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
@@ -39,12 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public static readonly Regex RestOfDateTimeRegex =
             new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexOptions.Singleline);
-
-        private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);
-
-        private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexOptions.Singleline);
 
         public static readonly Regex AmDescRegex =
             new Regex(DateTimeDefinitions.AmDescRegex, RegexOptions.Singleline);
@@ -73,7 +47,32 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex WeekDaysRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 
-        public EnglishDateTimePeriodExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        private static readonly Regex[] SimpleCases =
+        {
+            EnglishTimePeriodExtractorConfiguration.PureNumFromTo,
+            EnglishTimePeriodExtractorConfiguration.PureNumBetweenAnd,
+        };
+
+        private static readonly Regex PeriodTimeOfDayRegex =
+            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexOptions.Singleline);
+
+        private static readonly Regex PeriodSpecificTimeOfDayRegex =
+            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
+
+        private static readonly Regex TimeUnitRegex =
+            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
+
+        private static readonly Regex TimeFollowedUnit =
+            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
+
+        private static readonly Regex GeneralEndingRegex =
+            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);
+
+        private static readonly Regex MiddlePauseRegex =
+            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexOptions.Singleline);
+
+        public EnglishDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
 
@@ -135,6 +134,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         Regex IDateTimePeriodExtractorConfiguration.AfterRegex => AfterRegex;
 
+        public string TokenBeforeDate { get; }
+
         public IExtractor CardinalExtractor { get; }
 
         public IDateTimeExtractor SingleDateExtractor { get; }
@@ -147,7 +148,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
 
-        //TODO: these three methods are the same in DatePeriod, should be abstracted
+        // TODO: these three methods are the same in DatePeriod, should be abstracted
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
   public class JapaneseDateTimeParserConfiguration : BaseOptionsConfiguration, IFullDateTimeParserConfiguration
   {
-    public JapaneseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None) : base(options)
+    public JapaneseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
+            : base(options)
     {
       DateParser = new DateParser(this);
       TimeParser = new TimeParser(this);
@@ -51,8 +52,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
     public string DatePrefix => DateTimeDefinitions.ParserConfigurationDatePrefix;
 
-    #region internalParsers
-
     public IDateTimeParser DateParser { get; }
 
     public IDateTimeParser TimeParser { get; }
@@ -71,10 +70,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
     public IDateTimeParser HolidayParser { get; }
 
-    #endregion
-
-    #region Dictionaries
-
     public ImmutableDictionary<string, string> UnitMap { get; }
 
     public ImmutableDictionary<string, long> UnitValueMap { get; }
@@ -92,10 +87,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     public ImmutableDictionary<string, int> MonthOfYear { get; }
 
     public ImmutableDictionary<string, int> Numbers { get; }
-
-    #endregion
-
-    #region Regexes
 
     public IEnumerable<Regex> DateRegexList { get; }
 
@@ -119,18 +110,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
     public Regex SinceSuffixRegex { get; }
 
-    #endregion
-
-    private static ImmutableDictionary<string, int> InitNumbers()
-    {
-      return new Dictionary<string, int>
-      {
-      }.ToImmutableDictionary();
-    }
-
     public int GetSwiftDay(string text)
     {
-      //Today: 今天, 今日, 最近, きょう, この日
+      // Today: 今天, 今日, 最近, きょう, この日
       var value = 0;
 
       if (text.StartsWith("来") || text.Equals("あす") || text.Equals("あした") || text.Equals("明日"))
@@ -163,7 +145,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
     public int GetSwiftMonth(string text)
     {
-      //Current month: 今月
+      // Current month: 今月
       var value = 0;
 
       if (text.Equals("来月"))
@@ -178,13 +160,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
       {
         value = 2;
       }
-      
+
       return value;
     }
 
     public int GetSwiftYear(string text)
     {
-      //Current year: 今年
+      // Current year: 今年
       var value = 0;
 
       if (text.Equals("来年") || text.Equals("らいねん"))
@@ -197,6 +179,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
       }
 
       return value;
+    }
+
+    private static ImmutableDictionary<string, int> InitNumbers()
+    {
+        return new Dictionary<string, int>
+        {
+        }.ToImmutableDictionary();
     }
   }
 }


### PR DESCRIPTION
- Reordered fields, properties and methods. Public before private and static before non-static.
- Removed regions
- Added spaces when needed