### PR TITLE
[StyleCop] Fix all the warnings in TextMatchers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text/Matcher/AaNode.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/AaNode.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Recognizers.Text.Matcher
     {
         public AaNode()
         {
-
         }
 
         public AaNode(T c, int depth)
@@ -24,14 +23,20 @@ namespace Microsoft.Recognizers.Text.Matcher
         }
 
         public T Word { get; set; }
+
         public int Depth { get; set; }
+
         public AaNode<T> Parent { get; set; }
 
         public AaNode<T> Fail { get; set; } = null;
 
         public new AaNode<T> this[T c]
         {
-            get { return Children != null && Children.ContainsKey(c) ? Children[c] as AaNode<T> : null; }
+            get
+            {
+                return Children != null && Children.ContainsKey(c) ? Children[c] as AaNode<T> : null;
+            }
+
             set
             {
                 if (Children == null)

--- a/.NET/Microsoft.Recognizers.Text/Matcher/AbstractMatcher.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/AbstractMatcher.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Recognizers.Text.Matcher
 
         public abstract void Insert(IEnumerable<T> value, string id);
 
+        public bool IsMatch(IEnumerable<T> queryText)
+        {
+            return Find(queryText).FirstOrDefault() == null;
+        }
+
         protected void BatchInsert(IEnumerable<T>[] values, string[] ids)
         {
             if (values.Length != ids.Length)
@@ -24,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Matcher
                 Insert(values[i], ids[i]);
             }
         }
-        
+
         protected void ConvertDictToList(Node<T> node)
         {
             if (node.Values != null)
@@ -44,11 +49,6 @@ namespace Microsoft.Recognizers.Text.Matcher
 
             // re-malloc dictionary to reduce memory usage
             node.Children = new Dictionary<T, Node<T>>(node.Children);
-        }
-        
-        public bool IsMatch(IEnumerable<T> queryText)
-        {
-            return Find(queryText).FirstOrDefault() == null;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/AcAutomaton.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/AcAutomaton.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Recognizers.Text.Matcher
 
         public AcAutomaton()
         {
-
         }
 
         public override void Insert(IEnumerable<T> value, string id)

--- a/.NET/Microsoft.Recognizers.Text/Matcher/MatchResult.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/MatchResult.cs
@@ -4,17 +4,8 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class MatchResult<T>
     {
-        public int Start { get; set; }
-        public int Length { get; set; }
-        public int End { get { return Start + Length; } }
-
-        public T Text { get; set; }
-
-        public HashSet<string> CanonicalValues { get; set; } = new HashSet<string>();
-
         public MatchResult()
         {
-
         }
 
         public MatchResult(int start, int length)
@@ -29,5 +20,18 @@ namespace Microsoft.Recognizers.Text.Matcher
             Length = length;
             CanonicalValues = ids;
         }
+
+        public int Start { get; set; }
+
+        public int Length { get; set; }
+
+        public int End
+        {
+            get { return Start + Length; }
+        }
+
+        public T Text { get; set; }
+
+        public HashSet<string> CanonicalValues { get; set; } = new HashSet<string>();
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/MatchStrategy.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/MatchStrategy.cs
@@ -6,7 +6,14 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public enum MatchStrategy
     {
+        /// <summary>
+        /// AcAtomaton
+        /// </summary>
         AcAutomaton,
-        TrieTree
+
+        /// <summary>
+        /// TrieTree
+        /// </summary>
+        TrieTree,
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/Node.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/Node.cs
@@ -5,9 +5,20 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class Node<T>
     {
+        public bool End => Values != null && Values.Any();
+
+        public HashSet<string> Values { get; set; } = null;
+
+        // Set Default Children to null to avoid instantiating empty dictionaries
+        public Dictionary<T, Node<T>> Children { get; set; } = null;
+
         public Node<T> this[T c]
         {
-            get { return Children != null && Children.ContainsKey(c) ? Children[c] : null; }
+            get
+            {
+                return Children != null && Children.ContainsKey(c) ? Children[c] : null;
+            }
+
             set
             {
                 if (Children == null)
@@ -23,13 +34,6 @@ namespace Microsoft.Recognizers.Text.Matcher
         {
             return Children?.Values.GetEnumerator();
         }
-
-        public bool End { get { return Values != null && Values.Any(); } }
-
-        public HashSet<string> Values { get; set; } = null;
-
-        // Set Default Children to null to avoid instantiating empty dictionaries
-        public Dictionary<T, Node<T>> Children { get; set; } = null;
 
         public void AddValue(string value)
         {

--- a/.NET/Microsoft.Recognizers.Text/Matcher/NumberWithUnitTokenizer.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/NumberWithUnitTokenizer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class NumberWithUnitTokenizer : SimpleTokenizer
     {
-        private static HashSet<char> SpecialTokenCharacters = new HashSet<Char> { '$' };
+        private static HashSet<char> specialTokenCharacters = new HashSet<char> { '$' };
 
         /* The main difference between this strategy and SimpleTokenizer is for cases like
          * 'Bob's $ 100 cash'. 's' and '$' are independent tokens in SimpleTokenizer.
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.Matcher
                         inToken = false;
                     }
                 }
-                else if ((!SpecialTokenCharacters.Contains(c) && !char.IsLetterOrDigit(c)) || IsChinese(c) || IsJapanese(c))
+                else if ((!specialTokenCharacters.Contains(c) && !char.IsLetterOrDigit(c)) || IsChinese(c) || IsJapanese(c))
                 {
                     // Non-splittable currency units (as "$") are treated as regular letters. For instance, 'us$' should be a single token
                     if (inToken)
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.Text.Matcher
             }
 
             // Non-splittable currency units can't be mixed with digits. For example, '$100' or '100$' will be tokenized to '$' and '100', '1$50' will be tokenized to '1', '$', and '50'
-            if ((char.IsDigit(curChar) && SpecialTokenCharacters.Contains(preChar)) || (SpecialTokenCharacters.Contains(curChar) && char.IsDigit(preChar)))
+            if ((char.IsDigit(curChar) && specialTokenCharacters.Contains(preChar)) || (specialTokenCharacters.Contains(curChar) && char.IsDigit(preChar)))
             {
                 return true;
             }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/SimpleTokenizer.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/SimpleTokenizer.cs
@@ -60,30 +60,30 @@ namespace Microsoft.Recognizers.Text.Matcher
         // Check the character is Chinese by the unicode range (CJK Unified Ideographs, CJK Unified Ideographs Extension A)
         protected bool IsChinese(char c)
         {
-            UInt16 uc = (UInt16) c;
+            ushort uc = (ushort)c;
 
-            return (uc >= (UInt16)0x4E00 && uc <= (UInt16)0x9FBF) || (uc >= (UInt16)0x3400 && uc <= (UInt16)0x4DBF);
+            return (uc >= (ushort)0x4E00 && uc <= (ushort)0x9FBF) || (uc >= (ushort)0x3400 && uc <= (ushort)0x4DBF);
         }
 
         // Check the character is Japanese by the unicode range (Hiragana, Katakana, Katakana Pinyin)
         protected bool IsJapanese(char c)
         {
-            UInt16 uc = (UInt16) c;
+            ushort uc = (ushort)c;
 
-            return ((uc >= (UInt16)0x3040 && uc <= (UInt16)0x309F) || 
-                (uc >= (UInt16)0x30A0 && uc <= (UInt16)0x30FF) || 
-                (uc >= (UInt16)0xFF66 && uc <= (UInt16)0xFF9D));
+            return (uc >= 0x3040 && uc <= 0x309F) ||
+                (uc >= 0x30A0 && uc <= (ushort)0x30FF) ||
+                (uc >= (ushort)0xFF66 && uc <= (ushort)0xFF9D);
         }
 
         // Check the character is Korean by the unicode range (HangulSyllables, Hangul Jamo, Hangul Compatibility Jamo, Halfwidth Hangul Jamo)
         protected bool IsKorean(char c)
         {
-            UInt16 uc = (UInt16) c;
+            ushort uc = (ushort)c;
 
-            return ((uc >= (UInt16)0xAC00 && uc <= (UInt16)0xD7AF) || 
-                (uc >= (UInt16)0x1100 && uc <= (UInt16)0x11FF) || 
-                (uc >= (UInt16)0x3130 && uc <= (UInt16)0x318F) ||
-                (uc >= (UInt16)0xFFB0 && uc <= (UInt16)0xFFDC));
+            return (uc >= (ushort)0xAC00 && uc <= (ushort)0xD7AF) ||
+                (uc >= (ushort)0x1100 && uc <= (ushort)0x11FF) ||
+                (uc >= (ushort)0x3130 && uc <= (ushort)0x318F) ||
+                (uc >= (ushort)0xFFB0 && uc <= (ushort)0xFFDC);
         }
 
         // Check the character is Chinese/Japanese/Korean.

--- a/.NET/Microsoft.Recognizers.Text/Matcher/StringMatcher.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/StringMatcher.cs
@@ -6,12 +6,11 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class StringMatcher
     {
-        private readonly ITokenizer Tokenizer;
-        private IMatcher<string> Matcher { get; set; }
+        private readonly ITokenizer tokenizer;
 
         public StringMatcher(MatchStrategy matchStrategy = MatchStrategy.TrieTree, ITokenizer tokenizer = null)
         {
-            Tokenizer = tokenizer ?? new SimpleTokenizer();
+            this.tokenizer = tokenizer ?? new SimpleTokenizer();
             switch (matchStrategy)
             {
                 case MatchStrategy.AcAutomaton:
@@ -24,6 +23,8 @@ namespace Microsoft.Recognizers.Text.Matcher
                     throw new ArgumentException($"Unsupported match strategy: {matchStrategy.ToString()}");
             }
         }
+
+        private IMatcher<string> Matcher { get; set; }
 
         public void Init(IEnumerable<string> values)
         {
@@ -59,11 +60,6 @@ namespace Microsoft.Recognizers.Text.Matcher
             Matcher.Init(tokenizedValues, ids);
         }
 
-        private IEnumerable<string>[] GetTokenizedText(IEnumerable<string> values)
-        {
-            return values.Select(t => Tokenizer.Tokenize(t).Select(i => i.Text)).ToArray();
-        }
-
         // Return token based entity result
         public IEnumerable<MatchResult<string>> Find(IEnumerable<string> tokenizedQuery)
         {
@@ -72,7 +68,7 @@ namespace Microsoft.Recognizers.Text.Matcher
 
         public IEnumerable<MatchResult<string>> Find(string queryText)
         {
-            var queryTokens = Tokenizer.Tokenize(queryText);
+            var queryTokens = tokenizer.Tokenize(queryText);
             var tokenizedQueryText = queryTokens.Select(t => t.Text);
 
             foreach (var r in Find(tokenizedQueryText))
@@ -88,9 +84,14 @@ namespace Microsoft.Recognizers.Text.Matcher
                     Start = start,
                     Length = length,
                     Text = rtext,
-                    CanonicalValues = r.CanonicalValues
+                    CanonicalValues = r.CanonicalValues,
                 };
             }
+        }
+
+        private IEnumerable<string>[] GetTokenizedText(IEnumerable<string> values)
+        {
+            return values.Select(t => tokenizer.Tokenize(t).Select(i => i.Text)).ToArray();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/Token.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/Token.cs
@@ -2,21 +2,24 @@
 {
     public class Token
     {
-        public string Text { get; set; }
-
         public Token(int s, int l)
         {
             Start = s;
             Length = l;
         }
 
-        public Token(int s, int l, string t) : this(s, l)
+        public Token(int s, int l, string t)
+            : this(s, l)
         {
             Text = t;
         }
 
+        public string Text { get; set; }
+
         public int Start { get; private set; }
+
         public int Length { get; private set; }
+
         public int End
         {
             get
@@ -24,6 +27,5 @@
                 return Start + Length;
             }
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Matcher/TrieTree.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/TrieTree.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Recognizers.Text.Matcher
 
         public TrieTree()
         {
-
         }
 
         public override void Insert(IEnumerable<T> value, string id)


### PR DESCRIPTION
- Reorder properties, fields and methods
- Remove trailing whitespace
- Add trailing comma
- Reformat setters and getters