### PR TITLE
[StyleCop] Fix all StyleCop warnings in GermanTimePeriodExtractorConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -1,19 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-
+using Microsoft.Recognizers.Definitions.German;
 using Microsoft.Recognizers.Text.DateTime.German.Utilities;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
-using Microsoft.Recognizers.Definitions.German;
 using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
-        public string TokenBeforeDate { get; }
-
-        public static readonly Regex TillRegex = 
+        public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
         public static readonly Regex HourRegex =
@@ -22,13 +19,13 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex PeriodHourNumRegex =
             new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexOptions.Singleline);
 
-        public static readonly Regex PeriodDescRegex = 
+        public static readonly Regex PeriodDescRegex =
             new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
 
         public static readonly Regex PmRegex =
             new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AmRegex = 
+        public static readonly Regex AmRegex =
             new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
 
         public static readonly Regex PureNumFromTo =
@@ -41,7 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public static readonly Regex SpecificTimeBetweenAnd = new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexOptions.Singleline);
 
-        public static readonly Regex PrepositionRegex = 
+        public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexOptions.Singleline);
 
         public static readonly Regex TimeOfDayRegex =
@@ -53,7 +50,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex TimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TimeFollowedUnit = 
+        public static readonly Regex TimeFollowedUnit =
             new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
@@ -62,7 +59,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);
 
-        public GermanTimePeriodExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public GermanTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             SingleTimeExtractor = new BaseTimeExtractor(new GermanTimeExtractorConfiguration(this));
@@ -70,6 +68,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             IntegerExtractor = Number.German.IntegerExtractor.GetInstance();
             TimeZoneExtractor = new BaseTimeZoneExtractor(new GermanTimeZoneExtractorConfiguration(this));
         }
+
+        public string TokenBeforeDate { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 index = text.LastIndexOf("von", StringComparison.Ordinal);
                 return true;
             }
-            
+
             return false;
         }
 


### PR DESCRIPTION
- reordered usings and props
- fixed spacing