### PR TITLE
[StyleCop] Fix all the warnings in BooleanExtractorConfiguration files.

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/Chinese/Extractors/ChineseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Chinese/Extractors/ChineseBooleanExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.Choice.Chinese
 {
-    class ChineseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
+    public class ChineseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
             new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.Choice.Chinese
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public ChineseBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/Dutch/Extractors/DutchBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Dutch/Extractors/DutchBooleanExtractorConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.Choice.Dutch
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public DutchBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/English/Extractors/EnglishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/English/Extractors/EnglishBooleanExtractorConfiguration.cs
@@ -7,19 +7,19 @@ namespace Microsoft.Recognizers.Text.Choice.English
 {
     public class EnglishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
-        public static readonly Regex TrueRegex = 
+        public static readonly Regex TrueRegex =
             new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
-        public static readonly Regex FalseRegex = 
+        public static readonly Regex FalseRegex =
             new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TokenRegex = 
+        public static readonly Regex TokenRegex =
             new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
-        public static readonly IDictionary<Regex, string> MapRegexes =  new Dictionary<Regex, string>()
+        public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public EnglishBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/French/Extractors/FrenchBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/French/Extractors/FrenchBooleanExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.Choice.French
 {
-    class FrenchBooleanExtractorConfiguration : IBooleanExtractorConfiguration
+    public class FrenchBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
             new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.Choice.French
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public FrenchBooleanExtractorConfiguration(bool onlyTopMatch = true)
@@ -40,6 +40,5 @@ namespace Microsoft.Recognizers.Text.Choice.French
         public int MaxDistance => 2;
 
         public bool OnlyTopMatch { get; }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Choice/German/Extractors/GermanBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/German/Extractors/GermanBooleanExtractorConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.Choice.German
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public GermanBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/Japanese/Extractors/JapaneseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Japanese/Extractors/JapaneseBooleanExtractorConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.Choice.Japanese
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public JapaneseBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/Portuguese/Extractors/PortugueseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Portuguese/Extractors/PortugueseBooleanExtractorConfiguration.cs
@@ -7,19 +7,19 @@ namespace Microsoft.Recognizers.Text.Choice.Portuguese
 {
     public class PortugueseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
-        public static readonly Regex TrueRegex = 
+        public static readonly Regex TrueRegex =
             new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
-        public static readonly Regex FalseRegex = 
+        public static readonly Regex FalseRegex =
             new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TokenRegex = 
+        public static readonly Regex TokenRegex =
             new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public PortugueseBooleanExtractorConfiguration(bool onlyTopMatch = true)

--- a/.NET/Microsoft.Recognizers.Text.Choice/Spanish/Extractors/SpanishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Spanish/Extractors/SpanishBooleanExtractorConfiguration.cs
@@ -7,19 +7,19 @@ namespace Microsoft.Recognizers.Text.Choice.Spanish
 {
     public class SpanishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
-        public static readonly Regex TrueRegex = 
+        public static readonly Regex TrueRegex =
             new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
-        public static readonly Regex FalseRegex = 
+        public static readonly Regex FalseRegex =
             new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
-        public static readonly Regex TokenRegex = 
+        public static readonly Regex TokenRegex =
             new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
-        public static readonly IDictionary<Regex, string> MapRegexes =  new Dictionary<Regex, string>()
+        public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {
-            {TrueRegex, Constants.SYS_BOOLEAN_TRUE },
-            {FalseRegex, Constants.SYS_BOOLEAN_FALSE }
+            { TrueRegex, Constants.SYS_BOOLEAN_TRUE },
+            { FalseRegex, Constants.SYS_BOOLEAN_FALSE },
         };
 
         public SpanishBooleanExtractorConfiguration(bool onlyTopMatch = true)


### PR DESCRIPTION
- Fixed spacing.
- Added trailing commas when needed.
- Added access modifier to classes.