### PR TITLE
[StyleCop] Fix warnings in Text.Number Project

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BasePercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BasePercentageExtractor.cs
@@ -8,30 +8,28 @@ namespace Microsoft.Recognizers.Text.Number
 {
     public abstract class BasePercentageExtractor : IExtractor
     {
-        private readonly BaseNumberExtractor numberExtractor;
-
-        protected virtual NumberOptions Options { get; } = NumberOptions.None;
-
         protected static readonly string NumExtType = Constants.SYS_NUM; // @sys.num
 
         protected static readonly string FracNumExtType = Constants.SYS_NUM_FRACTION;
 
-        protected string ExtractType = Constants.SYS_NUM_PERCENTAGE;
-
-        protected ImmutableHashSet<Regex> Regexes;
+        private readonly BaseNumberExtractor numberExtractor;
 
         public BasePercentageExtractor(BaseNumberExtractor numberExtractor)
         {
             this.numberExtractor = numberExtractor;
         }
 
-        protected abstract ImmutableHashSet<Regex> InitRegexes();
+        protected string ExtractType { get; set; } = Constants.SYS_NUM_PERCENTAGE;
+
+        protected virtual NumberOptions Options { get; } = NumberOptions.None;
+
+        protected ImmutableHashSet<Regex> Regexes { get; set; }
 
         /// <summary>
-        /// extractor the percentage entities from the sentence
+        /// extractor the percentage entities from the sentence.
         /// </summary>
-        /// <param name="source"></param>
-        /// <returns></returns>
+        /// <param name="source">sentence.</param>
+        /// <returns>List of percentage entities from the sentence source.</returns>
         public List<ExtractResult> Extract(string source)
         {
             var originSource = source;
@@ -100,10 +98,11 @@ namespace Microsoft.Recognizers.Text.Number
         }
 
         /// <summary>
-        /// read the rules
+        /// read the rules.
         /// </summary>
-        /// <param name="regexStrs">rule list</param>
-        /// <param name="ignoreCase"></param>
+        /// <param name="regexStrs">rule list.</param>
+        /// <param name="ignoreCase">.</param>
+        /// <returns>Immutable HashSet of regex.</returns>
         protected static ImmutableHashSet<Regex> BuildRegexes(HashSet<string> regexStrs, bool ignoreCase = false)
         {
             var regexes = new HashSet<Regex>();
@@ -111,7 +110,6 @@ namespace Microsoft.Recognizers.Text.Number
             foreach (var regexStr in regexStrs)
             {
                 // var sl = "(?=\\b)(" + regexStr + ")(?=(s?\\b))";
-
                 var options = RegexOptions.Singleline;
                 if (ignoreCase)
                 {
@@ -126,12 +124,18 @@ namespace Microsoft.Recognizers.Text.Number
             return regexes.ToImmutableHashSet();
         }
 
+        protected abstract ImmutableHashSet<Regex> InitRegexes();
+
         /// <summary>
-        /// replace the @sys.num to the real patterns, directly modifies the ExtractResult
+        /// replace the @sys.num to the real patterns, directly modifies the ExtractResult.
         /// </summary>
-        /// <param name="results">extract results after number extractor</param>
-        /// <param name="originSource">the sentence after replacing the @sys.num, Example: @sys.num %</param>
-        private void PostProcessing(List<ExtractResult> results, string originSource, Dictionary<int, int> positionMap, IList<ExtractResult> numExtResults)
+        /// <param name="results">extract results after number extractor.</param>
+        /// <param name="originSource">the sentence after replacing the @sys.num, Example: @sys.num %.</param>
+        private void PostProcessing(
+            List<ExtractResult> results,
+            string originSource,
+            Dictionary<int, int> positionMap,
+            IList<ExtractResult> numExtResults)
         {
             string replaceNumText = "@" + NumExtType;
             string replaceFracNumText = "@" + FracNumExtType;
@@ -200,13 +204,15 @@ namespace Microsoft.Recognizers.Text.Number
         }
 
         /// <summary>
-        /// get the number extractor results and convert the extracted numbers to @sys.num, so that the regexes can work
+        /// get the number extractor results and convert the extracted numbers to @sys.num, so that the regexes can work.
         /// </summary>
-        /// <param name="str"></param>
-        /// <param name="positionMap"></param>
-        /// <param name="numExtResults"></param>
-        /// <returns></returns>
-        private string PreprocessStrWithNumberExtracted(string str, out Dictionary<int, int> positionMap,
+        /// <param name="str">sentence to process.</param>
+        /// <param name="positionMap">position Map.</param>
+        /// <param name="numExtResults">number extractor result.</param>
+        /// <returns>return according type "builtin.num" or "builtin.num.percentage".</returns>
+        private string PreprocessStrWithNumberExtracted(
+            string str,
+            out Dictionary<int, int> positionMap,
             out IList<ExtractResult> numExtResults)
         {
             positionMap = new Dictionary<int, int>();

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.csproj
@@ -8,6 +8,18 @@
     <CodeAnalysisRuleSet>../Recognizers-Text.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <PropertyGroup>
+	  <!--
+		Make sure any documentation comments which are included in code get checked for syntax during the build, but do
+		not report warnings for missing comments.
+
+		CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+		CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+	  -->
+	  <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
+	  <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
+	</PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008">
       <PrivateAssets>all</PrivateAssets>

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberMode.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberMode.cs
@@ -13,7 +13,7 @@
         Unit,
 
         /// <summary>
-        /// Add 67.5 billion & million support.
+        /// Add 67.5 billion and million support.
         /// </summary>
         Currency,
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
@@ -1,11 +1,31 @@
-﻿using Microsoft.Recognizers.Definitions.Spanish;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.Number.Spanish
 {
-    class SpanishNumberRangeParserConfiguration : INumberRangeParserConfiguration
+    public class SpanishNumberRangeParserConfiguration : INumberRangeParserConfiguration
     {
+        public SpanishNumberRangeParserConfiguration()
+            : this(new CultureInfo(Culture.Spanish))
+        {
+        }
+
+        public SpanishNumberRangeParserConfiguration(CultureInfo ci)
+        {
+            CultureInfo = ci;
+
+            NumberExtractor = Spanish.NumberExtractor.GetInstance();
+            OrdinalExtractor = Spanish.OrdinalExtractor.GetInstance();
+            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
+            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
+            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
+            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
+            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
+            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
+        }
+
         public CultureInfo CultureInfo { get; private set; }
 
         public IExtractor NumberExtractor { get; private set; }
@@ -25,26 +45,5 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
         public Regex MoreOrEqualSeparate { get; private set; }
 
         public Regex LessOrEqualSeparate { get; private set; }
-
-        public SpanishNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Spanish))
-        {
-
-        }
-
-        public SpanishNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
-
-            NumberExtractor = Spanish.NumberExtractor.GetInstance();
-            OrdinalExtractor = Spanish.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexOptions.Singleline);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexOptions.Singleline);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline);
-        }
     }
 }


### PR DESCRIPTION
- XML comment analysis warning

SpanishNumberRangeParserConfiguration  …
- Move constructor before properties
- Move constructor initializers on their own line
- Add class access modifier

BasePercentageExtractor  …
- Reorder properties a fields
- Set field to a property to keep the variable name with upper-case
- Add returns comments in methods
- Add trailing coma in multi-line initializers
- Use String.Empty instead empty strings

NumberMode  …
- Update comment to fix CS1570 XML comment has badly formed