### PR TITLE
[DateTime] Refactor StringExtension 'Normalized' method

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -573,5 +573,19 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
 			@"anos ate hoje",
 			@"anos ate a data"
 		};
+		public static readonly Dictionary<char, char> SpecialCharactersEquivalent = new Dictionary<char, char>
+		{
+			{ 'á', 'a' },
+			{ 'é', 'e' },
+			{ 'í', 'i' },
+			{ 'ó', 'o' },
+			{ 'ú', 'u' },
+			{ 'ê', 'e' },
+			{ 'ô', 'o' },
+			{ 'ü', 'u' },
+			{ 'ã', 'a' },
+			{ 'õ', 'o' },
+			{ 'ç', 'c' }
+		};
 	}
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -539,5 +539,13 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 			@"año a la fecha",
 			@"años a la fecha"
 		};
+		public static readonly Dictionary<char, char> SpecialCharactersEquivalent = new Dictionary<char, char>
+		{
+			{ 'á', 'a' },
+			{ 'é', 'e' },
+			{ 'í', 'i' },
+			{ 'ó', 'o' },
+			{ 'ú', 'u' }
+		};
 	}
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -154,28 +154,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public string Normalize(string text)
         {
-            return text.Normalized();
-        }
-    }
-
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Temporarily ignored because this method will be refactored.", Scope = "type", Target = "~T:Microsoft.Recognizers.Text.DateTime.Portuguese.StringExtension")]
-    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Temporarily ignored because this method will be refactored.", Scope = "type", Target = "~T:Microsoft.Recognizers.Text.DateTime.Portuguese.StringExtension")]
-    public static class StringExtension
-    {
-        public static string Normalized(this string text)
-        {
-            return text
-                .Replace('á', 'a')
-                .Replace('é', 'e')
-                .Replace('í', 'i')
-                .Replace('ó', 'o')
-                .Replace('ú', 'u')
-                .Replace("ê", "e")
-                .Replace("ô", "o")
-                .Replace("ü", "u")
-                .Replace("ã", "a")
-                .Replace("õ", "o")
-                .Replace("ç", "c");
+            return text.Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Portuguese;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
@@ -258,13 +259,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool IsMonthOnly(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o));
         }
 
         public bool IsMonthToDate(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             return DateTimeDefinitions.MonthToDateTerms.Any(o => trimmedText.Equals(o));
         }
 
@@ -289,7 +290,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool IsYearToDate(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             return DateTimeDefinitions.YearToDateTerms.Any(o => trimmedText.Equals(o));
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public int GetHour(string text, int hour)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             int result = hour;
 
             // TODO: Replace with a regex
@@ -105,7 +105,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool GetMatchedNowTimex(string text, out string timex)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
 
             if (trimmedText.EndsWith("agora") || trimmedText.EndsWith("mesmo") || trimmedText.EndsWith("momento"))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Definitions.Portuguese;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
+
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
@@ -113,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool GetMatchedTimeRange(string text, out string timeStr, out int beginHour, out int endHour, out int endMin)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             beginHour = 0;
             endHour = 0;
             endMin = 0;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Definitions.Portuguese;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
+
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
@@ -77,7 +80,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool GetMatchedDailyTimex(string text, out string timex)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
 
             if (trimmedText.EndsWith("diario") || trimmedText.EndsWith("diaria") || trimmedText.EndsWith("diariamente"))
             {
@@ -110,7 +113,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public bool GetMatchedUnitTimex(string text, out string timex)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
 
             if (trimmedText.Equals("dia") || trimmedText.Equals("dias"))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public int GetSwiftMonth(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             var swift = 0;
 
             if (NextPrefixRegex.IsMatch(trimmedText))
@@ -148,28 +148,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public bool IsCardinalLast(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant().Normalized();
+            var trimmedText = text.Trim().ToLowerInvariant().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             return PastPrefixRegex.IsMatch(trimmedText);
         }
 
         public string Normalize(string text)
         {
-            return text.Normalized();
-        }
-    }
-
-    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Temporarily ignored because this method will be refactored.", Scope = "type", Target = "~T:Microsoft.Recognizers.Text.DateTime.Spanish.StringExtension")]
-    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Temporarily ignored because this method will be refactored.", Scope = "type", Target = "~T:Microsoft.Recognizers.Text.DateTime.Spanish.StringExtension")]
-    public static class StringExtension
-    {
-        public static string Normalized(this string text)
-        {
-            return text
-                .Replace('á', 'a')
-                .Replace('é', 'e')
-                .Replace('í', 'i')
-                .Replace('ó', 'o')
-                .Replace('ú', 'u');
+            return text.Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/StringExtension.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/StringExtension.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Recognizers.Text.DateTime.Utilities
+{
+    public static class StringExtension
+    {
+        public static string Normalized(this string text, Dictionary<char, char> dic)
+        {
+            foreach (var keyPair in dic)
+            {
+                text = text.Replace(keyPair.Key, keyPair.Value);
+            }
+
+            return text;
+        }
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/PortugueseDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/PortugueseDateTime.java
@@ -903,4 +903,18 @@ public class PortugueseDateTime {
     public static final List<String> YearTerms = Arrays.asList("ano", "anos");
 
     public static final List<String> YearToDateTerms = Arrays.asList("ano ate agora", "ano ate hoje", "ano ate a data", "anos ate agora", "anos ate hoje", "anos ate a data");
+
+    public static final ImmutableMap<Character, Character> SpecialCharactersEquivalent = ImmutableMap.<Character, Character>builder()
+        .put('á', 'a')
+        .put('é', 'e')
+        .put('í', 'i')
+        .put('ó', 'o')
+        .put('ú', 'u')
+        .put('ê', 'e')
+        .put('ô', 'o')
+        .put('ü', 'u')
+        .put('ã', 'a')
+        .put('õ', 'o')
+        .put('ç', 'c')
+        .build();
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
@@ -879,4 +879,12 @@ public class SpanishDateTime {
     public static final List<String> YearTerms = Arrays.asList("año", "años");
 
     public static final List<String> YearToDateTerms = Arrays.asList("año a la fecha", "años a la fecha");
+
+    public static final ImmutableMap<Character, Character> SpecialCharactersEquivalent = ImmutableMap.<Character, Character>builder()
+        .put('á', 'a')
+        .put('é', 'e')
+        .put('í', 'i')
+        .put('ó', 'o')
+        .put('ú', 'u')
+        .build();
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/spanish/parsers/SpanishDateParserConfiguration.java
@@ -11,7 +11,9 @@ import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimePar
 import com.microsoft.recognizers.text.datetime.parsers.config.IDateParserConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.SpanishDateTime;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.StringExtension;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
 import java.util.Collections;
@@ -322,10 +324,6 @@ public class SpanishDateParserConfiguration  extends BaseOptionsConfiguration im
 
     @Override
     public String normalize(String text) {
-        return text.replace('á', 'a')
-                .replace('é', 'e')
-                .replace('í', 'i')
-                .replace('ó', 'o')
-                .replace('ú', 'u');
+        return StringExtension.normalize(text, SpanishDateTime.SpecialCharactersEquivalent);
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/StringExtension.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/StringExtension.java
@@ -1,0 +1,13 @@
+package com.microsoft.recognizers.text.datetime.utilities;
+
+import com.google.common.collect.ImmutableMap;
+
+public abstract class StringExtension {
+    public static String normalize(String text, ImmutableMap<Character, Character> dic) {
+        for (ImmutableMap.Entry<Character, Character> keyPair : dic.entrySet()) {
+            text = text.replace(keyPair.getKey(), keyPair.getValue());
+        }
+
+        return text;
+    }
+}

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -925,4 +925,18 @@ YearToDateTerms: !list
     - anos ate agora
     - anos ate hoje
     - anos ate a data
+SpecialCharactersEquivalent: !dictionary
+  types: [ char, char ]
+  entries:
+    á: a
+    é: e
+    í: i
+    ó: o
+    ú: u
+    ê: e
+    ô: o
+    ü: u
+    ã: a
+    õ: o
+    ç: c
 ...

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -888,4 +888,12 @@ YearToDateTerms: !list
   entries:
     - año a la fecha
     - años a la fecha
+SpecialCharactersEquivalent: !dictionary
+  types: [ char, char ]
+  entries:
+    á: a
+    é: e
+    í: i
+    ó: o
+    ú: u
 ...


### PR DESCRIPTION
# Description
Remove StringExtension 'Normalized' from Spanish and Portuguese parsers and create a unique String extension in utilities. This runs and replaces characters that are previously loaded using a YAML file.
- Add Spanish SpecialCharacters dictionary in YAML
- Add Portuguese SpecialCharacters dictionary in YAML
- Create in utilities StringExtension class with the normalized method
- Refactor Portuguese and Spanish parsers to start using this StringExtension
- Port changes to Java