### PR TITLE
[StyleCop] Fix all StyleCop warnings in PortugueseDateTimeExtractorConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex NowRegex = new Regex(DateTimeDefinitions.NowRegex, RegexOptions.Singleline);
         public static readonly Regex SuffixRegex = new Regex(DateTimeDefinitions.SuffixRegex, RegexOptions.Singleline);
 
-        //TODO: modify it according to the corresponding English regex
+        // TODO: modify it according to the corresponding English regex
         public static readonly Regex TimeOfDayRegex = new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexOptions.Singleline);
         public static readonly Regex SpecificTimeOfDayRegex = new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexOptions.Singleline);
         public static readonly Regex TimeOfTodayAfterRegex = new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexOptions.Singleline);
@@ -24,13 +24,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex SpecificEndOfRegex = new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexOptions.Singleline);
         public static readonly Regex UnspecificEndOfRegex = new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexOptions.Singleline);
 
-        //TODO: add this for Portuguese
+        // TODO: add this for Portuguese
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexOptions.Singleline);
         public static readonly Regex ConnectorRegex = new Regex(DateTimeDefinitions.ConnectorRegex, RegexOptions.Singleline);
         public static readonly Regex NumberAsTimeRegex = new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexOptions.Singleline);
         public static readonly Regex DateNumberConnectorRegex = new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexOptions.Singleline);
 
-        public PortugueseDateTimeExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public PortugueseDateTimeExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();
             DatePointExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
@@ -76,9 +77,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return (string.IsNullOrEmpty(text)
+            return string.IsNullOrEmpty(text)
                     || PrepositionRegex.IsMatch(text)
-                    || ConnectorRegex.IsMatch(text));
+                    || ConnectorRegex.IsMatch(text);
         }
     }
 }


### PR DESCRIPTION
- fixed comments
- removes extra parenthesis
- ctor formatted