### PR TITLE
Fix all StyleCop warnings in SetExtractor

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/SetExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/SetExtractor.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     ret.Add(new Token(match.Index, match.Index + match.Length + (er.Length ?? 0)));
                 }
             }
+
             return ret;
         }
 
@@ -106,6 +107,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     ret.Add(new Token(match.Index, match.Index + match.Length + (er.Length ?? 0)));
                 }
             }
+
             return ret;
         }
 
@@ -122,6 +124,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     ret.Add(new Token(match.Index, match.Index + match.Length + (er.Length ?? 0)));
                 }
             }
+
             return ret;
         }
     }


### PR DESCRIPTION
if you add the `&w=1` (ignore whitespace and line endings) parameter to the query string of this PR you'll the _"real"_ changes and only 3 new lines.

Are all those changes to new lines really necessary? Do StyleCop warns about the line endings?

Do not change line endings (which I know they are messed in this file) unless required.