### PR TITLE
[StyleCop] Fix warnings in DataDrivenTest/DateTime

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerCache.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerCache.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Recognizers.Text.DataDrivenTests;
+﻿using System.Linq;
+using Microsoft.Recognizers.Text.DataDrivenTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Linq;
 
 namespace Microsoft.Recognizers.Text.DateTime.Tests
 {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Recognizers.Text.DateTime.English;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Recognizers.Text.DateTime.English;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.DateTime.Tests
 {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Chinese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Chinese.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_Chinese : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,167 +25,167 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Chinese.csv", "DateExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-Chinese.csv", "TimeExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-Chinese.csv", "DatePeriodExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-Chinese.csv", "TimePeriodExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-Chinese.csv", "DateTimeExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-Chinese.csv", "DateTimePeriodExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-Chinese.csv", "HolidayExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-Chinese.csv", "DurationExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-Chinese.csv", "SetExtractor-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Chinese.csv", "DateParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-Chinese.csv", "TimeParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Chinese.csv", "DatePeriodParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-Chinese.csv", "TimePeriodParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Chinese.csv", "DateTimeParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-Chinese.csv", "DateTimePeriodParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-Chinese.csv", "HolidayParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-Chinese.csv", "DurationParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-Chinese.csv", "SetParser-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-Chinese.csv", "DateTimeModel-Chinese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_English.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_English.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_English : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,244 +25,244 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-English.csv", "DateExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-English.csv", "TimeExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-English.csv", "DatePeriodExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-English.csv", "TimePeriodExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-English.csv", "DateTimeExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-English.csv", "DateTimePeriodExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-English.csv", "HolidayExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeZoneExtractor-English.csv", "TimeZoneExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeZoneExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-English.csv", "DurationExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-English.csv", "SetExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-English.csv", "MergedExtractor-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractorSkipFromTo-English.csv", "MergedExtractorSkipFromTo-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractorSkipFromTo()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-English.csv", "DateParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-English.csv", "TimeParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-English.csv", "DatePeriodParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-English.csv", "TimePeriodParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-English.csv", "DateTimeParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-English.csv", "DateTimePeriodParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-English.csv", "HolidayParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeZoneParser-English.csv", "TimeZoneParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeZoneParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-English.csv", "DurationParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-English.csv", "SetParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedParser-English.csv", "MergedParser-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeMergedParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeMergedParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-English.csv", "DateTimeModel-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelSplitDateAndTime-English.csv", "DateTimeModelSplitDateAndTime-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelSplitDateAndTime()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelCalendarMode-English.csv", "DateTimeModelCalendarMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelCalendarMode()
         {
-            base.TestDateTimeAlt();
+            TestDateTimeAlt();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelExtendedTypes-English.csv", "DateTimeModelExtendedTypes-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelExtendedTypes()
         {
-            base.TestDateTimeAlt();
+            TestDateTimeAlt();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelComplexCalendar-English.csv", "DateTimeModelComplexCalendar-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelComplexCalendar()
         {
-            base.TestDateTimeAlt();
+            TestDateTimeAlt();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelExperimentalMode-English.csv", "DateTimeModelExperimentalMode-English#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelExperimentalMode()
         {
-            base.TestDateTimeAlt();
+            TestDateTimeAlt();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_EnglishOthers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_EnglishOthers.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_EnglishOthers : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,23 +25,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-EnglishOthers.csv", "DateParser-EnglishOthers#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-EnglishOthers.csv", "DateTimeModel-EnglishOthers#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_French.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_French.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_French : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,200 +25,200 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-French.csv", "DateExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-French.csv", "TimeExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-French.csv", "DatePeriodExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-French.csv", "TimePeriodExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-French.csv", "DateTimeExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-French.csv", "DateTimePeriodExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-French.csv", "HolidayExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-French.csv", "DurationExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-French.csv", "SetExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-French.csv", "MergedExtractor-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractorSkipFromTo-French.csv", "MergedExtractorSkipFromTo-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractorSkipFromTo()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-French.csv", "DateParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-French.csv", "TimeParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-French.csv", "DatePeriodParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-French.csv", "TimePeriodParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-French.csv", "DateTimeParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-French.csv", "DateTimePeriodParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-French.csv", "HolidayParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-French.csv", "DurationParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-French.csv", "SetParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedParser-French.csv", "MergedParser-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeMergedParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeMergedParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-French.csv", "DateTimeModel-French#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
 
         ////[DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelSplitDateAndTime-French.csv", "DateTimeModelSplitDateAndTime-French#csv", DataAccessMethod.Sequential)]
         ////[TestMethod]
         ////public void DateTimeModelSplitDateAndTime()
         ////{
-        ////    base.ModelInitialize(Models);
-        ////    base.TestDateTime();
+        ////    ModelInitialize(Models);
+        ////    TestDateTime();
         ////}
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_German.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_German.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_German : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,199 +25,199 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-German.csv", "DateExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-German.csv", "TimeExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-German.csv", "DatePeriodExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-German.csv", "TimePeriodExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-German.csv", "DateTimeExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-German.csv", "DateTimePeriodExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-German.csv", "HolidayExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-German.csv", "DurationExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-German.csv", "SetExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-German.csv", "MergedExtractor-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractorSkipFromTo-German.csv", "MergedExtractorSkipFromTo-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractorSkipFromTo()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-German.csv", "DateParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-German.csv", "TimeParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-German.csv", "DatePeriodParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-German.csv", "TimePeriodParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-German.csv", "DateTimeParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-German.csv", "DateTimePeriodParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-German.csv", "HolidayParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-German.csv", "DurationParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-German.csv", "SetParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedParser-German.csv", "MergedParser-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeMergedParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeMergedParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-German.csv", "DateTimeModel-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelSplitDateAndTime-German.csv", "DateTimeModelSplitDateAndTime-German#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModelSplitDateAndTime()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Italian.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Italian.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_Italian : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -24,200 +26,200 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Italian.csv", "DateExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-Italian.csv", "TimeExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-Italian.csv", "DatePeriodExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-Italian.csv", "TimePeriodExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-Italian.csv", "DateTimeExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-Italian.csv", "DateTimePeriodExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-Italian.csv", "HolidayExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-Italian.csv", "DurationExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-Italian.csv", "SetExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-Italian.csv", "MergedExtractor-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractorSkipFromTo-Italian.csv", "MergedExtractorSkipFromTo-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractorSkipFromTo()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Italian.csv", "DateParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-Italian.csv", "TimeParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Italian.csv", "DatePeriodParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-Italian.csv", "TimePeriodParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Italian.csv", "DateTimeParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-Italian.csv", "DateTimePeriodParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-Italian.csv", "HolidayParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-Italian.csv", "DurationParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-Italian.csv", "SetParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedParser-Italian.csv", "MergedParser-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeMergedParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeMergedParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-Italian.csv", "DateTimeModel-Italian#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
 
         ////[DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModelSplitDateAndTime-Italian.csv", "DateTimeModelSplitDateAndTime-Italian#csv", DataAccessMethod.Sequential)]
         ////[TestMethod]
         ////public void DateTimeModelSplitDateAndTime()
         ////{
-        ////    base.ModelInitialize(Models);
-        ////    base.TestDateTime();
+        ////    ModelInitialize(Models);
+        ////    TestDateTime();
         ////}
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Japanese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Japanese.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_Japanese : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,42 +25,42 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
-    [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Japanese.csv", "DateExtractor-Japanese#csv", DataAccessMethod.Sequential)]
-    [TestMethod]
-    public void DateExtractor()
-    {
-      base.ExtractorInitialize(Extractors);
-      base.TestDateTimeExtractor();
-    }
+        [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Japanese.csv", "DateExtractor-Japanese#csv", DataAccessMethod.Sequential)]
+        [TestMethod]
+        public void DateExtractor()
+        {
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
+        }
 
-    [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Japanese.csv", "DateParser-Japanese#csv", DataAccessMethod.Sequential)]
-    [TestMethod]
-    public void DateParser()
-    {
-      base.ExtractorInitialize(Extractors);
-      base.ParserInitialize(Parsers);
-      base.TestDateTimeParser();
-    }
+        [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Japanese.csv", "DateParser-Japanese#csv", DataAccessMethod.Sequential)]
+        [TestMethod]
+        public void DateParser()
+        {
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
+        }
 
-    [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Japanese.csv", "DatePeriodParser-Japanese#csv", DataAccessMethod.Sequential)]
-    [TestMethod]
-    public void DatePeriodParser()
-    {
-      base.ExtractorInitialize(Extractors);
-      base.ParserInitialize(Parsers);
-      base.TestDateTimeParser();
-    }
+        [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Japanese.csv", "DatePeriodParser-Japanese#csv", DataAccessMethod.Sequential)]
+        [TestMethod]
+        public void DatePeriodParser()
+        {
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
+        }
 
-    [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Japanese.csv", "DateTimeParser-Japanese#csv", DataAccessMethod.Sequential)]
-    [TestMethod]
-    public new void DateTimeParser()
-    {
-      base.ExtractorInitialize(Extractors);
-      base.ParserInitialize(Parsers);
-      base.TestDateTimeParser();
+        [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Japanese.csv", "DateTimeParser-Japanese#csv", DataAccessMethod.Sequential)]
+        [TestMethod]
+        public new void DateTimeParser()
+        {
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
+        }
     }
-  }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Portuguese.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Portuguese.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_Portuguese : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,176 +25,175 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Portuguese.csv", "DateExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-Portuguese.csv", "TimeExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-Portuguese.csv", "DatePeriodExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-Portuguese.csv", "TimePeriodExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-Portuguese.csv", "DateTimeExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-Portuguese.csv", "DateTimePeriodExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-Portuguese.csv", "HolidayExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-Portuguese.csv", "DurationExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-Portuguese.csv", "SetExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-Portuguese.csv", "MergedExtractor-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Portuguese.csv", "DateParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-Portuguese.csv", "TimeParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Portuguese.csv", "DatePeriodParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-Portuguese.csv", "TimePeriodParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Portuguese.csv", "DateTimeParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-Portuguese.csv", "DateTimePeriodParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-Portuguese.csv", "HolidayParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-Portuguese.csv", "DurationParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-Portuguese.csv", "SetParser-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-Portuguese.csv", "DateTimeModel-Portuguese#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Spanish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Spanish.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
     public class TestDateTime_Spanish : TestBase
     {
         public static TestResources TestResources { get; private set; }
+
         public static IDictionary<string, IDateTimeExtractor> Extractors { get; private set; }
+
         public static IDictionary<string, IDateTimeParser> Parsers { get; private set; }
 
         [ClassInitialize]
@@ -23,175 +25,175 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            base.TestSpecInitialize(TestResources);
+            TestSpecInitialize(TestResources);
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateExtractor-Spanish.csv", "DateExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeExtractor-Spanish.csv", "TimeExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodExtractor-Spanish.csv", "DatePeriodExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodExtractor-Spanish.csv", "TimePeriodExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeExtractor-Spanish.csv", "DateTimeExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodExtractor-Spanish.csv", "DateTimePeriodExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayExtractor-Spanish.csv", "HolidayExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationExtractor-Spanish.csv", "DurationExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetExtractor-Spanish.csv", "SetExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "MergedExtractor-Spanish.csv", "MergedExtractor-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void MergedExtractor()
         {
-            base.ExtractorInitialize(Extractors);
-            base.TestDateTimeExtractor();
+            ExtractorInitialize(Extractors);
+            TestDateTimeExtractor();
         }
-        
+
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateParser-Spanish.csv", "DateParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimeParser-Spanish.csv", "TimeParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DatePeriodParser-Spanish.csv", "DatePeriodParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DatePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "TimePeriodParser-Spanish.csv", "TimePeriodParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void TimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeParser-Spanish.csv", "DateTimeParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public new void DateTimeParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimePeriodParser-Spanish.csv", "DateTimePeriodParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimePeriodParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "HolidayParser-Spanish.csv", "HolidayParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void HolidayParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DurationParser-Spanish.csv", "DurationParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DurationParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "SetParser-Spanish.csv", "SetParser-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void SetParser()
         {
-            base.ExtractorInitialize(Extractors);
-            base.ParserInitialize(Parsers);
-            base.TestDateTimeParser();
+            ExtractorInitialize(Extractors);
+            ParserInitialize(Parsers);
+            TestDateTimeParser();
         }
 
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "DateTimeModel-Spanish.csv", "DateTimeModel-Spanish#csv", DataAccessMethod.Sequential)]
         [TestMethod]
         public void DateTimeModel()
         {
-            base.TestDateTime();
+            TestDateTime();
         }
     }
 }


### PR DESCRIPTION
Fixes
- Warning SA1100 Do not prefix calls with base unless local implementation exists
- Reorder using statements
