### PR TITLE
[DotNet][DateTime] Fix extractors and parsers name in Japanese and Chinese languages

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -357,27 +357,27 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
-                    return new DateTime.Chinese.DateExtractorChs();
+                    return new DateTime.Chinese.ChineseDateExtractorConfiguration();
                 case DateTimeExtractors.Time:
-                    return new DateTime.Chinese.TimeExtractorChs();
+                    return new DateTime.Chinese.ChineseTimeExtractorConfiguration();
                 case DateTimeExtractors.DatePeriod:
-                    return new DateTime.Chinese.DatePeriodExtractorChs();
+                    return new DateTime.Chinese.ChineseDatePeriodExtractorConfiguration();
                 case DateTimeExtractors.TimePeriod:
-                    return new DateTime.Chinese.TimePeriodExtractorChs();
+                    return new DateTime.Chinese.ChineseTimePeriodExtractorChsConfiguration();
                 case DateTimeExtractors.DateTime:
-                    return new DateTime.Chinese.DateTimeExtractorChs();
+                    return new DateTime.Chinese.ChineseDateTimeExtractorConfiguration();
                 case DateTimeExtractors.DateTimePeriod:
-                    return new DateTime.Chinese.DateTimePeriodExtractorChs();
+                    return new DateTime.Chinese.ChineseDateTimePeriodExtractorConfiguration();
                 case DateTimeExtractors.Duration:
-                    return new DateTime.Chinese.DurationExtractorChs();
+                    return new DateTime.Chinese.ChineseDurationExtractorConfiguration();
                 case DateTimeExtractors.Holiday:
                     return new BaseHolidayExtractor(new DateTime.Chinese.ChineseHolidayExtractorConfiguration());
                 case DateTimeExtractors.Set:
-                    return new DateTime.Chinese.SetExtractorChs();
+                    return new DateTime.Chinese.ChineseSetExtractorConfiguration();
                 case DateTimeExtractors.Merged:
-                    return new DateTime.Chinese.MergedExtractorChs(DateTimeOptions.None);
+                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(DateTimeOptions.None);
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new DateTime.Chinese.MergedExtractorChs(DateTimeOptions.SkipFromToMerge);
+                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge);
             }
 
             throw new Exception($"Extractor '{extractorName}' for English not supported");
@@ -389,23 +389,23 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             switch (parserName)
             {
                 case DateTimeParsers.Date:
-                    return new DateTime.Chinese.DateParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Time:
-                    return new DateTime.Chinese.TimeParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseTimeParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.DatePeriod:
-                    return new DateTime.Chinese.DatePeriodParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDatePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.TimePeriod:
-                    return new DateTime.Chinese.TimePeriodParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.DateTime:
-                    return new DateTime.Chinese.DateTimeParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.DateTimePeriod:
-                    return new DateTime.Chinese.DateTimePeriodParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Duration:
-                    return new DateTime.Chinese.DurationParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDurationParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Holiday:
-                    return new DateTime.Chinese.HolidayParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseHolidayParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Set:
-                    return new DateTime.Chinese.SetParserChs(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseSetParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
                 case DateTimeParsers.Merged:
                     return new FullDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
             }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -486,27 +486,27 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
           switch (extractorName)
           {
             case DateTimeExtractors.Date:
-              return new DateTime.Japanese.DateExtractor();
+              return new DateTime.Japanese.JapaneseDateExtractorConfiguration();
             case DateTimeExtractors.Time:
-              return new DateTime.Japanese.TimeExtractor();
+              return new DateTime.Japanese.JapaneseTimeExtractorConfiguration();
             case DateTimeExtractors.DatePeriod:
-              return new DateTime.Japanese.DatePeriodExtractor();
+              return new DateTime.Japanese.JapaneseDatePeriodExtractorConfiguration();
             case DateTimeExtractors.TimePeriod:
-              return new DateTime.Japanese.TimePeriodExtractor();
+              return new DateTime.Japanese.JapaneseTimePeriodExtractorConfiguration();
             case DateTimeExtractors.DateTime:
-              return new DateTime.Japanese.DateTimeExtractor();
+              return new DateTime.Japanese.JapaneseDateTimeExtractorConfiguration();
             case DateTimeExtractors.DateTimePeriod:
-              return new DateTime.Japanese.DateTimePeriodExtractor();
+              return new DateTime.Japanese.JapaneseDateTimePeriodExtractorConfiguration();
             case DateTimeExtractors.Duration:
-              return new DateTime.Japanese.DurationExtractor();
+              return new DateTime.Japanese.JapaneseDurationExtractorConfiguration();
             case DateTimeExtractors.Holiday:
               return new BaseHolidayExtractor(new DateTime.Japanese.JapaneseHolidayExtractorConfiguration());
             case DateTimeExtractors.Set:
-              return new DateTime.Japanese.SetExtractor();
+              return new DateTime.Japanese.JapaneseSetExtractorConfiguration();
             case DateTimeExtractors.Merged:
-              return new DateTime.Japanese.JapaneseMergedExtractor(DateTimeOptions.None);
+              return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(DateTimeOptions.None);
             case DateTimeExtractors.MergedSkipFromTo:
-              return new DateTime.Japanese.JapaneseMergedExtractor(DateTimeOptions.SkipFromToMerge);
+              return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge);
           }
 
           throw new Exception($"Extractor '{extractorName}' for Japanese not supported");
@@ -517,23 +517,23 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
           switch (parserName)
           {
             case DateTimeParsers.Date:
-              return new DateTime.Japanese.DateParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseDateParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.Time:
-              return new DateTime.Japanese.TimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseTimeParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.DatePeriod:
-              return new DateTime.Japanese.DatePeriodParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseDatePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.TimePeriod:
-              return new DateTime.Japanese.TimePeriodParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.DateTime:
-              return new DateTime.Japanese.DateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.DateTimePeriod:
-              return new DateTime.Japanese.DateTimePeriodParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseDateTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.Duration:
-              return new DateTime.Japanese.DurationParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseDurationParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.Holiday:
-              return new DateTime.Japanese.HolidayParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseHolidayParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.Set:
-              return new DateTime.Japanese.SetParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+              return new DateTime.Japanese.JapaneseSetParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
             case DateTimeParsers.Merged:
               return new FullDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
           }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseBaseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseBaseDateTimeExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public abstract class BaseDateTimeExtractor<T> : IDateTimeExtractor
+    public abstract class ChineseBaseDateTimeExtractorConfiguration<T> : IDateTimeExtractor
     {
         internal abstract ImmutableDictionary<Regex, T> Regexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateExtractorChs : IDateTimeExtractor
+    public class ChineseDateExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -103,7 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexOptions.Singleline);
 
-        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
+        private static readonly ChineseDurationExtractorConfiguration DurationExtractor = new ChineseDurationExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DatePeriodExtractorChs : IDateTimeExtractor
+    public class ChineseDatePeriodExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DecadeRegex = new Regex(DateTimeDefinitions.DecadeRegex, RegexOptions.Singleline);
 
-        private static readonly DateExtractorChs DatePointExtractor = new DateExtractorChs();
+        private static readonly ChineseDateExtractorConfiguration DatePointExtractor = new ChineseDateExtractorConfiguration();
         private static readonly IntegerExtractor IntegerExtractor = new IntegerExtractor();
 
         private static readonly Regex[] SimpleCasesRegexes =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateTimeExtractorChs : IDateTimeExtractor
+    public class ChineseDateTimeExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIME; // "DateTime";
 
@@ -25,9 +25,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexOptions.Singleline);
 
-        private static readonly DateExtractorChs DatePointExtractor = new DateExtractorChs();
-        private static readonly TimeExtractorChs TimePointExtractor = new TimeExtractorChs();
-        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
+        private static readonly ChineseDateExtractorConfiguration DatePointExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly ChineseTimeExtractorConfiguration TimePointExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly ChineseDurationExtractorConfiguration DurationExtractor = new ChineseDurationExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateTimePeriodExtractorChs : IDateTimeExtractor
+    public class ChineseDateTimePeriodExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
@@ -42,11 +42,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexOptions.Singleline);
 
-        private static readonly TimeExtractorChs SingleTimeExtractor = new TimeExtractorChs();
-        private static readonly DateTimeExtractorChs TimeWithDateExtractor = new DateTimeExtractorChs();
-        private static readonly DateExtractorChs SingleDateExtractor = new DateExtractorChs();
+        private static readonly ChineseTimeExtractorConfiguration SingleTimeExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly ChineseDateTimeExtractorConfiguration TimeWithDateExtractor = new ChineseDateTimeExtractorConfiguration();
+        private static readonly ChineseDateExtractorConfiguration SingleDateExtractor = new ChineseDateExtractorConfiguration();
         private static readonly CardinalExtractor CardinalExtractor = new CardinalExtractor();
-        private static readonly TimePeriodExtractorChs TimePeriodExtractor = new TimePeriodExtractorChs();
+        private static readonly ChineseTimePeriodExtractorChsConfiguration TimePeriodExtractor = new ChineseTimePeriodExtractorChsConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         WithNumber,
     }
 
-    public class DurationExtractorChs : BaseDateTimeExtractor<DurationType>
+    public class ChineseDurationExtractorConfiguration : ChineseBaseDateTimeExtractorConfiguration<DurationType>
     {
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class MergedExtractorChs : IDateTimeExtractor
+    public class ChineseMergedExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexOptions.Singleline);
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexOptions.Singleline);
@@ -14,19 +14,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexOptions.Singleline);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexOptions.Singleline);
 
-        private static readonly DateExtractorChs DateExtractor = new DateExtractorChs();
-        private static readonly TimeExtractorChs TimeExtractor = new TimeExtractorChs();
-        private static readonly DateTimeExtractorChs DateTimeExtractor = new DateTimeExtractorChs();
-        private static readonly DatePeriodExtractorChs DatePeriodExtractor = new DatePeriodExtractorChs();
-        private static readonly TimePeriodExtractorChs TimePeriodExtractor = new TimePeriodExtractorChs();
-        private static readonly DateTimePeriodExtractorChs DateTimePeriodExtractor = new DateTimePeriodExtractorChs();
-        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
-        private static readonly SetExtractorChs SetExtractor = new SetExtractorChs();
+        private static readonly ChineseDateExtractorConfiguration DateExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly ChineseTimeExtractorConfiguration TimeExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly ChineseDateTimeExtractorConfiguration DateTimeExtractor = new ChineseDateTimeExtractorConfiguration();
+        private static readonly ChineseDatePeriodExtractorConfiguration DatePeriodExtractor = new ChineseDatePeriodExtractorConfiguration();
+        private static readonly ChineseTimePeriodExtractorChsConfiguration TimePeriodExtractor = new ChineseTimePeriodExtractorChsConfiguration();
+        private static readonly ChineseDateTimePeriodExtractorConfiguration DateTimePeriodExtractor = new ChineseDateTimePeriodExtractorConfiguration();
+        private static readonly ChineseDurationExtractorConfiguration DurationExtractor = new ChineseDurationExtractorConfiguration();
+        private static readonly ChineseSetExtractorConfiguration SetExtractor = new ChineseSetExtractorConfiguration();
         private static readonly BaseHolidayExtractor HolidayExtractor = new BaseHolidayExtractor(new ChineseHolidayExtractorConfiguration());
 
         private readonly DateTimeOptions options;
 
-        public MergedExtractorChs(DateTimeOptions options)
+        public ChineseMergedExtractorConfiguration(DateTimeOptions options)
         {
             this.options = options;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class SetExtractorChs : IDateTimeExtractor
+    public class ChineseSetExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -20,10 +20,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexOptions.Singleline);
 
-        private static readonly DurationExtractorChs DurationExtractor = new DurationExtractorChs();
-        private static readonly TimeExtractorChs TimeExtractor = new TimeExtractorChs();
-        private static readonly DateExtractorChs DateExtractor = new DateExtractorChs();
-        private static readonly DateTimeExtractorChs DateTimeExtractor = new DateTimeExtractorChs();
+        private static readonly ChineseDurationExtractorConfiguration DurationExtractor = new ChineseDurationExtractorConfiguration();
+        private static readonly ChineseTimeExtractorConfiguration TimeExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly ChineseDateExtractorConfiguration DateExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly ChineseDateTimeExtractorConfiguration DateTimeExtractor = new ChineseDateTimeExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class TimeExtractorChs : BaseDateTimeExtractor<TimeType>
+    public class ChineseTimeExtractorConfiguration : ChineseBaseDateTimeExtractorConfiguration<TimeType>
     {
         public static readonly string HourNumRegex = DateTimeDefinitions.TimeHourNumRegex;
 
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly string ApproximateDescSuffixRegex = DateTimeDefinitions.TimeApproximateDescSuffixRegex;
 
-        public TimeExtractorChs()
+        public ChineseTimeExtractorConfiguration()
         {
             var regexes = new Dictionary<Regex, TimeType>
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorChsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorChsConfiguration.cs
@@ -6,12 +6,12 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class TimePeriodExtractorChs : BaseDateTimeExtractor<PeriodType>
+    public class ChineseTimePeriodExtractorChsConfiguration : ChineseBaseDateTimeExtractorConfiguration<PeriodType>
     {
         public const string TimePeriodConnectWords = DateTimeDefinitions.TimePeriodTimePeriodConnectWords;
 
         // 五点十分四十八秒
-        public static readonly string ChineseTimeRegex = TimeExtractorChs.ChineseTimeRegex;
+        public static readonly string ChineseTimeRegex = ChineseTimeExtractorConfiguration.ChineseTimeRegex;
 
         // 六点 到 九点 | 六 到 九点
         public static readonly string LeftChsTimeRegex = DateTimeDefinitions.TimePeriodLeftChsTimeRegex;
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly string RightChsTimeRegex = DateTimeDefinitions.TimePeriodRightChsTimeRegex;
 
         // 2:45
-        public static readonly string DigitTimeRegex = TimeExtractorChs.DigitTimeRegex;
+        public static readonly string DigitTimeRegex = ChineseTimeExtractorConfiguration.DigitTimeRegex;
 
         public static readonly string LeftDigitTimeRegex = DateTimeDefinitions.TimePeriodLeftDigitTimeRegex;
 
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly string ShortLeftDigitTimeRegex = DateTimeDefinitions.TimePeriodShortLeftDigitTimeRegex;
 
-        public TimePeriodExtractorChs()
+        public ChineseTimePeriodExtractorChsConfiguration()
         {
             var regexes = new Dictionary<Regex, PeriodType>
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateParser : IDateTimeParser
+    public class ChineseDateParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -20,12 +20,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private readonly IParser numberParser;
         private readonly IDateTimeExtractor durationExtractor;
 
-        public DateParser(ChineseDateTimeParserConfiguration configuration)
+        public ChineseDateParserConfiguration(ChineseDateTimeParserConfiguration configuration)
         {
             config = configuration;
             integerExtractor = new IntegerExtractor();
             ordinalExtractor = new OrdinalExtractor();
-            durationExtractor = new DurationExtractorChs();
+            durationExtractor = new ChineseDurationExtractorConfiguration();
             numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         // parse basic patterns in DateRegexList
         protected DateTimeResolutionResult ParseBasicRegexMatch(string text, DateObject referenceDate)
         {
-            foreach (var regex in DateExtractorChs.DateRegexList)
+            foreach (var regex in ChineseDateExtractorConfiguration.DateRegexList)
             {
                 var match = regex.MatchExact(text, trim: true);
 
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var ret = new DateTimeResolutionResult();
 
             // handle "十二日" "明年这个月三日" "本月十一日"
-            var match = DateExtractorChs.SpecialDate.MatchExact(text, trim: true);
+            var match = ChineseDateExtractorConfiguration.SpecialDate.MatchExact(text, trim: true);
             if (match.Success)
             {
                 var yearStr = match.Groups["thisyear"].Value.ToLower();
@@ -142,7 +142,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 if (!string.IsNullOrEmpty(monthStr))
                 {
                     hasMonth = true;
-                    if (DateExtractorChs.NextRe.Match(monthStr).Success)
+                    if (ChineseDateExtractorConfiguration.NextRe.Match(monthStr).Success)
                     {
                         month++;
                         if (month == Constants.MaxMonth + 1)
@@ -151,7 +151,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             year++;
                         }
                     }
-                    else if (DateExtractorChs.LastRe.Match(monthStr).Success)
+                    else if (ChineseDateExtractorConfiguration.LastRe.Match(monthStr).Success)
                     {
                         month--;
                         if (month == Constants.MinMonth - 1)
@@ -164,11 +164,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     if (!string.IsNullOrEmpty(yearStr))
                     {
                         hasYear = true;
-                        if (DateExtractorChs.NextRe.Match(yearStr).Success)
+                        if (ChineseDateExtractorConfiguration.NextRe.Match(yearStr).Success)
                         {
                             ++year;
                         }
-                        else if (DateExtractorChs.LastRe.Match(yearStr).Success)
+                        else if (ChineseDateExtractorConfiguration.LastRe.Match(yearStr).Success)
                         {
                             --year;
                         }
@@ -276,7 +276,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // handle cases like "昨日", "明日", "大后天"
-            match = DateExtractorChs.SpecialDayRegex.MatchExact(text, trim: true);
+            match = ChineseDateExtractorConfiguration.SpecialDayRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -561,7 +561,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private static bool IsLunarCalendar(string text)
         {
             var trimmedText = text.Trim();
-            var match = DateExtractorChs.LunarRegex.Match(trimmedText);
+            var match = ChineseDateExtractorConfiguration.LunarRegex.Match(trimmedText);
 
             return match.Success;
         }
@@ -604,7 +604,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var unitStr = string.Empty;
             if (durationRes.Count > 0)
             {
-                var match = DateExtractorChs.UnitRegex.Match(text);
+                var match = ChineseDateExtractorConfiguration.UnitRegex.Match(text);
                 if (match.Success)
                 {
                     var suffix =
@@ -622,7 +622,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
 
-                        var beforeMatch = DateExtractorChs.BeforeRegex.Match(suffix);
+                        var beforeMatch = ChineseDateExtractorConfiguration.BeforeRegex.Match(suffix);
                         if (beforeMatch.Success && suffix.StartsWith(beforeMatch.Value))
                         {
                             DateObject date;
@@ -650,7 +650,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             return ret;
                         }
 
-                        var afterMatch = DateExtractorChs.AfterRegex.Match(suffix);
+                        var afterMatch = ChineseDateExtractorConfiguration.AfterRegex.Match(suffix);
                         if (afterMatch.Success && suffix.StartsWith(afterMatch.Value))
                         {
                             DateObject date;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -7,23 +7,23 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DatePeriodParserChs : IDateTimeParser
+    public class ChineseDatePeriodParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractorChs();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new ChineseDateExtractorConfiguration();
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
         private static readonly IParser IntegerParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
 
-        private static readonly IDateTimeExtractor Durationextractor = new DurationExtractorChs();
+        private static readonly IDateTimeExtractor Durationextractor = new ChineseDurationExtractorConfiguration();
 
         private static readonly Calendar Cal = DateTimeFormatInfo.InvariantInfo.Calendar;
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DatePeriodParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseDatePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -236,7 +236,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var noYear = false;
             var inputYear = false;
 
-            var match = DatePeriodExtractorChs.SimpleCasesRegex.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.SimpleCasesRegex.MatchExact(text, trim: true);
             string beginLuisStr, endLuisStr;
 
             if (match.Success)
@@ -273,9 +273,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 else
                 {
                     monthStr = match.Groups["relmonth"].Value.Trim().ToLower();
-                    var thismatch = DatePeriodExtractorChs.ThisRegex.Match(monthStr);
-                    var nextmatch = DatePeriodExtractorChs.NextRegex.Match(monthStr);
-                    var lastmatch = DatePeriodExtractorChs.LastRegex.Match(monthStr);
+                    var thismatch = ChineseDatePeriodExtractorConfiguration.ThisRegex.Match(monthStr);
+                    var nextmatch = ChineseDatePeriodExtractorConfiguration.NextRegex.Match(monthStr);
+                    var lastmatch = ChineseDatePeriodExtractorConfiguration.LastRegex.Match(monthStr);
 
                     if (thismatch.Success)
                     {
@@ -307,8 +307,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     }
                 }
 
-                if (inputYear || DatePeriodExtractorChs.ThisRegex.Match(monthStr).Success ||
-                    DatePeriodExtractorChs.NextRegex.Match(monthStr).Success)
+                if (inputYear || ChineseDatePeriodExtractorConfiguration.ThisRegex.Match(monthStr).Success ||
+                    ChineseDatePeriodExtractorConfiguration.NextRegex.Match(monthStr).Success)
                 {
                     beginLuisStr = DateTimeFormatUtil.LuisDate(year, month, beginDay);
                     endLuisStr = DateTimeFormatUtil.LuisDate(year, month, endDay);
@@ -355,17 +355,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseYearToYear(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.YearToYear.Match(text);
+            var match = ChineseDatePeriodExtractorConfiguration.YearToYear.Match(text);
 
             if (!match.Success)
             {
-                match = DatePeriodExtractorChs.YearToYearSuffixRequired.Match(text);
+                match = ChineseDatePeriodExtractorConfiguration.YearToYearSuffixRequired.Match(text);
             }
 
             if (match.Success)
             {
-                var yearMatch = DatePeriodExtractorChs.YearRegex.Matches(text);
-                var yearInChineseMatch = DatePeriodExtractorChs.YearInChineseRegex.Matches(text);
+                var yearMatch = ChineseDatePeriodExtractorConfiguration.YearRegex.Matches(text);
+                var yearInChineseMatch = ChineseDatePeriodExtractorConfiguration.YearInChineseRegex.Matches(text);
                 var beginYear = 0;
                 var endYear = 0;
 
@@ -436,16 +436,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseMonthToMonth(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.MonthToMonth.Match(text);
+            var match = ChineseDatePeriodExtractorConfiguration.MonthToMonth.Match(text);
 
             if (!match.Success)
             {
-                match = DatePeriodExtractorChs.MonthToMonthSuffixRequired.Match(text);
+                match = ChineseDatePeriodExtractorConfiguration.MonthToMonthSuffixRequired.Match(text);
             }
 
             if (match.Success)
             {
-                var monthMatch = DatePeriodExtractorChs.MonthRegex.Matches(text);
+                var monthMatch = ChineseDatePeriodExtractorConfiguration.MonthRegex.Matches(text);
                 var beginMonth = 0;
                 var endMonth = 0;
 
@@ -522,11 +522,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseYearAndMonth(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.YearAndMonth.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.YearAndMonth.MatchExact(text, trim: true);
 
             if (!match.Success)
             {
-                match = DatePeriodExtractorChs.PureNumYearAndMonth.MatchExact(text, trim: true);
+                match = ChineseDatePeriodExtractorConfiguration.PureNumYearAndMonth.MatchExact(text, trim: true);
             }
 
             if (!match.Success)
@@ -606,7 +606,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             int futureYear = year, pastYear = year;
 
             var trimmedText = text.Trim().ToLower();
-            var match = DatePeriodExtractorChs.OneWordPeriodRegex.MatchExact(trimmedText, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.OneWordPeriodRegex.MatchExact(trimmedText, trim: true);
 
             if (match.Success)
             {
@@ -621,9 +621,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     return ret;
                 }
 
-                var thismatch = DatePeriodExtractorChs.ThisRegex.Match(trimmedText);
-                var nextmatch = DatePeriodExtractorChs.NextRegex.Match(trimmedText);
-                var lastmatch = DatePeriodExtractorChs.LastRegex.Match(trimmedText);
+                var thismatch = ChineseDatePeriodExtractorConfiguration.ThisRegex.Match(trimmedText);
+                var nextmatch = ChineseDatePeriodExtractorConfiguration.NextRegex.Match(trimmedText);
+                var lastmatch = ChineseDatePeriodExtractorConfiguration.LastRegex.Match(trimmedText);
 
                 if (!string.IsNullOrEmpty(monthStr))
                 {
@@ -767,7 +767,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseYear(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.YearRegex.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.YearRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -810,7 +810,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 return ret;
             }
 
-            match = DatePeriodExtractorChs.YearInChineseRegex.MatchExact(text, trim: true);
+            match = ChineseDatePeriodExtractorConfiguration.YearInChineseRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -905,7 +905,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             string numStr, unitStr;
 
             // if there are NO spaces between number and unit
-            var match = DatePeriodExtractorChs.NumberCombinedWithUnit.Match(text);
+            var match = ChineseDatePeriodExtractorConfiguration.NumberCombinedWithUnit.Match(text);
 
             if (match.Success)
             {
@@ -916,7 +916,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     unitStr = this.config.UnitMap[srcUnit];
                     numStr = match.Groups["num"].Value;
 
-                    if (DatePeriodExtractorChs.PastRegex.IsExactMatch(beforeStr, trim: true))
+                    if (ChineseDatePeriodExtractorConfiguration.PastRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -947,7 +947,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         return ret;
                     }
 
-                    if (DatePeriodExtractorChs.FutureRegex.IsExactMatch(beforeStr, trim: true))
+                    if (ChineseDatePeriodExtractorConfiguration.FutureRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -987,7 +987,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             if (durationRes.Count > 0)
             {
                 var beforeStr = text.Substring(0, (int)durationRes[0].Start).ToLowerInvariant();
-                match = DatePeriodExtractorChs.UnitRegex.Match(durationRes[0].Text);
+                match = ChineseDatePeriodExtractorConfiguration.UnitRegex.Match(durationRes[0].Text);
                 if (match.Success)
                 {
                     var srcUnit = match.Groups["unit"].Value.ToLowerInvariant();
@@ -997,7 +997,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     {
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
-                        var prefixMatch = DatePeriodExtractorChs.PastRegex.MatchExact(beforeStr, trim: true);
+                        var prefixMatch = ChineseDatePeriodExtractorConfiguration.PastRegex.MatchExact(beforeStr, trim: true);
 
                         if (prefixMatch.Success)
                         {
@@ -1030,7 +1030,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             return ret;
                         }
 
-                        prefixMatch = DatePeriodExtractorChs.FutureRegex.MatchExact(beforeStr, trim: true);
+                        prefixMatch = ChineseDatePeriodExtractorConfiguration.FutureRegex.MatchExact(beforeStr, trim: true);
 
                         if (prefixMatch.Success)
                         {
@@ -1077,7 +1077,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             var ret = new DateTimeResolutionResult();
             var trimmedText = text.Trim().ToLowerInvariant();
-            var match = DatePeriodExtractorChs.WeekOfMonthRegex.Match(text);
+            var match = ChineseDatePeriodExtractorConfiguration.WeekOfMonthRegex.Match(text);
             if (!match.Success)
             {
                 return ret;
@@ -1157,7 +1157,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseSeason(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.SeasonWithYear.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.SeasonWithYear.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -1228,7 +1228,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private DateTimeResolutionResult ParseQuarter(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractorChs.QuarterRegex.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.QuarterRegex.MatchExact(text, trim: true);
 
             if (!match.Success)
             {
@@ -1301,7 +1301,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             int decadeLastYear = 10;
             var inputCentury = false;
 
-            var match = DatePeriodExtractorChs.DecadeRegex.MatchExact(text, trim: true);
+            var match = ChineseDatePeriodExtractorConfiguration.DecadeRegex.MatchExact(text, trim: true);
 
             string beginLuisStr, endLuisStr;
 
@@ -1330,9 +1330,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     if (!string.IsNullOrEmpty(centuryStr))
                     {
                         centuryStr = centuryStr.Trim().ToLower();
-                        var thismatch = DatePeriodExtractorChs.ThisRegex.Match(centuryStr);
-                        var nextmatch = DatePeriodExtractorChs.NextRegex.Match(centuryStr);
-                        var lastmatch = DatePeriodExtractorChs.LastRegex.Match(centuryStr);
+                        var thismatch = ChineseDatePeriodExtractorConfiguration.ThisRegex.Match(centuryStr);
+                        var nextmatch = ChineseDatePeriodExtractorConfiguration.NextRegex.Match(centuryStr);
+                        var lastmatch = ChineseDatePeriodExtractorConfiguration.LastRegex.Match(centuryStr);
 
                         if (thismatch.Success)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateTimeParserChs : IDateTimeParser
+    public class ChineseDateTimeParser : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIME;
 
@@ -16,15 +16,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex SimplePmRegex = new Regex(DateTimeDefinitions.DateTimeSimplePmRegex, RegexOptions.Singleline);
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractorChs();
-        private static readonly IDateTimeExtractor SingleTimeExtractor = new TimeExtractorChs();
-        private readonly IDateTimeExtractor durationExtractor = new DurationExtractorChs();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor SingleTimeExtractor = new ChineseTimeExtractorConfiguration();
+        private readonly IDateTimeExtractor durationExtractor = new ChineseDurationExtractorConfiguration();
         private readonly IExtractor integerExtractor = new IntegerExtractor();
         private readonly IParser numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DateTimeParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseDateTimeParser(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var trimmedText = text.Trim().ToLower();
 
             // handle "现在"
-            var match = DateTimeExtractorChs.NowRegex.MatchExact(trimmedText, trim: true);
+            var match = ChineseDateTimeExtractorConfiguration.NowRegex.MatchExact(trimmedText, trim: true);
 
             if (match.Success)
             {
@@ -130,7 +130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private bool IsLunarCalendar(string text)
         {
             var trimmedText = text.Trim();
-            var match = DateExtractorChs.LunarRegex.Match(trimmedText);
+            var match = ChineseDateExtractorConfiguration.LunarRegex.Match(trimmedText);
             if (match.Success)
             {
                 return true;
@@ -230,7 +230,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var min = time.Minute;
             var sec = time.Second;
 
-            var match = DateTimeExtractorChs.TimeOfTodayRegex.Match(text);
+            var match = ChineseDateTimeExtractorConfiguration.TimeOfTodayRegex.Match(text);
 
             if (match.Success)
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var unitStr = string.Empty;
             if (durationRes.Count > 0)
             {
-                var match = DateTimeExtractorChs.DateTimePeriodUnitRegex.Match(text);
+                var match = ChineseDateTimeExtractorConfiguration.DateTimePeriodUnitRegex.Match(text);
                 if (match.Success)
                 {
                     var suffix =
@@ -330,7 +330,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
 
-                        var beforeMatch = DateTimeExtractorChs.BeforeRegex.Match(suffix);
+                        var beforeMatch = ChineseDateTimeExtractorConfiguration.BeforeRegex.Match(suffix);
                         if (beforeMatch.Success && suffix.StartsWith(beforeMatch.Value))
                         {
                             DateObject date;
@@ -355,7 +355,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             return ret;
                         }
 
-                        var afterMatch = DateTimeExtractorChs.AfterRegex.Match(suffix);
+                        var afterMatch = ChineseDateTimeExtractorConfiguration.AfterRegex.Match(suffix);
                         if (afterMatch.Success && suffix.StartsWith(afterMatch.Value))
                         {
                             DateObject date;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
             : base(options)
         {
-            DateParser = new DateParser(this);
-            TimeParser = new TimeParserChs(this);
-            DateTimeParser = new DateTimeParserChs(this);
-            DatePeriodParser = new DatePeriodParserChs(this);
-            TimePeriodParser = new TimePeriodParserChs(this);
-            DateTimePeriodParser = new DateTimePeriodParserChs(this);
-            DurationParser = new DurationParserChs(this);
-            GetParser = new SetParserChs(this);
-            HolidayParser = new HolidayParserChs(this);
+            DateParser = new ChineseDateParserConfiguration(this);
+            TimeParser = new ChineseTimeParserConfiguration(this);
+            DateTimeParser = new ChineseDateTimeParser(this);
+            DatePeriodParser = new ChineseDatePeriodParserConfiguration(this);
+            TimePeriodParser = new ChineseTimePeriodParserConfiguration(this);
+            DateTimePeriodParser = new ChineseDateTimePeriodParserConfiguration(this);
+            DurationParser = new ChineseDurationParserConfiguration(this);
+            GetParser = new ChineseSetParserConfiguration(this);
+            HolidayParser = new ChineseHolidayParserConfiguration(this);
             UnitMap = DateTimeDefinitions.ParserConfigurationUnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.ParserConfigurationUnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.ParserConfigurationSeasonMap.ToImmutableDictionary();
@@ -29,17 +29,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             DayOfWeek = DateTimeDefinitions.ParserConfigurationDayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.ParserConfigurationMonthOfYear.ToImmutableDictionary();
             Numbers = InitNumbers();
-            DateRegexList = DateExtractorChs.DateRegexList;
-            NextRegex = DateExtractorChs.NextRegex;
-            ThisRegex = DateExtractorChs.ThisRegex;
-            LastRegex = DateExtractorChs.LastRegex;
-            StrictWeekDayRegex = DateExtractorChs.WeekDayRegex;
-            WeekDayOfMonthRegex = DateExtractorChs.WeekDayOfMonthRegex;
-            BeforeRegex = MergedExtractorChs.BeforeRegex;
-            AfterRegex = MergedExtractorChs.AfterRegex;
-            UntilRegex = MergedExtractorChs.UntilRegex;
-            SincePrefixRegex = MergedExtractorChs.SincePrefixRegex;
-            SinceSuffixRegex = MergedExtractorChs.SinceSuffixRegex;
+            DateRegexList = ChineseDateExtractorConfiguration.DateRegexList;
+            NextRegex = ChineseDateExtractorConfiguration.NextRegex;
+            ThisRegex = ChineseDateExtractorConfiguration.ThisRegex;
+            LastRegex = ChineseDateExtractorConfiguration.LastRegex;
+            StrictWeekDayRegex = ChineseDateExtractorConfiguration.WeekDayRegex;
+            WeekDayOfMonthRegex = ChineseDateExtractorConfiguration.WeekDayOfMonthRegex;
+            BeforeRegex = ChineseMergedExtractorConfiguration.BeforeRegex;
+            AfterRegex = ChineseMergedExtractorConfiguration.AfterRegex;
+            UntilRegex = ChineseMergedExtractorConfiguration.UntilRegex;
+            SincePrefixRegex = ChineseMergedExtractorConfiguration.SincePrefixRegex;
+            SinceSuffixRegex = ChineseMergedExtractorConfiguration.SinceSuffixRegex;
         }
 
         public int TwoNumYear => int.Parse(DateTimeDefinitions.TwoNumYear);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -10,7 +10,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DateTimePeriodParserChs : IDateTimeParser
+    public class ChineseDateTimePeriodParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
@@ -22,10 +22,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex NIRegex = new Regex(DateTimeDefinitions.DateTimePeriodNIRegex, RegexOptions.Singleline);
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractorChs();
-        private static readonly IDateTimeExtractor SingleTimeExtractor = new TimeExtractorChs();
-        private static readonly IDateTimeExtractor TimeWithDateExtractor = new DateTimeExtractorChs();
-        private static readonly IDateTimeExtractor TimePeriodExtractor = new TimePeriodExtractorChs();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor SingleTimeExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimeWithDateExtractor = new ChineseDateTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimePeriodExtractor = new ChineseTimePeriodExtractorChsConfiguration();
         private static readonly IExtractor CardinalExtractor = new CardinalExtractor();
 
         private static readonly IParser CardinalParser = AgnosticNumberParserFactory.GetParser(
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DateTimePeriodParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseDateTimePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -368,7 +368,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             string timeStr;
 
             // handle 昨晚，今晨
-            if (DateTimePeriodExtractorChs.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
+            if (ChineseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
             {
                 var swift = 0;
                 switch (trimmedText)
@@ -453,14 +453,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 return ret;
             }
 
-            if (DateTimePeriodExtractorChs.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
+            if (ChineseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
             {
                 var swift = 0;
-                if (DateTimePeriodExtractorChs.NextRegex.IsMatch(trimmedText))
+                if (ChineseDateTimePeriodExtractorConfiguration.NextRegex.IsMatch(trimmedText))
                 {
                     swift = 1;
                 }
-                else if (DateTimePeriodExtractorChs.LastRegex.IsMatch(trimmedText))
+                else if (ChineseDateTimePeriodExtractorConfiguration.LastRegex.IsMatch(trimmedText))
                 {
                     swift = -1;
                 }
@@ -479,7 +479,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // handle Date followed by morning, afternoon
-            var match = DateTimePeriodExtractorChs.TimeOfDayRegex.Match(trimmedText);
+            var match = ChineseDateTimePeriodExtractorConfiguration.TimeOfDayRegex.Match(trimmedText);
 
             if (match.Success)
             {
@@ -537,7 +537,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     numStr = pr.ResolutionStr;
                     unitStr = this.config.UnitMap[srcUnit];
-                    var prefixMatch = DateTimePeriodExtractorChs.PastRegex.MatchExact(beforeStr, trim: true);
+                    var prefixMatch = ChineseDateTimePeriodExtractorConfiguration.PastRegex.MatchExact(beforeStr, trim: true);
 
                     if (prefixMatch.Success)
                     {
@@ -567,7 +567,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         return ret;
                     }
 
-                    prefixMatch = DateTimePeriodExtractorChs.FutureRegex.MatchExact(beforeStr, trim: true);
+                    prefixMatch = ChineseDateTimePeriodExtractorConfiguration.FutureRegex.MatchExact(beforeStr, trim: true);
 
                     if (prefixMatch.Success)
                     {
@@ -600,7 +600,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // handle "last hour"
-            var match = DateTimePeriodExtractorChs.UnitRegex.Match(text);
+            var match = ChineseDateTimePeriodExtractorConfiguration.UnitRegex.Match(text);
             if (match.Success)
             {
                 var srcUnit = match.Groups["unit"].Value.ToLower();
@@ -609,7 +609,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 {
                     unitStr = this.config.UnitMap[srcUnit];
 
-                    if (DateTimePeriodExtractorChs.PastRegex.IsExactMatch(beforeStr, trim: true))
+                    if (ChineseDateTimePeriodExtractorConfiguration.PastRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -637,7 +637,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                         return ret;
                     }
 
-                    if (DateTimePeriodExtractorChs.FutureRegex.IsExactMatch(beforeStr, trim: true))
+                    if (ChineseDateTimePeriodExtractorConfiguration.FutureRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
@@ -3,12 +3,12 @@ using System.Globalization;
 using Microsoft.Recognizers.Definitions.Chinese;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Microsoft.Recognizers.Text.NumberWithUnit.Chinese;
-using static Microsoft.Recognizers.Text.DateTime.Chinese.DurationExtractorChs;
+using static Microsoft.Recognizers.Text.DateTime.Chinese.ChineseDurationExtractorConfiguration;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class DurationParserChs : IDateTimeParser
+    public class ChineseDurationParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DURATION; // "Duration";
 
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DurationParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseDurationParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseHolidayParserConfiguration.cs
@@ -11,7 +11,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class HolidayParserChs : IDateTimeParser
+    public class ChineseHolidayParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -64,7 +64,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public HolidayParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseHolidayParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class MergedDateTimeParserChs : BaseMergedDateTimeParser
+    public class ChineseMergedDateTimeParserConfiguration : BaseMergedDateTimeParser
     {
         private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.MergedBeforeRegex, RegexOptions.Singleline);
 
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         // TODO implement SinceRegex
         private static readonly Regex SinceRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexOptions.Singleline);
 
-        public MergedDateTimeParserChs(IMergedParserConfiguration configuration)
+        public ChineseMergedDateTimeParserConfiguration(IMergedParserConfiguration configuration)
             : base(configuration)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
@@ -3,18 +3,18 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class SetParserChs : IDateTimeParser
+    public class ChineseSetParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_SET;
 
-        private static readonly IDateTimeExtractor DurationExtractor = new DurationExtractorChs();
-        private static readonly IDateTimeExtractor TimeExtractor = new TimeExtractorChs();
-        private static readonly IDateTimeExtractor DateExtractor = new DateExtractorChs();
-        private static readonly IDateTimeExtractor DateTimeExtractor = new DateTimeExtractorChs();
+        private static readonly IDateTimeExtractor DurationExtractor = new ChineseDurationExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimeExtractor = new ChineseTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor DateExtractor = new ChineseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor DateTimeExtractor = new ChineseDateTimeExtractorConfiguration();
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public SetParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseSetParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            if (SetExtractorChs.EachPrefixRegex.IsMatch(beforeStr))
+            if (ChineseSetExtractorConfiguration.EachPrefixRegex.IsMatch(beforeStr))
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
                 ret.Timex = pr.TimexStr;
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var ret = new DateTimeResolutionResult();
 
             // handle "each month"
-            var match = SetExtractorChs.EachUnitRegex.MatchExact(text, trim: true);
+            var match = ChineseSetExtractorConfiguration.EachUnitRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractorChs.EachDayRegex.Match(beforeStr);
+            var match = ChineseSetExtractorConfiguration.EachDayRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.TimeParser.Parse(ers[0], DateObject.Now);
@@ -190,7 +190,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractorChs.EachPrefixRegex.Match(beforeStr);
+            var match = ChineseSetExtractorConfiguration.EachPrefixRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.DateParser.Parse(ers[0], DateObject.Now);
@@ -213,7 +213,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractorChs.EachPrefixRegex.Match(beforeStr);
+            var match = ChineseSetExtractorConfiguration.EachPrefixRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.DateTimeParser.Parse(ers[0], DateObject.Now);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseTimeParserConfiguration.cs
@@ -6,15 +6,15 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class TimeParserChs : IDateTimeParser
+    public class ChineseTimeParserConfiguration : IDateTimeParser
     {
-        public static readonly IDateTimeExtractor TimeExtractor = new TimeExtractorChs();
+        public static readonly IDateTimeExtractor TimeExtractor = new ChineseTimeExtractorConfiguration();
 
         private static TimeFunctions timeFunc = new TimeFunctions
         {
             NumberDictionary = DateTimeDefinitions.TimeNumberDictionary,
             LowBoundDesc = DateTimeDefinitions.TimeLowBoundDesc,
-            DayDescRegex = TimeExtractorChs.DayDescRegex,
+            DayDescRegex = ChineseTimeExtractorConfiguration.DayDescRegex,
         };
 
         private static readonly Dictionary<TimeType, TimeFunction> FunctionMap =
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public TimeParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseTimeParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseTimePeriodParserConfiguration.cs
@@ -8,18 +8,18 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class TimePeriodParserChs : IDateTimeParser
+    public class ChineseTimePeriodParserConfiguration : IDateTimeParser
     {
         private static TimeFunctions timeFunc = new TimeFunctions
         {
             NumberDictionary = DateTimeDefinitions.TimeNumberDictionary,
             LowBoundDesc = DateTimeDefinitions.TimeLowBoundDesc,
-            DayDescRegex = TimeExtractorChs.DayDescRegex,
+            DayDescRegex = ChineseTimeExtractorConfiguration.DayDescRegex,
         };
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public TimePeriodParserChs(IFullDateTimeParserConfiguration configuration)
+        public ChineseTimePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var extra = er.Data as DateTimeExtra<PeriodType>;
             if (extra == null)
             {
-                var result = new TimeExtractorChs().Extract(er.Text, refDate);
+                var result = new ChineseTimeExtractorConfiguration().Extract(er.Text, refDate);
                 extra = result[0]?.Data as DateTimeExtra<PeriodType>;
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Culture.Chinese,
                 options => new DateTimeModel(
                     new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
-                    new MergedExtractorChs(options)));
+                    new ChineseMergedExtractorConfiguration(options)));
 
             RegisterModel<DateTimeModel>(
                 Culture.Spanish,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseBaseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseBaseDateTimeExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public abstract class BaseDateTimeExtractor<T> : IDateTimeExtractor
+    public abstract class JapaneseBaseDateTimeExtractorConfiguration<T> : IDateTimeExtractor
     {
         internal abstract ImmutableDictionary<Regex, T> Regexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateExtractor : IDateTimeExtractor
+    public class JapaneseDateExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -115,7 +115,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexOptions.Singleline);
 
-        private static readonly DurationExtractor DurationExtractor = new DurationExtractor();
+        private static readonly JapaneseDurationExtractorConfiguration DurationExtractor = new JapaneseDurationExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DatePeriodExtractor : IDateTimeExtractor
+    public class JapaneseDatePeriodExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
@@ -87,7 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex DecadeRegex = new Regex(DateTimeDefinitions.DecadeRegex, RegexOptions.Singleline);
 
-        private static readonly DateExtractor DatePointExtractor = new DateExtractor();
+        private static readonly JapaneseDateExtractorConfiguration DatePointExtractor = new JapaneseDateExtractorConfiguration();
         private static readonly IntegerExtractor IntegerExtractor = new IntegerExtractor();
 
         private static readonly Regex[] SimpleCasesRegexes =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateTimeExtractor : IDateTimeExtractor
+    public class JapaneseDateTimeExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIME; // "DateTime";
 
@@ -24,9 +24,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexOptions.Singleline);
 
-        private static readonly DateExtractor DatePointExtractor = new DateExtractor();
-        private static readonly TimeExtractor TimePointExtractor = new TimeExtractor();
-        private static readonly DurationExtractor DurationExtractor = new DurationExtractor();
+        private static readonly JapaneseDateExtractorConfiguration DatePointExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly JapaneseTimeExtractorConfiguration TimePointExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly JapaneseDurationExtractorConfiguration DurationExtractor = new JapaneseDurationExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateTimePeriodExtractor : IDateTimeExtractor
+    public class JapaneseDateTimePeriodExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
@@ -42,11 +42,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexOptions.Singleline);
 
-        private static readonly TimeExtractor SingleTimeExtractor = new TimeExtractor();
-        private static readonly DateTimeExtractor TimeWithDateExtractor = new DateTimeExtractor();
-        private static readonly DateExtractor SingleDateExtractor = new DateExtractor();
+        private static readonly JapaneseTimeExtractorConfiguration SingleTimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly JapaneseDateTimeExtractorConfiguration TimeWithDateExtractor = new JapaneseDateTimeExtractorConfiguration();
+        private static readonly JapaneseDateExtractorConfiguration SingleDateExtractor = new JapaneseDateExtractorConfiguration();
         private static readonly CardinalExtractor CardinalExtractor = new CardinalExtractor();
-        private static readonly TimePeriodExtractor TimePeriodExtractor = new TimePeriodExtractor();
+        private static readonly JapaneseTimePeriodExtractorConfiguration TimePeriodExtractor = new JapaneseTimePeriodExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         WithNumber,
     }
 
-    public class DurationExtractor : BaseDateTimeExtractor<DurationType>
+    public class JapaneseDurationExtractorConfiguration : JapaneseBaseDateTimeExtractorConfiguration<DurationType>
     {
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class JapaneseMergedExtractor : IDateTimeExtractor
+    public class JapaneseMergedExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexOptions.Singleline);
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexOptions.Singleline);
@@ -14,19 +14,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexOptions.Singleline);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexOptions.Singleline);
 
-        private static readonly DateExtractor DateExtractor = new DateExtractor();
-        private static readonly TimeExtractor TimeExtractor = new TimeExtractor();
-        private static readonly DateTimeExtractor DateTimeExtractor = new DateTimeExtractor();
-        private static readonly DatePeriodExtractor DatePeriodExtractor = new DatePeriodExtractor();
-        private static readonly TimePeriodExtractor TimePeriodExtractor = new TimePeriodExtractor();
-        private static readonly DateTimePeriodExtractor DateTimePeriodExtractor = new DateTimePeriodExtractor();
-        private static readonly DurationExtractor DurationExtractor = new DurationExtractor();
-        private static readonly SetExtractor SetExtractor = new SetExtractor();
+        private static readonly JapaneseDateExtractorConfiguration DateExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly JapaneseTimeExtractorConfiguration TimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly JapaneseDateTimeExtractorConfiguration DateTimeExtractor = new JapaneseDateTimeExtractorConfiguration();
+        private static readonly JapaneseDatePeriodExtractorConfiguration DatePeriodExtractor = new JapaneseDatePeriodExtractorConfiguration();
+        private static readonly JapaneseTimePeriodExtractorConfiguration TimePeriodExtractor = new JapaneseTimePeriodExtractorConfiguration();
+        private static readonly JapaneseDateTimePeriodExtractorConfiguration DateTimePeriodExtractor = new JapaneseDateTimePeriodExtractorConfiguration();
+        private static readonly JapaneseDurationExtractorConfiguration DurationExtractor = new JapaneseDurationExtractorConfiguration();
+        private static readonly JapaneseSetExtractorConfiguration SetExtractor = new JapaneseSetExtractorConfiguration();
         private static readonly BaseHolidayExtractor HolidayExtractor = new BaseHolidayExtractor(new JapaneseHolidayExtractorConfiguration());
 
         private readonly DateTimeOptions options;
 
-        public JapaneseMergedExtractor(DateTimeOptions options)
+        public JapaneseMergedExtractorConfiguration(DateTimeOptions options)
         {
             this.options = options;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class SetExtractor : IDateTimeExtractor
+    public class JapaneseSetExtractorConfiguration : IDateTimeExtractor
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexOptions.Singleline);
 
-        private static readonly DurationExtractor DurationExtractor = new DurationExtractor();
-        private static readonly TimeExtractor TimeExtractor = new TimeExtractor();
-        private static readonly DateExtractor DateExtractor = new DateExtractor();
-        private static readonly DateTimeExtractor DateTimeExtractor = new DateTimeExtractor();
+        private static readonly JapaneseDurationExtractorConfiguration DurationExtractor = new JapaneseDurationExtractorConfiguration();
+        private static readonly JapaneseTimeExtractorConfiguration TimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly JapaneseDateExtractorConfiguration DateExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly JapaneseDateTimeExtractorConfiguration DateTimeExtractor = new JapaneseDateTimeExtractorConfiguration();
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
@@ -6,12 +6,12 @@ using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class TimeExtractor : BaseDateTimeExtractor<TimeType>
+    public class JapaneseTimeExtractorConfiguration : JapaneseBaseDateTimeExtractorConfiguration<TimeType>
     {
         // e.g: 早上九点
         public static readonly string DayDescRegex = DateTimeDefinitions.TimeDayDescRegex;
 
-        public TimeExtractor()
+        public JapaneseTimeExtractorConfiguration()
         {
             var regexes = new Dictionary<Regex, TimeType>
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
@@ -6,9 +6,9 @@ using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class TimePeriodExtractor : BaseDateTimeExtractor<PeriodType>
+    public class JapaneseTimePeriodExtractorConfiguration : JapaneseBaseDateTimeExtractorConfiguration<PeriodType>
     {
-        public TimePeriodExtractor()
+        public JapaneseTimePeriodExtractorConfiguration()
         {
             var regexes = new Dictionary<Regex, PeriodType>
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateParser : IDateTimeParser
+    public class JapaneseDateParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -20,11 +20,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private readonly IParser numberParser;
         private readonly IDateTimeExtractor durationExtractor;
 
-        public DateParser(JapaneseDateTimeParserConfiguration configuration)
+        public JapaneseDateParserConfiguration(JapaneseDateTimeParserConfiguration configuration)
         {
             config = configuration;
             integerExtractor = new IntegerExtractor();
-            durationExtractor = new DurationExtractor();
+            durationExtractor = new JapaneseDurationExtractorConfiguration();
             numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         // parse basic patterns in DateRegexList
         protected DateTimeResolutionResult ParseBasicRegexMatch(string text, DateObject referenceDate)
         {
-            foreach (var regex in DateExtractor.DateRegexList)
+            foreach (var regex in JapaneseDateExtractorConfiguration.DateRegexList)
             {
                 var match = regex.MatchExact(text, trim: true);
 
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var ret = new DateTimeResolutionResult();
 
             // handle "十二日" "明年这个月三日" "本月十一日"
-            var match = DateExtractor.SpecialDate.MatchExact(text, trim: true);
+            var match = JapaneseDateExtractorConfiguration.SpecialDate.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 if (!string.IsNullOrEmpty(monthStr))
                 {
                     hasMonth = true;
-                    if (DateExtractor.NextRe.Match(monthStr).Success)
+                    if (JapaneseDateExtractorConfiguration.NextRe.Match(monthStr).Success)
                     {
                         month++;
                         if (month == 13)
@@ -151,7 +151,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                             year++;
                         }
                     }
-                    else if (DateExtractor.LastRe.Match(monthStr).Success)
+                    else if (JapaneseDateExtractorConfiguration.LastRe.Match(monthStr).Success)
                     {
                         month--;
                         if (month == 0)
@@ -164,11 +164,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     if (!string.IsNullOrEmpty(yearStr))
                     {
                         hasYear = true;
-                        if (DateExtractor.NextRe.Match(yearStr).Success)
+                        if (JapaneseDateExtractorConfiguration.NextRe.Match(yearStr).Success)
                         {
                             ++year;
                         }
-                        else if (DateExtractor.LastRe.Match(yearStr).Success)
+                        else if (JapaneseDateExtractorConfiguration.LastRe.Match(yearStr).Success)
                         {
                             --year;
                         }
@@ -222,7 +222,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             // handle cases like "昨日", "明日", "大后天"
-            match = DateExtractor.SpecialDayRegex.MatchExact(text, trim: true);
+            match = JapaneseDateExtractorConfiguration.SpecialDayRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -234,7 +234,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return ret;
             }
 
-            match = DateExtractor.SpecialMonthRegex.MatchExact(text, trim: true);
+            match = JapaneseDateExtractorConfiguration.SpecialMonthRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -246,7 +246,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
               return ret;
             }
 
-            match = DateExtractor.SpecialYearRegex.MatchExact(text, trim: true);
+            match = JapaneseDateExtractorConfiguration.SpecialYearRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -535,7 +535,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private static bool IsLunarCalendar(string text)
         {
             var trimmedText = text.Trim();
-            var match = DateExtractor.LunarRegex.Match(trimmedText);
+            var match = JapaneseDateExtractorConfiguration.LunarRegex.Match(trimmedText);
 
             return match.Success;
         }
@@ -566,7 +566,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var unitStr = string.Empty;
             if (durationRes.Count > 0)
             {
-                var match = DateExtractor.UnitRegex.Match(text);
+                var match = JapaneseDateExtractorConfiguration.UnitRegex.Match(text);
                 if (match.Success)
                 {
                     var suffix =
@@ -584,7 +584,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
 
-                        var beforeMatch = DateExtractor.BeforeRegex.Match(suffix);
+                        var beforeMatch = JapaneseDateExtractorConfiguration.BeforeRegex.Match(suffix);
                         if (beforeMatch.Success && suffix.StartsWith(beforeMatch.Value))
                         {
                             DateObject date;
@@ -612,7 +612,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                             return ret;
                         }
 
-                        var afterMatch = DateExtractor.AfterRegex.Match(suffix);
+                        var afterMatch = JapaneseDateExtractorConfiguration.AfterRegex.Match(suffix);
                         if (afterMatch.Success && suffix.StartsWith(afterMatch.Value))
                         {
                             DateObject date;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
@@ -7,25 +7,25 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DatePeriodParser : IDateTimeParser
+    public class JapaneseDatePeriodParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
         private const int LastMonthOfYear = 12;
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractor();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new JapaneseDateExtractorConfiguration();
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
         private static readonly IParser IntegerParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
 
-        private static readonly IDateTimeExtractor Durationextractor = new DurationExtractor();
+        private static readonly IDateTimeExtractor Durationextractor = new JapaneseDurationExtractorConfiguration();
 
         private static readonly Calendar Cal = DateTimeFormatInfo.InvariantInfo.Calendar;
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DatePeriodParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseDatePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -238,7 +238,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var noYear = false;
             var inputYear = false;
 
-            var match = DatePeriodExtractor.SimpleCasesRegex.MatchExact(text, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.SimpleCasesRegex.MatchExact(text, trim: true);
             string beginLuisStr, endLuisStr;
 
             if (match.Success)
@@ -275,9 +275,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 else
                 {
                     monthStr = match.Groups["relmonth"].Value.Trim().ToLower();
-                    var thismatch = DatePeriodExtractor.ThisRegex.Match(monthStr);
-                    var nextmatch = DatePeriodExtractor.NextRegex.Match(monthStr);
-                    var lastmatch = DatePeriodExtractor.LastRegex.Match(monthStr);
+                    var thismatch = JapaneseDatePeriodExtractorConfiguration.ThisRegex.Match(monthStr);
+                    var nextmatch = JapaneseDatePeriodExtractorConfiguration.NextRegex.Match(monthStr);
+                    var lastmatch = JapaneseDatePeriodExtractorConfiguration.LastRegex.Match(monthStr);
 
                     if (thismatch.Success)
                     {
@@ -309,8 +309,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     }
                 }
 
-                if (inputYear || DatePeriodExtractor.ThisRegex.Match(monthStr).Success ||
-                    DatePeriodExtractor.NextRegex.Match(monthStr).Success)
+                if (inputYear || JapaneseDatePeriodExtractorConfiguration.ThisRegex.Match(monthStr).Success ||
+                    JapaneseDatePeriodExtractorConfiguration.NextRegex.Match(monthStr).Success)
                 {
                     beginLuisStr = DateTimeFormatUtil.LuisDate(year, month, beginDay);
                     endLuisStr = DateTimeFormatUtil.LuisDate(year, month, endDay);
@@ -357,12 +357,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private DateTimeResolutionResult ParseYearToYear(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.YearToYear.Match(text);
+            var match = JapaneseDatePeriodExtractorConfiguration.YearToYear.Match(text);
 
             if (match.Success)
             {
-                var yearMatch = DatePeriodExtractor.YearRegex.Matches(text);
-                var yearInJapaneseMatch = DatePeriodExtractor.YearInJapaneseRegex.Matches(text);
+                var yearMatch = JapaneseDatePeriodExtractorConfiguration.YearRegex.Matches(text);
+                var yearInJapaneseMatch = JapaneseDatePeriodExtractorConfiguration.YearInJapaneseRegex.Matches(text);
                 var beginYear = 0;
                 var endYear = 0;
 
@@ -435,11 +435,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             int undefinedValue = -1;
 
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.MonthToMonth.Match(text);
+            var match = JapaneseDatePeriodExtractorConfiguration.MonthToMonth.Match(text);
 
             if (match.Success)
             {
-                var monthMatch = DatePeriodExtractor.MonthRegex.Matches(text);
+                var monthMatch = JapaneseDatePeriodExtractorConfiguration.MonthRegex.Matches(text);
                 var beginMonth = 0;
                 var endMonth = 0;
 
@@ -516,11 +516,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         {
             int undefinedValue = -1;
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.DayToDay.Match(text);
+            var match = JapaneseDatePeriodExtractorConfiguration.DayToDay.Match(text);
 
             if (match.Success)
             {
-                var dayMatchMatch = DatePeriodExtractor.DayRegexForPeriod.Matches(text);
+                var dayMatchMatch = JapaneseDatePeriodExtractorConfiguration.DayRegexForPeriod.Matches(text);
                 var beginDay = 0;
                 var endDay = 0;
 
@@ -647,7 +647,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             int futureYear = year, pastYear = year;
 
             var trimmedText = text.Trim().ToLower();
-            var match = DatePeriodExtractor.OneWordPeriodRegex.MatchExact(trimmedText, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.OneWordPeriodRegex.MatchExact(trimmedText, trim: true);
 
             if (match.Success)
             {
@@ -662,9 +662,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     return ret;
                 }
 
-                var thismatch = DatePeriodExtractor.ThisRegex.Match(trimmedText);
-                var nextmatch = DatePeriodExtractor.NextRegex.Match(trimmedText);
-                var lastmatch = DatePeriodExtractor.LastRegex.Match(trimmedText);
+                var thismatch = JapaneseDatePeriodExtractorConfiguration.ThisRegex.Match(trimmedText);
+                var nextmatch = JapaneseDatePeriodExtractorConfiguration.NextRegex.Match(trimmedText);
+                var lastmatch = JapaneseDatePeriodExtractorConfiguration.LastRegex.Match(trimmedText);
 
                 if (!string.IsNullOrEmpty(monthStr))
                 {
@@ -808,7 +808,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private DateTimeResolutionResult ParseYear(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.YearRegex.MatchExact(text, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.YearRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -851,7 +851,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return ret;
             }
 
-            match = DatePeriodExtractor.YearInJapaneseRegex.MatchExact(text, trim: true);
+            match = JapaneseDatePeriodExtractorConfiguration.YearInJapaneseRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -930,8 +930,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 pastEnd = futureEnd;
             }
 
-            if ((DatePeriodExtractor.YearAndMonth.IsMatch(pr1.Text) && DatePeriodExtractor.YearAndMonth.IsMatch(pr2.Text)) ||
-                (DatePeriodExtractor.SimpleYearAndMonth.IsMatch(pr1.Text) && DatePeriodExtractor.SimpleYearAndMonth.IsMatch(pr2.Text)))
+            if ((JapaneseDatePeriodExtractorConfiguration.YearAndMonth.IsMatch(pr1.Text) && JapaneseDatePeriodExtractorConfiguration.YearAndMonth.IsMatch(pr2.Text)) ||
+                (JapaneseDatePeriodExtractorConfiguration.SimpleYearAndMonth.IsMatch(pr1.Text) && JapaneseDatePeriodExtractorConfiguration.SimpleYearAndMonth.IsMatch(pr2.Text)))
             {
                 ret.Timex = $"({pr1.TimexStr},{pr2.TimexStr},P{(int)(futureEnd - futureBegin).TotalDays / 30}M)";
             }
@@ -955,7 +955,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             string numStr, unitStr;
 
             // if there are NO spaces between number and unit
-            var match = DatePeriodExtractor.NumberCombinedWithUnit.Match(text);
+            var match = JapaneseDatePeriodExtractorConfiguration.NumberCombinedWithUnit.Match(text);
             if (match.Success)
             {
                 var srcUnit = match.Groups["unit"].Value.ToLowerInvariant();
@@ -965,7 +965,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     unitStr = this.config.UnitMap[srcUnit];
                     numStr = match.Groups["num"].Value;
 
-                    var prefixMatch = DatePeriodExtractor.PastRegex.MatchExact(beforeStr, trim: true);
+                    var prefixMatch = JapaneseDatePeriodExtractorConfiguration.PastRegex.MatchExact(beforeStr, trim: true);
 
                     if (prefixMatch.Success)
                     {
@@ -998,7 +998,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         return ret;
                     }
 
-                    prefixMatch = DatePeriodExtractor.FutureRegex.MatchExact(beforeStr, trim: true);
+                    prefixMatch = JapaneseDatePeriodExtractorConfiguration.FutureRegex.MatchExact(beforeStr, trim: true);
 
                     if (prefixMatch.Success)
                     {
@@ -1040,7 +1040,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             if (durationRes.Count > 0)
             {
                 var beforeStr = text.Substring(0, (int)durationRes[0].Start).ToLowerInvariant();
-                match = DatePeriodExtractor.UnitRegex.Match(durationRes[0].Text);
+                match = JapaneseDatePeriodExtractorConfiguration.UnitRegex.Match(durationRes[0].Text);
                 if (match.Success)
                 {
                     var srcUnit = match.Groups["unit"].Value.ToLowerInvariant();
@@ -1050,7 +1050,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     {
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
-                        var prefixMatch = DatePeriodExtractor.PastRegex.MatchExact(beforeStr, trim: true);
+                        var prefixMatch = JapaneseDatePeriodExtractorConfiguration.PastRegex.MatchExact(beforeStr, trim: true);
 
                         if (prefixMatch.Success)
                         {
@@ -1083,7 +1083,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                             return ret;
                         }
 
-                        prefixMatch = DatePeriodExtractor.FutureRegex.MatchExact(beforeStr, trim: true);
+                        prefixMatch = JapaneseDatePeriodExtractorConfiguration.FutureRegex.MatchExact(beforeStr, trim: true);
 
                         if (prefixMatch.Success)
                         {
@@ -1130,7 +1130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         {
             var ret = new DateTimeResolutionResult();
             var trimmedText = text.Trim().ToLowerInvariant();
-            var match = DatePeriodExtractor.WeekOfMonthRegex.Match(text);
+            var match = JapaneseDatePeriodExtractorConfiguration.WeekOfMonthRegex.Match(text);
             if (!match.Success)
             {
                 return ret;
@@ -1210,7 +1210,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private DateTimeResolutionResult ParseSeason(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.SeasonWithYear.MatchExact(text, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.SeasonWithYear.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -1281,7 +1281,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private DateTimeResolutionResult ParseQuarter(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
-            var match = DatePeriodExtractor.QuarterRegex.MatchExact(text, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.QuarterRegex.MatchExact(text, trim: true);
 
             if (!match.Success)
             {
@@ -1354,7 +1354,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             int decadeLastYear = 10;
             var inputCentury = false;
 
-            var match = DatePeriodExtractor.DecadeRegex.MatchExact(text, trim: true);
+            var match = JapaneseDatePeriodExtractorConfiguration.DecadeRegex.MatchExact(text, trim: true);
             string beginLuisStr, endLuisStr;
 
             if (match.Success)
@@ -1382,9 +1382,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     if (!string.IsNullOrEmpty(centuryStr))
                     {
                         centuryStr = centuryStr.Trim().ToLower();
-                        var thismatch = DatePeriodExtractor.ThisRegex.Match(centuryStr);
-                        var nextmatch = DatePeriodExtractor.NextRegex.Match(centuryStr);
-                        var lastmatch = DatePeriodExtractor.LastRegex.Match(centuryStr);
+                        var thismatch = JapaneseDatePeriodExtractorConfiguration.ThisRegex.Match(centuryStr);
+                        var nextmatch = JapaneseDatePeriodExtractorConfiguration.NextRegex.Match(centuryStr);
+                        var lastmatch = JapaneseDatePeriodExtractorConfiguration.LastRegex.Match(centuryStr);
 
                         if (thismatch.Success)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
@@ -8,7 +8,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateTimeParser : IDateTimeParser
+    public class JapaneseDateTimeParser : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIME;
 
@@ -16,15 +16,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex SimplePmRegex = new Regex(DateTimeDefinitions.DateTimeSimplePmRegex, RegexOptions.Singleline);
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractor();
-        private static readonly IDateTimeExtractor SingleTimeExtractor = new TimeExtractor();
-        private readonly IDateTimeExtractor durationExtractor = new DurationExtractor();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor SingleTimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private readonly IDateTimeExtractor durationExtractor = new JapaneseDurationExtractorConfiguration();
         private readonly IExtractor integerExtractor = new IntegerExtractor();
         private readonly IParser numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DateTimeParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseDateTimeParser(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -100,7 +100,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var trimmedText = text.Trim().ToLower();
 
             // handle "现在"
-            var match = DateTimeExtractor.NowRegex.MatchExact(trimmedText, trim: true);
+            var match = JapaneseDateTimeExtractorConfiguration.NowRegex.MatchExact(trimmedText, trim: true);
 
             if (match.Success)
             {
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private bool IsLunarCalendar(string text)
         {
             var trimmedText = text.Trim();
-            var match = DateExtractor.LunarRegex.Match(trimmedText);
+            var match = JapaneseDateExtractorConfiguration.LunarRegex.Match(trimmedText);
             if (match.Success)
             {
                 return true;
@@ -229,7 +229,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var min = time.Minute;
             var sec = time.Second;
 
-            var match = DateTimeExtractor.TimeOfTodayRegex.Match(text);
+            var match = JapaneseDateTimeExtractorConfiguration.TimeOfTodayRegex.Match(text);
 
             if (match.Success)
             {
@@ -310,7 +310,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var unitStr = string.Empty;
             if (durationRes.Count > 0)
             {
-                var match = DateTimeExtractor.DateTimePeriodUnitRegex.Match(text);
+                var match = JapaneseDateTimeExtractorConfiguration.DateTimePeriodUnitRegex.Match(text);
                 if (match.Success)
                 {
                     var suffix =
@@ -328,7 +328,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         unitStr = this.config.UnitMap[srcUnit];
                         numStr = number.ToString();
 
-                        var beforeMatch = DateTimeExtractor.BeforeRegex.Match(suffix);
+                        var beforeMatch = JapaneseDateTimeExtractorConfiguration.BeforeRegex.Match(suffix);
                         if (beforeMatch.Success && suffix.StartsWith(beforeMatch.Value))
                         {
                             DateObject date;
@@ -353,7 +353,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                             return ret;
                         }
 
-                        var afterMatch = DateTimeExtractor.AfterRegex.Match(suffix);
+                        var afterMatch = JapaneseDateTimeExtractorConfiguration.AfterRegex.Match(suffix);
                         if (afterMatch.Success && suffix.StartsWith(afterMatch.Value))
                         {
                             DateObject date;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     public JapaneseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
             : base(options)
     {
-      DateParser = new DateParser(this);
-      TimeParser = new TimeParser(this);
-      DateTimeParser = new DateTimeParser(this);
-      DatePeriodParser = new DatePeriodParser(this);
-      TimePeriodParser = new TimePeriodParser(this);
-      DateTimePeriodParser = new DateTimePeriodParser(this);
-      DurationParser = new DurationParser(this);
-      GetParser = new SetParser(this);
-      HolidayParser = new HolidayParser(this);
+      DateParser = new JapaneseDateParserConfiguration(this);
+      TimeParser = new JapaneseTimeParserConfiguration(this);
+      DateTimeParser = new JapaneseDateTimeParser(this);
+      DatePeriodParser = new JapaneseDatePeriodParserConfiguration(this);
+      TimePeriodParser = new JapaneseTimePeriodParserConfiguration(this);
+      DateTimePeriodParser = new JapaneseDateTimePeriodParserConfiguration(this);
+      DurationParser = new JapaneseDurationParserConfiguration(this);
+      GetParser = new JapaneseSetParserConfiguration(this);
+      HolidayParser = new JapaneseHolidayParserConfiguration(this);
       UnitMap = DateTimeDefinitions.ParserConfigurationUnitMap.ToImmutableDictionary();
       UnitValueMap = DateTimeDefinitions.ParserConfigurationUnitValueMap.ToImmutableDictionary();
       SeasonMap = DateTimeDefinitions.ParserConfigurationSeasonMap.ToImmutableDictionary();
@@ -29,17 +29,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
       DayOfWeek = DateTimeDefinitions.ParserConfigurationDayOfWeek.ToImmutableDictionary();
       MonthOfYear = DateTimeDefinitions.ParserConfigurationMonthOfYear.ToImmutableDictionary();
       Numbers = InitNumbers();
-      DateRegexList = DateExtractor.DateRegexList;
-      NextRegex = DateExtractor.NextRegex;
-      ThisRegex = DateExtractor.ThisRegex;
-      LastRegex = DateExtractor.LastRegex;
-      StrictWeekDayRegex = DateExtractor.WeekDayRegex;
-      WeekDayOfMonthRegex = DateExtractor.WeekDayOfMonthRegex;
-      BeforeRegex = JapaneseMergedExtractor.BeforeRegex;
-      AfterRegex = JapaneseMergedExtractor.AfterRegex;
-      UntilRegex = JapaneseMergedExtractor.UntilRegex;
-      SincePrefixRegex = JapaneseMergedExtractor.SincePrefixRegex;
-      SinceSuffixRegex = JapaneseMergedExtractor.SinceSuffixRegex;
+      DateRegexList = JapaneseDateExtractorConfiguration.DateRegexList;
+      NextRegex = JapaneseDateExtractorConfiguration.NextRegex;
+      ThisRegex = JapaneseDateExtractorConfiguration.ThisRegex;
+      LastRegex = JapaneseDateExtractorConfiguration.LastRegex;
+      StrictWeekDayRegex = JapaneseDateExtractorConfiguration.WeekDayRegex;
+      WeekDayOfMonthRegex = JapaneseDateExtractorConfiguration.WeekDayOfMonthRegex;
+      BeforeRegex = JapaneseMergedExtractorConfiguration.BeforeRegex;
+      AfterRegex = JapaneseMergedExtractorConfiguration.AfterRegex;
+      UntilRegex = JapaneseMergedExtractorConfiguration.UntilRegex;
+      SincePrefixRegex = JapaneseMergedExtractorConfiguration.SincePrefixRegex;
+      SinceSuffixRegex = JapaneseMergedExtractorConfiguration.SinceSuffixRegex;
     }
 
     public int TwoNumYear => int.Parse(DateTimeDefinitions.TwoNumYear);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -10,7 +10,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DateTimePeriodParser : IDateTimeParser
+    public class JapaneseDateTimePeriodParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
@@ -22,10 +22,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex NIRegex = new Regex(DateTimeDefinitions.DateTimePeriodNIRegex, RegexOptions.Singleline);
 
-        private static readonly IDateTimeExtractor SingleDateExtractor = new DateExtractor();
-        private static readonly IDateTimeExtractor SingleTimeExtractor = new TimeExtractor();
-        private static readonly IDateTimeExtractor TimeWithDateExtractor = new DateTimeExtractor();
-        private static readonly IDateTimeExtractor TimePeriodExtractor = new TimePeriodExtractor();
+        private static readonly IDateTimeExtractor SingleDateExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor SingleTimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimeWithDateExtractor = new JapaneseDateTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimePeriodExtractor = new JapaneseTimePeriodExtractorConfiguration();
         private static readonly IExtractor CardinalExtractor = new CardinalExtractor();
 
         private static readonly IParser CardinalParser = AgnosticNumberParserFactory.GetParser(
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DateTimePeriodParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseDateTimePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -372,7 +372,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             string timeStr;
 
             // handle 昨晚，今晨
-            var exactMatch = DateTimePeriodExtractor.SpecificTimeOfDayRegex.MatchExact(trimmedText, trim: true);
+            var exactMatch = JapaneseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex.MatchExact(trimmedText, trim: true);
 
             if (exactMatch.Success)
             {
@@ -459,16 +459,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return ret;
             }
 
-            exactMatch = DateTimePeriodExtractor.SpecificTimeOfDayRegex.MatchExact(trimmedText, trim: true);
+            exactMatch = JapaneseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex.MatchExact(trimmedText, trim: true);
 
             if (exactMatch.Success)
             {
                 var swift = 0;
-                if (DateTimePeriodExtractor.NextRegex.IsMatch(trimmedText))
+                if (JapaneseDateTimePeriodExtractorConfiguration.NextRegex.IsMatch(trimmedText))
                 {
                     swift = 1;
                 }
-                else if (DateTimePeriodExtractor.LastRegex.IsMatch(trimmedText))
+                else if (JapaneseDateTimePeriodExtractorConfiguration.LastRegex.IsMatch(trimmedText))
                 {
                     swift = -1;
                 }
@@ -487,7 +487,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             // handle Date followed by morning, afternoon
-            var match = DateTimePeriodExtractor.TimeOfDayRegex.Match(trimmedText);
+            var match = JapaneseDateTimePeriodExtractorConfiguration.TimeOfDayRegex.Match(trimmedText);
 
             if (match.Success)
             {
@@ -545,7 +545,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     numStr = pr.ResolutionStr;
                     unitStr = this.config.UnitMap[srcUnit];
 
-                    if (DateTimePeriodExtractor.PastRegex.IsExactMatch(beforeStr, trim: true))
+                    if (JapaneseDateTimePeriodExtractorConfiguration.PastRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -573,7 +573,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         return ret;
                     }
 
-                    if (DateTimePeriodExtractor.FutureRegex.IsExactMatch(beforeStr, trim: true))
+                    if (JapaneseDateTimePeriodExtractorConfiguration.FutureRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -604,7 +604,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             // handle "last hour"
-            var match = DateTimePeriodExtractor.UnitRegex.Match(text);
+            var match = JapaneseDateTimePeriodExtractorConfiguration.UnitRegex.Match(text);
             if (match.Success)
             {
                 var srcUnit = match.Groups["unit"].Value.ToLower();
@@ -613,7 +613,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 {
                     unitStr = this.config.UnitMap[srcUnit];
 
-                    if (DateTimePeriodExtractor.PastRegex.IsExactMatch(beforeStr, trim: true))
+                    if (JapaneseDateTimePeriodExtractorConfiguration.PastRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)
@@ -641,7 +641,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                         return ret;
                     }
 
-                    if (DateTimePeriodExtractor.FutureRegex.IsExactMatch(beforeStr, trim: true))
+                    if (JapaneseDateTimePeriodExtractorConfiguration.FutureRegex.IsExactMatch(beforeStr, trim: true))
                     {
                         DateObject beginDate, endDate;
                         switch (unitStr)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
@@ -3,12 +3,12 @@ using System.Globalization;
 using Microsoft.Recognizers.Definitions.Japanese;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Microsoft.Recognizers.Text.NumberWithUnit.Japanese;
-using static Microsoft.Recognizers.Text.DateTime.Japanese.DurationExtractor;
+using static Microsoft.Recognizers.Text.DateTime.Japanese.JapaneseDurationExtractorConfiguration;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class DurationParser : IDateTimeParser
+    public class JapaneseDurationParserConfiguration : IDateTimeParser
     {
         public static readonly Dictionary<string, int> UnitValueMap = DateTimeDefinitions.DurationUnitValueMap;
 
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public DurationParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseDurationParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
@@ -11,7 +11,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class HolidayParser : IDateTimeParser
+    public class JapaneseHolidayParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATE; // "Date";
 
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public HolidayParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseHolidayParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedDateTimeParserConfiguration.cs
@@ -4,7 +4,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class MergedDateTimeParser : BaseMergedDateTimeParser
+    public class JapaneseMergedDateTimeParserConfiguration : BaseMergedDateTimeParser
     {
         private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.MergedBeforeRegex,  RegexOptions.Singleline);
 
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         // TODO implement SinceRegex
         private static readonly Regex SinceRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexOptions.Singleline);
 
-        public MergedDateTimeParser(IMergedParserConfiguration configuration)
+        public JapaneseMergedDateTimeParserConfiguration(IMergedParserConfiguration configuration)
             : base(configuration)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
@@ -3,18 +3,18 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class SetParser : IDateTimeParser
+    public class JapaneseSetParserConfiguration : IDateTimeParser
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_SET;
 
-        private static readonly IDateTimeExtractor DurationExtractor = new DurationExtractor();
-        private static readonly IDateTimeExtractor TimeExtractor = new TimeExtractor();
-        private static readonly IDateTimeExtractor DateExtractor = new DateExtractor();
-        private static readonly IDateTimeExtractor DateTimeExtractor = new DateTimeExtractor();
+        private static readonly IDateTimeExtractor DurationExtractor = new JapaneseDurationExtractorConfiguration();
+        private static readonly IDateTimeExtractor TimeExtractor = new JapaneseTimeExtractorConfiguration();
+        private static readonly IDateTimeExtractor DateExtractor = new JapaneseDateExtractorConfiguration();
+        private static readonly IDateTimeExtractor DateTimeExtractor = new JapaneseDateTimeExtractorConfiguration();
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public SetParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseSetParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -103,7 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            if (SetExtractor.EachPrefixRegex.IsMatch(beforeStr))
+            if (JapaneseSetExtractorConfiguration.EachPrefixRegex.IsMatch(beforeStr))
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
                 ret.Timex = pr.TimexStr;
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var ret = new DateTimeResolutionResult();
 
             // handle "each month"
-            var match = SetExtractor.EachUnitRegex.MatchExact(text, trim: true);
+            var match = JapaneseSetExtractorConfiguration.EachUnitRegex.MatchExact(text, trim: true);
 
             if (match.Success)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractor.EachDayRegex.Match(beforeStr);
+            var match = JapaneseSetExtractorConfiguration.EachDayRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.TimeParser.Parse(ers[0], DateObject.Now);
@@ -190,7 +190,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractor.EachPrefixRegex.Match(beforeStr);
+            var match = JapaneseSetExtractorConfiguration.EachPrefixRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.DateParser.Parse(ers[0], DateObject.Now);
@@ -213,7 +213,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            var match = SetExtractor.EachPrefixRegex.Match(beforeStr);
+            var match = JapaneseSetExtractorConfiguration.EachPrefixRegex.Match(beforeStr);
             if (match.Success)
             {
                 var pr = this.config.DateTimeParser.Parse(ers[0], DateObject.Now);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimeParserConfiguration.cs
@@ -3,13 +3,13 @@
 using Microsoft.Recognizers.Definitions.Japanese;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 using DateObject = System.DateTime;
-using TimeExtractorJpn = Microsoft.Recognizers.Text.DateTime.Japanese.TimeExtractor;
+using TimeExtractorJpn = Microsoft.Recognizers.Text.DateTime.Japanese.JapaneseTimeExtractorConfiguration;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class TimeParser : IDateTimeParser
+    public class JapaneseTimeParserConfiguration : IDateTimeParser
     {
-        public static readonly IDateTimeExtractor TimeExtractor = new TimeExtractor();
+        public static readonly IDateTimeExtractor TimeExtractor = new JapaneseTimeExtractorConfiguration();
 
         private static TimeFunctions timeFunctions = new TimeFunctions
         {
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public TimeParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseTimeParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
@@ -7,18 +7,18 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class TimePeriodParser : IDateTimeParser
+    public class JapaneseTimePeriodParserConfiguration : IDateTimeParser
     {
         private static TimeFunctions timeFunc = new TimeFunctions
         {
             NumberDictionary = DateTimeDefinitions.TimeNumberDictionary,
             LowBoundDesc = DateTimeDefinitions.TimeLowBoundDesc,
-            DayDescRegex = TimeExtractor.DayDescRegex,
+            DayDescRegex = JapaneseTimeExtractorConfiguration.DayDescRegex,
         };
 
         private readonly IFullDateTimeParserConfiguration config;
 
-        public TimePeriodParser(IFullDateTimeParserConfiguration configuration)
+        public JapaneseTimePeriodParserConfiguration(IFullDateTimeParserConfiguration configuration)
         {
             config = configuration;
         }
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var extra = er.Data as DateTimeExtra<PeriodType>;
             if (extra == null)
             {
-                var result = new TimeExtractor().Extract(er.Text, refDate);
+                var result = new JapaneseTimeExtractorConfiguration().Extract(er.Text, refDate);
                 extra = result[0]?.Data as DateTimeExtra<PeriodType>;
             }
 


### PR DESCRIPTION
_Disclaimer_: In this pull request we are changing several class names which will incur in a breaking change with previous versions.

- Applied the name convention for their respective language