### PR TITLE
[CI][DotNet] Fix Build.CI.cmd to fail on build errors

### DIFF
--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -15,6 +15,10 @@ CALL msbuild Microsoft.Recognizers.Definitions.Common\Microsoft.Recognizers.Defi
 
 ECHO # Building .NET solution (%configuration%)
 CALL msbuild Microsoft.Recognizers.Text.sln /t:Clean,Build /p:Configuration=%configuration%
+IF %ERRORLEVEL% NEQ 0 (
+	ECHO # Failed to build.
+	EXIT /b %ERRORLEVEL%
+)
 
 ECHO.
 ECHO # Running .NET Tests


### PR DESCRIPTION
# Description
- Fix Build.CI.cmd to abort and throw an error if the build fails. Currently, if the compile step fails but the tests pass, the build is marked as successful.
- We found this issue after #1280 was merged which should have broken the build but it still passes due to this issue.