### PR TITLE
[Java][Datetime] Port SpanishDateTimeAltExtractorConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimeAltExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateTimeAltExtractorConfiguration.java
@@ -1,0 +1,85 @@
+package com.microsoft.recognizers.text.datetime.spanish.extractors;
+
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimeAltExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class SpanishDateTimeAltExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimeAltExtractorConfiguration {
+
+    private static final Pattern OrRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.OrRegex);
+    private static final Pattern DayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.DayRegex);
+
+    public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
+    public static final Pattern PastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.AmRegex);
+    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PmRegex);
+    public static final Pattern RangePrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RangePrefixRegex);
+
+    public static final Iterable<Pattern> RelativePrefixList = new ArrayList<Pattern>() {
+        {
+            add(ThisPrefixRegex);
+            add(PastPrefixRegex);
+            add(NextPrefixRegex);
+        }
+    };
+
+    public static final Iterable<Pattern> AmPmRegexList = new ArrayList<Pattern>() {
+        {
+            add(AmRegex);
+            add(PmRegex);
+        }
+    };
+
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+
+    public SpanishDateTimeAltExtractorConfiguration(IOptionsConfiguration config) {
+        super(config.getOptions());
+        dateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
+        datePeriodExtractor = new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(this));
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public Iterable<Pattern> getRelativePrefixList() {
+        return RelativePrefixList;
+    }
+
+    @Override
+    public Iterable<Pattern> getAmPmRegexList() {
+        return AmPmRegexList;
+    }
+
+    @Override
+    public Pattern getOrRegex() {
+        return OrRegex;
+    }
+
+    @Override
+    public Pattern getDayRegex() {
+        return DayRegex;
+    }
+
+    @Override public Pattern getRangePrefixRegex() {
+        return RangePrefixRegex;
+    }
+}


### PR DESCRIPTION
* Port SpanishDateTimeAltExtractorConfiguration from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs) to Java