### PR TITLE
[StyleCop] Fix all warnings in Portuguese Extractors and Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
@@ -1,27 +1,11 @@
-﻿using System.Text.RegularExpressions;
-
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Portuguese;
-using System.Collections.Generic;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    class PortugueseDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    internal class PortugueseDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
-        public PortugueseDateTimeAltExtractorConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
-            DatePeriodExtractor = new BaseDatePeriodExtractor(new PortugueseDatePeriodExtractorConfiguration(this));
-        }
-
-        public IDateExtractor DateExtractor { get; }
-        public IDateTimeExtractor DatePeriodExtractor { get; }
-
-        private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
-
-        private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
-
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.Singleline);
 
@@ -49,6 +33,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             AmRegex, PmRegex,
         };
+
+        private static readonly Regex OrRegex =
+            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
+
+        private static readonly Regex DayRegex =
+            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
+
+        public PortugueseDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
+            DatePeriodExtractor = new BaseDatePeriodExtractor(new PortugueseDatePeriodExtractorConfiguration(this));
+        }
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IDateTimeExtractor DatePeriodExtractor { get; }
 
         IEnumerable<Regex> IDateTimeAltExtractorConfiguration.RelativePrefixList => RelativePrefixList;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -1,6 +1,5 @@
-﻿using System.Text.RegularExpressions;
-using System.Collections.Generic;
-
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Portuguese;
 using Microsoft.Recognizers.Text.Matcher;
 
@@ -8,20 +7,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
     {
-        public static readonly Regex BeforeRegex = 
+        public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AfterRegex = 
+        public static readonly Regex AfterRegex =
             new Regex(DateTimeDefinitions.AfterRegex, RegexOptions.Singleline);
 
-        public static readonly Regex SinceRegex = 
+        public static readonly Regex SinceRegex =
             new Regex(DateTimeDefinitions.SinceRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AroundRegex = 
+        public static readonly Regex AroundRegex =
             new Regex(DateTimeDefinitions.AroundRegex, RegexOptions.Singleline);
 
-        //TODO: change the following three regexes to Portuguese if there are the same requirement of splitting from A to B as two time points
-        public static readonly Regex FromToRegex = 
+        // TODO: change the following three regexes to Portuguese if there are the same requirement of splitting from A to B as two time points
+        public static readonly Regex FromToRegex =
             new Regex(DateTimeDefinitions.FromToRegex, RegexOptions.Singleline);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
@@ -30,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex PrepositionSuffixRegex =
             new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexOptions.Singleline);
 
-        public static readonly Regex NumberEndingPattern = 
+        public static readonly Regex NumberEndingPattern =
             new Regex(DateTimeDefinitions.NumberEndingPattern, RegexOptions.Singleline);
 
         public static readonly Regex DateAfterRegex =
@@ -44,6 +43,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex[] TermFilterRegexes =
         {
         };
+
+        public PortugueseMergedExtractorConfiguration(DateTimeOptions options)
+            : base(options)
+        {
+            DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
+            TimeExtractor = new BaseTimeExtractor(new PortugueseTimeExtractorConfiguration(this));
+            DateTimeExtractor = new BaseDateTimeExtractor(new PortugueseDateTimeExtractorConfiguration(this));
+            DatePeriodExtractor = new BaseDatePeriodExtractor(new PortugueseDatePeriodExtractorConfiguration(this));
+            TimePeriodExtractor = new BaseTimePeriodExtractor(new PortugueseTimePeriodExtractorConfiguration(this));
+            DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new PortugueseDateTimePeriodExtractorConfiguration(this));
+            DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
+            SetExtractor = new BaseSetExtractor(new PortugueseSetExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new PortugueseHolidayExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new PortugueseTimeZoneExtractorConfiguration(this));
+            IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();
+            DateTimeAltExtractor = new BaseDateTimeAltExtractor(new PortugueseDateTimeAltExtractorConfiguration(this));
+        }
 
         public IDateExtractor DateExtractor { get; }
 
@@ -71,33 +87,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
-        public PortugueseMergedExtractorConfiguration(DateTimeOptions options) : base(options)
-        {
-            DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
-            TimeExtractor = new BaseTimeExtractor(new PortugueseTimeExtractorConfiguration(this));
-            DateTimeExtractor = new BaseDateTimeExtractor(new PortugueseDateTimeExtractorConfiguration(this));
-            DatePeriodExtractor = new BaseDatePeriodExtractor(new PortugueseDatePeriodExtractorConfiguration(this));
-            TimePeriodExtractor = new BaseTimePeriodExtractor(new PortugueseTimePeriodExtractorConfiguration(this));
-            DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new PortugueseDateTimePeriodExtractorConfiguration(this));
-            DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
-            SetExtractor = new BaseSetExtractor(new PortugueseSetExtractorConfiguration(this));
-            HolidayExtractor = new BaseHolidayExtractor(new PortugueseHolidayExtractorConfiguration(this));
-            TimeZoneExtractor = new BaseTimeZoneExtractor(new PortugueseTimeZoneExtractorConfiguration(this));
-            IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();
-            DateTimeAltExtractor = new BaseDateTimeAltExtractor(new PortugueseDateTimeAltExtractorConfiguration(this));
-        }
-
         Regex IMergedExtractorConfiguration.AfterRegex => AfterRegex;
+
         Regex IMergedExtractorConfiguration.BeforeRegex => BeforeRegex;
+
         Regex IMergedExtractorConfiguration.SinceRegex => SinceRegex;
+
         Regex IMergedExtractorConfiguration.AroundRegex => AroundRegex;
+
         Regex IMergedExtractorConfiguration.FromToRegex => FromToRegex;
+
         Regex IMergedExtractorConfiguration.SingleAmbiguousMonthRegex => SingleAmbiguousMonthRegex;
+
         Regex IMergedExtractorConfiguration.PrepositionSuffixRegex => PrepositionSuffixRegex;
+
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
+
         Regex IMergedExtractorConfiguration.DateAfterRegex => DateAfterRegex;
+
         Regex IMergedExtractorConfiguration.UnspecificDatePeriodRegex => UnspecificDatePeriodRegex;
+
         IEnumerable<Regex> IMergedExtractorConfiguration.TermFilterRegexes => TermFilterRegexes;
+
         StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -9,6 +9,35 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
     {
+        public PortugueseDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            NowRegex = PortugueseDateTimeExtractorConfiguration.NowRegex;
+            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexOptions.Singleline);
+            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexOptions.Singleline);
+            SimpleTimeOfTodayAfterRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
+            SimpleTimeOfTodayBeforeRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
+            SpecificTimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            SpecificEndOfRegex = PortugueseDateTimeExtractorConfiguration.SpecificEndOfRegex;
+            UnspecificEndOfRegex = PortugueseDateTimeExtractorConfiguration.UnspecificEndOfRegex;
+            UnitRegex = PortugueseDateTimeExtractorConfiguration.UnitRegex;
+            DateNumberConnectorRegex = PortugueseDateTimeExtractorConfiguration.DateNumberConnectorRegex;
+            Numbers = config.Numbers;
+            CardinalExtractor = config.CardinalExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            NumberParser = config.NumberParser;
+            DurationExtractor = config.DurationExtractor;
+            DurationParser = config.DurationParser;
+            UnitMap = config.UnitMap;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public string TokenBeforeDate { get; }
 
         public string TokenBeforeTime { get; }
@@ -57,40 +86,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public PortugueseDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
-            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            NowRegex = PortugueseDateTimeExtractorConfiguration.NowRegex;
-            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexOptions.Singleline);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexOptions.Singleline);
-            SimpleTimeOfTodayAfterRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
-            SimpleTimeOfTodayBeforeRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
-            SpecificTimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            SpecificEndOfRegex = PortugueseDateTimeExtractorConfiguration.SpecificEndOfRegex;
-            UnspecificEndOfRegex = PortugueseDateTimeExtractorConfiguration.UnspecificEndOfRegex;
-            UnitRegex = PortugueseDateTimeExtractorConfiguration.UnitRegex;
-            DateNumberConnectorRegex = PortugueseDateTimeExtractorConfiguration.DateNumberConnectorRegex;
-            Numbers = config.Numbers;
-            CardinalExtractor = config.CardinalExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            NumberParser = config.NumberParser;
-            DurationExtractor = config.DurationExtractor;
-            DurationParser = config.DurationParser;
-            UnitMap = config.UnitMap;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public int GetHour(string text, int hour)
         {
             var trimmedText = text.Trim().ToLowerInvariant().Normalized();
             int result = hour;
 
-            //TODO: Replace with a regex
+            // TODO: Replace with a regex
             if ((trimmedText.EndsWith("manha") || trimmedText.EndsWith("madrugada")) && hour >= Constants.HalfDayHourCount)
             {
                 result -= Constants.HalfDayHourCount;
@@ -99,6 +100,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             {
                 result += Constants.HalfDayHourCount;
             }
+
             return result;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -7,6 +7,46 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
+        public PortugueseDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TokenBeforeDate = Definitions.Portuguese.DateTimeDefinitions.TokenBeforeDate;
+
+            DateExtractor = config.DateExtractor;
+            TimeExtractor = config.TimeExtractor;
+            DateTimeExtractor = config.DateTimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
+            CardinalExtractor = config.CardinalExtractor;
+            DurationExtractor = config.DurationExtractor;
+            NumberParser = config.NumberParser;
+            DateParser = config.DateParser;
+            TimeParser = config.TimeParser;
+            DateTimeParser = config.DateTimeParser;
+            TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
+
+            PureNumberFromToRegex = PortugueseTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+            TimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.TimeOfDayRegex;
+            PastRegex = PortugueseDatePeriodExtractorConfiguration.PastRegex;
+            FutureRegex = PortugueseDatePeriodExtractorConfiguration.FutureRegex;
+            FutureSuffixRegex = PortugueseDatePeriodExtractorConfiguration.FutureSuffixRegex;
+            NumberCombinedWithUnitRegex = PortugueseDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
+            UnitRegex = PortugueseTimePeriodExtractorConfiguration.UnitRegex;
+            PeriodTimeOfDayWithDateRegex = PortugueseDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+            RelativeTimeUnitRegex = PortugueseDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+            RestOfDateTimeRegex = PortugueseDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+            AmDescRegex = PortugueseDateTimePeriodExtractorConfiguration.AmDescRegex;
+            PmDescRegex = PortugueseDateTimePeriodExtractorConfiguration.PmDescRegex;
+            WithinNextPrefixRegex = PortugueseDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+            PrefixDayRegex = PortugueseDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+            BeforeRegex = PortugueseDateTimePeriodExtractorConfiguration.BeforeRegex;
+            AfterRegex = PortugueseDateTimePeriodExtractorConfiguration.AfterRegex;
+            UnitMap = config.UnitMap;
+            Numbers = config.Numbers;
+        }
+
         public string TokenBeforeDate { get; }
 
         public IDateExtractor DateExtractor { get; }
@@ -73,45 +113,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IImmutableDictionary<string, int> Numbers { get; }
 
-        public PortugueseDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TokenBeforeDate = Definitions.Portuguese.DateTimeDefinitions.TokenBeforeDate;
-
-            DateExtractor = config.DateExtractor;
-            TimeExtractor = config.TimeExtractor;
-            DateTimeExtractor = config.DateTimeExtractor;
-            TimePeriodExtractor = config.TimePeriodExtractor;
-            CardinalExtractor = config.CardinalExtractor;
-            DurationExtractor = config.DurationExtractor;
-            NumberParser = config.NumberParser;
-            DateParser = config.DateParser;
-            TimeParser = config.TimeParser;
-            DateTimeParser = config.DateTimeParser;
-            TimePeriodParser = config.TimePeriodParser;
-            DurationParser = config.DurationParser;
-
-            PureNumberFromToRegex = PortugueseTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
-            TimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.TimeOfDayRegex;
-            PastRegex = PortugueseDatePeriodExtractorConfiguration.PastRegex;
-            FutureRegex = PortugueseDatePeriodExtractorConfiguration.FutureRegex;
-            FutureSuffixRegex = PortugueseDatePeriodExtractorConfiguration.FutureSuffixRegex;
-            NumberCombinedWithUnitRegex = PortugueseDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
-            UnitRegex = PortugueseTimePeriodExtractorConfiguration.UnitRegex;
-            PeriodTimeOfDayWithDateRegex = PortugueseDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
-            RelativeTimeUnitRegex = PortugueseDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
-            RestOfDateTimeRegex = PortugueseDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
-            AmDescRegex = PortugueseDateTimePeriodExtractorConfiguration.AmDescRegex;
-            PmDescRegex = PortugueseDateTimePeriodExtractorConfiguration.PmDescRegex;
-            WithinNextPrefixRegex = PortugueseDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
-            PrefixDayRegex = PortugueseDateTimePeriodExtractorConfiguration.PrefixDayRegex;
-            BeforeRegex = PortugueseDateTimePeriodExtractorConfiguration.BeforeRegex;
-            AfterRegex = PortugueseDateTimePeriodExtractorConfiguration.AfterRegex;
-            UnitMap = config.UnitMap;
-            Numbers = config.Numbers;
-        }
-
         public bool GetMatchedTimeRange(string text, out string timeStr, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant().Normalized();
@@ -119,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             endHour = 0;
             endMin = 0;
 
-            //TODO: modify it according to the coresponding function in English part
+            // TODO: modify it according to the coresponding function in English part
             if (trimmedText.EndsWith("madrugada"))
             {
                 timeStr = "TDA";
@@ -165,7 +166,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var trimmedText = text.Trim().ToLowerInvariant();
             var swift = 0;
 
-            //TODO: Replace with a regex
+            // TODO: Replace with a regex
             if (PortugueseDatePeriodParserConfiguration.PastPrefixRegex.IsMatch(trimmedText) ||
                 trimmedText.Equals("anoche"))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
@@ -6,6 +6,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public sealed class PortugueseMergedParserConfiguration : PortugueseCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+        public PortugueseMergedParserConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            BeforeRegex = PortugueseMergedExtractorConfiguration.BeforeRegex;
+            AfterRegex = PortugueseMergedExtractorConfiguration.AfterRegex;
+            SinceRegex = PortugueseMergedExtractorConfiguration.SinceRegex;
+            AroundRegex = PortugueseMergedExtractorConfiguration.AroundRegex;
+            DateAfter = PortugueseMergedExtractorConfiguration.DateAfterRegex;
+            YearRegex = PortugueseDatePeriodExtractorConfiguration.YearRegex;
+            SuperfluousWordMatcher = PortugueseMergedExtractorConfiguration.SuperfluousWordMatcher;
+
+            DatePeriodParser = new BaseDatePeriodParser(new PortugueseDatePeriodParserConfiguration(this));
+            TimePeriodParser = new BaseTimePeriodParser(new PortugueseTimePeriodParserConfiguration(this));
+            DateTimePeriodParser = new DateTimePeriodParser(new PortugueseDateTimePeriodParserConfiguration(this));
+            SetParser = new BaseSetParser(new PortugueseSetParserConfiguration(this));
+            HolidayParser = new BaseHolidayParser(new PortugueseHolidayParserConfiguration(this));
+            TimeZoneParser = new DummyTimeZoneParser();
+        }
 
         public Regex BeforeRegex { get; }
 
@@ -24,23 +42,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateTimeParser HolidayParser { get; }
 
         public StringMatcher SuperfluousWordMatcher { get; }
-
-        public PortugueseMergedParserConfiguration(IOptionsConfiguration config) : base(config)
-        {
-            BeforeRegex = PortugueseMergedExtractorConfiguration.BeforeRegex;
-            AfterRegex = PortugueseMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = PortugueseMergedExtractorConfiguration.SinceRegex;
-            AroundRegex = PortugueseMergedExtractorConfiguration.AroundRegex;
-            DateAfter = PortugueseMergedExtractorConfiguration.DateAfterRegex;
-            YearRegex = PortugueseDatePeriodExtractorConfiguration.YearRegex;
-            SuperfluousWordMatcher = PortugueseMergedExtractorConfiguration.SuperfluousWordMatcher;
-
-            DatePeriodParser = new BaseDatePeriodParser(new PortugueseDatePeriodParserConfiguration(this));
-            TimePeriodParser = new BaseTimePeriodParser(new PortugueseTimePeriodParserConfiguration(this));
-            DateTimePeriodParser = new DateTimePeriodParser(new PortugueseDateTimePeriodParserConfiguration(this));
-            SetParser = new BaseSetParser(new PortugueseSetParserConfiguration(this));
-            HolidayParser = new BaseHolidayParser(new PortugueseHolidayParserConfiguration(this));
-            TimeZoneParser = new DummyTimeZoneParser();
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
@@ -9,6 +9,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
     {
+        public PortugueseTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
+            : base(config)
+        {
+            TimeExtractor = config.TimeExtractor;
+            IntegerExtractor = config.IntegerExtractor;
+            TimeParser = config.TimeParser;
+            TimeZoneParser = config.TimeZoneParser;
+            PureNumberFromToRegex = PortugueseTimePeriodExtractorConfiguration.PureNumFromTo;
+            PureNumberBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+            SpecificTimeFromToRegex = PortugueseTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+            SpecificTimeBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+            TimeOfDayRegex = PortugueseTimePeriodExtractorConfiguration.TimeOfDayRegex;
+            GeneralEndingRegex = PortugueseTimePeriodExtractorConfiguration.GeneralEndingRegex;
+            TillRegex = PortugueseTimePeriodExtractorConfiguration.TillRegex;
+            Numbers = config.Numbers;
+            UtilityConfiguration = config.UtilityConfiguration;
+        }
+
         public IDateTimeExtractor TimeExtractor { get; }
 
         public IDateTimeParser TimeParser { get; }
@@ -35,23 +53,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
-        public PortugueseTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) : base(config)
-        {
-            TimeExtractor = config.TimeExtractor;
-            IntegerExtractor = config.IntegerExtractor;
-            TimeParser = config.TimeParser;
-            TimeZoneParser = config.TimeZoneParser;
-            PureNumberFromToRegex = PortugueseTimePeriodExtractorConfiguration.PureNumFromTo;
-            PureNumberBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.PureNumBetweenAnd;
-            SpecificTimeFromToRegex = PortugueseTimePeriodExtractorConfiguration.SpecificTimeFromTo;
-            SpecificTimeBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
-            TimeOfDayRegex = PortugueseTimePeriodExtractorConfiguration.TimeOfDayRegex;
-            GeneralEndingRegex = PortugueseTimePeriodExtractorConfiguration.GeneralEndingRegex;
-            TillRegex = PortugueseTimePeriodExtractorConfiguration.TillRegex;
-            Numbers = config.Numbers;
-            UtilityConfiguration = config.UtilityConfiguration;
-        }
-
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim().ToLowerInvariant();
@@ -60,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             endHour = 0;
             endMin = 0;
 
-            var timeOfDay = "";
+            var timeOfDay = string.Empty;
             if (DateTimeDefinitions.EarlyMorningTermList.Any(o => trimmedText.EndsWith(o)))
             {
                 timeOfDay = Constants.EarlyMorning;


### PR DESCRIPTION
- Reorder usings
- Reorder methods
- Remove extra whitespace
- Add spacing
-Change "" to string.Empty