### PR TITLE
[StyleCop] Fix warnings TextNumber Options

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Recognizers.Text.Number
 {
-    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Reviwed.")]
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Constant names are written in upper case so they can be readily distinguished from camel case variable names.")]
     public static class Constants
     {
         public const string SYS_NUM_CARDINAL = "builtin.num.cardinal";

--- a/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Constants.cs
@@ -1,9 +1,9 @@
-﻿// ReSharper disable InconsistentNaming
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Recognizers.Text.Number
 {
+    [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Reviwed.")]
     public static class Constants
     {
         public const string SYS_NUM_CARDINAL = "builtin.num.cardinal";

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberMapGenerator.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberMapGenerator.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Recognizers.Text.Number
     {
         public static ImmutableDictionary<string, long> InitOrdinalNumberMap(Dictionary<string, long> ordinalNumberMap, Dictionary<string, long> prefixCardinalMap, Dictionary<string, long> suffixOrdinalMap)
         {
-            var simpleOrdinalDictionary = ordinalNumberMap.ToDictionary(entry => entry.Key,
-                              entry => entry.Value);
+            var simpleOrdinalDictionary = ordinalNumberMap.ToDictionary(
+                                          entry => entry.Key, entry => entry.Value);
 
             foreach (var suffix in suffixOrdinalMap)
             {

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Recognizers.Text.Number
     {
         None = 0,
         PercentageMode = 1,
-        ExperimentalMode = 2
+        ExperimentalMode = 2,
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberOptions.cs
@@ -5,8 +5,19 @@ namespace Microsoft.Recognizers.Text.Number
     [Flags]
     public enum NumberOptions
     {
+        /// <summary>
+        /// Represents None
+        /// </summary>
         None = 0,
+
+        /// <summary>
+        /// Represents PercentageMode
+        /// </summary>
         PercentageMode = 1,
+
+        /// <summary>
+        /// Represents ExperimentalMode
+        /// </summary>
         ExperimentalMode = 2,
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -7,9 +7,9 @@ using Microsoft.Recognizers.Text.Number.French;
 using Microsoft.Recognizers.Text.Number.German;
 using Microsoft.Recognizers.Text.Number.Italian;
 using Microsoft.Recognizers.Text.Number.Japanese;
+using Microsoft.Recognizers.Text.Number.Korean;
 using Microsoft.Recognizers.Text.Number.Portuguese;
 using Microsoft.Recognizers.Text.Number.Spanish;
-using Microsoft.Recognizers.Text.Number.Korean;
 
 namespace Microsoft.Recognizers.Text.Number
 {
@@ -35,26 +35,6 @@ namespace Microsoft.Recognizers.Text.Number
         {
         }
 
-        public NumberModel GetNumberModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<NumberModel>(culture, fallbackToDefaultCulture);
-        }
-
-        public OrdinalModel GetOrdinalModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<OrdinalModel>(culture, fallbackToDefaultCulture);
-        }
-
-        public PercentModel GetPercentageModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<PercentModel>(culture, fallbackToDefaultCulture);
-        }
-
-        public NumberRangeModel GetNumberRangeModel(string culture = null, bool fallbackToDefaultCulture = true)
-        {
-            return GetModel<NumberRangeModel>(culture, fallbackToDefaultCulture);
-        }
-
         public static List<ModelResult> RecognizeNumber(string query, string culture, NumberOptions options = NumberOptions.None, bool fallbackToDefaultCulture = true)
         {
             return RecognizeByModel(recognizer => recognizer.GetNumberModel(culture, fallbackToDefaultCulture), query, options);
@@ -77,36 +57,44 @@ namespace Microsoft.Recognizers.Text.Number
             return RecognizeByModel(recognizer => recognizer.GetNumberRangeModel(culture, fallbackToDefaultCulture), query, options);
         }
 
-        private static List<ModelResult> RecognizeByModel(Func<NumberRecognizer, IModel> getModelFunc, string query, NumberOptions options)
+        public NumberModel GetNumberModel(string culture = null, bool fallbackToDefaultCulture = true)
         {
-            var recognizer = new NumberRecognizer(options);
-            var model = getModelFunc(recognizer);
-            return model.Parse(query);
+            return GetModel<NumberModel>(culture, fallbackToDefaultCulture);
+        }
+
+        public OrdinalModel GetOrdinalModel(string culture = null, bool fallbackToDefaultCulture = true)
+        {
+            return GetModel<OrdinalModel>(culture, fallbackToDefaultCulture);
+        }
+
+        public PercentModel GetPercentageModel(string culture = null, bool fallbackToDefaultCulture = true)
+        {
+            return GetModel<PercentModel>(culture, fallbackToDefaultCulture);
+        }
+
+        public NumberRangeModel GetNumberRangeModel(string culture = null, bool fallbackToDefaultCulture = true)
+        {
+            return GetModel<NumberRangeModel>(culture, fallbackToDefaultCulture);
         }
 
         protected override void InitializeConfiguration()
         {
-            #region English
-
             RegisterModel<NumberModel>(
                 Culture.English,
                 options => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number,
-                        new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration(options)),
                     English.MergedNumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.English,
                 options => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal,
-                        new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new EnglishNumberParserConfiguration(options)),
                     English.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.English,
                 options => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage,
-                        new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new EnglishNumberParserConfiguration(options)),
                     new English.PercentageExtractor(options)));
 
             RegisterModel<NumberRangeModel>(
@@ -114,11 +102,7 @@ namespace Microsoft.Recognizers.Text.Number
                 options => new NumberRangeModel(
                     new BaseNumberRangeParser(new EnglishNumberRangeParserConfiguration()),
                     new English.NumberRangeExtractor(options)));
-                    
-            #endregion
 
-            #region Chinese
-            
             RegisterModel<NumberModel>(
                 Culture.Chinese,
                 (options) => new NumberModel(
@@ -142,11 +126,7 @@ namespace Microsoft.Recognizers.Text.Number
                 (options) => new NumberRangeModel(
                             new BaseNumberRangeParser(new ChineseNumberRangeParserConfiguration()),
                             new Chinese.NumberRangeExtractor(options)));
-                            
-            #endregion
 
-            #region Spanish
-            
             RegisterModel<NumberModel>(
                 Culture.Spanish,
                 (options) => new NumberModel(
@@ -170,11 +150,7 @@ namespace Microsoft.Recognizers.Text.Number
                 (options) => new NumberRangeModel(
                     new BaseNumberRangeParser(new SpanishNumberRangeParserConfiguration()),
                     new Spanish.NumberRangeExtractor(options)));
-                    
-            #endregion
 
-            #region Portuguese
-            
             RegisterModel<NumberModel>(
                 Culture.Portuguese,
                 (options) => new NumberModel(
@@ -192,11 +168,7 @@ namespace Microsoft.Recognizers.Text.Number
                 (options) => new PercentModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new PortugueseNumberParserConfiguration()),
                     new Portuguese.PercentageExtractor()));
-                    
-            #endregion
 
-            #region French
-            
             RegisterModel<NumberModel>(
                 Culture.French,
                 (options) => new NumberModel(
@@ -214,11 +186,7 @@ namespace Microsoft.Recognizers.Text.Number
                 (options) => new PercentModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration()),
                     new French.PercentageExtractor()));
-                    
-            #endregion
 
-            #region German
-            
             RegisterModel<NumberModel>(
                 Culture.German,
                 (options) => new NumberModel(
@@ -236,10 +204,6 @@ namespace Microsoft.Recognizers.Text.Number
                 (options) => new PercentModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new GermanNumberParserConfiguration()),
                     new German.PercentageExtractor()));
-
-            #endregion
-
-            #region Italian
 
             /*
             RegisterModel<NumberModel>(
@@ -260,10 +224,6 @@ namespace Microsoft.Recognizers.Text.Number
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ItalianNumberParserConfiguration()),
                     new Italian.PercentageExtractor()));
             */
-
-            #endregion
-
-            #region Japanese
 
             RegisterModel<NumberModel>(
                 Culture.Japanese,
@@ -290,27 +250,19 @@ namespace Microsoft.Recognizers.Text.Number
                     new BaseNumberRangeParser(new JapaneseNumberRangeParserConfiguration()),
                     new Japanese.NumberRangeExtractor(options)));
             */
-                            
-            #endregion
 
-            #region Korean
-            
             RegisterModel<NumberModel>(
                 Culture.Korean,
                 (options) => new NumberModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new KoreanNumberParserConfiguration()),
                     new Korean.NumberExtractor()));
 
-            #endregion
-
-            #region Dutch
-
             RegisterModel<NumberModel>(
                 Culture.Dutch,
                 (options) => new NumberModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration()),
                     Dutch.NumberExtractor.GetInstance(NumberMode.PureNumber)));
-   
+
             RegisterModel<OrdinalModel>(
                 Culture.Dutch,
                 (options) => new OrdinalModel(
@@ -330,7 +282,13 @@ namespace Microsoft.Recognizers.Text.Number
                     new BaseNumberRangeParser(new DutchNumberRangeParserConfiguration()),
                     new Dutch.NumberRangeExtractor(options)));
             */
-            #endregion
+        }
+
+        private static List<ModelResult> RecognizeByModel(Func<NumberRecognizer, IModel> getModelFunc, string query, NumberOptions options)
+        {
+            var recognizer = new NumberRecognizer(options);
+            var model = getModelFunc(recognizer);
+            return model.Parse(query);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Recognizers.Text.Number")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/RegexTagGenerator.cs
@@ -3,21 +3,10 @@
     public static class RegexTagGenerator
     {
         private static int priority;
+
         public static TypeTag GenerateRegexTag(string extractorType, string suffix)
         {
             return new TypeTag($"{extractorType}{suffix}", ++priority);
-        }
-    }
-
-    public class TypeTag
-    {
-        public string Name { get; }
-        public int Priority { get; }
-
-        public TypeTag(string name, int priority)
-        {
-            Name = name;
-            Priority = priority;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/TypeTag.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/TypeTag.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Recognizers.Text.Number
+{
+
+    public class TypeTag
+    {
+        public string Name { get; }
+
+        public int Priority { get; }
+
+        public TypeTag(string name, int priority)
+        {
+            Name = name;
+            Priority = priority;
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/TypeTag.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/TypeTag.cs
@@ -1,16 +1,15 @@
 ﻿namespace Microsoft.Recognizers.Text.Number
 {
-
     public class TypeTag
     {
-        public string Name { get; }
-
-        public int Priority { get; }
-
         public TypeTag(string name, int priority)
         {
             Name = name;
             Priority = priority;
         }
+
+        public string Name { get; }
+
+        public int Priority { get; }
     }
 }


### PR DESCRIPTION
- Reordered properties and methods
- Added spaces and trailing commas when needed
- Fixed spacing
- Suppress StyleCop Message in constants variables
- Remove region comments