### PR TITLE
[StyleCop] Fix all warnings in Dutch Parser files

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/AgeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class AgeParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public AgeParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public AgeParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public AgeParserConfiguration(CultureInfo ci) : base(ci)
+        public AgeParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(AgeExtractorConfiguration.AgeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/AreaParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/AreaParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class AreaParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public AreaParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public AreaParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public AreaParserConfiguration(CultureInfo ci) : base(ci)
+        public AreaParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(AreaExtractorConfiguration.AreaSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/CurrencyParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/CurrencyParserConfiguration.cs
@@ -7,15 +7,18 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class CurrencyParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public CurrencyParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public CurrencyParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public CurrencyParserConfiguration(CultureInfo ci) : base(ci)
+        public CurrencyParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencySuffixList);
             this.BindDictionary(CurrencyExtractorConfiguration.CurrencyPrefixList);
             this.CurrencyNameToIsoCodeMap = NumbersWithUnitDefinitions.CurrencyNameToIsoCodeMap.ToImmutableDictionary();
             this.CurrencyFractionCodeList = NumbersWithUnitDefinitions.FractionalUnitNameToCodeMap.ToImmutableDictionary();
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DimensionParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DimensionParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class DimensionParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public DimensionParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public DimensionParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public DimensionParserConfiguration(CultureInfo ci) : base(ci)
+        public DimensionParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(DimensionExtractorConfiguration.DimensionSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DutchNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DutchNumberWithUnitParserConfiguration.cs
@@ -1,13 +1,13 @@
 ﻿using System.Globalization;
-
-using Microsoft.Recognizers.Text.Number.Dutch;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Number.Dutch;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class DutchNumberWithUnitParserConfiguration : BaseNumberWithUnitParserConfiguration
     {
-        public DutchNumberWithUnitParserConfiguration(CultureInfo ci) : base(ci)
+        public DutchNumberWithUnitParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration());

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/LengthParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/LengthParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class LengthParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public LengthParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public LengthParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public LengthParserConfiguration(CultureInfo ci) : base(ci)
+        public LengthParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(LengthExtractorConfiguration.LengthSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/SpeedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/SpeedParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class SpeedParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public SpeedParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public SpeedParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public SpeedParserConfiguration(CultureInfo ci) : base(ci)
+        public SpeedParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(SpeedExtractorConfiguration.SpeedSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/TemperatureParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/TemperatureParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class TemperatureParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public TemperatureParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public TemperatureParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public TemperatureParserConfiguration(CultureInfo ci) : base(ci)
+        public TemperatureParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(TemperatureExtractorConfiguration.TemperatureSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/VolumeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/VolumeParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class VolumeParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public VolumeParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public VolumeParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public VolumeParserConfiguration(CultureInfo ci) : base(ci)
+        public VolumeParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(VolumeExtractorConfiguration.VolumeSuffixList);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/WeightParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/WeightParserConfiguration.cs
@@ -4,9 +4,13 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 {
     public class WeightParserConfiguration : DutchNumberWithUnitParserConfiguration
     {
-        public WeightParserConfiguration() : this(new CultureInfo(Culture.Dutch)) { }
+        public WeightParserConfiguration()
+            : this(new CultureInfo(Culture.Dutch))
+        {
+        }
 
-        public WeightParserConfiguration(CultureInfo ci) : base(ci)
+        public WeightParserConfiguration(CultureInfo ci)
+            : base(ci)
         {
             this.BindDictionary(WeightExtractorConfiguration.WeightSuffixList);
         }


### PR DESCRIPTION
- Fixed spacing.
- Reordered using statements.