### PR TITLE
[DotNet][Datetime] Remove Dutch unused regexes

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -18,12 +18,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex WeekDayRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
@@ -7,9 +7,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
     {
-        public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexOptions.Singleline);
-
         public static readonly Regex H1 =
             new Regex(DateTimeDefinitions.HolidayRegex1, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
     {
-        public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexOptions.Singleline);
-
         public static readonly Regex PeriodicRegex =
             new Regex(DateTimeDefinitions.PeriodicRegex, RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -7,45 +7,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
     {
-        // part 1: smallest component
-        // --------------------------------------
-        public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexOptions.Singleline);
-
-        // part 2: middle level component
-        // --------------------------------------
-        // handle "... o'clock"
-        public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexOptions.Singleline);
-
-        // handle "... afternoon"
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        // handle "... in the morning"
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
             new Regex(DateTimeDefinitions.LessThanOneHour, RegexOptions.Singleline);
-
-        // handle "six thirty", "six twenty one"
-        public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexOptions.Singleline);
-
-        public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexOptions.Singleline);
 
         public static readonly Regex BasicTime =
             new Regex(DateTimeDefinitions.BasicTime, RegexOptions.Singleline);
@@ -54,20 +19,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex MidnightRegex =
             new Regex(DateTimeDefinitions.MidnightRegex, RegexOptions.Singleline);
 
-        public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexOptions.Singleline);
-
-        public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexOptions.Singleline);
-
-        // part 3: regex for time
-        // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
             new Regex(DateTimeDefinitions.AtRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -14,21 +14,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
-        public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexOptions.Singleline);
-
-        public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexOptions.Singleline);
-
-        public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexOptions.Singleline);
-
         public static readonly Regex PureNumFromTo =
             new Regex(DateTimeDefinitions.PureNumFromTo, RegexOptions.Singleline);
 
@@ -47,17 +32,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex TimeOfDayRegex =
             new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexOptions.Singleline);
 
-        public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexOptions.Singleline);
-
         public static readonly Regex TimeUnitRegex =
             new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
-        public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);


### PR DESCRIPTION
Remove unused regexes from Dutch extractors. This was a split from PR #1421, the reasons were explained on that PR.