### PR TITLE
[StyleCop] Fix all the warnings in TextUtilities

### DIFF
--- a/.NET/Microsoft.Recognizers.Text/Utilities/EnumUtils.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/EnumUtils.cs
@@ -4,18 +4,16 @@ namespace Microsoft.Recognizers.Text.Utilities
 {
     public static class EnumUtils
     {
-
         public static bool IsFlagDefined(Enum en)
         {
-
             // For enums with FlagsAttribute, IsDefined() doesn't work.
             // ToString() will return a comma-separated list of enum string values if defined and an int if not.
-            return (!int.TryParse(en.ToString(), out int val));
+            return !int.TryParse(en.ToString(), out int val);
         }
 
-        public static T Convert<T>(int value) where T : struct 
+        public static T Convert<T>(int value)
+            where T : struct
         {
-
             if (!typeof(T).IsEnum)
             {
                 throw new InvalidOperationException("Invalid Enum Type. " + typeof(T).ToString() + "  must be an Enum.");
@@ -29,10 +27,9 @@ namespace Microsoft.Recognizers.Text.Utilities
                 return returnEnum;
             }
             else
-            { 
+            {
                 throw new ArgumentOutOfRangeException(value.ToString(), "Bad configuration parameter value.");
             }
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Utilities/QueryProcessor.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/QueryProcessor.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -7,9 +7,12 @@ namespace Microsoft.Recognizers.Text.Utilities
 {
     public static class QueryProcessor
     {
+        private static readonly string Expression = @"(?<=(\s|\d))(kB|K[Bb]|K|M[Bb]|M|G[Bb]|G|B)\b";
+
+        private static readonly Regex SpecialTokensRegex = new Regex(Expression, RegexOptions.Compiled);
+
         public static string Preprocess(string query, bool caseSensitive = false, bool recode = true)
         {
-
             if (recode)
             {
                 query = query.Replace("０", "0");
@@ -38,22 +41,11 @@ namespace Microsoft.Recognizers.Text.Utilities
                 query = query.Replace("、", ",");
             }
 
-            query = caseSensitive ? 
-                ToLowerTermSensitive(query) : 
+            query = caseSensitive ?
+                ToLowerTermSensitive(query) :
                 query.ToLowerInvariant();
 
             return query;
-        }
-
-        private static readonly string Expression = @"(?<=(\s|\d))(kB|K[Bb]|K|M[Bb]|M|G[Bb]|G|B)\b";
-        private static readonly Regex SpecialTokensRegex = new Regex(Expression, RegexOptions.Compiled);
-
-        private static void ReApplyValue(int idx, ref StringBuilder outString, string value)
-        {
-            for (int i = 0; i < value.Length; ++i)
-            {
-                outString[idx + i] = value[i];
-            }
         }
 
         public static string ToLowerTermSensitive(string input)
@@ -87,11 +79,19 @@ namespace Microsoft.Recognizers.Text.Utilities
                 where uc != UnicodeCategory.NonSpacingMark
                 select c;
 
-            // FormC indicates that a Unicode string is normalized using full canonical decomposition, 
+            // FormC indicates that a Unicode string is normalized using full canonical decomposition,
             // followed by the replacement of sequences with their primary composites, if possible.
             var normalizedQuery = new string(chars.ToArray()).Normalize(NormalizationForm.FormC);
 
             return normalizedQuery;
+        }
+
+        private static void ReApplyValue(int idx, ref StringBuilder outString, string value)
+        {
+            for (int i = 0; i < value.Length; ++i)
+            {
+                outString[idx + i] = value[i];
+            }
         }
     }
 }


### PR DESCRIPTION
- Put generic type constraints on their own line
- Remove spaces after opening braces
- Fix encoding
- Remove trailing whitespaces
- Move fields on top of methods