### PR TITLE
[StyleCop] Fix warnings in TimeAssemblyInfo

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Recognizers.Text.DataTypes.TimexExpression")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             d = d.AddDays(1);
             return TimexProperty.FromDate(d).TimexValue;
         }
+
         public static string Yesterday(DateObject date = default(DateObject))
         {
             var d = (date == default(DateObject)) ? DateObject.Now : date;
@@ -86,7 +87,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return t.TimexValue;
         }
 
-        public static string NextWeeksFromToday(int n, DateObject date = default(DateObject)) 
+        public static string NextWeeksFromToday(int n, DateObject date = default(DateObject))
         {
             var d = (date == default(DateObject)) ? DateObject.Now : date;
             var t = TimexProperty.FromDate(d);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             while (ds < de)
             {
-                var csDayOfWeek = ds.DayOfWeek;
+                var dayOfWeek = ds.DayOfWeek;
 
-                var isoDayOfWeek = (csDayOfWeek == 0) ? 7 : (int)csDayOfWeek;
+                var isoDayOfWeek = (dayOfWeek == 0) ? 7 : (int)dayOfWeek;
                 if (isoDayOfWeek == 7)
                 {
                     weeks++;

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -9,11 +9,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             var types = timex.Types.Count != 0 ? timex.Types : TimexInference.Infer(timex);
 
-            if (types.Contains(Constants.TimexTypes.Present)) {
+            if (types.Contains(Constants.TimexTypes.Present))
+            {
                 return "PRESENT_REF";
             }
 
-            if ((types.Contains(Constants.TimexTypes.DateTimeRange) || types.Contains(Constants.TimexTypes.DateRange) || 
+            if ((types.Contains(Constants.TimexTypes.DateTimeRange) || types.Contains(Constants.TimexTypes.DateRange) ||
                  types.Contains(Constants.TimexTypes.TimeRange)) && types.Contains(Constants.TimexTypes.Duration))
             {
                 var range = TimexHelpers.ExpandDateTimeRange(timex);
@@ -70,7 +71,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 return $"P{timex.Months}M";
             }
 
-            if (timex.Weeks != null) {
+            if (timex.Weeks != null)
+            {
                 return $"P{timex.Weeks}W";
             }
 
@@ -124,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
             }
 
-            if (timex.DayOfWeek != null) 
+            if (timex.DayOfWeek != null)
             {
                 return $"XXXX-WXX-{timex.DayOfWeek}";
             }
@@ -144,7 +146,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-W{TimexDateHelpers.FixedFormatNumber(timex.WeekOfYear, 2)}";
             }
 
-            if (timex.Year != null && timex.Season != null) {
+            if (timex.Year != null && timex.Season != null)
+            {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{timex.Season}";
             }
 


### PR DESCRIPTION
-Remove trailing whitespace
-Rename variable with Hungarian notation