### PR TITLE
[StyleCop]  Add warning fixes generating Breaking Changes 

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/BaseMergedUnitParser.cs
@@ -6,11 +6,11 @@
 
         public BaseMergedUnitParser(BaseNumberWithUnitParserConfiguration config)
         {
-            this.config = config;
+            this.Config = config;
             numberWithUnitParser = new NumberWithUnitParser(config);
         }
 
-        protected BaseNumberWithUnitParserConfiguration config { get; private set; }
+        protected BaseNumberWithUnitParserConfiguration Config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -19,7 +19,7 @@
             // For now only currency model recognizes compound units.
             if (extResult.Type.Equals(Constants.SYS_UNIT_CURRENCY))
             {
-                pr = new BaseCurrencyParser(config).Parse(extResult);
+                pr = new BaseCurrencyParser(Config).Parse(extResult);
             }
             else
             {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Parsers/NumberWithUnitParser.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
     {
         public NumberWithUnitParser(INumberWithUnitParserConfiguration config)
         {
-            this.config = config;
+            this.Config = config;
         }
 
-        protected INumberWithUnitParserConfiguration config { get; private set; }
+        protected INumberWithUnitParserConfiguration Config { get; private set; }
 
         public ParseResult Parse(ExtractResult extResult)
         {
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             }
             else if (extResult.Type.Equals(Constants.SYS_NUM))
             {
-                ret.Value = config.InternalNumberParser.Parse(extResult).Value;
+                ret.Value = Config.InternalNumberParser.Parse(extResult).Value;
                 return ret;
             }
             else
@@ -70,20 +70,20 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             // Unit type depends on last unit in suffix
             var lastUnit = unitKeys.Last();
             var normalizedLastUnit = lastUnit.ToLowerInvariant();
-            if (!string.IsNullOrEmpty(config.ConnectorToken) && normalizedLastUnit.StartsWith(config.ConnectorToken))
+            if (!string.IsNullOrEmpty(Config.ConnectorToken) && normalizedLastUnit.StartsWith(Config.ConnectorToken))
             {
-                normalizedLastUnit = normalizedLastUnit.Substring(config.ConnectorToken.Length).Trim();
-                lastUnit = lastUnit.Substring(config.ConnectorToken.Length).Trim();
+                normalizedLastUnit = normalizedLastUnit.Substring(Config.ConnectorToken.Length).Trim();
+                lastUnit = lastUnit.Substring(Config.ConnectorToken.Length).Trim();
             }
 
-            if (!string.IsNullOrWhiteSpace(key) && config.UnitMap != null)
+            if (!string.IsNullOrWhiteSpace(key) && Config.UnitMap != null)
             {
-                if (config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
-                    config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
+                if (Config.UnitMap.TryGetValue(lastUnit, out var unitValue) ||
+                    Config.UnitMap.TryGetValue(normalizedLastUnit, out unitValue))
                 {
                     var numValue = string.IsNullOrEmpty(numberResult.Text) ?
                         null :
-                        this.config.InternalNumberParser.Parse(numberResult);
+                        this.Config.InternalNumberParser.Parse(numberResult);
 
                     ret.Value = new UnitValue
                     {

--- a/.NET/Microsoft.Recognizers.Text/Matcher/AcAutomaton.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/AcAutomaton.cs
@@ -5,15 +5,15 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class AcAutomaton<T> : AbstractMatcher<T>
     {
-        protected readonly AaNode<T> root = new AaNode<T>();
-
         public AcAutomaton()
         {
         }
 
+        protected AaNode<T> Root { get; private set; } = new AaNode<T>();
+
         public override void Insert(IEnumerable<T> value, string id)
         {
-            var node = root;
+            var node = Root;
             int i = 0;
             foreach (var item in value)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.Matcher
         {
             BatchInsert(values, ids);
             var queue = new Queue<AaNode<T>>();
-            queue.Enqueue(root);
+            queue.Enqueue(Root);
 
             while (queue.Any())
             {
@@ -49,41 +49,41 @@ namespace Microsoft.Recognizers.Text.Matcher
                     }
                 }
 
-                if (node == root)
+                if (node == Root)
                 {
-                    root.Fail = root;
+                    Root.Fail = Root;
                     continue;
                 }
 
                 var fail = node.Parent.Fail;
 
-                while (fail[node.Word] == null && fail != root)
+                while (fail[node.Word] == null && fail != Root)
                 {
                     fail = fail.Fail;
                 }
 
-                node.Fail = fail[node.Word] ?? root;
-                node.Fail = node.Fail == node ? root : node.Fail;
+                node.Fail = fail[node.Word] ?? Root;
+                node.Fail = node.Fail == node ? Root : node.Fail;
             }
 
-            ConvertDictToList(root);
+            ConvertDictToList(Root);
         }
 
         public override IEnumerable<MatchResult<T>> Find(IEnumerable<T> queryText)
         {
-            var node = root;
+            var node = Root;
             var i = 0;
 
             foreach (var c in queryText)
             {
-                while (node[c] == null && node != root)
+                while (node[c] == null && node != Root)
                 {
                     node = node.Fail;
                 }
 
-                node = node[c] ?? root;
+                node = node[c] ?? Root;
 
-                for (var t = node; t != root; t = t.Fail)
+                for (var t = node; t != Root; t = t.Fail)
                 {
                     if (t.End)
                     {

--- a/.NET/Microsoft.Recognizers.Text/Matcher/TrieTree.cs
+++ b/.NET/Microsoft.Recognizers.Text/Matcher/TrieTree.cs
@@ -5,15 +5,15 @@ namespace Microsoft.Recognizers.Text.Matcher
 {
     public class TrieTree<T> : AbstractMatcher<T>
     {
-        protected readonly Node<T> root = new Node<T>();
-
         public TrieTree()
         {
         }
 
+        protected Node<T> Root { get; private set; } = new Node<T>();
+
         public override void Insert(IEnumerable<T> value, string id)
         {
-            var node = root;
+            var node = Root;
 
             foreach (var item in value)
             {
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.Matcher
         public override void Init(IEnumerable<T>[] values, string[] ids)
         {
             BatchInsert(values, ids);
-            ConvertDictToList(root);
+            ConvertDictToList(Root);
         }
 
         public override IEnumerable<MatchResult<T>> Find(IEnumerable<T> queryText)
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.Matcher
             var queryArray = queryText.ToArray();
             for (var i = 0; i < queryArray.Length; i++)
             {
-                var node = root;
+                var node = Root;
                 for (var j = i; j <= queryArray.Length; j++)
                 {
                     if (node.End)


### PR DESCRIPTION
*Disclaimer*: To fix some StyleCop warnings we might incur in breaking changes. In this case, related to protected properties that might be used by end users.
- Rename protected field to match the recommended casing