### PR TITLE
[Java][Datetime] Port SpanishDateParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/extractors/SpanishDateExtractorConfiguration.java
@@ -3,6 +3,7 @@ package com.microsoft.recognizers.text.datetime.spanish.extractors;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -17,9 +18,13 @@ import com.microsoft.recognizers.text.number.spanish.extractors.IntegerExtractor
 import com.microsoft.recognizers.text.number.spanish.extractors.OrdinalExtractor;
 import com.microsoft.recognizers.text.number.spanish.parsers.SpanishNumberParserConfiguration;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.sun.nio.sctp.PeerAddressChangeNotification;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.regex.Pattern;
 
 
@@ -71,6 +76,8 @@ public class SpanishDateExtractorConfiguration extends BaseOptionsConfiguration 
     public static final ImmutableMap<String, Integer> DayOfWeek = SpanishDateTime.DayOfWeek;
     public static final ImmutableMap<String, Integer> MonthOfYear = SpanishDateTime.MonthOfYear;
 
+    public static List<Pattern> DateRegexList;
+
     public SpanishDateExtractorConfiguration(IOptionsConfiguration config) {
         super(config.getOptions());
         integerExtractor = new IntegerExtractor(); // in other languages (english) has a method named get instance
@@ -79,22 +86,34 @@ public class SpanishDateExtractorConfiguration extends BaseOptionsConfiguration 
         durationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
         utilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 
-    }
+        DateRegexList = new ArrayList<Pattern>() {
+            {
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor1));
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor2));
+                add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor3));
+            }
+        };
 
-    public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
-        {
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor1));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor2));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor3));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
-            add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
+        boolean enableDmy = getDmyDateFormat() || SpanishDateTime.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY;
+
+        if (enableDmy) {
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
+        } else {
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor4));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor6));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor7));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor5));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor8));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor9));
+            DateRegexList.add(RegExpUtility.getSafeRegExp(SpanishDateTime.DateExtractor10));
         }
-    };
+    }
 
     private final IExtractor integerExtractor;
     private final IExtractor ordinalExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -72,10 +72,10 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeExtractor timePeriodExtractor;
     private final IDateTimeExtractor dateTimePeriodExtractor;
 
-    //private final IDateTimeParser dateParser;
+    private final IDateTimeParser dateParser;
     private final IDateTimeParser timeParser;
     //private final IDateTimeParser dateTimeParser;
-    //private final IDateTimeParser durationParser;
+    private final IDateTimeParser durationParser;
     //private final IDateTimeParser datePeriodParser;
     //private final IDateTimeParser timePeriodParser;
     //private final IDateTimeParser dateTimePeriodParser;
@@ -112,10 +112,10 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         timePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(options));
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration(options));
 
-        //dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
+        dateParser = new BaseDateParser(new SpanishDateParserConfiguration(this));
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
-        //durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
+        durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
         //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         //timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
         //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
@@ -179,8 +179,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDateParser() {
-        //return dateParser;
-        return null;
+        return dateParser;
     }
 
     @Override
@@ -196,8 +195,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDurationParser() {
-        //return durationParser;
-        return null;
+        return durationParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
@@ -1,0 +1,331 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SpanishDateParserConfiguration  extends BaseOptionsConfiguration implements IDateParserConfiguration {
+
+    private final String dateTokenPrefix;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IExtractor cardinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeParser durationParser;
+    private final ImmutableMap<String, String> unitMap;
+    private final Iterable<Pattern> dateRegexes;
+    private final Pattern onRegex;
+    private final Pattern specialDayRegex;
+    private final Pattern specialDayWithNumRegex;
+    private final Pattern nextRegex;
+    private final Pattern thisRegex;
+    private final Pattern lastRegex;
+    private final Pattern unitRegex;
+    private final Pattern weekDayRegex;
+    private final Pattern monthRegex;
+    private final Pattern weekDayOfMonthRegex;
+    private final Pattern forTheRegex;
+    private final Pattern weekDayAndDayOfMonthRegex;
+    private final Pattern relativeMonthRegex;
+    private final Pattern yearSuffix;
+    private final Pattern relativeWeekDayRegex;
+    private final Pattern relativeDayRegex;
+    private final Pattern nextPrefixRegex;
+    private final Pattern pastPrefixRegex;
+
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final List<String> sameDayTerms;
+    private final List<String> plusOneDayTerms;
+    private final List<String> plusTwoDayTerms;
+    private final List<String> minusOneDayTerms;
+    private final List<String> minusTwoDayTerms;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public SpanishDateParserConfiguration(ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        dateTokenPrefix = SpanishDateTime.DateTokenPrefix;
+        integerExtractor = config.getIntegerExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateRegexes = Collections.unmodifiableList(SpanishDateExtractorConfiguration.DateRegexList);
+        onRegex = SpanishDateExtractorConfiguration.OnRegex;
+        specialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
+        specialDayWithNumRegex = SpanishDateExtractorConfiguration.SpecialDayWithNumRegex;
+        nextRegex = SpanishDateExtractorConfiguration.NextDateRegex;
+        thisRegex = SpanishDateExtractorConfiguration.ThisRegex;
+        lastRegex = SpanishDateExtractorConfiguration.LastDateRegex;
+        unitRegex = SpanishDateExtractorConfiguration.DateUnitRegex;
+        weekDayRegex = SpanishDateExtractorConfiguration.WeekDayRegex;
+        monthRegex = SpanishDateExtractorConfiguration.MonthRegex;
+        weekDayOfMonthRegex = SpanishDateExtractorConfiguration.WeekDayOfMonthRegex;
+        forTheRegex = SpanishDateExtractorConfiguration.ForTheRegex;
+        weekDayAndDayOfMonthRegex = SpanishDateExtractorConfiguration.WeekDayAndDayOfMonthRegex;
+        relativeMonthRegex = SpanishDateExtractorConfiguration.RelativeMonthRegex;
+        yearSuffix = SpanishDateExtractorConfiguration.YearSuffix;
+        relativeWeekDayRegex = SpanishDateExtractorConfiguration.RelativeWeekDayRegex;
+        relativeDayRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeDayRegex);
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+        dayOfMonth = config.getDayOfMonth();
+        dayOfWeek = config.getDayOfWeek();
+        monthOfYear = config.getMonthOfYear();
+        cardinalMap = config.getCardinalMap();
+        unitMap = config.getUnitMap();
+        utilityConfiguration = config.getUtilityConfiguration();
+        sameDayTerms = Collections.unmodifiableList(SpanishDateTime.SameDayTerms);
+        plusOneDayTerms = Collections.unmodifiableList(SpanishDateTime.PlusOneDayTerms);
+        plusTwoDayTerms = Collections.unmodifiableList(SpanishDateTime.PlusTwoDayTerms);
+        minusOneDayTerms = Collections.unmodifiableList(SpanishDateTime.MinusOneDayTerms);
+        minusTwoDayTerms = Collections.unmodifiableList(SpanishDateTime.MinusTwoDayTerms);
+    }
+
+    @Override
+    public String getDateTokenPrefix() {
+        return dateTokenPrefix;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public Iterable<Pattern> getDateRegexes() {
+        return dateRegexes;
+    }
+
+    @Override
+    public Pattern getOnRegex() {
+        return onRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayRegex() {
+        return specialDayRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayWithNumRegex() {
+        return specialDayWithNumRegex;
+    }
+
+    @Override
+    public Pattern getNextRegex() {
+        return nextRegex;
+    }
+
+    @Override
+    public Pattern getThisRegex() {
+        return thisRegex;
+    }
+
+    @Override
+    public Pattern getLastRegex() {
+        return lastRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return weekDayRegex;
+    }
+
+    @Override
+    public Pattern getMonthRegex() {
+        return monthRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayOfMonthRegex() {
+        return weekDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getForTheRegex() {
+        return forTheRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayAndDayOfMonthRegex() {
+        return weekDayAndDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getRelativeMonthRegex() {
+        return relativeMonthRegex;
+    }
+
+    @Override
+    public Pattern getYearSuffix() {
+        return yearSuffix;
+    }
+
+    @Override
+    public Pattern getRelativeWeekDayRegex() {
+        return relativeWeekDayRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDayRegex() {
+        return relativeDayRegex;
+    }
+
+    @Override
+    public Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getPastPrefixRegex() {
+        return pastPrefixRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public List<String> getSameDayTerms() {
+        return sameDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusOneDayTerms() {
+        return plusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusOneDayTerms() {
+        return minusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusTwoDayTerms() {
+        return plusTwoDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusTwoDayTerms() {
+        return minusTwoDayTerms;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public Integer getSwiftMonth(String text) {
+        String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+        int swift = 0;
+
+        Matcher regexMatcher = nextPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = 1;
+        }
+
+        regexMatcher = pastPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public Boolean isCardinalLast(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return trimmedText.equals("last");
+    }
+
+    @Override
+    public String normalize(String text) {
+        return text.replace('á', 'a')
+                .replace('é', 'e')
+                .replace('í', 'i')
+                .replace('ó', 'o')
+                .replace('ú', 'u');
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -36,6 +36,7 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
@@ -213,8 +214,8 @@ public class DateTimeParserTest extends AbstractTest {
     private static IDateTimeParser getSpanishParser(String name) {
 
         switch (name) {
-            //case "DateParser":
-            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateParser":
+                return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DatePeriodParser":
             //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeAltParser":


### PR DESCRIPTION
**Note:** This branch is based on #1237, also includes changes in #1239. We will rebase once they are merged with master. 

---
# Description
- Enable `DateParser` tests
- Port `SpanishDateParserConfiguration` from C# to Java
- Fix `DateRegexList` values assignation

# Passing Tests
![image](https://user-images.githubusercontent.com/39467613/50922540-89d28280-1429-11e9-911b-578a940acb32.png)
