### PR TITLE
[DotNet][DateTime] Renamed regex variable 'AndRegex' to match used regex

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AndRegex =
+        public static readonly Regex RangeConnectorRegex =
             new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexOptions.Singleline);
 
         public static readonly Regex DayRegex =
@@ -329,8 +329,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public bool HasConnectorToken(string text)
         {
-            return AndRegex.IsExactMatch(text, trim: true);
+            return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AndRegex =
+        public static readonly Regex RangeConnectorRegex =
             new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexOptions.Singleline);
 
         public static readonly Regex DayRegex =
@@ -329,7 +329,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public bool HasConnectorToken(string text)
         {
-            return AndRegex.IsExactMatch(text, trim: true);
+            return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
         // and
-        public static readonly Regex AndRegex =
+        public static readonly Regex RangeConnectorRegex =
             new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexOptions.Singleline);
 
         public static readonly Regex DayRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AndRegex =
+        public static readonly Regex RangeConnectorRegex =
             new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexOptions.Singleline);
 
         public static readonly Regex DayRegex =
@@ -285,7 +285,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public bool HasConnectorToken(string text)
         {
-            return AndRegex.IsExactMatch(text, trim: true);
+            return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DateTimeDefinitions.TillRegex, // until
             RegexOptions.Singleline);
 
-        public static readonly Regex AndRegex = new Regex(
+        public static readonly Regex RangeConnectorRegex = new Regex(
             DateTimeDefinitions.RangeConnectorRegex, // and
             RegexOptions.Singleline);
 


### PR DESCRIPTION
- Renamed regex variable 'AndRegex' to match used regex 'RangeConnectorRegex'