### PR TITLE
 [StyleCop] Fix all the warnings in Definitions 

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
+++ b/.NET/Microsoft.Recognizers.Definitions/Microsoft.Recognizers.Definitions.csproj
@@ -5,6 +5,7 @@
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <CodeAnalysisRuleSet>../Recognizers-Text.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">

--- a/.NET/Microsoft.Recognizers.Definitions/Utilities/DefinitionLoader.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Utilities/DefinitionLoader.cs
@@ -5,25 +5,22 @@ namespace Microsoft.Recognizers.Definitions.Utilities
 {
     public static class DefinitionLoader
     {
-
         public static Dictionary<Regex, Regex> LoadAmbiguityFilters(Dictionary<string, string> filters)
         {
             var ambiguityFiltersDict = new Dictionary<Regex, Regex>();
 
-            if (filters != null) {
-
+            if (filters != null)
+            {
                 foreach (var item in filters)
                 {
                     if (!"null".Equals(item.Key))
                     {
-                        ambiguityFiltersDict.Add(new Regex(item.Key, RegexOptions.Singleline),
-                                                 new Regex(item.Value, RegexOptions.Singleline));
+                        ambiguityFiltersDict.Add(new Regex(item.Key, RegexOptions.Singleline), new Regex(item.Value, RegexOptions.Singleline));
                     }
                 }
             }
 
             return ambiguityFiltersDict;
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Properties/AssemblyInfo.cs
@@ -1,3 +1,7 @@
+﻿// <copyright file="AssemblyInfo.cs" company="Microsoft Corporation">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Properties/AssemblyInfo.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="AssemblyInfo.cs" company="Microsoft Corporation">
-// Copyright (c) PlaceholderCompany. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
 using System.Reflection;


### PR DESCRIPTION
- Remove or add spacing when needed
- Reorder parameters
- Remove trailing whitespace
- Add header