### PR TITLE
Fix spanish dateperiod cases

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 	public static class DateTimeDefinitions
 	{
 		public const string TillRegex = @"(?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?";
-		public const string OfPrepositionRegex = @"do|da|del|de";
 		public const string AndRegex = @"(?<and>y|y\s*el|--|-|—|——)";
 		public const string DayRegex = @"(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(?=\b|t)";
 		public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b";
@@ -26,9 +25,11 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
 		public static readonly string AmPmDescRegex = $@"({BaseDateTime.BaseAmPmDescRegex})";
 		public static readonly string DescRegex = $@"(?<desc>({AmDescRegex}|{PmDescRegex}))";
+		public const string OfPrepositionRegex = @"(do|da|del|de)";
+		public const string AfterNextSuffixRegex = @"\b(que\s+viene|pasad[oa])\b";
 		public const string RangePrefixRegex = @"((desde|de|entre)\s+(la(s)?\s+)?)";
 		public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
-		public const string RelativeRegex = @"(?<rela>((((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\s+)(semana|semanas|año|mes|días|fin\s+de\s+semana))|(fin\s+de\s+semana))|((fin de semana|semana|semanas|año|mes|días)\s+((que\s+viene)|pasado)))\b";
+		public const string RelativeRegex = @"(?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b";
 		public const string FullTextYearRegex = @"^[\*]";
 		public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
 		public const string RelativeMonthRegex = @"(?<relmonth>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+mes)|(mes\s+((que\s+viene)|pasado)))\b";
@@ -41,7 +42,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string MonthFrontSimpleCasesRegex = $@"\b{MonthSuffixRegex}\s+((desde\s+el|desde|del)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre|entre\s+el)\s+)({DayRegex})\s*{AndRegex}\s*({DayRegex})((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string DayBetweenRegex = $@"\b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
-		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?{RelativeRegex})";
+		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))";
 		public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
 		public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.](\s*?){YearRegex})";
 		public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
@@ -51,6 +52,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string QuarterRegex = $@"(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3ro|cuarto|4to|((1|2|3|4)º))\s+(cuatrimestre|cuarto)((\s+de|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))?";
 		public static readonly string QuarterRegexYearFront = $@"({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año)\s+(el\s+)?(?<cardinal>(primer|primero)|1er|segundo|2do|(tercer|terceo)|3ro|cuarto|4to)\s+cuatrimestre";
 		public const string AllHalfYearRegex = @"^[.]";
+		public static readonly string EarlyPrefixRegex = $@"\b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b";
+		public const string MidPrefixRegex = @"^[.]";
+		public static readonly string LaterPrefixRegex = $@"\b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b";
+		public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
 		public const string PrefixDayRegex = @"^[.]";
 		public const string CenturySuffixRegex = @"^[.]";
 		public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
@@ -171,13 +176,14 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string EachDayRegex = $@"\s*({EachExpression})\s*d[ií]as\s*\b";
 		public static readonly string BeforeEachDayRegex = $@"({EachExpression})\s*d[ií]as(\s+a\s+las?)?\s*\b";
 		public static readonly string SetEachRegex = $@"(?<each>({EachExpression})\s*)";
-		public static readonly string LaterEarlyPeriodRegex = $@"\b((fines\s+({OfPrepositionRegex}))\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b";
-		public const string WeekWithWeekDayRangeRegex = @"^[.]";
+		public static readonly string LaterEarlyPeriodRegex = $@"\b(({PrefixPeriodRegex})\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b";
+		public const string RelativeWeekRegex = @"(((la|el)\s+)?(((esta|este|pr[oó]xim[oa]|[uú]ltim(o|as|os))\s+semana(s)?)|(semana(s)?\s+(que\s+viene|pasad[oa]))))";
+		public static readonly string WeekWithWeekDayRangeRegex = $@"\b((({RelativeWeekRegex})((\s+entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(\s+de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})))|((entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})){OfPrepositionRegex}\s+{RelativeWeekRegex})\b";
 		public const string GeneralEndingRegex = @"^[.]";
 		public const string MiddlePauseRegex = @"^[.]";
 		public const string PrefixArticleRegex = @"^[\.]";
 		public const string OrRegex = @"^[.]";
-		public const string YearPlusNumberRegex = @"^[.]";
+		public static readonly string YearPlusNumberRegex = $@"\b(años?\s+((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
 		public const string NumberAsTimeRegex = @"^[.]";
 		public const string TimeBeforeAfterRegex = @"^[.]";
 		public const string DateNumberConnectorRegex = @"^[.]";

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -1,8 +1,6 @@
 ﻿---
 TillRegex: !simpleRegex
   def: (?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?
-OfPrepositionRegex: !simpleRegex
-  def: do|da|del|de
 AndRegex: !simpleRegex
   def: (?<and>y|y\s*el|--|-|—|——)
 DayRegex: !simpleRegex
@@ -21,6 +19,10 @@ AmPmDescRegex: !nestedRegex
 DescRegex: !nestedRegex
   def: (?<desc>({AmDescRegex}|{PmDescRegex}))
   references: [ AmDescRegex, PmDescRegex ]
+OfPrepositionRegex: !simpleRegex
+  def: (do|da|del|de)
+AfterNextSuffixRegex: !simpleRegex
+  def: \b(que\s+viene|pasad[oa])\b
 RangePrefixRegex: !simpleRegex
   def: ((desde|de|entre)\s+(la(s)?\s+)?)
 # As month number can't be 0, so add (?!\.0\b) to filter out some wrong cases
@@ -28,7 +30,7 @@ TwoDigitYearRegex: !nestedRegex
   def: \b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
-  def: (?<rela>((((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\s+)(semana|semanas|año|mes|días|fin\s+de\s+semana))|(fin\s+de\s+semana))|((fin de semana|semana|semanas|año|mes|días)\s+((que\s+viene)|pasado)))\b
+  def: (?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b
 FullTextYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[\*]
@@ -61,8 +63,8 @@ DayBetweenRegex: !nestedRegex
   def: \b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b
   references: [ DayRegex, AndRegex, MonthSuffixRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?{RelativeRegex})
-  references: [MonthRegex, RelativeRegex, OfPrepositionRegex]
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))
+  references: [MonthRegex, RelativeRegex, OfPrepositionRegex, AfterNextSuffixRegex]
 MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
   references: [ MonthRegex, YearRegex ]
@@ -90,6 +92,18 @@ QuarterRegexYearFront: !nestedRegex
 AllHalfYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+EarlyPrefixRegex: !nestedRegex
+  def: \b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b
+  references: [OfPrepositionRegex]
+MidPrefixRegex: !simpleRegex
+  # TODO
+  def: ^[.]
+LaterPrefixRegex: !nestedRegex
+  def: \b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b
+  references: [OfPrepositionRegex]
+PrefixPeriodRegex: !nestedRegex
+  def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
+  references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
 PrefixDayRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -448,11 +462,13 @@ SetEachRegex: !nestedRegex
   def: (?<each>({EachExpression})\s*)
   references: [ EachExpression ]
 LaterEarlyPeriodRegex: !nestedRegex
-  def: \b((fines\s+({OfPrepositionRegex}))\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b
-  references: [OneWordPeriodRegex, UnspecificEndOfRangeRegex, OfPrepositionRegex]
-WeekWithWeekDayRangeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(({PrefixPeriodRegex})\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b
+  references: [OneWordPeriodRegex, UnspecificEndOfRangeRegex, PrefixPeriodRegex]
+RelativeWeekRegex: !simpleRegex
+  def: (((la|el)\s+)?(((esta|este|pr[oó]xim[oa]|[uú]ltim(o|as|os))\s+semana(s)?)|(semana(s)?\s+(que\s+viene|pasad[oa]))))
+WeekWithWeekDayRangeRegex: !nestedRegex
+  def: \b((({RelativeWeekRegex})((\s+entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(\s+de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})))|((entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})){OfPrepositionRegex}\s+{RelativeWeekRegex})\b
+  references: [RelativeWeekRegex, WeekDayRegex, OfPrepositionRegex]
 GeneralEndingRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -465,9 +481,9 @@ PrefixArticleRegex: !simpleRegex
 OrRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
-YearPlusNumberRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+YearPlusNumberRegex: !nestedRegex
+  def: \b(años?\s+((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
+  references: [ FullTextYearRegex ]
 NumberAsTimeRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -3139,7 +3139,6 @@
   },
   {
     "Input": "Nos vimos a finales de la semana pasada",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3152,7 +3151,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de este mes",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3165,7 +3163,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de esta semana",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3178,7 +3175,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de la próxima semana",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3191,7 +3187,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos del próximo año",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3204,7 +3199,6 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio entre miércoles y viernes de la próxima semana.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3217,33 +3211,30 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la próxima semana entre miércoles y viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "próxima semana entre miércoles y viernes",
+        "Text": "la próxima semana entre miércoles y viernes",
         "Type": "daterange",
-        "Start": 64,
-        "Length": 40
+        "Start": 61,
+        "Length": 43
       }
     ]
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la semana pasada de miércoles a viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "semana pasada de miércoles a viernes",
+        "Text": "la semana pasada de miércoles a viernes",
         "Type": "daterange",
-        "Start": 64,
-        "Length": 36
+        "Start": 61,
+        "Length": 39
       }
     ]
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para esta semana entre miércoles y viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3269,7 +3260,6 @@
   },
   {
     "Input": "en los años 1970",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3282,7 +3272,6 @@
   },
   {
     "Input": "Nació en los años 2000",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3308,14 +3297,13 @@
   },
   {
     "Input": "en los años 70",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
         "Text": "años 70",
         "Type": "daterange",
         "Start": 7,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -3328,7 +3316,7 @@
         "Text": "los 70",
         "Type": "daterange",
         "Start": 3,
-        "Length": 6
+        "Length": 7
       }
     ]
   },


### PR DESCRIPTION
DatePeriodExtractor: ❌(86 of 365 still unsupported)

Fix Spanish DatePeriod cases below type.

1.entre miércoles y viernes de la próxima semana
2.la próxima semana entre miércoles y viernes
3.comienzos de la próxima semana
4.finales de la semana pasada
5.años $year