### PR TITLE
[StyleCop] Fix all the warnings in Spanish\Extractors

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/AgeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/AgeExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class AgeExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public AgeExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
 
-        public AgeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public AgeExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public AgeExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AgeSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_AGE;
-
-        public static readonly ImmutableDictionary<string, string> AgeSuffixList = NumbersWithUnitDefinitions.AgeSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/AreaExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/AreaExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class AreaExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public AreaExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
 
-        public AreaExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AreaAmbiguousValues.ToImmutableList();
+
+        public AreaExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public AreaExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => AreaSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_AREA;
-
-        public static readonly ImmutableDictionary<string, string> AreaSuffixList = NumbersWithUnitDefinitions.AreaSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AreaAmbiguousValues.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/CurrencyExtractorConfiguration.cs
@@ -7,9 +7,21 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class CurrencyExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public CurrencyExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> CurrencySuffixList = NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
 
-        public CurrencyExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
+
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
+
+        public CurrencyExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public CurrencyExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => CurrencySuffixList;
 
@@ -18,11 +30,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_CURRENCY;
-
-        public static readonly ImmutableDictionary<string, string> CurrencySuffixList = NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
-
-        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousCurrencyUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/DimensionExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/DimensionExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class DimensionExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public DimensionExtractorConfiguration() : base(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> DimensionSuffixList = NumbersWithUnitDefinitions.DimensionSuffixList.ToImmutableDictionary();
 
-        public DimensionExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousDimensionUnitList.ToImmutableList();
+
+        public DimensionExtractorConfiguration()
+               : base(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public DimensionExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => DimensionSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_DIMENSION;
-
-        public static readonly ImmutableDictionary<string, string> DimensionSuffixList = NumbersWithUnitDefinitions.DimensionSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousDimensionUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/LengthExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/LengthExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class LengthExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public LengthExtractorConfiguration() : base(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
 
-        public LengthExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
+
+        public LengthExtractorConfiguration()
+               : base(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public LengthExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => LengthSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_LENGTH;
-
-        public static readonly ImmutableDictionary<string, string> LengthSuffixList = NumbersWithUnitDefinitions.LengthSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousLengthUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public abstract class SpanishNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
+        private static readonly Regex CompoundUnitConnRegex =
+            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
+
+        private static readonly Regex NonUnitsRegex =
+            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
+
         protected SpanishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -45,11 +51,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public abstract ImmutableDictionary<string, string> PrefixList { get; }
 
         public abstract ImmutableList<string> AmbiguousUnitList { get; }
-
-        private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
-
-        private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpeedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpeedExtractorConfiguration.cs
@@ -7,9 +7,19 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class SpeedExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public SpeedExtractorConfiguration() : base(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
 
-        public SpeedExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousSpeedUnitList.ToImmutableList();
+
+        public SpeedExtractorConfiguration()
+               : base(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public SpeedExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => SpeedSuffixList;
 
@@ -18,9 +28,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => AmbiguousValues;
 
         public override string ExtractType => Constants.SYS_UNIT_SPEED;
-
-        public static readonly ImmutableDictionary<string, string> SpeedSuffixList = NumbersWithUnitDefinitions.SpeedSuffixList.ToImmutableDictionary();
-
-        private static readonly ImmutableList<string> AmbiguousValues = NumbersWithUnitDefinitions.AmbiguousSpeedUnitList.ToImmutableList();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
@@ -9,9 +9,21 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class TemperatureExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public TemperatureExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList =
+            NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
 
-        public TemperatureExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        private static readonly Regex AmbiguousUnitMultiplierRegex =
+            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
+
+        public TemperatureExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public TemperatureExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => TemperatureSuffixList;
 
@@ -21,12 +33,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public static readonly ImmutableDictionary<string, string> TemperatureSuffixList = 
-            NumbersWithUnitDefinitions.TemperatureSuffixList.ToImmutableDictionary();
-
         public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
-
-        private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/VolumeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/VolumeExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class VolumeExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public VolumeExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
 
-        public VolumeExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public VolumeExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public VolumeExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => VolumeSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_VOLUME;
-
-        public static readonly ImmutableDictionary<string, string> VolumeSuffixList = NumbersWithUnitDefinitions.VolumeSuffixList.ToImmutableDictionary();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/WeightExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/WeightExtractorConfiguration.cs
@@ -7,9 +7,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 {
     public class WeightExtractorConfiguration : SpanishNumberWithUnitExtractorConfiguration
     {
-        public WeightExtractorConfiguration() : this(new CultureInfo(Culture.Spanish)) { }
+        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
 
-        public WeightExtractorConfiguration(CultureInfo ci) : base(ci) { }
+        public WeightExtractorConfiguration()
+               : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public WeightExtractorConfiguration(CultureInfo ci)
+               : base(ci)
+        {
+        }
 
         public override ImmutableDictionary<string, string> SuffixList => WeightSuffixList;
 
@@ -18,7 +26,5 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         public override ImmutableList<string> AmbiguousUnitList => null;
 
         public override string ExtractType => Constants.SYS_UNIT_WEIGHT;
-
-        public static readonly ImmutableDictionary<string, string> WeightSuffixList = NumbersWithUnitDefinitions.WeightSuffixList.ToImmutableDictionary();
     }
 }


### PR DESCRIPTION
- SA1502: Element should not be on a single line - Move curly braces to different lines
- SA1201: A field should not follow a property - Reorder fields and properties
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line