### PR TITLE
[StyleCop] Fix all StyleCop warnings in DurationExtractorChs

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DurationExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DurationExtractorChs.cs
@@ -5,34 +5,42 @@ using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Chinese;
 using Microsoft.Recognizers.Text.Number;
-using Microsoft.Recognizers.Text.NumberWithUnit.Chinese;
 using Microsoft.Recognizers.Text.NumberWithUnit;
+using Microsoft.Recognizers.Text.NumberWithUnit.Chinese;
 
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
+    public enum DurationType
+    {
+        /// <summary>
+        /// Types of DurationType.
+        /// </summary>
+        WithNumber,
+    }
+
     public class DurationExtractorChs : BaseDateTimeExtractor<DurationType>
     {
-        internal override ImmutableDictionary<Regex, DurationType> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_DATETIME_DURATION; // "Duration";
-
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 
         private static readonly Regex YearRegex = new Regex(DateTimeDefinitions.DurationYearRegex, RegexOptions.Singleline);
 
         private static readonly Regex HalfSuffixRegex = new Regex(DateTimeDefinitions.DurationHalfSuffixRegex, RegexOptions.Singleline);
 
+        internal override ImmutableDictionary<Regex, DurationType> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_DATETIME_DURATION; // "Duration";
+
         // extract by number with unit
         public override List<ExtractResult> Extract(string source, DateObject referenceTime)
         {
-            //Use Unit to extract 
+            // Use Unit to extract
             var retList = InternalExtractor.Extract(source);
             var res = new List<ExtractResult>();
             foreach (var ret in retList)
             {
-                //filter
+                // filter
                 var match = YearRegex.Match(ret.Text);
                 if (match.Success)
                 {
@@ -52,12 +60,18 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 res.Add(ret);
             }
+
             return res;
         }
 
         internal class DurationExtractorConfiguration : ChineseNumberWithUnitExtractorConfiguration
         {
-            public DurationExtractorConfiguration() : base(new CultureInfo("zh-CN")) { }
+            public static readonly ImmutableDictionary<string, string> DurationSuffixList = DateTimeDefinitions.DurationSuffixList.ToImmutableDictionary();
+
+            public DurationExtractorConfiguration()
+                : base(new CultureInfo("zh-CN"))
+            {
+            }
 
             public override ImmutableDictionary<string, string> SuffixList => DurationSuffixList;
 
@@ -65,14 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             public override string ExtractType => Constants.SYS_DATETIME_DURATION;
 
-            public static readonly ImmutableDictionary<string, string> DurationSuffixList = DateTimeDefinitions.DurationSuffixList.ToImmutableDictionary();
-
             public override ImmutableList<string> AmbiguousUnitList => DateTimeDefinitions.DurationAmbiguousUnits.ToImmutableList();
         }
-    }
-
-    public enum DurationType
-    {
-        WithNumber
     }
 }


### PR DESCRIPTION
- reodered using
- reordered enum
- reordered properties
- fixed comments
- fixed spacing