### PR TITLE
[Java][Datetime] Port SpanishHolidayParserConfiguration from C# to Java

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
@@ -49,9 +49,9 @@ public class SpanishDateTime {
             .replace("{BaseDateTime.FourDigitYearRegex}", BaseDateTime.FourDigitYearRegex)
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 
-    public static final String RelativeMonthRegex = "(?<relmonth>(este|pr[oó]ximo|[uú]ltimo)\\s+mes)\\b";
+    public static final String RelativeMonthRegex = "(?<relmonth>((este|pr[oó]ximo|[uú]ltimo)\\s+mes)|(mes\\s+que\\s+viene))\\b";
 
-    public static final String MonthRegex = "\\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)\\b";
+    public static final String MonthRegex = "\\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set|sep)\\b";
 
     public static final String MonthSuffixRegex = "(?<msuf>(en\\s+|del\\s+|de\\s+)?({RelativeMonthRegex}|{MonthRegex}))"
             .replace("{RelativeMonthRegex}", RelativeMonthRegex)
@@ -63,33 +63,35 @@ public class SpanishDateTime {
 
     public static final String FutureRegex = "(?<past>\\b(siguiente(s)?|pr[oó]xim[oa](s)?|dentro\\s+de|en)\\b)";
 
-    public static final String SimpleCasesRegex = "\\b((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String SimpleCasesRegex = "\\b((desde\\s+el|desde|del|de)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{TillRegex}", TillRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String MonthFrontSimpleCasesRegex = "\\b{MonthSuffixRegex}\\s+((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String MonthFrontSimpleCasesRegex = "\\b{MonthSuffixRegex}\\s+((desde\\s+el|desde|del)\\s+)?({DayRegex})\\s*{TillRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{DayRegex}", DayRegex)
             .replace("{TillRegex}", TillRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String MonthFrontBetweenRegex = "\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String MonthFrontBetweenRegex = "\\b{MonthSuffixRegex}\\s+((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{AndRegex}", AndRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String DayBetweenRegex = "\\b((entre|entre\\s+el)\\s+)({DayRegex})\\s*{AndRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*){YearRegex})?\\b"
+    public static final String DayBetweenRegex = "\\b((entre|entre\\s+el)\\s+)({DayRegex})(\\s+{MonthSuffixRegex})?\\s*{AndRegex}\\s*({DayRegex})\\s+{MonthSuffixRegex}((\\s+|\\s*,\\s*)(en\\s+|del\\s+|de\\s+)?{YearRegex})?\\b"
             .replace("{DayRegex}", DayRegex)
             .replace("{AndRegex}", AndRegex)
             .replace("{MonthSuffixRegex}", MonthSuffixRegex)
             .replace("{YearRegex}", YearRegex);
 
-    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b";
+    public static final String OneWordPeriodRegex = "\\b(((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\\s+)?({MonthRegex})|(?<=\\b(del|de la|el|la)\\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]?|est(e|a))\\s+(fin de semana|semana|mes|año)|fin de semana|(mes|años)? a la fecha)\\b"
+            .replace("{MonthRegex}", MonthRegex);
 
-    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?|en)\\s+)?(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set)\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
+    public static final String MonthWithYearRegex = "\\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\\s+)?({MonthRegex})\\s+((de|del|de la)\\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\\s+año))\\b"
+            .replace("{MonthRegex}", MonthRegex)
             .replace("{YearRegex}", YearRegex);
 
     public static final String MonthNumWithYearRegex = "({YearRegex}(\\s*?)[/\\-\\.](\\s*?){MonthNumRegex})|({MonthNumRegex}(\\s*?)[/\\-](\\s*?){YearRegex})"
@@ -129,7 +131,8 @@ public class SpanishDateTime {
 
     public static final String WeekOfRegex = "(semana)(\\s*)((do|da|de))";
 
-    public static final String MonthOfRegex = "(mes)(\\s*)((do|da|de))";
+    public static final String MonthOfRegex = "(mes)(\\s+)((do|da|de)\\s+){MonthRegex}"
+            .replace("{MonthRegex}", MonthRegex);
 
     public static final String RangeUnitRegex = "\\b(?<unit>años|año|meses|mes|semanas|semana)\\b";
 
@@ -143,7 +146,7 @@ public class SpanishDateTime {
 
     public static final String BetweenRegex = "(entre\\s*(la(s)?)?)";
 
-    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lu|ma|mi|ju|vi|sa|do)\\b";
+    public static final String WeekDayRegex = "\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|sa|do)\\b";
 
     public static final String OnRegex = "(?<=\\ben\\s+)({DayRegex}s?)\\b"
             .replace("{DayRegex}", DayRegex);
@@ -370,7 +373,7 @@ public class SpanishDateTime {
 
     public static final String TimeOfDayRegex = "\\b(?<timeOfDay>mañana|madrugada|(pasado\\s+(el\\s+)?)?medio\\s?d[ií]a|tarde|noche|anoche)\\b";
 
-    public static final String SpecificTimeOfDayRegex = "\\b(((((a)?\\s+la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\\s+)?{TimeOfDayRegex}))\\b"
+    public static final String SpecificTimeOfDayRegex = "\\b(((((a\\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\\s+)?{TimeOfDayRegex}))\\b"
             .replace("{TimeOfDayRegex}", TimeOfDayRegex);
 
     public static final String TimeOfTodayAfterRegex = "^\\s*(,\\s*)?(en|de(l)?\\s+)?{SpecificTimeOfDayRegex}"

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -284,7 +284,3 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         return utilityConfiguration;
     }
 }
-    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
-        return utilityConfiguration;
-    }
-}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -285,3 +285,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         return utilityConfiguration;
     }
 }
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishCommonDateTimeParserConfiguration.java
@@ -76,7 +76,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
     private final IDateTimeParser timeParser;
     //private final IDateTimeParser dateTimeParser;
     private final IDateTimeParser durationParser;
-    //private final IDateTimeParser datePeriodParser;
+    private final IDateTimeParser datePeriodParser;
     private final IDateTimeParser timePeriodParser;
     //private final IDateTimeParser dateTimePeriodParser;
     //private final IDateTimeParser dateTimeAltParser;
@@ -116,7 +116,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
         timeParser = new TimeParser(new SpanishTimeParserConfiguration(this));
         //dateTimeParser = new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(this));
         durationParser = new BaseDurationParser(new SpanishDurationParserConfiguration(this));
-        //datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
+        datePeriodParser = new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(this));
         //dateTimePeriodParser = new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(this));
         //dateTimeAltParser = new BaseDateTimeAltParser(new SpanishDateTimeAltParserConfiguration(this));
@@ -200,8 +200,7 @@ public class SpanishCommonDateTimeParserConfiguration extends BaseDateParserConf
 
     @Override
     public IDateTimeParser getDatePeriodParser() {
-        //return datePeriodParser;
-        return null;
+        return datePeriodParser;
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
@@ -22,6 +22,12 @@ import java.util.regex.Pattern;
 
 public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfiguration implements IDatePeriodParserConfiguration {
 
+    public static final Pattern nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+    public static final Pattern pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+    public static final Pattern thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
+    public static final Pattern relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
+    public static final Pattern unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
+
     public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
         super(config.getOptions());
 
@@ -80,13 +86,6 @@ public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfigurati
         numbers = config.getNumbers();
         writtenDecades = config.getWrittenDecades();
         specialDecadeCases = config.getSpecialDecadeCases();
-
-        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
-        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
-        thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
-        relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
-        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
-        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex);
     }
 
     // Regex
@@ -182,18 +181,6 @@ public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfigurati
     private final Pattern moreThanRegex;
 
     private final Pattern centurySuffixRegex;
-
-    private final Pattern nextPrefixRegex;
-
-    private final Pattern pastPrefixRegex;
-
-    private final Pattern thisPrefixRegex;
-
-    private final Pattern relativeRegex;
-
-    private final Pattern unspecificEndOfRangeRegex;
-
-    private final Pattern afterNextSuffixRegex;
 
     // Dictionaries
     private final ImmutableMap<String, String> unitMap;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDatePeriodParserConfiguration.java
@@ -1,0 +1,596 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.EnglishDateTime;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class SpanishDatePeriodParserConfiguration extends BaseOptionsConfiguration implements IDatePeriodParserConfiguration {
+
+    public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+
+        tokenBeforeDate = SpanishDateTime.TokenBeforeDate;
+        cardinalExtractor = config.getCardinalExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        integerExtractor = config.getIntegerExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateParser = config.getDateParser();
+        monthFrontBetweenRegex = SpanishDatePeriodExtractorConfiguration.MonthFrontBetweenRegex;
+        betweenRegex = SpanishDatePeriodExtractorConfiguration.DayBetweenRegex;
+        monthFrontSimpleCasesRegex = SpanishDatePeriodExtractorConfiguration.MonthFrontSimpleCasesRegex;
+        simpleCasesRegex = SpanishDatePeriodExtractorConfiguration.SimpleCasesRegex;
+        oneWordPeriodRegex = SpanishDatePeriodExtractorConfiguration.OneWordPeriodRegex;
+        monthWithYear = SpanishDatePeriodExtractorConfiguration.MonthWithYearRegex;
+        monthNumWithYear = SpanishDatePeriodExtractorConfiguration.MonthNumWithYearRegex;
+        yearRegex = SpanishDatePeriodExtractorConfiguration.YearRegex;
+        pastRegex = SpanishDatePeriodExtractorConfiguration.PastRegex;
+        futureRegex = SpanishDatePeriodExtractorConfiguration.FutureRegex;
+        futureSuffixRegex = SpanishDatePeriodExtractorConfiguration.FutureSuffixRegex;
+        numberCombinedWithUnit = SpanishDurationExtractorConfiguration.NumberCombinedWithUnit;
+        weekOfMonthRegex = SpanishDatePeriodExtractorConfiguration.WeekOfMonthRegex;
+        weekOfYearRegex = SpanishDatePeriodExtractorConfiguration.WeekOfYearRegex;
+        quarterRegex = SpanishDatePeriodExtractorConfiguration.QuarterRegex;
+        quarterRegexYearFront = SpanishDatePeriodExtractorConfiguration.QuarterRegexYearFront;
+        allHalfYearRegex = SpanishDatePeriodExtractorConfiguration.AllHalfYearRegex;
+        seasonRegex = SpanishDatePeriodExtractorConfiguration.SeasonRegex;
+        whichWeekRegex = SpanishDatePeriodExtractorConfiguration.WhichWeekRegex;
+        weekOfRegex = SpanishDatePeriodExtractorConfiguration.WeekOfRegex;
+        monthOfRegex = SpanishDatePeriodExtractorConfiguration.MonthOfRegex;
+        restOfDateRegex = SpanishDatePeriodExtractorConfiguration.RestOfDateRegex;
+        laterEarlyPeriodRegex = SpanishDatePeriodExtractorConfiguration.LaterEarlyPeriodRegex;
+        weekWithWeekDayRangeRegex = SpanishDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
+        yearPlusNumberRegex = SpanishDatePeriodExtractorConfiguration.YearPlusNumberRegex;
+        decadeWithCenturyRegex = SpanishDatePeriodExtractorConfiguration.DecadeWithCenturyRegex;
+        yearPeriodRegex = SpanishDatePeriodExtractorConfiguration.YearPeriodRegex;
+        complexDatePeriodRegex = SpanishDatePeriodExtractorConfiguration.ComplexDatePeriodRegex;
+        relativeDecadeRegex = SpanishDatePeriodExtractorConfiguration.RelativeDecadeRegex;
+        inConnectorRegex = config.getUtilityConfiguration().getInConnectorRegex();
+        withinNextPrefixRegex = SpanishDatePeriodExtractorConfiguration.WithinNextPrefixRegex;
+        referenceDatePeriodRegex = SpanishDatePeriodExtractorConfiguration.ReferenceDatePeriodRegex;
+        agoRegex = SpanishDatePeriodExtractorConfiguration.AgoRegex;
+        laterRegex = SpanishDatePeriodExtractorConfiguration.LaterRegex;
+        lessThanRegex = SpanishDatePeriodExtractorConfiguration.LessThanRegex;
+        moreThanRegex = SpanishDatePeriodExtractorConfiguration.MoreThanRegex;
+        centurySuffixRegex = SpanishDatePeriodExtractorConfiguration.CenturySuffixRegex;
+
+        unitMap = config.getUnitMap();
+        cardinalMap = config.getCardinalMap();
+        dayOfMonth = config.getDayOfMonth();
+        monthOfYear = config.getMonthOfYear();
+        seasonMap = config.getSeasonMap();
+        numbers = config.getNumbers();
+        writtenDecades = config.getWrittenDecades();
+        specialDecadeCases = config.getSpecialDecadeCases();
+
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.NextPrefixRegex);
+        pastPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.PastPrefixRegex);
+        thisPrefixRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.ThisPrefixRegex);
+        relativeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.RelativeRegex);
+        unspecificEndOfRangeRegex = RegExpUtility.getSafeRegExp(SpanishDateTime.UnspecificEndOfRangeRegex);
+        afterNextSuffixRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.AfterNextSuffixRegex);
+    }
+
+    // Regex
+
+    private final String tokenBeforeDate;
+
+    private final IDateExtractor dateExtractor;
+
+    private final IExtractor cardinalExtractor;
+
+    private final IExtractor ordinalExtractor;
+
+    private final IDateTimeExtractor durationExtractor;
+
+    private final IExtractor integerExtractor;
+
+    private final IParser numberParser;
+
+    private final IDateTimeParser dateParser;
+
+    private final IDateTimeParser durationParser;
+
+    private final Pattern monthFrontBetweenRegex;
+
+    private final Pattern betweenRegex;
+
+    private final Pattern monthFrontSimpleCasesRegex;
+
+    private final Pattern simpleCasesRegex;
+
+    private final Pattern oneWordPeriodRegex;
+
+    private final Pattern monthWithYear;
+
+    private final Pattern monthNumWithYear;
+
+    private final Pattern yearRegex;
+
+    private final Pattern pastRegex;
+
+    private final Pattern futureRegex;
+
+    private final Pattern futureSuffixRegex;
+
+    private final Pattern numberCombinedWithUnit;
+
+    private final Pattern weekOfMonthRegex;
+
+    private final Pattern weekOfYearRegex;
+
+    private final Pattern quarterRegex;
+
+    private final Pattern quarterRegexYearFront;
+
+    private final Pattern allHalfYearRegex;
+
+    private final Pattern seasonRegex;
+
+    private final Pattern whichWeekRegex;
+
+    private final Pattern weekOfRegex;
+
+    private final Pattern monthOfRegex;
+
+    private final Pattern inConnectorRegex;
+
+    private final Pattern withinNextPrefixRegex;
+
+    private final Pattern restOfDateRegex;
+
+    private final Pattern laterEarlyPeriodRegex;
+
+    private final Pattern weekWithWeekDayRangeRegex;
+
+    private final Pattern yearPlusNumberRegex;
+
+    private final Pattern decadeWithCenturyRegex;
+
+    private final Pattern yearPeriodRegex;
+
+    private final Pattern complexDatePeriodRegex;
+
+    private final Pattern relativeDecadeRegex;
+
+    private final Pattern referenceDatePeriodRegex;
+
+    private final Pattern agoRegex;
+
+    private final Pattern laterRegex;
+
+    private final Pattern lessThanRegex;
+
+    private final Pattern moreThanRegex;
+
+    private final Pattern centurySuffixRegex;
+
+    private final Pattern nextPrefixRegex;
+
+    private final Pattern pastPrefixRegex;
+
+    private final Pattern thisPrefixRegex;
+
+    private final Pattern relativeRegex;
+
+    private final Pattern unspecificEndOfRangeRegex;
+
+    private final Pattern afterNextSuffixRegex;
+
+    // Dictionaries
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    @Override
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public final IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public final IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public final IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public final IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public final Pattern getMonthFrontBetweenRegex() {
+        return monthFrontBetweenRegex;
+    }
+
+    @Override
+    public final Pattern getBetweenRegex() {
+        return betweenRegex;
+    }
+
+    @Override
+    public final Pattern getMonthFrontSimpleCasesRegex() {
+        return monthFrontSimpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getSimpleCasesRegex() {
+        return simpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getOneWordPeriodRegex() {
+        return oneWordPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getMonthWithYear() {
+        return monthWithYear;
+    }
+
+    @Override
+    public final Pattern getMonthNumWithYear() {
+        return monthNumWithYear;
+    }
+
+    @Override
+    public final Pattern getYearRegex() {
+        return yearRegex;
+    }
+
+    @Override
+    public final Pattern getPastRegex() {
+        return pastRegex;
+    }
+
+    @Override
+    public final Pattern getFutureRegex() {
+        return futureRegex;
+    }
+
+    @Override
+    public final Pattern getFutureSuffixRegex() {
+        return futureSuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public final Pattern getWeekOfMonthRegex() {
+        return weekOfMonthRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfYearRegex() {
+        return weekOfYearRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegex() {
+        return quarterRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegexYearFront() {
+        return quarterRegexYearFront;
+    }
+
+    @Override
+    public final Pattern getAllHalfYearRegex() {
+        return allHalfYearRegex;
+    }
+
+    @Override
+    public final Pattern getSeasonRegex() {
+        return seasonRegex;
+    }
+
+    @Override
+    public final Pattern getWhichWeekRegex() {
+        return whichWeekRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfRegex() {
+        return weekOfRegex;
+    }
+
+    @Override
+    public final Pattern getMonthOfRegex() {
+        return monthOfRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex() {
+        return inConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex() {
+        return withinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRestOfDateRegex() {
+        return restOfDateRegex;
+    }
+
+    @Override
+    public final Pattern getLaterEarlyPeriodRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getWeekWithWeekDayRangeRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getYearPlusNumberRegex() {
+        return yearPlusNumberRegex;
+    }
+
+    @Override
+    public final Pattern getDecadeWithCenturyRegex() {
+        return decadeWithCenturyRegex;
+    }
+
+    @Override
+    public final Pattern getYearPeriodRegex() {
+        return yearPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getComplexDatePeriodRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeDecadeRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getReferenceDatePeriodRegex() {
+        return referenceDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex() {
+        return agoRegex;
+    }
+
+    @Override
+    public final Pattern getLaterRegex() {
+        return laterRegex;
+    }
+
+    @Override
+    public final Pattern getLessThanRegex() {
+        return lessThanRegex;
+    }
+
+    @Override
+    public final Pattern getMoreThanRegex() {
+        return moreThanRegex;
+    }
+
+    @Override
+    public final Pattern getCenturySuffixRegex() {
+        return centurySuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getPastPrefixRegex() {
+        return pastPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getThisPrefixRegex() {
+        return thisPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeRegex() {
+        return relativeRegex;
+    }
+
+    @Override
+    public final Pattern getUnspecificEndOfRangeRegex() {
+        return unspecificEndOfRangeRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public int getSwiftDayOrMonth(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+        int swift = 0;
+
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchPast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+
+        if (matchNext.isPresent()) {
+            swift = 1;
+        } else if (matchPast.isPresent()) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public int getSwiftYear(String text) {
+
+        String trimmedText = text.trim().toLowerCase();
+        int swift = -10;
+
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchPast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchThisPresent = Arrays.stream(RegExpUtility.getMatches(thisPrefixRegex, trimmedText)).findFirst();
+
+        if (matchNext.isPresent()) {
+            swift = 1;
+        } else if (matchPast.isPresent()) {
+            swift = -1;
+        } else if (matchThisPresent.isPresent()) {
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public boolean isFuture(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        Optional<Match> matchThis = Arrays.stream(RegExpUtility.getMatches(thisPrefixRegex, trimmedText)).findFirst();
+        Optional<Match> matchNext = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText)).findFirst();
+        return matchThis.isPresent() || matchNext.isPresent();
+    }
+
+    @Override
+    public boolean isLastCardinal(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        Optional<Match> matchLast = Arrays.stream(RegExpUtility.getMatches(pastPrefixRegex, trimmedText)).findFirst();
+        return matchLast.isPresent();
+    }
+
+    @Override
+    public boolean isMonthOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.MonthTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isMonthToDate(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.MonthToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekend(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) &&
+                !SpanishDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearOnly(String text) {
+        String trimmedText = text.trim().toLowerCase();
+        return SpanishDateTime.YearTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearToDate(String text) {
+        String trimmedText = text.trim().toLowerCase();
+
+        return SpanishDateTime.YearToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishHolidayParserConfiguration.java
@@ -1,0 +1,136 @@
+package com.microsoft.recognizers.text.datetime.spanish.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.IntFunction;
+
+public class SpanishHolidayParserConfiguration extends BaseHolidayParserConfiguration {
+
+    public SpanishHolidayParserConfiguration() {
+
+        super();
+
+        this.setHolidayRegexList(SpanishHolidayExtractorConfiguration.HolidayRegexList);
+
+        HashMap<String, Iterable<String>> holidayNamesMap = new HashMap<>();
+        for (Map.Entry<String, String[]> entry : SpanishDateTime.HolidayNames.entrySet()) {
+            if (entry.getValue() instanceof String[]) {
+                holidayNamesMap.put(entry.getKey(), Arrays.asList(entry.getValue()));
+            }
+        }
+        this.setHolidayNames(ImmutableMap.copyOf(holidayNamesMap));
+
+        HashMap<String, String> variableHolidaysTimexMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : SpanishDateTime.VariableHolidaysTimexDictionary.entrySet()) {
+            if (entry.getValue() instanceof String) {
+                variableHolidaysTimexMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        this.setVariableHolidaysTimexDictionary(ImmutableMap.copyOf(variableHolidaysTimexMap));
+    }
+
+    @Override
+    public int getSwiftYear(String text) {
+
+        String trimmedText = StringUtility
+            .trimStart(StringUtility.trimEnd(text)).toLowerCase(Locale.ROOT);
+        int swift = -10;
+        Optional<Match> matchNextPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.nextPrefixRegex, text)).findFirst();
+        Optional<Match> matchPastPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.pastPrefixRegex, text)).findFirst();
+        Optional<Match> matchThisPrefixRegex = Arrays.stream(RegExpUtility.getMatches(
+            SpanishDatePeriodParserConfiguration.thisPrefixRegex, text)).findFirst();
+        if (matchNextPrefixRegex.isPresent() && matchNextPrefixRegex.get().length == text.trim().length()) {
+            swift = 1;
+        } else if (matchPastPrefixRegex.isPresent() && matchPastPrefixRegex.get().length == text.trim().length()) {
+            swift = -1;
+        } else if (matchThisPrefixRegex.isPresent() && matchThisPrefixRegex.get().length == text.trim().length()) {
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    public String sanitizeHolidayToken(String holiday) {
+        return holiday.replace(" ", "")
+            .replace("á", "a")
+            .replace("é", "e")
+            .replace("í", "i")
+            .replace("ó", "o")
+            .replace("ú", "u");
+    }
+
+    @Override
+    protected HashMap<String, IntFunction<LocalDateTime>> initHolidayFuncs() {
+
+        HashMap<String, IntFunction<LocalDateTime>> holidays = new HashMap<>(super.initHolidayFuncs());
+        holidays.put("padres", SpanishHolidayParserConfiguration::fathersDay);
+        holidays.put("madres", SpanishHolidayParserConfiguration::mothersDay);
+        holidays.put("acciondegracias", SpanishHolidayParserConfiguration::thanksgivingDay);
+        holidays.put("trabajador", SpanishHolidayParserConfiguration::labourDay);
+        holidays.put("delaraza", SpanishHolidayParserConfiguration::columbusDay);
+        holidays.put("memoria", SpanishHolidayParserConfiguration::memorialDay);
+        holidays.put("pascuas", SpanishHolidayParserConfiguration::pascuas);
+        holidays.put("navidad", SpanishHolidayParserConfiguration::christmasDay);
+        holidays.put("nochebuena", SpanishHolidayParserConfiguration::christmasEve);
+        holidays.put("añonuevo", SpanishHolidayParserConfiguration::newYear);
+        holidays.put("nochevieja", SpanishHolidayParserConfiguration::newYearEve);
+        holidays.put("yuandan", SpanishHolidayParserConfiguration::newYear);
+        holidays.put("maestro", SpanishHolidayParserConfiguration::teacherDay);
+        holidays.put("todoslossantos", SpanishHolidayParserConfiguration::halloweenDay);
+        holidays.put("niño", SpanishHolidayParserConfiguration::childrenDay);
+        holidays.put("mujer", SpanishHolidayParserConfiguration::femaleDay);
+
+        return holidays;
+    }
+
+    private static LocalDateTime newYear(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 1, 1);
+    }
+
+    private static LocalDateTime newYearEve(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 31);
+    }
+
+    private static LocalDateTime christmasDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 25);
+    }
+
+    private static LocalDateTime christmasEve(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 24);
+    }
+
+    private static LocalDateTime femaleDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 8);
+    }
+
+    private static LocalDateTime childrenDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 6, 1);
+    }
+
+    private static LocalDateTime halloweenDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 10, 31);
+    }
+
+    private static LocalDateTime teacherDay(int year) {
+        return DateUtil.safeCreateFromMinValue(year, 9, 10);
+    }
+
+    private static LocalDateTime pascuas(int year) {
+        return DateUtil.minValue();
+    }
+}

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -36,6 +36,7 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
 import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishHolidayParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
@@ -229,8 +230,8 @@ public class DateTimeParserTest extends AbstractTest {
             //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "DurationParser":
                 return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "HolidayParser":
-            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            case "HolidayParser":
+                return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
             //case "SetParser":
             //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "MergedParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -37,6 +37,7 @@ import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDatePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
@@ -218,8 +219,8 @@ public class DateTimeParserTest extends AbstractTest {
         switch (name) {
             case "DateParser":
                 return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DatePeriodParser":
-            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DatePeriodParser":
+                return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeAltParser":
             //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             //case "DateTimeParser":

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -37,6 +37,7 @@ import com.microsoft.recognizers.text.datetime.parsers.DateTimeParseResult;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishCommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.parsers.SpanishTimeParserConfiguration;
@@ -237,36 +238,6 @@ public class DateTimeParserTest extends AbstractTest {
                 return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "TimePeriodParser":
                 return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            default:
-                throw new AssumptionViolatedException("Parser Type/Name not supported.");
-        }
-    }
-
-    private static IDateTimeParser getSpanishParser(String name) {
-
-        switch (name) {
-            //case "DateParser":
-            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DatePeriodParser":
-            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimeAltParser":
-            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimeParser":
-            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DateTimePeriodParser":
-            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "DurationParser":
-            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "HolidayParser":
-            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
-            //case "SetParser":
-            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "MergedParser":
-            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
-            //case "TimeParser":
-            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "TimePeriodParser":
-            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             default:
                 throw new AssumptionViolatedException("Parser Type/Name not supported.");
         }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -242,6 +242,36 @@ public class DateTimeParserTest extends AbstractTest {
         }
     }
 
+    private static IDateTimeParser getSpanishParser(String name) {
+
+        switch (name) {
+            //case "DateParser":
+            //    return new BaseDateParser(new SpanishDateParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DatePeriodParser":
+            //    return new BaseDatePeriodParser(new SpanishDatePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeAltParser":
+            //    return new BaseDateTimeAltParser(new EnglishDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeParser":
+            //    return new BaseDateTimeParser(new SpanishDateTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimePeriodParser":
+            //    return new BaseDateTimePeriodParser(new SpanishDateTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DurationParser":
+            //    return new BaseDurationParser(new SpanishDurationParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "HolidayParser":
+            //    return new BaseHolidayParser(new SpanishHolidayParserConfiguration());
+            //case "SetParser":
+            //    return new BaseSetParser(new SpanishSetParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "MergedParser":
+            //    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(DateTimeOptions.None));
+            //case "TimeParser":
+            //    return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "TimePeriodParser":
+            //    return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            default:
+                throw new AssumptionViolatedException("Parser Type/Name not supported.");
+        }
+    }
+
     private IDateTimeExtractor getExtractor(TestCase currentCase) {
 
         String extractorName = currentCase.modelName.replace("Parser", "Extractor");


### PR DESCRIPTION
This PR is based on #1269 and will be rebased once parent PR is merged.

# Description
- Enable `SpanishHolidayParser` tests
- Port `SpanishHolidayParserConfiguration` from [C#](https://github.com/Microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs) to Java

# Passing tests

![image](https://user-images.githubusercontent.com/42191764/51038636-84447c00-1592-11e9-9e41-66d389e24fd3.png)
