### PR TITLE
[StyleCop] Fix all the warnings in Portuguese\Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/AgeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class AgeParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public AgeParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public AgeParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public AgeParserConfiguration(CultureInfo ci) : base(ci)
+        public AgeParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(AgeExtractorConfiguration.AgeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/AreaParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/AreaParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class AreaParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public AreaParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public AreaParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public AreaParserConfiguration(CultureInfo ci) : base(ci)
+        public AreaParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(AreaExtractorConfiguration.AreaSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/CurrencyParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/CurrencyParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class CurrencyParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public CurrencyParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public CurrencyParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public CurrencyParserConfiguration(CultureInfo ci) : base(ci)
+        public CurrencyParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/DimensionParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/DimensionParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class DimensionParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public DimensionParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public DimensionParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public DimensionParserConfiguration(CultureInfo ci) : base(ci)
+        public DimensionParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/LengthParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/LengthParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class LengthParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public LengthParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public LengthParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public LengthParserConfiguration(CultureInfo ci) : base(ci)
+        public LengthParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(LengthExtractorConfiguration.LengthSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/PortugueseNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/PortugueseNumberWithUnitParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class PortugueseNumberWithUnitParserConfiguration : BaseNumberWithUnitParserConfiguration
     {
-        public PortugueseNumberWithUnitParserConfiguration(CultureInfo ci) : base(ci)
+        public PortugueseNumberWithUnitParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/SpeedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/SpeedParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class SpeedParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public SpeedParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public SpeedParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public SpeedParserConfiguration(CultureInfo ci) : base(ci)
+        public SpeedParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/TemperatureParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/TemperatureParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class TemperatureParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public TemperatureParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public TemperatureParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public TemperatureParserConfiguration(CultureInfo ci) : base(ci)
+        public TemperatureParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/VolumeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/VolumeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class VolumeParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public VolumeParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public VolumeParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public VolumeParserConfiguration(CultureInfo ci) : base(ci)
+        public VolumeParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/WeightParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/WeightParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 {
     public class WeightParserConfiguration : PortugueseNumberWithUnitParserConfiguration
     {
-        public WeightParserConfiguration() : this(new CultureInfo(Culture.Portuguese)) { }
+        public WeightParserConfiguration()
+               : this(new CultureInfo(Culture.Portuguese))
+        {
+        }
 
-        public WeightParserConfiguration(CultureInfo ci) : base(ci)
+        public WeightParserConfiguration(CultureInfo ci)
+               : base(ci)
         {
             this.BindDictionary(WeightExtractorConfiguration.WeightSuffixList);
         }


### PR DESCRIPTION
- SA1502: Element should not be on a single line - Move curly braces to different lines
- SA1201: A field should not follow a property - Reorder fields and properties
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line