### PR TITLE
[DateTime] Fix DateTimePeriodExtractor test

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var begin = er.Start ?? 0;
 
                             var middleStr = beforeStr.Substring(begin + (er.Length ?? 0)).Trim().ToLower();
-                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsExactMatch(middleStr, trim: true))
+                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsMatch(middleStr))
                             {
                                 ret.Add(new Token(begin, match.Index + match.Length));
                                 hasBeforeDate = true;
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             var begin = er[0].Start ?? 0;
                             var end = (er[0].Start ?? 0) + (er[0].Length ?? 0);
                             var middleStr = followedStr.Substring(0, begin).Trim().ToLower();
-                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsExactMatch(middleStr, trim: true))
+                            if (string.IsNullOrEmpty(middleStr) || this.config.PrepositionRegex.IsMatch(middleStr))
                             {
                                 ret.Add(new Token(match.Index, match.Index + match.Length + end));
                             }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateExtractor.java
@@ -245,11 +245,11 @@ public class BaseDateExtractor extends AbstractYearExtractor implements IDateTim
 
                 // Handling cases like '20th of next month'
                 String suffixStr = text.substring(result.getStart() + result.getLength());
-                match = Arrays.stream(RegExpUtility.getMatches(config.getRelativeMonthRegex(), suffixStr.trim())).findFirst();
-                if (match.isPresent() && match.get().index == 0) {
+                ConditionalMatch beginMatch = RegexExtension.matchBegin(config.getRelativeMonthRegex(), suffixStr.trim(), true);
+                if (beginMatch.getSuccess() && beginMatch.getMatch().get().index == 0) {
                     int spaceLen = suffixStr.length() - suffixStr.trim().length();
                     int resStart = result.getStart();
-                    int resEnd = resStart + result.getLength() + spaceLen + match.get().length;
+                    int resEnd = resStart + result.getLength() + spaceLen + beginMatch.getMatch().get().length;
 
                     // Check if prefix contains 'the', include it if any
                     String prefix = text.substring(0, resStart);
@@ -263,12 +263,12 @@ public class BaseDateExtractor extends AbstractYearExtractor implements IDateTim
 
                 // Handling cases like 'second Sunday'
                 suffixStr = text.substring(result.getStart() + result.getLength());
-                match = Arrays.stream(RegExpUtility.getMatches(config.getWeekDayRegex(), suffixStr.trim())).findFirst();
-                if (match.isPresent() && match.get().index == 0 && num <= 5 && result.getType().equals("builtin.num.ordinal")) {
-                    String weekDayStr = match.get().getGroup("weekday").value.toLowerCase();
+                beginMatch = RegexExtension.matchBegin(config.getWeekDayRegex(), suffixStr.trim(), true);
+                if (beginMatch.getSuccess() && num >= 1 && num <= 5 && result.getType().equals("builtin.num.ordinal")) {
+                    String weekDayStr = beginMatch.getMatch().get().getGroup("weekday").value.toLowerCase();
                     if (config.getDayOfWeek().containsKey(weekDayStr)) {
                         int spaceLen = suffixStr.length() - suffixStr.trim().length();
-                        tokens.add(new Token(result.getStart(), result.getStart() + result.getLength() + spaceLen + match.get().length));
+                        tokens.add(new Token(result.getStart(), result.getStart() + result.getLength() + spaceLen + beginMatch.getMatch().get().length));
                     }
                 }
             }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
@@ -125,8 +125,8 @@ public class BaseDatePeriodExtractor implements IDateTimeExtractor {
             }
 
             String middleStr = input.substring(middleBegin, middleEnd).trim().toLowerCase();
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getTillRegex(), middleStr)).findFirst();
-            if (match.isPresent() && match.get().index == 0 && match.get().length == middleStr.length()) {
+
+            if (RegexExtension.isExactMatch(config.getTillRegex(), middleStr, true)) {
                 int periodBegin = thisResult.getStart();
                 int periodEnd = nextResult.getStart() + nextResult.getLength();
 
@@ -420,14 +420,6 @@ public class BaseDatePeriodExtractor implements IDateTimeExtractor {
         }
 
         return results;
-    }
-
-    private boolean matchSuffixRegexInSegment(String input, Optional<Match> match) {
-        return match.isPresent() && StringUtility.isNullOrWhiteSpace(input.substring(0, match.get().index));
-    }
-
-    private boolean matchPrefixRegexInSegment(String input, Optional<Match> match) {
-        return match.isPresent() && StringUtility.isNullOrWhiteSpace(input.substring(match.get().index + match.get().length));
     }
 
     private boolean isDateRelativeToNowOrToday(ExtractResult input) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
@@ -5,6 +5,8 @@ import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.AgoLaterUtil;
+import com.microsoft.recognizers.text.datetime.utilities.ConditionalMatch;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.datetime.utilities.Token;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
@@ -151,9 +153,9 @@ public class BaseDateTimeExtractor implements IDateTimeExtractor {
             String beforeStr = input.substring(0, (er != null) ? er.getStart() : 0);
 
             // handle "this morningh at 7am"
-            Match innerMatch = Arrays.stream(RegExpUtility.getMatches(this.config.getTimeOfDayRegex(), er.getText())).findFirst().orElse(null);
-            if (innerMatch != null && innerMatch.index == 0) {
-                beforeStr = input.substring(0, ((er != null) ? er.getStart() : 0) + innerMatch.length);
+            ConditionalMatch innerMatch = RegexExtension.matchBegin(this.config.getTimeOfDayRegex(), er.getText(), true);
+            if (innerMatch.getSuccess()) {
+                beforeStr = input.substring(0, ((er != null) ? er.getStart() : 0) + innerMatch.getMatch().get().length);
             }
 
             if (StringUtility.isNullOrEmpty(beforeStr)) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimePeriodExtractor.java
@@ -71,7 +71,7 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                         ExtractResult er = ers.get(ers.size() - 1);
                         int begin = er.getStart();
                         String middleStr = beforeStr.substring(begin + er.getLength()).trim().toLowerCase();
-                        if (StringUtility.isNullOrEmpty(middleStr) || RegExpUtility.getMatches(config.getPrepositionRegex(), middleStr).length > 0) {
+                        if (StringUtility.isNullOrEmpty(middleStr) || RegexExtension.isExactMatch(config.getPrepositionRegex(), middleStr, true)) {
                             results.add(new Token(begin, match.index + match.length));
                             hasBeforeDate = true;
                         }
@@ -87,7 +87,7 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                         int begin = er.getStart();
                         int end = er.getStart() + er.getLength();
                         String middleStr = followedStr.substring(0, begin).trim().toLowerCase();
-                        if (StringUtility.isNullOrEmpty(middleStr) || RegExpUtility.getMatches(config.getPrepositionRegex(), middleStr).length > 0) {
+                        if (StringUtility.isNullOrEmpty(middleStr) || RegexExtension.isExactMatch(config.getPrepositionRegex(), middleStr, true)) {
                             results.add(new Token(match.index, match.index + match.length + end));
                         }
                     }
@@ -380,9 +380,8 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                     results.add(new Token(er.getStart(), er.getStart() + er.getLength() + match.get().index + match.get().length));
                 } else {
                     String connectorStr = afterStr.substring(0, match.get().index);
-                    Optional<Match> pauseMatch = Arrays.stream(RegExpUtility.getMatches(config.getMiddlePauseRegex(), connectorStr)).findFirst();
-
-                    if (pauseMatch.isPresent() && pauseMatch.get().length == connectorStr.length()) {
+                    // Trim here is set to false as the Regex might catch white spaces before or after the text
+                    if (RegexExtension.isExactMatch(config.getMiddlePauseRegex(), connectorStr, false)) {
                         String suffix = afterStr.substring(match.get().index + match.get().length).replaceAll("^\\s+", "");
 
                         Optional<Match> endingMatch = Arrays.stream(RegExpUtility.getMatches(config.getGeneralEndingRegex(), suffix)).findFirst();
@@ -406,8 +405,6 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                     String connectorStr = prefixStr.substring(match.get().index + match.get().length);
 
                     // Trim here is set to false as the Regex might catch white spaces before or after the text
-                    Optional<Match> pauseMatch = Arrays.stream(RegExpUtility.getMatches(config.getMiddlePauseRegex(), connectorStr)).findFirst();
-
                     if (RegexExtension.isExactMatch(config.getMiddlePauseRegex(), connectorStr, false)) {
                         String suffix = StringUtility.trimStart(input.substring(er.getStart() + er.getLength()));
 
@@ -560,8 +557,7 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
         beforeAfterRegexes.add(config.getAfterRegex());
 
         for (Pattern regex : beforeAfterRegexes) {
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(regex, text)).findFirst();
-            if (match.isPresent() && match.get().length == text.length()) {
+            if (RegexExtension.isExactMatch(regex, text, true)) {
                 return true;
             }
         }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimePeriodExtractor.java
@@ -71,7 +71,7 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                         ExtractResult er = ers.get(ers.size() - 1);
                         int begin = er.getStart();
                         String middleStr = beforeStr.substring(begin + er.getLength()).trim().toLowerCase();
-                        if (StringUtility.isNullOrEmpty(middleStr) || RegexExtension.isExactMatch(config.getPrepositionRegex(), middleStr, true)) {
+                        if (StringUtility.isNullOrEmpty(middleStr) || RegExpUtility.getMatches(config.getPrepositionRegex(), middleStr).length > 0) {
                             results.add(new Token(begin, match.index + match.length));
                             hasBeforeDate = true;
                         }
@@ -87,7 +87,7 @@ public class BaseDateTimePeriodExtractor implements IDateTimeExtractor {
                         int begin = er.getStart();
                         int end = er.getStart() + er.getLength();
                         String middleStr = followedStr.substring(0, begin).trim().toLowerCase();
-                        if (StringUtility.isNullOrEmpty(middleStr) || RegexExtension.isExactMatch(config.getPrepositionRegex(), middleStr, true)) {
+                        if (StringUtility.isNullOrEmpty(middleStr) || RegExpUtility.getMatches(config.getPrepositionRegex(), middleStr).length > 0) {
                             results.add(new Token(match.index, match.index + match.length + end));
                         }
                     }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDurationExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDurationExtractor.java
@@ -235,9 +235,9 @@ public class BaseDurationExtractor implements IDateTimeExtractor {
         List<ExtractResult> ers = this.config.getCardinalExtractor().extract(text);
         for (ExtractResult er : ers) {
             String afterStr = text.substring(er.getStart() + er.getLength());
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getFollowedUnit(), afterStr)).findFirst();
-            if (match.isPresent() && match.get().index == 0) {
-                result.add(new Token(er.getStart(), er.getStart() + er.getLength() + match.get().length));
+            ConditionalMatch match = RegexExtension.matchBegin(this.config.getFollowedUnit(), afterStr, true);
+            if (match.getSuccess() && match.getMatch().get().index == 0) {
+                result.add(new Token(er.getStart(), er.getStart() + er.getLength() + match.getMatch().get().length));
             }
         }
 
@@ -270,9 +270,9 @@ public class BaseDurationExtractor implements IDateTimeExtractor {
 
         for (Token token : tokens) {
             String afterStr = text.substring(token.getStart() + token.getLength());
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(this.config.getSuffixAndRegex(), afterStr)).findFirst();
-            if (match.isPresent() && match.get().index == 0) {
-                result.add(new Token(token.getStart(), token.getStart() + token.getLength() + match.get().length));
+            ConditionalMatch match = RegexExtension.matchBegin(this.config.getSuffixAndRegex(), afterStr, true);
+            if (match.getSuccess() && match.getMatch().get().index == 0) {
+                result.add(new Token(token.getStart(), token.getStart() + token.getLength() + match.getMatch().get().length));
             }
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseTimePeriodExtractor.java
@@ -5,6 +5,8 @@ import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.extractors.config.ITimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.utilities.ConditionalMatch;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.datetime.utilities.TimeZoneUtility;
 import com.microsoft.recognizers.text.datetime.utilities.Token;
 import com.microsoft.recognizers.text.utilities.Match;
@@ -178,8 +180,7 @@ public class BaseTimePeriodExtractor implements IDateTimeExtractor {
                 // check connector string
                 String midStr = input.substring(numEndPoint, ers.get(j).getStart());
                 Pattern tillRegex = this.config.getTillRegex();
-                Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(tillRegex, midStr)).findFirst();
-                if ((match.isPresent() && match.get().length == midStr.trim().length()) || config.hasConnectorToken(midStr.trim())) {
+                if (RegexExtension.isExactMatch(tillRegex, midStr, true) || config.hasConnectorToken(midStr.trim())) {
                     timeNumbers.add(numErs.get(i));
                 }
 
@@ -215,10 +216,9 @@ public class BaseTimePeriodExtractor implements IDateTimeExtractor {
 
             String middleStr = input.substring(middleBegin, middleEnd).trim().toLowerCase(java.util.Locale.ROOT);
             Pattern tillRegex = this.config.getTillRegex();
-            Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(tillRegex, middleStr)).findFirst();
 
             // Handle "{TimePoint} to {TimePoint}"
-            if (match.isPresent() && match.get().index == 0 && match.get().length == middleStr.length()) {
+            if (RegexExtension.isExactMatch(tillRegex, middleStr, true)) {
                 int periodBegin = ers.get(idx).getStart();
                 int periodEnd = ers.get(idx + 1).getStart() + ers.get(idx + 1).getLength();
 

--- a/Specs/DateTime/Spanish/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DateTimePeriodExtractor.json
@@ -12,8 +12,15 @@
   },
   {
     "Input": "Hoy estaré fuera de cinco a siete",
-    "NotSupported": "javascript, python, java",
-    "Results": []
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "Hoy estaré fuera de cinco a siete",
+        "Type": "datetimerange",
+        "Start": 0,
+        "Length": 33
+      }
+    ]
   },
   {
     "Input": "Estaré fuera hoy de cinco a siete",


### PR DESCRIPTION
**Note:** This branch is based on PR #1344. We will rebase once it is merged with master. 

---
# Description
Revert one of the changes done in PR#1003 that broke "Hoy estaré fuera de cinco a siete" test. This closes issue #1342
- Fix tests
- Revert change from PR #1003

# Passing Tests
**Before**
![image](https://user-images.githubusercontent.com/42191764/51343086-46ed5c00-1a74-11e9-964e-e0d7eee98a31.png)

**After**
![image](https://user-images.githubusercontent.com/42191764/51343099-4fde2d80-1a74-11e9-96e6-bfede1b88161.png)
