### PR TITLE
[JavaScript] Rename DinoComparer to StringComparer and update implementation 

### DIFF
--- a/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
+++ b/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
@@ -330,16 +330,16 @@ export class NumberWithUnitExtractor implements IExtractor {
         return RegExpUtility.getSafeRegExp(pattern, options);
     }
 
-    protected stringComparer(x: string, y: string): number {
-        let localCompare= x.localeCompare(y);
-        if (localCompare !== 0 )
+    protected stringComparer(stringA: string, stringB: string): number {
+        if (!stringA && !stringB)
         {
-            return x.localeCompare(y);
+            return 0;
         }
         else
         {
-            if(localCompare === 0) return 0;
-            else return x.toLowerCase < y.toLowerCase? -1 : 1;
+            if (!stringA) return 1;
+            if (!stringB) return -1;
+            return stringB.localeCompare(stringA);
         }
     }
     

--- a/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
+++ b/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
@@ -322,7 +322,7 @@ export class NumberWithUnitExtractor implements IExtractor {
         }
 
         // Sort SeparateWords using descending length.
-        regexTokens = regexTokens.sort(this.dinoComparer);
+        regexTokens = regexTokens.sort(this.stringComparer);
 
         let pattern = `${this.config.buildPrefix}(${regexTokens.join('|')})${this.config.buildSuffix}`;
         let options = "gs";
@@ -330,58 +330,19 @@ export class NumberWithUnitExtractor implements IExtractor {
         return RegExpUtility.getSafeRegExp(pattern, options);
     }
 
-    protected dinoComparer(x: string, y: string): number {
-        if (x === null) {
-            if (y === null) {
-                // If x is null and y is null, they're
-                // equal.
-                return 0;
-            }
-            else {
-                // If x is null and y is not null, y
-                // is greater.
-                return 1;
-            }
+    protected stringComparer(x: string, y: string): number {
+        let localCompare= x.localeCompare(y);
+        if (localCompare !== 0 )
+        {
+            return x.localeCompare(y);
         }
-        else {
-            // If x is not null...
-            //
-            if (y === null)
-            // ...and y is null, x is greater.
-            {
-                return -1;
-            }
-            else {
-                // ...and y is not null, compare the
-                // lengths of the two strings.
-                //
-                let retval = y.length - x.length;
-
-                if (retval !== 0) {
-                    // If the strings are not of equal length,
-                    // the longer string is greater.
-                    //
-                    return retval;
-                }
-                else {
-                    // If the strings are of equal length,
-                    // sort them with ordinary string comparison.
-                    //
-                    let xl = x.toLowerCase();
-                    let yl = y.toLowerCase();
-                    if (xl < yl) {
-                        return -1;
-                    }
-
-                    if (xl > yl) {
-                        return 1;
-                    }
-
-                    return 0;
-                }
-            }
+        else
+        {
+            if(localCompare === 0) return 0;
+            else return x.toLowerCase < y.toLowerCase? -1 : 1;
         }
     }
+    
 
     private DimensionInsideTime(dimension: Match, time: Match): boolean {
         let isSubMatch = false;

--- a/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
+++ b/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
@@ -337,8 +337,14 @@ export class NumberWithUnitExtractor implements IExtractor {
         }
         else
         {
-            if (!stringA) return 1;
-            if (!stringB) return -1;
+            if (!stringA) 
+            {
+                return 1;
+            }
+            if (!stringB)
+            {
+                return -1;
+            } 
             return stringB.localeCompare(stringA);
         }
     }


### PR DESCRIPTION
# Description

- Change the method DinoComparer to StringComparer for more clarity within the code. This method will take two strings and compare them, taking into consideration that they may be null or empty. 
- The method was refactored for a more clear implementation. 
- The extractor.ts file was updated to work with the changed name.

All the tests passed succesfully

![imagen](https://user-images.githubusercontent.com/22912283/51697943-d7cdb580-1fe7-11e9-8ad4-97d70e7bae0a.png)
