### PR TITLE
[StyleCop] Fix all warnings in French Unit Extractor files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/AgeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/AgeExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class AgeExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public AgeExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
 
-        public AgeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AgeExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public AgeExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AgeSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_AGE;
-
-        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/AreaExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/AreaExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class AreaExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public AreaExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
 
-        public AreaExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AreaExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public AreaExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AreaSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_AREA;
-
-        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/CurrencyExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/CurrencyExtractorConfiguration.cs
@@ -7,9 +7,24 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class CurrencyExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public CurrencyExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> CurrencySuffixList =
+            NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
 
-        public CurrencyExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList =
+            NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
+
+        private static readonly ImmutableList<string> AmbiguousValues =
+            NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
+
+        public CurrencyExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public CurrencyExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => CurrencySuffixList;
 
@@ -18,14 +33,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_CURRENCY;
-
-        public static readonly ImmutableDictionary<string, string> CurrencySuffixList = 
-            NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
-
-        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = 
-            NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = 
-            NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/DimensionExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/DimensionExtractorConfiguration.cs
@@ -8,18 +8,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class DimensionExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public DimensionExtractorConfiguration() : base(new CultureInfo(Culture.French)) { }
-
-        public DimensionExtractorConfiguration(CultureInfo ci) : base(ci) { }
-
-        public override ImmutableDictionary<string, string> SuffixList => DimensionSuffixList;
-
-        public override ImmutableDictionary<string, string> PrefixList => null;
-
-        public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
-
-        public override string ExtractType => Constants.SYS_UNIT_DIMENSION;
-
         public static readonly ImmutableDictionary<string, string> DimensionSuffixList = NumbersWithUnitDefinitions.InformationSuffixList
             .Concat(AreaExtractorConfiguration.AreaSuffixList)
             .Concat(LengthExtractorConfiguration.LengthSuffixList)
@@ -29,5 +17,23 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
             .ToImmutableDictionary(x => x.Key, x => x.Value);
 
         private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousDimensionUnitList.ToImmutableList();
+
+        public DimensionExtractorConfiguration()
+            : base(new CultureInfo(Culture.French))
+        {
+        }
+
+        public DimensionExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
+
+        public override ImmutableDictionary<string, string> SuffixList => DimensionSuffixList;
+
+        public override ImmutableDictionary<string, string> PrefixList => null;
+
+        public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
+
+        public override string ExtractType => Constants.SYS_UNIT_DIMENSION;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public abstract class FrenchNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
+        private static readonly Regex CompoundUnitConnRegex =
+            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
+
+        private static readonly Regex NonUnitsRegex =
+            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
+
         protected FrenchNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -48,11 +54,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public abstract ImmutableDictionary<string, string> PrefixList { get; }
 
         public abstract ImmutableList<string> AmbiguousUnitList { get; }
-
-        private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
-
-        private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/LengthExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/LengthExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class LengthExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public LengthExtractorConfiguration() : base(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
 
-        public LengthExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
+
+        public LengthExtractorConfiguration()
+            : base(new CultureInfo(Culture.French))
+        {
+        }
+
+        public LengthExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => LengthSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_LENGTH;
-
-        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/SpeedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/SpeedExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class SpeedExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public SpeedExtractorConfiguration() : base(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
 
-        public SpeedExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public SpeedExtractorConfiguration()
+            : base(new CultureInfo(Culture.French))
+        {
+        }
+
+        public SpeedExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => SpeedSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_SPEED;
-
-        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
@@ -9,9 +9,21 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class TemperatureExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public TemperatureExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList =
+            NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
 
-        public TemperatureExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly Regex AmbiguousUnitMultiplierRegex =
+            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
+
+        public TemperatureExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public TemperatureExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => TemperatureSuffixList;
 
@@ -21,12 +33,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList = 
-            NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
-
         public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
-
-        private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/VolumeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/VolumeExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class VolumeExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public VolumeExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
 
-        public VolumeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousVolumeUnitList.ToImmutableList();
+
+        public VolumeExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public VolumeExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => VolumeSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_VOLUME;
-
-        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousVolumeUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/WeightExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/WeightExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class WeightExtractorConfiguration : FrenchNumberWithUnitExtractorConfiguration
     {
-        public WeightExtractorConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
 
-        public WeightExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousWeightUnitList.ToImmutableList();
+
+        public WeightExtractorConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
+
+        public WeightExtractorConfiguration(CultureInfo ci)
+            : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => WeightSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_WEIGHT;
-
-        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousWeightUnitList.ToImmutableList();
     }
 }


### PR DESCRIPTION
- Fixed spacing.
- Reordered field, properties and methods.