### PR TITLE
[StyleCop] Fix all StyleCop warnings in GermanTimeExtractorConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
@@ -9,11 +9,13 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     {
         // part 1: smallest component
         // --------------------------------------
-        public static readonly Regex DescRegex = new Regex(DateTimeDefinitions.DescRegex,
+        public static readonly Regex DescRegex = new Regex(
+            DateTimeDefinitions.DescRegex,
             RegexOptions.Singleline);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex,
+            new Regex(
+                DateTimeDefinitions.HourNumRegex,
                 RegexOptions.Singleline);
 
         public static readonly Regex MinuteNumRegex =
@@ -24,16 +26,19 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
-        public static readonly Regex OclockRegex = new Regex(DateTimeDefinitions.OclockRegex,
+        public static readonly Regex OclockRegex = new Regex(
+            DateTimeDefinitions.OclockRegex,
             RegexOptions.Singleline);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex,
+            new Regex(
+                DateTimeDefinitions.PmRegex,
                 RegexOptions.Singleline);
 
         // handle "... in the morning"
-        public static readonly Regex AmRegex = new Regex(DateTimeDefinitions.AmRegex,
+        public static readonly Regex AmRegex = new Regex(
+            DateTimeDefinitions.AmRegex,
             RegexOptions.Singleline);
 
         // handle "half past ..." "a quarter to ..."
@@ -42,14 +47,15 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             new Regex(
                 DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
 
-        // handle "six thirty", "six twenty one" 
+        // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
             new Regex(
                 DateTimeDefinitions.WrittenTimeRegex,
                 RegexOptions.Singleline);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix,
+            new Regex(
+                DateTimeDefinitions.TimePrefix,
                 RegexOptions.Singleline);
 
         public static readonly Regex TimeSuffix =
@@ -84,13 +90,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex,
+            new Regex(
+                DateTimeDefinitions.AtRegex,
                 RegexOptions.Singleline);
 
-        public static readonly Regex IshRegex = new Regex(DateTimeDefinitions.IshRegex,
+        public static readonly Regex IshRegex = new Regex(
+            DateTimeDefinitions.IshRegex,
             RegexOptions.Singleline);
 
-        public static readonly Regex TimeUnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex,
+        public static readonly Regex TimeUnitRegex = new Regex(
+            DateTimeDefinitions.TimeUnitRegex,
             RegexOptions.Singleline);
 
         public static readonly Regex ConnectNumRegex =
@@ -114,39 +123,54 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 DateTimeDefinitions.TimeRegex2, RegexOptions.Singleline),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3,
+            new Regex(
+                DateTimeDefinitions.TimeRegex3,
                 RegexOptions.Singleline),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4,
+            new Regex(
+                DateTimeDefinitions.TimeRegex4,
                 RegexOptions.Singleline),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5,
+            new Regex(
+                DateTimeDefinitions.TimeRegex5,
                 RegexOptions.Singleline),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6,
+            new Regex(
+                DateTimeDefinitions.TimeRegex6,
                 RegexOptions.Singleline),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7,
+            new Regex(
+                DateTimeDefinitions.TimeRegex7,
                 RegexOptions.Singleline),
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8,
+            new Regex(
+                DateTimeDefinitions.TimeRegex8,
                 RegexOptions.Singleline),
 
-            new Regex(DateTimeDefinitions.TimeRegex9,
+            new Regex(
+                DateTimeDefinitions.TimeRegex9,
                 RegexOptions.Singleline),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10,
+            new Regex(
+                DateTimeDefinitions.TimeRegex10,
                 RegexOptions.Singleline),
 
             // 340pm
-            ConnectNumRegex
+            ConnectNumRegex,
         };
+
+        public GermanTimeExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new GermanTimeZoneExtractorConfiguration(this));
+        }
 
         IEnumerable<Regex> ITimeExtractorConfiguration.TimeRegexList => TimeRegexList;
 
@@ -159,11 +183,5 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimeZoneExtractor { get; }
-
-        public GermanTimeExtractorConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
-            TimeZoneExtractor = new BaseTimeZoneExtractor(new GermanTimeZoneExtractorConfiguration(this));
-        }
     }
 }


### PR DESCRIPTION
- reordered constructor
- parameters in new line