### PR TITLE
[StyleCop] Fix StyleCop warnings in IHolidayParserConfiguration, ICommonDateTimeParserConfiguration & IMergedDateTimeParserConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         IImmutableDictionary<string, Func<int, DateObject>> HolidayFuncDictionary { get; }
 
         IImmutableDictionary<string, IEnumerable<string>> HolidayNames { get; }
-        
+
         IEnumerable<Regex> HolidayRegexList { get; }
 
         int GetSwiftYear(string text);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IMergedParserConfiguration.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public interface IMergedParserConfiguration : ICommonDateTimeParserConfiguration
     {
-
         Regex BeforeRegex { get; }
 
         Regex AfterRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
@@ -22,6 +22,5 @@ namespace Microsoft.Recognizers.Text.DateTime
         void AdjustByPrefix(string prefix, ref int hour, ref int min, ref bool hasMin);
 
         void AdjustBySuffix(string suffix, ref int hour, ref int min, ref bool hasMin, ref bool hasAm, ref bool hasPm);
-
     }
 }


### PR DESCRIPTION
- fixed spacing
- removed using