### PR TITLE
[StyleCop] Fix warnings TextNumberGerman Extractors and Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/CardinalExtractor.cs
@@ -8,16 +8,31 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
+        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances =
+            new ConcurrentDictionary<string, CardinalExtractor>();
+
+        private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
+
+            // Add Integer Regexes
+            var intExtract = IntegerExtractor.GetInstance(placeholder);
+            builder.AddRange(intExtract.Regexes);
+
+            // Add Double Regexes
+            var douExtract = DoubleExtractor.GetInstance(placeholder);
+            builder.AddRange(douExtract.Regexes);
+
+            Regexes = builder.ToImmutable();
+        }
+
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; //"Cardinal";
-
-        private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances = 
-            new ConcurrentDictionary<string, CardinalExtractor>();
+        // "Cardinal";
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
 
         public static CardinalExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
-
             if (!Instances.ContainsKey(placeholder))
             {
                 var instance = new CardinalExtractor(placeholder);
@@ -25,21 +40,6 @@ namespace Microsoft.Recognizers.Text.Number.German
             }
 
             return Instances[placeholder];
-        }
-
-        private CardinalExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
-
-            //Add Integer Regexes
-            var intExtract = IntegerExtractor.GetInstance(placeholder);
-            builder.AddRange(intExtract.Regexes);
-
-            //Add Double Regexes
-            var douExtract = DoubleExtractor.GetInstance(placeholder);
-            builder.AddRange(douExtract.Regexes);
-
-            Regexes = builder.ToImmutable();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE; // "Double";
-
-        private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances = 
+        private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances =
             new ConcurrentDictionary<string, DoubleExtractor>();
-
-        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new DoubleExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private DoubleExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -67,10 +51,26 @@ namespace Microsoft.Recognizers.Text.Number.German
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.DoubleNumNoBreakSpaceComma, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        // "Double";
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_DOUBLE;
+
+        public static DoubleExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new DoubleExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class FractionExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION; // "Fraction";
-
-        private static readonly ConcurrentDictionary<string, FractionExtractor> Instances = 
-            new ConcurrentDictionary<string, FractionExtractor>();
-
-        public static FractionExtractor GetInstance(string placeholder = "")
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new FractionExtractor();
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
+        private static readonly ConcurrentDictionary<string, FractionExtractor> Instances =
+         new ConcurrentDictionary<string, FractionExtractor>();
 
         private FractionExtractor()
         {
@@ -51,10 +35,26 @@ namespace Microsoft.Recognizers.Text.Number.German
                 {
                     new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.GERMAN)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        // "Fraction";
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_FRACTION;
+
+        public static FractionExtractor GetInstance(string placeholder = "")
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new FractionExtractor();
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
-
-        private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances = 
+        private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances =
             new ConcurrentDictionary<string, IntegerExtractor>();
-
-        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new IntegerExtractor(placeholder);
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private IntegerExtractor(string placeholder = NumbersDefinitions.PlaceHolderDefault)
         {
@@ -67,10 +51,26 @@ namespace Microsoft.Recognizers.Text.Number.German
                 {
                     GenerateLongFormatNumberRegexes(LongFormatType.IntegerNumNoBreakSpace, placeholder),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        // "Integer";
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
+
+        public static IntegerExtractor GetInstance(string placeholder = NumbersDefinitions.PlaceHolderDefault)
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new IntegerExtractor(placeholder);
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
@@ -8,31 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class NumberExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
-
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor>();
-
-        public static NumberExtractor GetInstance(NumberMode mode = NumberMode.Default,
-            NumberOptions options = NumberOptions.None)
-        {
-
-            var cacheKey = (mode, options);
-            if (!Instances.ContainsKey(cacheKey))
-            {
-                var instance = new NumberExtractor(mode);
-                Instances.TryAdd(cacheKey, instance);
-            }
-
-            return Instances[cacheKey];
-        }
 
         private NumberExtractor(NumberMode mode = NumberMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
-            
+
             // Add Cardinal
             CardinalExtractor cardExtract = null;
             switch (mode)
@@ -41,8 +23,9 @@ namespace Microsoft.Recognizers.Text.Number.German
                     cardExtract = CardinalExtractor.GetInstance(NumbersDefinitions.PlaceHolderPureNumber);
                     break;
                 case NumberMode.Currency:
-                    builder.Add(BaseNumberExtractor.CurrencyRegex,
-                                RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
+                    builder.Add(
+                        BaseNumberExtractor.CurrencyRegex,
+                        RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
                     break;
                 case NumberMode.Default:
                     break;
@@ -54,12 +37,30 @@ namespace Microsoft.Recognizers.Text.Number.German
             }
 
             builder.AddRange(cardExtract.Regexes);
-            
+
             // Add Fraction
             var fracExtract = FractionExtractor.GetInstance();
             builder.AddRange(fracExtract.Regexes);
 
             Regexes = builder.ToImmutable();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
+
+        public static NumberExtractor GetInstance(
+            NumberMode mode = NumberMode.Default,
+            NumberOptions options = NumberOptions.None)
+        {
+            var cacheKey = (mode, options);
+            if (!Instances.ContainsKey(cacheKey))
+            {
+                var instance = new NumberExtractor(mode);
+                Instances.TryAdd(cacheKey, instance);
+            }
+
+            return Instances[cacheKey];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
@@ -9,24 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
-        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
-
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
-
-        private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances = 
+        private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances =
             new ConcurrentDictionary<string, OrdinalExtractor>();
-
-        public static OrdinalExtractor GetInstance(string placeholder = "")
-        {
-
-            if (!Instances.ContainsKey(placeholder))
-            {
-                var instance = new OrdinalExtractor();
-                Instances.TryAdd(placeholder, instance);
-            }
-
-            return Instances[placeholder];
-        }
 
         private OrdinalExtractor()
         {
@@ -47,10 +31,25 @@ namespace Microsoft.Recognizers.Text.Number.German
                 {
                     new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexOptions.Singleline),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.GERMAN)
-                }
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL; // "Ordinal";
+
+        public static OrdinalExtractor GetInstance(string placeholder = "")
+        {
+            if (!Instances.ContainsKey(placeholder))
+            {
+                var instance = new OrdinalExtractor();
+                Instances.TryAdd(placeholder, instance);
+            }
+
+            return Instances[placeholder];
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/PercentageExtractor.cs
@@ -8,21 +8,21 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public sealed class PercentageExtractor : BasePercentageExtractor
     {
-        protected override NumberOptions Options { get; }
-
-        public PercentageExtractor(NumberOptions options = NumberOptions.None) : base(
-            NumberExtractor.GetInstance(options: options))
+        public PercentageExtractor(NumberOptions options = NumberOptions.None)
+            : base(NumberExtractor.GetInstance(options: options))
         {
             Options = options;
             Regexes = InitRegexes();
         }
+
+        protected override NumberOptions Options { get; }
 
         protected override ImmutableHashSet<Regex> InitRegexes()
         {
             var regexStrs = new HashSet<string>
             {
                 NumbersDefinitions.NumberWithSuffixPercentage,
-                NumbersDefinitions.NumberWithPrefixPercentage
+                NumbersDefinitions.NumberWithPrefixPercentage,
             };
 
             return BuildRegexes(regexStrs);

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
@@ -10,7 +10,10 @@ namespace Microsoft.Recognizers.Text.Number.German
 {
     public class GermanNumberParserConfiguration : INumberParserConfiguration
     {
-        public GermanNumberParserConfiguration() : this(new CultureInfo(Culture.German)) { }
+        public GermanNumberParserConfiguration()
+            : this(new CultureInfo(Culture.German))
+        {
+        }
 
         public GermanNumberParserConfiguration(CultureInfo ci)
         {
@@ -34,7 +37,7 @@ namespace Microsoft.Recognizers.Text.Number.German
             this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);
             this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexOptions.Singleline);
-            this.FractionPrepositionRegex  = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
+            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
         }
 
         public ImmutableDictionary<string, long> CardinalNumberMap { get; private set; }
@@ -101,7 +104,6 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         public long ResolveCompositeNumber(string numberStr)
         {
-
             if (numberStr.Contains("-"))
             {
                 var numbers = numberStr.Split('-');


### PR DESCRIPTION
-Reordered properties and methods
-Added spaces and trailing commas when needed
-Fixed spacing