### PR TITLE
[StyleCop] Fix all the warnings in Dutch Extractors

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -12,12 +12,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
     {
-        public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
-
-        private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexOptions.Singleline);
-
         public static readonly Regex MonthNumRegex =
             new Regex(DateTimeDefinitions.MonthNumRegex, RegexOptions.Singleline);
 
@@ -110,6 +104,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public static readonly ImmutableDictionary<string, int> MonthOfYear =
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
+
+        public static readonly Regex MonthRegex =
+            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
+
+        private static readonly Regex DayRegex =
+            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexOptions.Singleline);
 
         public DutchDateExtractorConfiguration(IOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
@@ -6,22 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
-        public DutchDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
-            : base(config)
-        {
-            DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));
-            DatePeriodExtractor = new BaseDatePeriodExtractor(new DutchDatePeriodExtractorConfiguration(this));
-        }
-
-        public IDateExtractor DateExtractor { get; }
-        public IDateTimeExtractor DatePeriodExtractor { get; }
-
-        private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
-
-        private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
-
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexOptions.Singleline);
 
@@ -49,6 +33,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             AmRegex, PmRegex,
         };
+
+        private static readonly Regex OrRegex =
+            new Regex(DateTimeDefinitions.OrRegex, RegexOptions.Singleline);
+
+        private static readonly Regex DayRegex =
+            new Regex(DateTimeDefinitions.DayRegex, RegexOptions.Singleline);
+
+        public DutchDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));
+            DatePeriodExtractor = new BaseDatePeriodExtractor(new DutchDatePeriodExtractorConfiguration(this));
+        }
+
+        public IDateExtractor DateExtractor { get; }
+
+        public IDateTimeExtractor DatePeriodExtractor { get; }
 
         IEnumerable<Regex> IDateTimeAltExtractorConfiguration.RelativePrefixList => RelativePrefixList;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
@@ -99,8 +99,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return (string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text));
+            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -8,44 +8,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
-        public string TokenBeforeDate { get; }
-
-        private static readonly Regex[] SimpleCases =
-        {
-            DutchTimePeriodExtractorConfiguration.PureNumFromTo,
-            DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd,
-        };
-
-        private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexOptions.Singleline);
-
-        private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
-
-        private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
-
-        private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
-
-        public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
-
-        public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexOptions.Singleline);
-
-        public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexOptions.Singleline);
-
-        public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexOptions.Singleline);
-
-        private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);
-
-        private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexOptions.Singleline);
-
         public static readonly Regex AmDescRegex =
             new Regex(DateTimeDefinitions.AmDescRegex, RegexOptions.Singleline);
 
@@ -73,6 +35,42 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex WeekDaysRegex =
             new Regex(DateTimeDefinitions.WeekDayRegex, RegexOptions.Singleline);
 
+        public static readonly Regex TimeNumberCombinedWithUnit =
+            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexOptions.Singleline);
+
+        public static readonly Regex PeriodTimeOfDayWithDateRegex =
+            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexOptions.Singleline);
+
+        public static readonly Regex RelativeTimeUnitRegex =
+            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexOptions.Singleline);
+
+        public static readonly Regex RestOfDateTimeRegex =
+            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexOptions.Singleline);
+
+        private static readonly Regex GeneralEndingRegex =
+            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexOptions.Singleline);
+
+        private static readonly Regex MiddlePauseRegex =
+            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexOptions.Singleline);
+
+        private static readonly Regex PeriodTimeOfDayRegex =
+            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexOptions.Singleline);
+
+        private static readonly Regex PeriodSpecificTimeOfDayRegex =
+            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
+
+        private static readonly Regex TimeUnitRegex =
+            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexOptions.Singleline);
+
+        private static readonly Regex TimeFollowedUnit =
+            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexOptions.Singleline);
+
+        private static readonly Regex[] SimpleCases =
+{
+            DutchTimePeriodExtractorConfiguration.PureNumFromTo,
+            DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd,
+        };
+
         public DutchDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
             : base(config)
         {
@@ -85,6 +83,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new DutchTimePeriodExtractorConfiguration(this));
         }
+
+        public string TokenBeforeDate { get; }
 
         public IEnumerable<Regex> SimpleCasesRegex => SimpleCases;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
@@ -50,6 +50,30 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
+        public DutchMergedExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));
+            TimeExtractor = new BaseTimeExtractor(new DutchTimeExtractorConfiguration(this));
+            DateTimeExtractor = new BaseDateTimeExtractor(new DutchDateTimeExtractorConfiguration(this));
+            DatePeriodExtractor = new BaseDatePeriodExtractor(new DutchDatePeriodExtractorConfiguration(this));
+            TimePeriodExtractor = new BaseTimePeriodExtractor(new DutchTimePeriodExtractorConfiguration(this));
+            DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new DutchDateTimePeriodExtractorConfiguration(this));
+            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
+            SetExtractor = new BaseSetExtractor(new DutchSetExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new DutchHolidayExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
+            DateTimeAltExtractor = new BaseDateTimeAltExtractor(new DutchDateTimeAltExtractorConfiguration(this));
+            IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();
+
+            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityFiltersDict);
+
+            if ((Options & DateTimeOptions.EnablePreview) != 0)
+            {
+                SuperfluousWordMatcher.Init(DateTimeDefinitions.SuperfluousWordList);
+            }
+        }
+
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
@@ -76,42 +100,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
 
-        public DutchMergedExtractorConfiguration(IOptionsConfiguration config)
-            : base(config)
-        {
-            DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));
-            TimeExtractor = new BaseTimeExtractor(new DutchTimeExtractorConfiguration(this));
-            DateTimeExtractor = new BaseDateTimeExtractor(new DutchDateTimeExtractorConfiguration(this));
-            DatePeriodExtractor = new BaseDatePeriodExtractor(new DutchDatePeriodExtractorConfiguration(this));
-            TimePeriodExtractor = new BaseTimePeriodExtractor(new DutchTimePeriodExtractorConfiguration(this));
-            DateTimePeriodExtractor = new BaseDateTimePeriodExtractor(new DutchDateTimePeriodExtractorConfiguration(this));
-            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
-            SetExtractor = new BaseSetExtractor(new DutchSetExtractorConfiguration(this));
-            HolidayExtractor = new BaseHolidayExtractor(new DutchHolidayExtractorConfiguration(this));
-            TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
-            DateTimeAltExtractor = new BaseDateTimeAltExtractor(new DutchDateTimeAltExtractorConfiguration(this));
-            IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();
-
-            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityFiltersDict);
-
-            if ((Options & DateTimeOptions.EnablePreview) != 0)
-            {
-                SuperfluousWordMatcher.Init(DateTimeDefinitions.SuperfluousWordList);
-            }
-
-        }
-
         Regex IMergedExtractorConfiguration.AfterRegex => AfterRegex;
+
         Regex IMergedExtractorConfiguration.BeforeRegex => BeforeRegex;
+
         Regex IMergedExtractorConfiguration.SinceRegex => SinceRegex;
+
         Regex IMergedExtractorConfiguration.AroundRegex => AroundRegex;
+
         Regex IMergedExtractorConfiguration.FromToRegex => FromToRegex;
+
         Regex IMergedExtractorConfiguration.SingleAmbiguousMonthRegex => SingleAmbiguousMonthRegex;
+
         Regex IMergedExtractorConfiguration.PrepositionSuffixRegex => PrepositionSuffixRegex;
+
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
+
         Regex IMergedExtractorConfiguration.DateAfterRegex => DateAfterRegex;
+
         Regex IMergedExtractorConfiguration.UnspecificDatePeriodRegex => UnspecificDatePeriodRegex;
+
         IEnumerable<Regex> IMergedExtractorConfiguration.TermFilterRegexes => TermFilterRegexes;
+
         StringMatcher IMergedExtractorConfiguration.SuperfluousWordMatcher => SuperfluousWordMatcher;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -123,6 +123,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             ConnectNumRegex,
         };
 
+        public DutchTimeExtractorConfiguration(IOptionsConfiguration config)
+            : base(config)
+        {
+            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
+        }
+
         IEnumerable<Regex> ITimeExtractorConfiguration.TimeRegexList => TimeRegexList;
 
         Regex ITimeExtractorConfiguration.AtRegex => AtRegex;
@@ -134,12 +141,5 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimeZoneExtractor { get; }
-
-        public DutchTimeExtractorConfiguration(IOptionsConfiguration config)
-            : base(config)
-        {
-            DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
-            TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
-        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
-        public string TokenBeforeDate { get; }
-
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexOptions.Singleline);
 
@@ -71,6 +69,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();
             TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
         }
+
+        public string TokenBeforeDate { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 


### PR DESCRIPTION
- Reorder fields, properties, methods and constructors
- Add and remove spaces when needed
- Remove unnecessary parenthesis