### PR TITLE
[NL DateTime] Fix tests which have Start set to -1

### DIFF
--- a/Specs/DateTime/Dutch/DateExtractor.json
+++ b/Specs/DateTime/Dutch/DateExtractor.json
@@ -160,10 +160,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22.4.",
+        "Text": "22.4",
         "Type": "date",
-        "Start": -1,
-        "Length": 5
+        "Length": 5,
+        "Start": 15
       }
     ],
     "NotSupported": "dotNet"
@@ -407,9 +407,9 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Dinsdag",
+        "Text": "dinsdag",
         "Type": "date",
-        "Start": -1,
+        "Start": 15,
         "Length": 7
       }
     ],

--- a/Specs/DateTime/Dutch/DateParser.json
+++ b/Specs/DateTime/Dutch/DateParser.json
@@ -483,7 +483,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "08/12,15",
+        "Text": "12-08-2015",
         "Type": "date",
         "Value": {
           "Timex": "2015-08-12",
@@ -494,8 +494,8 @@
             "date": "2015-08-12"
           }
         },
-        "Start": -1,
-        "Length": 8
+        "Length": 8,
+        "Start": 15
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimeExtractor.json
+++ b/Specs/DateTime/Dutch/DateTimeExtractor.json
@@ -82,10 +82,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "04/21/2016, 20u",
+        "Text": "21/04/2016, 20u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 15
+        "Length": 15,
+        "Start": 15
       }
     ],
     "NotSupported": "dotNet"
@@ -95,10 +95,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "04/21/2016, 20:00:13u",
+        "Text": "21/04/2016, 20:00:13u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 21
+        "Length": 21,
+        "Start": 15
       }
     ],
     "NotSupported": "dotNet"
@@ -108,22 +108,22 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "23 Okt om zeven",
+        "Text": "23 Okt om 7",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 15
+        "Length": 15,
+        "Start": 15
       }
     ],
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga terug op 14 oktober 8u",
+    "Input": "Ik ga terug op 14 oktober 20:00",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Oktober 14 8:00u",
+        "Text": "14 oktober 20:00",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 15,
         "Length": 16
       }
     ],
@@ -134,10 +134,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Oktober 14 8:00:00u",
+        "Text": "14 oktober om 8:00:00u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 19
+        "Start": 15,
+        "Length": 22
       }
     ],
     "NotSupported": "dotNet"
@@ -147,49 +147,49 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Oktober 14, 8:00u",
+        "Text": "14 oktober, 8:00u",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 15,
         "Length": 17
       }
     ],
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga terug op 14 oktober, 8:00:01u",
+    "Input": "Ik ga terug op 14 oktober, 8:00:01",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "14 Oktober, 8:00:01u",
+        "Text": "14 oktober, 8:00:01",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 15,
+        "Length": 19
+      }
+    ],
+    "NotSupported": "dotNet"
+  },
+  {
+    "Input": "Ik ga morgen terug om 8:00",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgen terug om 8:00",
+        "Type": "datetime",
+        "Start": 6,
         "Length": 20
       }
     ],
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga morgen terug om 8u",
+    "Input": "Ik ga morgen terug rond 8 uur",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "morgen, 8u",
+        "Text": "morgen terug rond 8 uur",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 10
-      }
-    ],
-    "NotSupported": "dotNet"
-  },
-  {
-    "Input": "Ik ga morgen terug rond 8u",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "morgen rond 8u",
-        "Type": "datetime",
-        "Start": -1,
-        "Length": 14
+        "Start": 6,
+        "Length": 23
       }
     ],
     "NotSupported": "dotNet"
@@ -199,10 +199,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "morgen voor 8u",
+        "Text": "morgen terug voor 8u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 14
+        "Start": 6,
+        "Length": 20
       }
     ],
     "NotSupported": "dotNet"
@@ -212,22 +212,22 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "morgen 8:00:05u",
+        "Text": "morgen terug 8:00:05u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 15
+        "Start": 6,
+        "Length": 21
       }
     ],
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga volgende week vrijdag terug om half 4",
+    "Input": "Ik ga volgende week vrijdag om half 4 terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende week vrijdag om half 4",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 6,
         "Length": 31
       }
     ],
@@ -238,10 +238,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5 mei, 2016, 20 minuten over 8 in de avond",
+        "Text": "5 mei 2016, 20 minuten over 8 in de avond",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 42
+        "Start": 15,
+        "Length": 41
       }
     ],
     "NotSupported": "dotNet"
@@ -290,10 +290,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20u vandaag",
+        "Text": "vandaag om 20u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 11
+        "Start": 6,
+        "Length": 14
       }
     ],
     "NotSupported": "dotNet"
@@ -342,10 +342,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "morgenochtend 7uur",
+        "Text": "7 uur morgenochtend",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 18
+        "Start": 15,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet"
@@ -368,23 +368,23 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "twintig minuten over vijf morgenochtend",
+        "Text": "20 minuten over vijf morgenochtend",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 39
+        "Start": 12,
+        "Length": 34
       }
     ],
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga terug op 14 oktober om 8:00, 14 oktober",
+    "Input": "Ik ga terug op 14 oktober om 8:00",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "14 oktober 8:00",
+        "Text": "14 oktober om 8:00",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 15
+        "Start": 15,
+        "Length": 18
       }
     ],
     "NotSupported": "dotNet"
@@ -433,9 +433,9 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20u vanavond, 1 Jan",
+        "Text": "20u vanavond, 1 jan",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 15,
         "Length": 19
       }
     ],
@@ -481,13 +481,13 @@
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga terug vanaond rond 7",
+    "Input": "Ik ga terug vanavond rond 7",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond rond 7",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 12,
         "Length": 15
       }
     ],
@@ -611,13 +611,13 @@
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga morgen einde dag terug",
+    "Input": "Ik ga morgen einde van de dag terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen einde van de dag",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 6,
         "Length": 23
       }
     ],
@@ -641,10 +641,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5e om 4u ‘s morgens",
+        "Text": "5e terug om 4u ‘s morgens",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 19
+        "Start": 12,
+        "Length": 25
       }
     ],
     "NotSupported": "dotNet"
@@ -676,13 +676,13 @@
     "NotSupported": "dotNet"
   },
   {
-    "Input": "belkijk of ik beschikbaar ben om 15u op zondag",
+    "Input": "bekijk of ik beschikbaar ben om 15u op zondag",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15h op zondag",
+        "Text": "15u op zondag",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 32,
         "Length": 13
       }
     ],
@@ -758,10 +758,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "deze middag om 13u",
+        "Text": "deze vrijdag om 13u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 18
+        "Start": 0,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet"
@@ -797,10 +797,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 augustus 11u",
+        "Text": "1 augustus om 11u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 14
+        "Start": 9,
+        "Length": 17
       }
     ],
     "NotSupported": "dotNet"
@@ -819,13 +819,13 @@
     "NotSupported": "dotNet"
   },
   {
-    "Input": "Ik ga 1 augutus 23u terug",
+    "Input": "Ik ga 1 augustus 23u terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 augustus 23u",
         "Type": "datetime",
-        "Start": -1,
+        "Start": 6,
         "Length": 14
       }
     ],
@@ -836,10 +836,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "25/02 om 11u",
+        "Text": "25/2 om 11u",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 12
+        "Start": 6,
+        "Length": 11
       }
     ],
     "NotSupported": "dotNet"
@@ -876,10 +876,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 dag 2 uur later",
+        "Text": "1 dag en 2 uur later",
         "Type": "datetime",
-        "Start": -1,
-        "Length": 17
+        "Start": 11,
+        "Length": 20
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -6,7 +6,7 @@
     },
     "Results": [
       {
-        "Text": "vijf tot zeven vandaag",
+        "Text": "vandaag weg tussen vijf en zeven",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T05,2016-11-07T07,PT2H)",
@@ -19,15 +19,15 @@
             "endDateTime": "2016-11-07 07:00:00"
           }
         },
-        "Start": -1,
-        "Length": 22
+        "Start": 7,
+        "Length": 32
       }
     ],
     "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "ik ben weg tussen 5 en 6 op 22/4/2016",
+    "Input": "ik ben weg van 5 tot 6 op 22/4/2016",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
@@ -46,7 +46,7 @@
             "endDateTime": "2016-04-22 06:00:00"
           }
         },
-        "Start": -1,
+        "Start": 11,
         "Length": 24
       }
     ],
@@ -81,7 +81,7 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg van 5 to 6 ‘s middags op 22 april",
+    "Input": "Ik ben weg van 5 tot 6 ‘s middags op 22 april",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
@@ -100,7 +100,7 @@
             "endDateTime": "2016-04-22 18:00:00"
           }
         },
-        "Start": -1,
+        "Start": 11,
         "Length": 34
       }
     ],
@@ -114,7 +114,7 @@
     },
     "Results": [
       {
-        "Text": "op 1 januari van 5 tot 6",
+        "Text": "op 1 januari weg van 5 tot 6",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
@@ -127,8 +127,8 @@
             "endDateTime": "2016-01-01 06:00:00"
           }
         },
-        "Start": -1,
-        "Length": 24
+        "Start": 7,
+        "Length": 28
       }
     ],
     "NotSupported": "dotNet",
@@ -141,7 +141,7 @@
     },
     "Results": [
       {
-        "Text": "morgen tussen 3 en 4 uur ‘s middags",
+        "Text": "tussen 3 en 4 uur ’s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
@@ -154,8 +154,8 @@
             "endDateTime": "2016-11-08 16:00:00"
           }
         },
-        "Start": -1,
-        "Length": 35
+        "Start": 18,
+        "Length": 28
       }
     ],
     "NotSupported": "dotNet",
@@ -168,7 +168,7 @@
     },
     "Results": [
       {
-        "Text": "Morgen van 3 tot 4 uur",
+        "Text": "tussen 3 en 4 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T03:00,2016-11-08T04:00,PT1H)",
@@ -181,8 +181,8 @@
             "endDateTime": "2016-11-08 04:00:00"
           }
         },
-        "Start": -1,
-        "Length": 22
+        "Start": 18,
+        "Length": 28
       }
     ],
     "NotSupported": "dotNet",
@@ -196,7 +196,7 @@
     "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "morgen van half acht tot 4 uur ‘s middags",
+        "Text": "van half acht tot 4 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
@@ -209,8 +209,8 @@
             "endDateTime": "2016-11-08 16:00:00"
           }
         },
-        "Start": -1,
-        "Length": 41
+        "Start": 18,
+        "Length": 34
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -222,7 +222,7 @@
     },
     "Results": [
       {
-        "Text": "Vandaag van 4 tot morgen 5 uur",
+        "Text": "vanaf 4 uur vandaag tot morgen 5 uur ’s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16,2016-11-08T17,PT25H)",
@@ -235,8 +235,8 @@
             "endDateTime": "2016-11-08 17:00:00"
           }
         },
-        "Start": -1,
-        "Length": 30
+        "Start": 11,
+        "Length": 47
       }
     ],
     "NotSupported": "dotNet",
@@ -249,7 +249,7 @@
     },
     "Results": [
       {
-        "Text": "van 2016-2-21 14:00 tot 2016-04-23 15:32",
+        "Text": "van 2016-2-21 vanaf 14:00 tot 2016-04-23 15:32",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
@@ -262,8 +262,8 @@
             "endDateTime": "2016-04-23 03:32:00"
           }
         },
-        "Start": -1,
-        "Length": 40
+        "Start": 11,
+        "Length": 46
       }
     ],
     "NotSupported": "dotNet",
@@ -276,7 +276,7 @@
     },
     "Results": [
       {
-        "Text": "Vanmiddag tussen 4 en 5",
+        "Text": "tussen 4 en 5 uur in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16,2016-11-07T17,PT1H)",
@@ -289,8 +289,8 @@
             "endDateTime": "2016-11-07 17:00:00"
           }
         },
-        "Start": -1,
-        "Length": 23
+        "Start": 15,
+        "Length": 30
       }
     ],
     "NotSupported": "dotNet",
@@ -303,7 +303,7 @@
     },
     "Results": [
       {
-        "Text": "Tussen 4 uur van 1 jan 2016 en 5 uur vandaag",
+        "Text": "tussen 1 januari 2016 vanaf 4 uur tot vandaag 5 uur in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-01-01T16,2016-11-07T17,PT7465H)",
@@ -316,8 +316,8 @@
             "endDateTime": "2016-11-07 17:00:00"
           }
         },
-        "Start": -1,
-        "Length": 44
+        "Start": 24,
+        "Length": 64
       }
     ],
     "NotSupported": "dotNet",
@@ -411,7 +411,7 @@
     },
     "Results": [
       {
-        "Text": "deze avond",
+        "Text": "vanavond",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2016-11-07TEV",
@@ -424,8 +424,8 @@
             "endDateTime": "2016-11-07 20:00:00"
           }
         },
-        "Start": -1,
-        "Length": 10
+        "Start": 6,
+        "Length": 8
       }
     ],
     "NotSupported": "dotNet",
@@ -621,13 +621,13 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ga drie minute terug ",
+    "Input": "Ik ga drie minuten terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
     "Results": [
       {
-        "Text": "laatste 3 minuten",
+        "Text": "drie minuten terug",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)",
@@ -640,8 +640,8 @@
             "endDateTime": "2016-11-07 16:12:00"
           }
         },
-        "Start": -1,
-        "Length": 17
+        "Start": 6,
+        "Length": 18
       }
     ],
     "NotSupported": "dotNet",
@@ -681,7 +681,7 @@
     },
     "Results": [
       {
-        "Text": "vorige 3 minuten",
+        "Text": "3 minuten terug",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)",
@@ -694,8 +694,8 @@
             "endDateTime": "2016-11-07 16:12:00"
           }
         },
-        "Start": -1,
-        "Length": 16
+        "Start": 6,
+        "Length": 15
       }
     ],
     "NotSupported": "dotNet",
@@ -708,7 +708,7 @@
     },
     "Results": [
       {
-        "Text": "vorige 3 minuten",
+        "Text": "drie minuten terug",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:09:00,2016-11-07T16:12:00,PT3M)",
@@ -721,8 +721,8 @@
             "endDateTime": "2016-11-07 16:12:00"
           }
         },
-        "Start": -1,
-        "Length": 16
+        "Start": 6,
+        "Length": 18
       }
     ],
     "NotSupported": "dotNet",
@@ -1188,7 +1188,7 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Laten we dinsdagvond laat afspreken",
+    "Input": "Laten we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
@@ -1207,7 +1207,7 @@
             "endDateTime": "2016-11-01 23:59:59"
           }
         },
-        "Start": -1,
+        "Start": 9,
         "Length": 17
       }
     ],
@@ -1437,7 +1437,7 @@
     },
     "Results": [
       {
-        "Text": "dinsdagavond",
+        "Text": "dinsdag in de avond",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
@@ -1450,8 +1450,8 @@
             "endDateTime": "2016-11-01 22:00:00"
           }
         },
-        "Start": -1,
-        "Length": 12
+        "Start": 10,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet",
@@ -1788,7 +1788,7 @@
     },
     "Results": [
       {
-        "Text": "9 december tussen 8 en 2",
+        "Text": "9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-12-09T08,XXXX-12-09T14,PT6H)",
@@ -1801,8 +1801,8 @@
             "endDateTime": "2016-12-09 14:00:00"
           }
         },
-        "Start": -1,
-        "Length": 24
+        "Start": 14,
+        "Length": 55
       }
     ],
     "NotSupported": "dotNet",
@@ -2349,7 +2349,7 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "ik ben maandag tussen 8 en  terug",
+    "Input": "ik ben maandag tussen 8 en 9 terug",
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
@@ -2369,7 +2369,7 @@
             "endDateTime": "2018-04-16 09:00:00"
           }
         },
-        "Start": -1,
+        "Start": 7,
         "Length": 21
       }
     ],

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -281,7 +281,7 @@
     },
     "Results": [
       {
-        "Text": "two weken",
+        "Text": "twee weken",
         "Type": "duration",
         "Value": {
           "Timex": "P2W",
@@ -292,8 +292,8 @@
             "duration": "1209600"
           }
         },
-        "Start": -1,
-        "Length": 9
+        "Start": 7,
+        "Length": 10
       }
     ],
     "NotSupported": "dotNet",

--- a/Specs/DateTime/Dutch/SetExtractor.json
+++ b/Specs/DateTime/Dutch/SetExtractor.json
@@ -107,10 +107,10 @@
     "Input": "Ik zal elke dag om 15:00 vertrekken",
     "Results": [
       {
-        "Text": "15:00 elke dag",
+        "Text": "elke dag om 15:00",
         "Type": "set",
-        "Start": -1,
-        "Length": 14
+        "Start": 7,
+        "Length": 17
       }
     ],
     "NotSupported": "dotNet",
@@ -120,20 +120,20 @@
     "Input": "Ik zal iedere dag om 15:00 vertrekken",
     "Results": [
       {
-        "Text": "15:00 iedere dag",
+        "Text": "iedere dag om 15:00",
         "Type": "set",
-        "Start": -1,
-        "Length": 16
+        "Start": 7,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik zal elke 4/15 vertrekken",
+    "Input": "Ik zal elke 15/4 vertrekken",
     "Results": [
       {
-        "Text": "elke 4/15",
+        "Text": "elke 15/4",
         "Type": "set",
         "Start": 7,
         "Length": 9
@@ -221,13 +221,13 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik zal elke avond vertrekken om 9",
+    "Input": "Ik zal elke avond om 9 uur vertrekken",
     "Results": [
       {
-        "Text": "elke avond om 9",
+        "Text": "elke avond om 9 uur",
         "Type": "set",
-        "Start": -1,
-        "Length": 15
+        "Start": 7,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet",
@@ -263,10 +263,10 @@
     "Input": "Ik vertrek elke zondag ochtend om 9 uur",
     "Results": [
       {
-        "Text": "9am every Sunday",
+        "Text": "elke zondag ochtend om 9 uur",
         "Type": "set",
-        "Start": -1,
-        "Length": 16
+        "Start": 11,
+        "Length": 28
       }
     ],
     "NotSupported": "dotNet",

--- a/Specs/DateTime/Dutch/TimeExtractor.json
+++ b/Specs/DateTime/Dutch/TimeExtractor.json
@@ -211,10 +211,10 @@
     "Input": "Het is kwart over acht",
     "Results": [
       {
-        "Text": "kwart over 8",
+        "Text": "kwart over acht",
         "Type": "time",
-        "Start": -1,
-        "Length": 12
+        "Start": 7,
+        "Length": 15
       }
     ],
     "NotSupported": "dotNet",
@@ -627,9 +627,9 @@
     "Input": "Ik ben om 7 uur p.m. terug",
     "Results": [
       {
-        "Text": "7 uur p. m",
+        "Text": "7 uur p.m.",
         "Type": "time",
-        "Start": -1,
+        "Start": 10,
         "Length": 10
       }
     ],
@@ -754,10 +754,10 @@
     "Input": "Ik ben met lunchtijd 12 uur terug",
     "Results": [
       {
-        "Text": "at lunchtijd 12 uur",
+        "Text": "met lunchtijd 12 uur",
         "Type": "time",
-        "Start": -1,
-        "Length": 19
+        "Start": 7,
+        "Length": 20
       }
     ],
     "NotSupported": "dotNet",

--- a/Specs/DateTime/Dutch/TimeParser.json
+++ b/Specs/DateTime/Dutch/TimeParser.json
@@ -1235,7 +1235,7 @@
     "Input": "Ik ben om 12 uur in de nacht terug",
     "Results": [
       {
-        "Text": "12 uur in the nacht",
+        "Text": "12 uur in de nacht",
         "Type": "time",
         "Value": {
           "Timex": "T00",
@@ -1246,8 +1246,8 @@
             "time": "00:00:00"
           }
         },
-        "Start": -1,
-        "Length": 19
+        "Start": 10,
+        "Length": 18
       }
     ],
     "NotSupported": "dotNet",
@@ -1455,7 +1455,7 @@
     "Input": "Ik ga om half zes ’s avonds terug",
     "Results": [
       {
-        "Text": "half zes ‘s avonds",
+        "Text": "half zes ’s avonds",
         "Type": "time",
         "Value": {
           "Timex": "T17:30",
@@ -1466,7 +1466,7 @@
             "time": "17:30:00"
           }
         },
-        "Start": -1,
+        "Start": 9,
         "Length": 18
       }
     ],

--- a/Specs/DateTime/Dutch/TimePeriodExtractor.json
+++ b/Specs/DateTime/Dutch/TimePeriodExtractor.json
@@ -13,12 +13,12 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg 17:00 tot 18:00",
+    "Input": "Ik ben weg van 17:00 tot 18:00",
     "Results": [
       {
         "Text": "van 17:00 tot 18:00",
         "Type": "timerange",
-        "Start": -1,
+        "Start": 11,
         "Length": 19
       }
     ],
@@ -26,12 +26,12 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg 17:00 tot 18:00 uur",
+    "Input": "Ik ben weg van 17:00 tot 18:00 uur",
     "Results": [
       {
         "Text": "van 17:00 tot 18:00 uur",
         "Type": "timerange",
-        "Start": -1,
+        "Start": 11,
         "Length": 23
       }
     ],
@@ -39,12 +39,12 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg 5 tot 6 ʼs middags",
+    "Input": "Ik ben weg van 5 tot 6 ʼs middags",
     "Results": [
       {
         "Text": "van 5 tot 6 ʼs middags",
         "Type": "timerange",
-        "Start": -1,
+        "Start": 11,
         "Length": 22
       }
     ],
@@ -52,12 +52,12 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg 5 tot zeven in de ochtend",
+    "Input": "Ik ben weg van 5 tot zeven in de ochtend",
     "Results": [
       {
         "Text": "van 5 tot zeven in de ochtend",
         "Type": "timerange",
-        "Start": -1,
+        "Start": 11,
         "Length": 29
       }
     ],
@@ -208,12 +208,12 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg 4pm – 5pm",
+    "Input": "Ik ben weg van 4pm - 5pm",
     "Results": [
       {
         "Text": "4pm - 5pm",
         "Type": "timerange",
-        "Start": -1,
+        "Start": 15,
         "Length": 9
       }
     ],
@@ -286,13 +286,13 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg van 4pm tot 5 pm",
+    "Input": "Ik ben weg van 4 pm tot 5 pm",
     "Results": [
       {
-        "Text": "van 4pm tot 5pm",
+        "Text": "van 4 pm tot 5 pm",
         "Type": "timerange",
-        "Start": -1,
-        "Length": 15
+        "Start": 11,
+        "Length": 17
       }
     ],
     "NotSupported": "dotNet",
@@ -312,13 +312,13 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg van 16:00 tot 5 pm",
+    "Input": "Ik ben weg van 16:00 tot 17:00",
     "Results": [
       {
-        "Text": "van 16:00 tot 5pm",
+        "Text": "van 16:00 tot 17:00",
         "Type": "timerange",
-        "Start": -1,
-        "Length": 17
+        "Start": 11,
+        "Length": 19
       }
     ],
     "NotSupported": "dotNet",
@@ -811,10 +811,10 @@
     "Input": "maak afspraak van 1 tot 3:30",
     "Results": [
       {
-        "Text": "van 1 tot t3:30",
+        "Text": "van 1 tot 3:30",
         "Type": "timerange",
-        "Start": -1,
-        "Length": 15
+        "Start": 14,
+        "Length": 14
       }
     ],
     "NotSupported": "dotNet",


### PR DESCRIPTION
I added the `Start` + `Length` properties with a script I wrote myself, however it didn't take into account that some tests had a deviant `Input` and `Text` property. Fixed.