### PR TITLE
[DotNet][Datetime] Remove unused regexes from Dutch, French, Portuguese, Japanese, and Italian extractors.

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -18,12 +18,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
@@ -7,9 +7,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex H1 =
             new Regex(DateTimeDefinitions.HolidayRegex1, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
@@ -6,11 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
-        public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
-
-        public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.Singleline);
-
         // TODO: Decide between adjective and adverb, i.e monthly - 'mensuel' vs 'mensuellement'
         public static readonly Regex PeriodicRegex =
             new Regex(DateTimeDefinitions.PeriodicRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -7,43 +7,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------
-        public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
         public static readonly Regex MinuteNumRegex =
             new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... heures (o'clock, en punto)"
-        public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... après midi (afternoon, tarde)"
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... dans la matinee (in the morning)"
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
             new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
-
-        public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        // TODO - will have change below
-        // handle "six heures et demie" (six thirty), "six heures et vingt-et-un" (six twenty one)
-        public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
 
         public static readonly Regex TimeSuffix =
             new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
@@ -57,20 +27,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex MidnightRegex =
             new Regex(DateTimeDefinitions.MidnightRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexOptions.Singleline);
-
-        // part 3: regex for time
-        // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
             new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -14,15 +14,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.PeriodDescRegex, RegexOptions.Singleline);
-
         public static readonly Regex PmRegex =
             new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
 
@@ -52,12 +43,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public static readonly Regex TimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
-        public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -18,12 +18,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
@@ -6,10 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex = new Regex(
-            DateTimeDefinitions.YearRegex,
-            RegexOptions.Singleline);
-
         public static readonly Regex H1 =
             new Regex(
                 DateTimeDefinitions.HolidayRegex1,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
-        public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.Singleline);
-
         public static readonly Regex PeriodicRegex =
             new Regex(DateTimeDefinitions.PeriodicRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
@@ -7,45 +7,10 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------------
-        public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... o'clock"
-        public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... afternoon"
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... in the morning"
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
             new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
-
-        // handle "six thirty", "six twenty one"
-        public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
-
-        public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
 
         public static readonly Regex BasicTime =
             new Regex(DateTimeDefinitions.BasicTime, RegexOptions.Singleline);
@@ -54,20 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex MidnightRegex =
             new Regex(DateTimeDefinitions.MidnightRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexOptions.Singleline);
-
-        // part 3: regex for time
-        // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
             new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -12,21 +12,6 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         public static readonly Regex PureNumFromTo =
             new Regex(DateTimeDefinitions.PureNumFromTo, RegexOptions.Singleline);
 
@@ -43,17 +28,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly Regex TimeOfDayRegex =
             new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexOptions.Singleline);
-
         public static readonly Regex TimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
-        public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -22,16 +22,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                 DateTimeDefinitions.DayRegex,
                 RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(
-                DateTimeDefinitions.MonthNumRegex,
-                RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(
-                DateTimeDefinitions.YearRegex,
-                RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(
                 DateTimeDefinitions.WeekDayRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
@@ -7,10 +7,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex =
-            new Regex(
-                DateTimeDefinitions.YearRegex,
-                RegexOptions.Singleline);
 
         public static readonly Regex H1 =
             new Regex(

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
@@ -8,9 +8,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
-        public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.Singleline);
-
         public static readonly Regex PeriodicRegex =
             new Regex(
                 DateTimeDefinitions.PeriodicRegex, // TODO: Decide between adjective and adverb, i.e monthly - 'mensuel' vs 'mensuellement'

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
@@ -7,43 +7,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------
-        public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... heures (o'clock, en punto)"
-        public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... après midi (afternoon, tarde)"
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... dans la matinee (in the morning)"
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
             new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
-
-        public static readonly Regex FrTimeRegex =
-            new Regex(DateTimeDefinitions.EngTimeRegex, RegexOptions.Singleline);
-
-        // TODO - will have change below
-        // handle "six heures et demie" (six thirty), "six heures et vingt-et-un" (six twenty one)
-        public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
 
         public static readonly Regex TimeSuffix =
             new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
@@ -57,20 +24,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public static readonly Regex MidnightRegex =
             new Regex(DateTimeDefinitions.MidnightRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexOptions.Singleline);
-
-        // part 3: regex for time
-        // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
             new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/DateExtractor.cs
@@ -9,19 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
-
         public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex DayRegexInJapanese = new Regex(DateTimeDefinitions.DateDayRegexInJapanese, RegexOptions.Singleline);
-
-        public static readonly Regex DayRegexNumInJapanese = new Regex(DateTimeDefinitions.DayRegexNumInJapanese, RegexOptions.Singleline);
-
         public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
-        public static readonly Regex ZeroToNineIntegerRegexJap = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexJap, RegexOptions.Singleline);
 
         public static readonly Regex YearInJapaneseRegex = new Regex(DateTimeDefinitions.DateYearInJapaneseRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -19,12 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
@@ -7,41 +7,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------------
-        public static readonly Regex DescRegex = new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex = new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... en punto"
-        public static readonly Regex OclockRegex = new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... tarde"
-        public static readonly Regex PmRegex = new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... de la mañana"
-        public static readonly Regex AmRegex = new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "y media ..." "menos cuarto ..."
         public static readonly Regex LessThanOneHour = new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
 
-        public static readonly Regex TensTimeRegex = new Regex(DateTimeDefinitions.TensTimeRegex, RegexOptions.Singleline);
-
         // handle "seis treinta", "seis veintiuno", "seis menos diez"
         public static readonly Regex WrittenTimeRegex = new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimePrefix = new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
 
         public static readonly Regex TimeSuffix = new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
 
         public static readonly Regex BasicTime = new Regex(DateTimeDefinitions.BasicTime, RegexOptions.Singleline);
 
-        // part 3: regex for time
-        // --------------------------------------
         // handle "a las cuatro" "a las 3"
         // TODO: add some new regex which have used in AtRegex
         // TODO: modify according to corresponding English regex

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
@@ -10,15 +10,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
-
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.TimeHourNumRegex, RegexOptions.Singleline);
+        
         public static readonly Regex PureNumFromTo = new Regex(DateTimeDefinitions.PureNumFromTo, RegexOptions.Singleline);
         public static readonly Regex PureNumBetweenAnd = new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexOptions.Singleline);
         public static readonly Regex SpecificTimeFromTo = new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexOptions.Singleline);
         public static readonly Regex SpecificTimeBetweenAnd = new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexOptions.Singleline);
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
         public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         // TODO: add this according to coresponding English regex
         public static readonly Regex TimeOfDayRegex = new Regex(string.Empty, RegexOptions.Singleline);


### PR DESCRIPTION
# Description
Remove unused regexes from Dutch, French, Portuguese, Japanese, and Italian extractors. This is just to clean the code.