### PR TITLE
Fix/english datetime/extractors and parsers

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDatePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDatePeriodExtractorConfiguration.java
@@ -12,6 +12,7 @@ import com.microsoft.recognizers.text.datetime.extractors.config.IDatePeriodExtr
 import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
 import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
 import com.microsoft.recognizers.text.datetime.resources.EnglishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.number.english.extractors.CardinalExtractor;
 import com.microsoft.recognizers.text.number.english.extractors.OrdinalExtractor;
 import com.microsoft.recognizers.text.number.english.parsers.EnglishNumberParserConfiguration;
@@ -99,14 +100,14 @@ public class EnglishDatePeriodExtractorConfiguration extends BaseOptionsConfigur
         }
     };
 
-    private final Pattern rangeConnectorRegex;
+    private final Pattern rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
+    private final String[] durationDateRestrictions = EnglishDateTime.DurationDateRestrictions.toArray(new String[0]);
 
     private final IDateTimeExtractor datePointExtractor;
     private final IExtractor cardinalExtractor;
     private final IExtractor ordinalExtractor;
     private final IDateTimeExtractor durationExtractor;
     private final IParser numberParser;
-    private final String[] durationDateRestrictions;
 
     public EnglishDatePeriodExtractorConfiguration(IOptionsConfiguration config) {
         super(config.getOptions());
@@ -116,9 +117,6 @@ public class EnglishDatePeriodExtractorConfiguration extends BaseOptionsConfigur
         ordinalExtractor = OrdinalExtractor.getInstance();
         durationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
         numberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
-
-        durationDateRestrictions = EnglishDateTime.DurationDateRestrictions.toArray(new String[0]);
-        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
     }
 
     @Override
@@ -302,7 +300,6 @@ public class EnglishDatePeriodExtractorConfiguration extends BaseOptionsConfigur
 
     @Override
     public boolean hasConnectorToken(String text) {
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(rangeConnectorRegex, text)).findFirst();
-        return match.isPresent() && match.get().length == text.trim().length();
+        return RegexExtension.isExactMatch(rangeConnectorRegex, text, true);
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/extractors/EnglishDateTimePeriodExtractorConfiguration.java
@@ -12,6 +12,7 @@ import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
 import com.microsoft.recognizers.text.datetime.resources.EnglishDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.number.english.extractors.CardinalExtractor;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
@@ -58,8 +59,8 @@ public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
     private final IDateTimeExtractor durationExtractor;
     private final IDateTimeExtractor timePeriodExtractor;
 
-    private final Pattern weekDayRegex;
-    private final Pattern rangeConnectorRegex;
+    private final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex);
+    private final Pattern rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
 
     public EnglishDateTimePeriodExtractorConfiguration() {
         this(DateTimeOptions.None);
@@ -78,9 +79,6 @@ public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
         singleDateTimeExtractor = new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration(options));
         durationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(options));
         timePeriodExtractor = new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration(options));
-
-        weekDayRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.WeekDayRegex);
-        rangeConnectorRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.RangeConnectorRegex);
     }
 
     @Override
@@ -270,7 +268,6 @@ public class EnglishDateTimePeriodExtractorConfiguration extends BaseOptionsConf
 
     @Override
     public boolean hasConnectorToken(String text) {
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(rangeConnectorRegex, text)).findFirst();
-        return match.isPresent() && match.get().length == text.trim().length();
+        return RegexExtension.isExactMatch(rangeConnectorRegex, text, true);
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/TimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/english/parsers/TimeParser.java
@@ -4,8 +4,10 @@ import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.BaseTimeParser;
 import com.microsoft.recognizers.text.datetime.parsers.config.ITimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.ConditionalMatch;
 import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
@@ -34,11 +36,11 @@ public class TimeParser extends BaseTimeParser {
     // parse "noonish", "11-ish"
     private DateTimeResolutionResult parseIsh(String text, LocalDateTime referenceTime) {
         DateTimeResolutionResult result = new DateTimeResolutionResult();
-        String trimmedText = text.trim().toLowerCase();
+        String lowerText = text.toLowerCase();
 
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(EnglishTimeExtractorConfiguration.IshRegex, trimmedText)).findFirst();
-        if (match.isPresent() && match.get().length == trimmedText.length()) {
-            String hourStr = match.get().getGroup(Constants.HourGroupName).value;
+        ConditionalMatch match = RegexExtension.matchExact(EnglishTimeExtractorConfiguration.IshRegex, text, true);
+        if (match.getSuccess()) {
+            String hourStr = match.getMatch().get().getGroup(Constants.HourGroupName).value;
             int hour = Constants.HalfDayHourCount;
 
             if (!StringUtility.isNullOrEmpty(hourStr)) {


### PR DESCRIPTION
# Description
Start using RegexExtension to make the code clearer. Applied the same changes that were applied in PR #1003 
- Fix EnglishDatePeriodExtractorConfiguration
- Fix EnglishDateTimePeriodExtractorConfiguration
- Fix EnglishTimeParserConfiguration
- Fix TimeParser