### PR TITLE
[StyleCop] Fix all the warnings in TextParsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text/Parsers/IParser.cs
+++ b/.NET/Microsoft.Recognizers.Text/Parsers/IParser.cs
@@ -21,15 +21,14 @@
             Metadata = er.Metadata;
         }
 
-        //Value is for resolution. 
-        //e.g. 1000 for "one thousand".
-        //The resolutions are different for different parsers.
-        //Therefore, we use object here.
+        // Value is for resolution.
+        // e.g. 1000 for "one thousand".
+        // The resolutions are different for different parsers.
+        // Therefore, we use object here.
         public object Value { get; set; } = null;
 
-        //Output the value in string format.
-        //It is used in some parsers.
-        public string ResolutionStr { get; set; } = "";
-
+        // Output the value in string format.
+        // It is used in some parsers.
+        public string ResolutionStr { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
- Add whitespace before comments
- Remove trailing whitespace
- Replace "" with string.Empty
- Remove space before closing brace