### PR TITLE
[DotNet][Datetime] Remove unused regexes from English, Spanish, and Chinese

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DateExtractorChs.cs
@@ -14,15 +14,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex DayRegexInChinese = new Regex(DateTimeDefinitions.DateDayRegexInChinese, RegexOptions.Singleline);
-
-        public static readonly Regex DayRegexNumInChinese = new Regex(DateTimeDefinitions.DayRegexNumInChinese, RegexOptions.Singleline);
-
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
-        public static readonly Regex ZeroToNineIntegerRegexChs = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexOptions.Singleline);
 
         public static readonly Regex YearInChineseRegex = new Regex(DateTimeDefinitions.DateYearInChineseRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DatePeriodExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/DatePeriodExtractorChs.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex DayRegexInChinese = new Regex(DateTimeDefinitions.DatePeriodDayRegexInChinese, RegexOptions.Singleline);
-
         public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
 
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DatePeriodThisRegex, RegexOptions.Singleline);
@@ -32,10 +30,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.DatePeriodYearRegex, RegexOptions.Singleline);
 
         public static readonly Regex StrictYearRegex = new Regex(DateTimeDefinitions.StrictYearRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegexInNumber = new Regex(DateTimeDefinitions.YearRegexInNumber, RegexOptions.Singleline);
-
-        public static readonly Regex ZeroToNineIntegerRegexChs = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexOptions.Singleline);
 
         public static readonly Regex YearInChineseRegex = new Regex(DateTimeDefinitions.DatePeriodYearInChineseRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/SetExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/SetExtractorChs.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.SetUnitRegex, RegexOptions.Singleline);
-
         public static readonly Regex EachUnitRegex = new Regex(DateTimeDefinitions.SetEachUnitRegex, RegexOptions.Singleline);
 
         public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimeExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimeExtractorChs.cs
@@ -8,25 +8,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class TimeExtractorChs : BaseDateTimeExtractor<TimeType>
     {
-        public static readonly string HourNumRegex = DateTimeDefinitions.TimeHourNumRegex;
-
         public static readonly string MinuteNumRegex = DateTimeDefinitions.TimeMinuteNumRegex;
-
-        public static readonly string SecondNumRegex = DateTimeDefinitions.TimeSecondNumRegex;
-
-        public static readonly string HourChsRegex = DateTimeDefinitions.TimeHourChsRegex;
-
-        public static readonly string MinuteChsRegex = DateTimeDefinitions.TimeMinuteChsRegex;
-
-        public static readonly string SecondChsRegex = DateTimeDefinitions.TimeSecondChsRegex;
-
-        public static readonly string ClockDescRegex = DateTimeDefinitions.TimeClockDescRegex;
 
         public static readonly string MinuteDescRegex = DateTimeDefinitions.TimeMinuteDescRegex;
 
         public static readonly string SecondDescRegex = DateTimeDefinitions.TimeSecondDescRegex;
-
-        public static readonly string BanHourPrefixRegex = DateTimeDefinitions.TimeBanHourPrefixRegex;
 
         // e.g: 12点, 十二点, 十二点整
         public static readonly string HourRegex = DateTimeDefinitions.TimeHourRegex;
@@ -47,10 +33,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         // e.g: 早上九点
         public static readonly string DayDescRegex = DateTimeDefinitions.TimeDayDescRegex;
-
-        public static readonly string ApproximateDescPreffixRegex = DateTimeDefinitions.TimeApproximateDescPreffixRegex;
-
-        public static readonly string ApproximateDescSuffixRegex = DateTimeDefinitions.TimeApproximateDescSuffixRegex;
 
         public TimeExtractorChs()
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimePeriodExtractorChs.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/TimePeriodExtractorChs.cs
@@ -8,26 +8,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class TimePeriodExtractorChs : BaseDateTimeExtractor<PeriodType>
     {
-        public const string TimePeriodConnectWords = DateTimeDefinitions.TimePeriodTimePeriodConnectWords;
-
         // 五点十分四十八秒
         public static readonly string ChineseTimeRegex = TimeExtractorChs.ChineseTimeRegex;
 
-        // 六点 到 九点 | 六 到 九点
-        public static readonly string LeftChsTimeRegex = DateTimeDefinitions.TimePeriodLeftChsTimeRegex;
-
-        public static readonly string RightChsTimeRegex = DateTimeDefinitions.TimePeriodRightChsTimeRegex;
-
         // 2:45
         public static readonly string DigitTimeRegex = TimeExtractorChs.DigitTimeRegex;
-
-        public static readonly string LeftDigitTimeRegex = DateTimeDefinitions.TimePeriodLeftDigitTimeRegex;
-
-        public static readonly string RightDigitTimeRegex = DateTimeDefinitions.TimePeriodRightDigitTimeRegex;
-
-        public static readonly string ShortLeftChsTimeRegex = DateTimeDefinitions.TimePeriodShortLeftChsTimeRegex;
-
-        public static readonly string ShortLeftDigitTimeRegex = DateTimeDefinitions.TimePeriodShortLeftDigitTimeRegex;
 
         public TimePeriodExtractorChs()
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -15,12 +15,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
@@ -7,9 +7,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex H1 =
             new Regex(DateTimeDefinitions.HolidayRegex1, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
-        public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.Singleline);
-
         public static readonly Regex PeriodicRegex =
             new Regex(DateTimeDefinitions.PeriodicRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -7,67 +7,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------------
-        public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... o'clock"
-        public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... afternoon"
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... in the morning"
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
             new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
 
-        // handle "six thirty", "six twenty one"
-        public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
-
-        public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
-
-        public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexOptions.Singleline);
-
-        // handle special time such as 'at midnight', 'midnight', 'midday'
-        public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexOptions.Singleline);
-
-        // part 3: regex for time
-        // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
             new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -12,21 +12,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         public static readonly Regex PureNumFromTo =
             new Regex(DateTimeDefinitions.PureNumFromTo, RegexOptions.Singleline);
 
@@ -45,17 +30,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex TimeOfDayRegex =
             new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexOptions.Singleline);
-
         public static readonly Regex TimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
-        public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -16,14 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
 
+        // The functionality for this regex has not yet been implemented
         public static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
 
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -13,29 +13,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex AndRegex =
-            new Regex(DateTimeDefinitions.AndRegex, RegexOptions.Singleline);
-
-        public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
         public static readonly Regex IllegalYearRegex =
             new Regex(BaseDateTime.IllegalYearRegex, RegexOptions.Singleline);
 
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
-        public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexOptions.Singleline);
 
         public static readonly Regex DateUnitRegex =
             new Regex(DateTimeDefinitions.DateUnitRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -7,42 +7,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------------
-        public static readonly Regex DescRegex = new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex = new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... en punto"
-        public static readonly Regex OclockRegex = new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... tarde"
-        public static readonly Regex PmRegex = new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... de la mañana"
-        public static readonly Regex AmRegex = new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "y media ..." "menos cuarto ..."
         public static readonly Regex LessThanOneHour = new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
 
-        public static readonly Regex TensTimeRegex = new Regex(DateTimeDefinitions.TensTimeRegex, RegexOptions.Singleline);
-
         // handle "seis treinta", "seis veintiuno", "seis menos diez"
-        public static readonly Regex WrittenTimeRegex = new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimePrefix = new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
-
         public static readonly Regex TimeSuffix = new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
 
+        // The functionality for this regex has not yet been implemented
         public static readonly Regex BasicTime = new Regex(DateTimeDefinitions.BasicTime, RegexOptions.Singleline);
 
-        // part 3: regex for time
-        // --------------------------------------
-        // handle "a las cuatro" "a las 3"
         // TODO: add some new regex which have used in AtRegex
         // TODO: modify according to corresponding English regex
         public static readonly Regex AtRegex = new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -10,15 +10,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
-
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.TimeHourNumRegex, RegexOptions.Singleline);
+        
         public static readonly Regex PureNumFromTo = new Regex(DateTimeDefinitions.PureNumFromTo, RegexOptions.Singleline);
         public static readonly Regex PureNumBetweenAnd = new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexOptions.Singleline);
         public static readonly Regex SpecificTimeFromTo = new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexOptions.Singleline);
         public static readonly Regex SpecificTimeBetweenAnd = new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexOptions.Singleline);
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
         public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         // TODO: add this according to coresponding English regex
         public static readonly Regex TimeOfDayRegex = new Regex(string.Empty, RegexOptions.Singleline);
@@ -38,14 +36,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             SingleTimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(this));
-            UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
             TimeZoneExtractor = new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(this));
         }
 
         public string TokenBeforeDate { get; }
-
-        public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public IDateTimeExtractor SingleTimeExtractor { get; }
 


### PR DESCRIPTION
*Disclaimer*: _Because we are removing multiple unused `public static readonly` properties, this involves a breaking change if final users are relying on them. However, they are not being used anymore anywhere in the code.
Our suggestion, if we want to maintain the external interface intact is to review and explicitly expose them or comment on those properties to keep._

# Description
Remove unused regexes from English, Spanish, and Chinese parsers and extractors. This is just to clean the code.