### PR TITLE
[StyleCop] Fix all the warnings in French Parsers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/AgeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class AgeParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public AgeParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public AgeParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public AgeParserConfiguration(CultureInfo ci) : base(ci)
+        public AgeParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(AgeExtractorConfiguration.AgeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/AreaParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/AreaParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class AreaParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public AreaParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public AreaParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public AreaParserConfiguration(CultureInfo ci) : base(ci)
+        public AreaParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(AreaExtractorConfiguration.AreaSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/CurrencyParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/CurrencyParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class CurrencyParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public CurrencyParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public CurrencyParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public CurrencyParserConfiguration(CultureInfo ci) : base(ci)
+        public CurrencyParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/DimensionParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/DimensionParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class DimensionParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public DimensionParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public DimensionParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public DimensionParserConfiguration(CultureInfo ci) : base(ci)
+        public DimensionParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/FrenchNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/FrenchNumberWithUnitParserConfiguration.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class FrenchNumberWithUnitParserConfiguration : BaseNumberWithUnitParserConfiguration
     {
-        public FrenchNumberWithUnitParserConfiguration(CultureInfo ci) : base(ci)
+        public FrenchNumberWithUnitParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/LengthParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/LengthParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class LengthParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public LengthParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public LengthParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public LengthParserConfiguration(CultureInfo ci) : base(ci)
+        public LengthParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(LengthExtractorConfiguration.LengthSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/SpeedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/SpeedParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class SpeedParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public SpeedParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public SpeedParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public SpeedParserConfiguration(CultureInfo ci) : base(ci)
+        public SpeedParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/TemperatureParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/TemperatureParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class TemperatureParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public TemperatureParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public TemperatureParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public TemperatureParserConfiguration(CultureInfo ci) : base(ci)
+        public TemperatureParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/VolumeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/VolumeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class VolumeParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public VolumeParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public VolumeParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public VolumeParserConfiguration(CultureInfo ci) : base(ci)
+        public VolumeParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/WeightParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/WeightParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 {
     public class WeightParserConfiguration : FrenchNumberWithUnitParserConfiguration
     {
-        public WeightParserConfiguration() : this(new CultureInfo(Culture.French)) { }
+        public WeightParserConfiguration()
+            : this(new CultureInfo(Culture.French))
+        {
+        }
 
-        public WeightParserConfiguration(CultureInfo ci) : base(ci)
+        public WeightParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(WeightExtractorConfiguration.WeightSuffixList);
         }


### PR DESCRIPTION
- SA1502: Element should not be on a single line - Move curly braces to different lines
- SA1201: A field should not follow a property - Reorder fields and properties
- SA1128: Put constructor initializers on their own line - Move constructor initializer to a different line