### PR TITLE
[StyleCop] Fix Constructor and Properties order in Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -6,8 +6,60 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimePeriodParserConfiguration : BaseOptionsConfiguration,IDateTimePeriodParserConfiguration
+    public class GermanDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
+        public static readonly Regex MorningStartEndRegex =
+            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex AfternoonStartEndRegex =
+            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex EveningStartEndRegex =
+            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexOptions.Singleline);
+
+        public static readonly Regex NightStartEndRegex =
+            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexOptions.Singleline);
+
+        public GermanDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
+            NumberParser = config.NumberParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
+            DateTimeParser = config.DateTimeParser;
+
+            PureNumberFromToRegex = GermanTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = GermanTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeOfDayRegex = GermanDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            TimeOfDayRegex = GermanDateTimeExtractorConfiguration.TimeOfDayRegex;
+            PastRegex = GermanDatePeriodExtractorConfiguration.PastPrefixRegex;
+            FutureRegex = GermanDatePeriodExtractorConfiguration.NextPrefixRegex;
+            FutureSuffixRegex = GermanDatePeriodExtractorConfiguration.FutureSuffixRegex;
+            NumberCombinedWithUnitRegex = GermanDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
+            UnitRegex = GermanTimePeriodExtractorConfiguration.TimeUnitRegex;
+            PeriodTimeOfDayWithDateRegex = GermanDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = GermanDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+            RestOfDateTimeRegex = GermanDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+            AmDescRegex = GermanDateTimePeriodExtractorConfiguration.AmDescRegex;
+            PmDescRegex = GermanDateTimePeriodExtractorConfiguration.PmDescRegex;
+            WithinNextPrefixRegex = GermanDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+            PrefixDayRegex = GermanDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+            BeforeRegex = GermanDateTimePeriodExtractorConfiguration.BeforeRegex;
+            AfterRegex = GermanDateTimePeriodExtractorConfiguration.AfterRegex;
+            UnitMap = config.UnitMap;
+            Numbers = config.Numbers;
+        }
+
         public string TokenBeforeDate { get; }
 
         public IDateExtractor DateExtractor { get; }
@@ -73,57 +125,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public IImmutableDictionary<string, int> Numbers { get; }
-
-        public GermanDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
-
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            DurationExtractor = config.DurationExtractor;
-            NumberParser = config.NumberParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DurationParser = config.DurationParser;
-            DateTimeParser = config.DateTimeParser;
-
-            PureNumberFromToRegex = GermanTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = GermanTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeOfDayRegex = GermanDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            TimeOfDayRegex = GermanDateTimeExtractorConfiguration.TimeOfDayRegex;
-            PastRegex = GermanDatePeriodExtractorConfiguration.PastPrefixRegex;
-            FutureRegex = GermanDatePeriodExtractorConfiguration.NextPrefixRegex;
-            FutureSuffixRegex = GermanDatePeriodExtractorConfiguration.FutureSuffixRegex;
-            NumberCombinedWithUnitRegex = GermanDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
-            UnitRegex = GermanTimePeriodExtractorConfiguration.TimeUnitRegex;
-            PeriodTimeOfDayWithDateRegex = GermanDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
-            RelativeTimeUnitRegex = GermanDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
-            RestOfDateTimeRegex = GermanDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
-            AmDescRegex = GermanDateTimePeriodExtractorConfiguration.AmDescRegex;
-            PmDescRegex = GermanDateTimePeriodExtractorConfiguration.PmDescRegex;
-            WithinNextPrefixRegex = GermanDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
-            PrefixDayRegex = GermanDateTimePeriodExtractorConfiguration.PrefixDayRegex;
-            BeforeRegex = GermanDateTimePeriodExtractorConfiguration.BeforeRegex;
-            AfterRegex = GermanDateTimePeriodExtractorConfiguration.AfterRegex;
-            UnitMap = config.UnitMap;
-            Numbers = config.Numbers;
-        }
-
-        public static readonly Regex MorningStartEndRegex = 
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex AfternoonStartEndRegex = 
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex EveningStartEndRegex = 
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex NightStartEndRegex = 
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexOptions.Singleline);
 
         public bool GetMatchedTimeRange(string text, out string timeStr, out int beginHour, out int endHour, out int endMin)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
@@ -6,6 +6,24 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public sealed class GermanMergedParserConfiguration : GermanCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+        public GermanMergedParserConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            BeforeRegex = GermanMergedExtractorConfiguration.BeforeRegex;
+            AfterRegex = GermanMergedExtractorConfiguration.AfterRegex;
+            SinceRegex = GermanMergedExtractorConfiguration.SinceRegex;
+            AroundRegex = GermanMergedExtractorConfiguration.AroundRegex;
+            DateAfter = GermanMergedExtractorConfiguration.DateAfterRegex;
+            YearRegex = GermanDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = GermanMergedExtractorConfiguration.SuperfluousWordMatcher;
+            DatePeriodParser = new BaseDatePeriodParser(new GermanDatePeriodParserConfiguration(this));
+            TimePeriodParser = new BaseTimePeriodParser(new GermanTimePeriodParserConfiguration(this));
+            DateTimePeriodParser = new BaseDateTimePeriodParser(new GermanDateTimePeriodParserConfiguration(this));
+            SetParser = new BaseSetParser(new GermanSetParserConfiguration(this));
+            HolidayParser = new HolidayParserGer(new GermanHolidayParserConfiguration(this));
+            TimeZoneParser = new DummyTimeZoneParser();
+        }
+
         public Regex BeforeRegex { get; }
 
         public Regex AfterRegex { get; }
@@ -23,22 +41,5 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateTimeParser HolidayParser { get; }
 
         public StringMatcher SuperfluousWordMatcher { get; }
-
-        public GermanMergedParserConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            BeforeRegex = GermanMergedExtractorConfiguration.BeforeRegex;
-            AfterRegex = GermanMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = GermanMergedExtractorConfiguration.SinceRegex;
-            AroundRegex = GermanMergedExtractorConfiguration.AroundRegex;
-            DateAfter = GermanMergedExtractorConfiguration.DateAfterRegex;
-            YearRegex = GermanDatePeriodExtractorConfiguration.YearRegex;
-            SuperfluousWordMatcher = GermanMergedExtractorConfiguration.SuperfluousWordMatcher;
-            DatePeriodParser = new BaseDatePeriodParser(new GermanDatePeriodParserConfiguration(this));
-            TimePeriodParser = new BaseTimePeriodParser(new GermanTimePeriodParserConfiguration(this));
-            DateTimePeriodParser = new BaseDateTimePeriodParser(new GermanDateTimePeriodParserConfiguration(this));
-            SetParser = new BaseSetParser(new GermanSetParserConfiguration(this));
-            HolidayParser = new HolidayParserGer(new GermanHolidayParserConfiguration(this));
-            TimeZoneParser = new DummyTimeZoneParser();
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
@@ -8,6 +8,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
+        public ItalianTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config.Options)
+        {
+            TimeExtractor = config.TimeExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            TimeParser = config.TimeParser;
+            TimeZoneParser = config.TimeZoneParser;
+            PureNumberFromToRegex = ItalianTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = ItalianTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeFromToRegex = ItalianTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+            SpecificTimeBetweenAndRegex = ItalianTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+            TimeOfDayRegex = ItalianTimePeriodExtractorConfiguration.TimeOfDayRegex;
+            GeneralEndingRegex = ItalianTimePeriodExtractorConfiguration.GeneralEndingRegex;
+            TillRegex = ItalianTimePeriodExtractorConfiguration.TillRegex;
+            Numbers = config.Numbers;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public IDateTimeExtractor TimeExtractor { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -34,23 +52,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public ItalianTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config.Options)
-        {
-            TimeExtractor = config.TimeExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            TimeParser = config.TimeParser;
-            TimeZoneParser = config.TimeZoneParser;
-            PureNumberFromToRegex = ItalianTimePeriodExtractorConfiguration.PureNumFromTo; 
-            PureNumberBetweenAndRegex = ItalianTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeFromToRegex = ItalianTimePeriodExtractorConfiguration.SpecificTimeFromTo;
-            SpecificTimeBetweenAndRegex = ItalianTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
-            TimeOfDayRegex = ItalianTimePeriodExtractorConfiguration.TimeOfDayRegex;
-            GeneralEndingRegex = ItalianTimePeriodExtractorConfiguration.GeneralEndingRegex;
-            TillRegex = ItalianTimePeriodExtractorConfiguration.TillRegex;
-            Numbers = config.Numbers;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -63,7 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             endHour = 0;
             endMin = 0;
 
-            var timeOfDay = "";
+            var timeOfDay = string.Empty;
             if (DateTimeDefinitions.MorningTermList.Any(o => trimmedText.EndsWith(o)))
             {
                 timeOfDay = Constants.Morning;
@@ -98,6 +99,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
             return true;
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/TimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/TimeParser.cs
@@ -1,10 +1,13 @@
 ﻿using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
-{ 
+{
     public class TimeParser : BaseTimeParser
     {
-        public TimeParser(ITimeParserConfiguration configuration) : base(configuration) { }
+        public TimeParser(ITimeParserConfiguration configuration)
+            : base(configuration)
+        {
+        }
 
         protected override DateTimeResolutionResult InternalParse(string text, DateObject referenceTime)
         {
@@ -13,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             {
                 innerResult = ParseIsh(text, referenceTime);
             }
+
             return innerResult;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public SpanishCommonDateTimeParserConfiguration(IOptionsConfiguration config) : base(config)
+        public SpanishCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeAltParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeAltParserConfiguration.cs
@@ -2,6 +2,16 @@
 {
     public class SpanishDateTimeAltParserConfiguration : IDateTimeAltParserConfiguration
     {
+        public SpanishDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
+        {
+            DateTimeParser = config.DateTimeParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            DateTimePeriodParser = config.DateTimePeriodParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DatePeriodParser = config.DatePeriodParser;
+        }
+
         public IDateTimeParser DateTimeParser { get; }
 
         public IDateTimeParser DateParser { get; }
@@ -13,16 +23,5 @@
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DatePeriodParser { get; }
-
-        public SpanishDateTimeAltParserConfiguration(ICommonDateTimeParserConfiguration config)
-        {
-            DateTimeParser = config.DateTimeParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            DateTimePeriodParser = config.DateTimePeriodParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DatePeriodParser = config.DatePeriodParser;
-        }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -8,6 +8,35 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
+        public SpanishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            NowRegex = SpanishDateTimeExtractorConfiguration.NowRegex;
+            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexOptions.Singleline);
+            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexOptions.Singleline);
+            SimpleTimeOfTodayAfterRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
+            SimpleTimeOfTodayBeforeRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
+            SpecificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            SpecificEndOfRegex = SpanishDateTimeExtractorConfiguration.SpecificEndOfRegex;
+            UnspecificEndOfRegex = SpanishDateTimeExtractorConfiguration.UnspecificEndOfRegex;
+            UnitRegex = SpanishDateTimeExtractorConfiguration.UnitRegex;
+            DateNumberConnectorRegex = SpanishDateTimeExtractorConfiguration.DateNumberConnectorRegex;
+            Numbers = config.Numbers;
+            CardinalExtractor = config.CardinalExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DurationParser = config.DurationParser;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public string TokenBeforeDate { get; }
 
         public string TokenBeforeTime { get; }
@@ -60,40 +89,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
-            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            NowRegex = SpanishDateTimeExtractorConfiguration.NowRegex;
-            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexOptions.Singleline);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexOptions.Singleline);
-            SimpleTimeOfTodayAfterRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
-            SimpleTimeOfTodayBeforeRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
-            SpecificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            SpecificEndOfRegex = SpanishDateTimeExtractorConfiguration.SpecificEndOfRegex;
-            UnspecificEndOfRegex = SpanishDateTimeExtractorConfiguration.UnspecificEndOfRegex;
-            UnitRegex = SpanishDateTimeExtractorConfiguration.UnitRegex;
-            DateNumberConnectorRegex = SpanishDateTimeExtractorConfiguration.DateNumberConnectorRegex;
-            Numbers = config.Numbers;
-            CardinalExtractor = config.CardinalExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DurationParser = config.DurationParser;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public int GetHour(string text, int hour)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
             int result = hour;
 
-            //TODO: Replace with a regex
+            // TODO: Replace with a regex
             if ((trimmedText.EndsWith("mañana") || trimmedText.EndsWith("madrugada")) && hour >= Constants.HalfDayHourCount)
             {
                 result -= Constants.HalfDayHourCount;
@@ -102,6 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             {
                 result += Constants.HalfDayHourCount;
             }
+
             return result;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -7,6 +7,46 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
+        public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = Definitions.Spanish.DateTimeDefinitions.TokenBeforeDate;
+
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
+            NumberParser = config.NumberParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            DateTimeParser = config.DateTimeParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
+
+            PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            TimeOfDayRegex = SpanishDateTimeExtractorConfiguration.TimeOfDayRegex;
+            PastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
+            FutureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
+            FutureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
+            NumberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
+            UnitRegex = SpanishTimePeriodExtractorConfiguration.UnitRegex;
+            PeriodTimeOfDayWithDateRegex = SpanishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = SpanishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+            RestOfDateTimeRegex = SpanishDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+            AmDescRegex = SpanishDateTimePeriodExtractorConfiguration.AmDescRegex;
+            PmDescRegex = SpanishDateTimePeriodExtractorConfiguration.PmDescRegex;
+            WithinNextPrefixRegex = SpanishDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+            PrefixDayRegex = SpanishDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+            BeforeRegex = SpanishDateTimePeriodExtractorConfiguration.BeforeRegex;
+            AfterRegex = SpanishDateTimePeriodExtractorConfiguration.AfterRegex;
+            UnitMap = config.UnitMap;
+            Numbers = config.Numbers;
+        }
+
         public string TokenBeforeDate { get; }
 
         public IDateExtractor DateExtractor { get; }
@@ -73,45 +113,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TokenBeforeDate = Definitions.Spanish.DateTimeDefinitions.TokenBeforeDate;
-
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            DurationExtractor = config.DurationExtractor;
-            NumberParser = config.NumberParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            DateTimeParser = config.DateTimeParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DurationParser = config.DurationParser;
-
-            PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeOfDayRegex = SpanishDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            TimeOfDayRegex = SpanishDateTimeExtractorConfiguration.TimeOfDayRegex;
-            PastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
-            FutureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
-            FutureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
-            NumberCombinedWithUnitRegex = SpanishDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
-            UnitRegex = SpanishTimePeriodExtractorConfiguration.UnitRegex;
-            PeriodTimeOfDayWithDateRegex = SpanishDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
-            RelativeTimeUnitRegex = SpanishDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
-            RestOfDateTimeRegex = SpanishDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
-            AmDescRegex = SpanishDateTimePeriodExtractorConfiguration.AmDescRegex;
-            PmDescRegex = SpanishDateTimePeriodExtractorConfiguration.PmDescRegex;
-            WithinNextPrefixRegex = SpanishDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
-            PrefixDayRegex = SpanishDateTimePeriodExtractorConfiguration.PrefixDayRegex;
-            BeforeRegex = SpanishDateTimePeriodExtractorConfiguration.BeforeRegex;
-            AfterRegex = SpanishDateTimePeriodExtractorConfiguration.AfterRegex;
-            UnitMap = config.UnitMap;
-            Numbers = config.Numbers;
-        }
-
         public bool GetMatchedTimeRange(string text, out string timeStr, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -119,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             endHour = 0;
             endMin = 0;
 
-            //TODO: modify it according to the coresponding function in English part
+            // TODO: modify it according to the coresponding function in English part
             if (trimmedText.EndsWith("madrugada"))
             {
                 timeStr = "TDA";
@@ -165,7 +166,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimmedText = text.Trim().ToLowerInvariant();
             var swift = 0;
 
-            //TODO: Replace with a regex
+            // TODO: Replace with a regex
             if (SpanishDatePeriodParserConfiguration.PastPrefixRegex.IsMatch(trimmedText) ||
                 trimmedText.Equals("anoche"))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -6,6 +6,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+        public SpanishMergedParserConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
+            AfterRegex = SpanishMergedExtractorConfiguration.AfterRegex;
+            SinceRegex = SpanishMergedExtractorConfiguration.SinceRegex;
+            AroundRegex = SpanishMergedExtractorConfiguration.AroundRegex;
+            DateAfter = SpanishMergedExtractorConfiguration.DateAfterRegex;
+            YearRegex = SpanishDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = SpanishMergedExtractorConfiguration.SuperfluousWordMatcher;
+
+            DatePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
+            TimePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
+            DateTimePeriodParser = new DateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
+            SetParser = new BaseSetParser(new SpanishSetParserConfiguration(this));
+            HolidayParser = new BaseHolidayParser(new SpanishHolidayParserConfiguration(this));
+            TimeZoneParser = new DummyTimeZoneParser();
+        }
 
         public Regex BeforeRegex { get; }
 
@@ -24,23 +42,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeParser HolidayParser { get; }
 
         public StringMatcher SuperfluousWordMatcher { get; }
-
-        public SpanishMergedParserConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
-            AfterRegex = SpanishMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = SpanishMergedExtractorConfiguration.SinceRegex;
-            AroundRegex = SpanishMergedExtractorConfiguration.AroundRegex;
-            DateAfter = SpanishMergedExtractorConfiguration.DateAfterRegex;
-            YearRegex = SpanishDatePeriodExtractorConfiguration.YearRegex;
-            SuperfluousWordMatcher = SpanishMergedExtractorConfiguration.SuperfluousWordMatcher;
-
-            DatePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
-            TimePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
-            DateTimePeriodParser = new DateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
-            SetParser = new BaseSetParser(new SpanishSetParserConfiguration(this));
-            HolidayParser = new BaseHolidayParser(new SpanishHolidayParserConfiguration(this));
-            TimeZoneParser = new DummyTimeZoneParser();
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
@@ -9,6 +9,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
+        public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeExtractor = config.TimeExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            TimeParser = config.TimeParser;
+            TimeZoneParser = config.TimeZoneParser;
+            PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeFromToRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+            SpecificTimeBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+            TimeOfDayRegex = SpanishTimePeriodExtractorConfiguration.TimeOfDayRegex;
+            GeneralEndingRegex = SpanishTimePeriodExtractorConfiguration.GeneralEndingRegex;
+            TillRegex = SpanishTimePeriodExtractorConfiguration.TillRegex;
+            Numbers = config.Numbers;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public IDateTimeExtractor TimeExtractor { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -35,23 +53,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeExtractor = config.TimeExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            TimeParser = config.TimeParser;
-            TimeZoneParser = config.TimeZoneParser;
-            PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeFromToRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeFromTo;
-            SpecificTimeBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
-            TimeOfDayRegex = SpanishTimePeriodExtractorConfiguration.TimeOfDayRegex;
-            GeneralEndingRegex = SpanishTimePeriodExtractorConfiguration.GeneralEndingRegex;
-            TillRegex = SpanishTimePeriodExtractorConfiguration.TillRegex;
-            Numbers = config.Numbers;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -60,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             endHour = 0;
             endMin = 0;
 
-            var timeOfDay = "";
+            var timeOfDay = string.Empty;
             if (DateTimeDefinitions.EarlyMorningTermList.Any(o => trimmedText.EndsWith(o)))
             {
                 timeOfDay = Constants.EarlyMorning;


### PR DESCRIPTION
- mainly reordering ctor and props
- fix spacing
- use stirng.Empty