### PR TITLE
[StyleCop] Fix all warnings in FrenchTimeZoneExtractorConfiguration

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    internal class FrenchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class FrenchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex[] TimeZoneRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
@@ -5,19 +5,23 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    class FrenchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    internal class FrenchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex[] TimeZoneRegexList =
         {
         };
 
-        public FrenchTimeZoneExtractorConfiguration(IOptionsConfiguration config) : base(config)
+        public FrenchTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
         {
         }
 
         public IEnumerable<Regex> TimeZoneRegexes => TimeZoneRegexList;
+
         public Regex LocationTimeSuffixRegex { get; }
+
         public StringMatcher LocationMatcher { get; }
+
         public List<string> AmbiguousTimezoneList => new List<string>();
     }
 }


### PR DESCRIPTION
- Added class access modifier 'public.
- Added spaces when needed.