### PR TITLE
Fix spanish dateperiod cases

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 	public static class DateTimeDefinitions
 	{
 		public const string TillRegex = @"(?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?";
-		public const string OfPrepositionRegex = @"do|da|del|de";
 		public const string AndRegex = @"(?<and>y|y\s*el|--|-|—|——)";
 		public const string DayRegex = @"(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(?=\b|t)";
 		public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b";
@@ -26,9 +25,11 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
 		public static readonly string AmPmDescRegex = $@"({BaseDateTime.BaseAmPmDescRegex})";
 		public static readonly string DescRegex = $@"(?<desc>({AmDescRegex}|{PmDescRegex}))";
+		public const string OfPrepositionRegex = @"(do|da|del|de)";
+		public const string AfterNextSuffixRegex = @"\b(que\s+viene|pasad[oa])\b";
 		public const string RangePrefixRegex = @"((desde|de|entre)\s+(la(s)?\s+)?)";
 		public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
-		public const string RelativeRegex = @"(?<rela>((((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\s+)(semana|semanas|año|mes|días|fin\s+de\s+semana))|(fin\s+de\s+semana))|((fin de semana|semana|semanas|año|mes|días)\s+((que\s+viene)|pasado)))\b";
+		public const string RelativeRegex = @"(?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b";
 		public const string FullTextYearRegex = @"^[\*]";
 		public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
 		public const string RelativeMonthRegex = @"(?<relmonth>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+mes)|(mes\s+((que\s+viene)|pasado)))\b";
@@ -41,7 +42,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string MonthFrontSimpleCasesRegex = $@"\b{MonthSuffixRegex}\s+((desde\s+el|desde|del)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre|entre\s+el)\s+)({DayRegex})\s*{AndRegex}\s*({DayRegex})((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string DayBetweenRegex = $@"\b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
-		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?{RelativeRegex})";
+		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))";
 		public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
 		public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.](\s*?){YearRegex})";
 		public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
@@ -51,6 +52,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string QuarterRegex = $@"(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3ro|cuarto|4to|((1|2|3|4)º))\s+(cuatrimestre|cuarto)((\s+de|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))?";
 		public static readonly string QuarterRegexYearFront = $@"({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año)\s+(el\s+)?(?<cardinal>(primer|primero)|1er|segundo|2do|(tercer|terceo)|3ro|cuarto|4to)\s+cuatrimestre";
 		public const string AllHalfYearRegex = @"^[.]";
+		public static readonly string EarlyPrefixRegex = $@"\b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b";
+		public const string MidPrefixRegex = @"^[.]";
+		public static readonly string LaterPrefixRegex = $@"\b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b";
+		public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
 		public const string PrefixDayRegex = @"^[.]";
 		public const string CenturySuffixRegex = @"^[.]";
 		public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
@@ -171,13 +176,14 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string EachDayRegex = $@"\s*({EachExpression})\s*d[ií]as\s*\b";
 		public static readonly string BeforeEachDayRegex = $@"({EachExpression})\s*d[ií]as(\s+a\s+las?)?\s*\b";
 		public static readonly string SetEachRegex = $@"(?<each>({EachExpression})\s*)";
-		public static readonly string LaterEarlyPeriodRegex = $@"\b((fines\s+({OfPrepositionRegex}))\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b";
-		public const string WeekWithWeekDayRangeRegex = @"^[.]";
+		public static readonly string LaterEarlyPeriodRegex = $@"\b(({PrefixPeriodRegex})\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b";
+		public const string RelativeWeekRegex = @"(((la|el)\s+)?(((esta|este|pr[oó]xim[oa]|[uú]ltim(o|as|os))\s+semana(s)?)|(semana(s)?\s+(que\s+viene|pasad[oa]))))";
+		public static readonly string WeekWithWeekDayRangeRegex = $@"\b((({RelativeWeekRegex})((\s+entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(\s+de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})))|((entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})){OfPrepositionRegex}\s+{RelativeWeekRegex})\b";
 		public const string GeneralEndingRegex = @"^[.]";
 		public const string MiddlePauseRegex = @"^[.]";
 		public const string PrefixArticleRegex = @"^[\.]";
 		public const string OrRegex = @"^[.]";
-		public const string YearPlusNumberRegex = @"^[.]";
+		public static readonly string YearPlusNumberRegex = $@"\b(años?\s+((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
 		public const string NumberAsTimeRegex = @"^[.]";
 		public const string TimeBeforeAfterRegex = @"^[.]";
 		public const string DateNumberConnectorRegex = @"^[.]";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string RangePrefixRegex = @"((desde|de|entre)\s+(la(s)?\s+)?)";
 		public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
 		public const string RelativeRegex = @"(?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b";
-		public const string FullTextYearRegex = @"^[\*]";
+		public const string WrittenOneToNineRegex = @"(uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)";
+		public const string WrittenOneHundredToNineHundredRegex = @"(cien|ciento|doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s)";
+		public static readonly string WrittenOneToNinetyNineRegex = $@"(uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+(WrittenOneToNineRegex))?))";
+		public static readonly string FullTextYearRegex = $@"(((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?(\s+{WrittenOneToNinetyNineRegex})?)";
 		public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
 		public const string RelativeMonthRegex = @"(?<relmonth>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+mes)|(mes\s+((que\s+viene)|pasado)))\b";
 		public const string MonthRegex = @"\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set|sep)\b";
@@ -44,7 +47,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string DayBetweenRegex = $@"\b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))";
 		public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
-		public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.](\s*?){YearRegex})";
+		public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex})";
 		public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
 		public static readonly string WeekOfYearRegex = $@"(?<woy>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima?|([12345]ª))\s+semana(\s+del?)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))";
 		public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
@@ -188,8 +191,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string TimeBeforeAfterRegex = @"^[.]";
 		public const string DateNumberConnectorRegex = @"^[.]";
 		public const string CenturyRegex = @"^[.]";
-		public const string DecadeRegex = @"^[.]";
-		public const string DecadeWithCenturyRegex = @"^[.]";
+		public const string DecadeRegex = @"(?<decade>diez|veinte|treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)";
+		public static readonly string DecadeWithCenturyRegex = $@"(los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))";
 		public const string RelativeDecadeRegex = @"^[.]";
 		public const string ComplexDatePeriodRegex = @"^[.]";
 		public static readonly string YearSuffix = $@"(,?\s*({YearRegex}|{FullTextYearRegex}))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string RelativeRegex = @"(?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b";
 		public const string WrittenOneToNineRegex = @"(uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)";
 		public const string WrittenOneHundredToNineHundredRegex = @"(cien|ciento|doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s)";
-		public static readonly string WrittenOneToNinetyNineRegex = $@"(uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+(WrittenOneToNineRegex))?))";
-		public static readonly string FullTextYearRegex = $@"(((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?(\s+{WrittenOneToNinetyNineRegex})?)";
+		public static readonly string WrittenOneToNinetyNineRegex = $@"(uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+{WrittenOneToNineRegex})?))";
+		public static readonly string FullTextYearRegex = $@"(((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex})?(\s+{WrittenOneToNinetyNineRegex})?)";
 		public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
 		public const string RelativeMonthRegex = @"(?<relmonth>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+mes)|(mes\s+((que\s+viene)|pasado)))\b";
 		public const string MonthRegex = @"\b(?<month>abril|abr|agosto|ago|diciembre|dic|febrero|feb|enero|ene|julio|jul|junio|jun|marzo|mar|mayo|may|noviembre|nov|octubre|oct|septiembre|setiembre|sept|set|sep)\b";
@@ -46,7 +46,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre|entre\s+el)\s+)({DayRegex})\s*{AndRegex}\s*({DayRegex})((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string DayBetweenRegex = $@"\b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b";
 		public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))";
-		public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
+		public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
 		public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex})";
 		public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
 		public static readonly string WeekOfYearRegex = $@"(?<woy>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima?|([12345]ª))\s+semana(\s+del?)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))";
@@ -55,13 +55,13 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string QuarterRegex = $@"(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3ro|cuarto|4to|((1|2|3|4)º))\s+(cuatrimestre|cuarto)((\s+de|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))?";
 		public static readonly string QuarterRegexYearFront = $@"({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año)\s+(el\s+)?(?<cardinal>(primer|primero)|1er|segundo|2do|(tercer|terceo)|3ro|cuarto|4to)\s+cuatrimestre";
 		public const string AllHalfYearRegex = @"^[.]";
-		public static readonly string EarlyPrefixRegex = $@"\b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b";
-		public const string MidPrefixRegex = @"^[.]";
-		public static readonly string LaterPrefixRegex = $@"\b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b";
+		public static readonly string EarlyPrefixRegex = $@"\b(?<EarlyPrefix>((comienzos|inicios)\s+({OfPrepositionRegex})))\b";
+		public static readonly string MidPrefixRegex = $@"\b(?<MidPrefix>(mediados\s+({OfPrepositionRegex})))\b";
+		public static readonly string LaterPrefixRegex = $@"\b(?<LatePrefix>((fines|finales)\s+({OfPrepositionRegex})))\b";
 		public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
 		public const string PrefixDayRegex = @"^[.]";
 		public const string CenturySuffixRegex = @"^[.]";
-		public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
+		public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente)|{PrefixPeriodRegex})\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
 		public const string WhichWeekRegex = @"(semana)(\s*)(?<number>\d\d|\d|0\d)";
 		public static readonly string WeekOfRegex = $@"((del|de|la|el)\s+)?(semana)(\s*)({OfPrepositionRegex})";
 		public static readonly string MonthOfRegex = $@"(mes)(\s+)({OfPrepositionRegex})";
@@ -193,7 +193,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string CenturyRegex = @"^[.]";
 		public const string DecadeRegex = @"(?<decade>diez|veinte|treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)";
 		public static readonly string DecadeWithCenturyRegex = $@"(los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))";
-		public const string RelativeDecadeRegex = @"^[.]";
+		public static readonly string RelativeDecadeRegex = $@"\b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b";
 		public const string ComplexDatePeriodRegex = @"^[.]";
 		public static readonly string YearSuffix = $@"(,?\s*({YearRegex}|{FullTextYearRegex}))";
 		public const string AgoRegex = @"\b(antes)\b";
@@ -450,9 +450,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public static readonly string PreviousPrefixRegex = $@"([uú]ltim[oa]|{PastPrefixRegex})\b";
 		public const string ThisPrefixRegex = @"(est[ea])\b";
 		public const string RelativeDayRegex = @"(?<relday>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+días)|(días\s+((que\s+viene)|pasado)))\b";
-		public const string RestOfDateRegex = @"\bresto\s+((del|de)\s+)?((la|el|est[ae])\s+)?(?<duration>semana|mes|año|decade)(\s+actual)?\b";
+		public const string RestOfDateRegex = @"\bresto\s+((del|de)\s+)?((la|el|est[ae])\s+)?(?<duration>semana|mes|año|decada)(\s+actual)?\b";
 		public const string RelativeDurationUnitRegex = @"^[\.]";
-		public const string ReferenceDatePeriodRegex = @"^[.]";
+		public const string ReferencePrefixRegex = @"(mism[ao]|aquel)\b";
+		public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+({DateUnitRegex}|fin\s+de\s+semana)\b";
 		public const string FromToRegex = @"\b(from).+(to)\b.+";
 		public const string SingleAmbiguousMonthRegex = @"^(the\s+)?(may|march)$";
 		public const string UnspecificDatePeriodRegex = @"^[.]";
@@ -465,7 +466,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 		public const string DurationConnectorRegex = @"^[.]";
 		public const string DateAfterRegex = @"^[.]";
 		public const string YearPeriodRegex = @"^[.]";
-		public const string FutureSuffixRegex = @"^[.]";
+		public const string FutureSuffixRegex = @"\b(despu[ée]s)\b";
 		public static readonly Dictionary<string, int> WrittenDecades = new Dictionary<string, int>
 		{
 			{ @"", 0 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -191,7 +191,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             WeekWithWeekDayRangeRegex,
             YearPlusNumberRegex,
             DecadeWithCenturyRegex,
-            RelativeDecadeRegex
+            RelativeDecadeRegex,
+            WhichWeekRegex,
+            ReferenceDatePeriodRegex
         };
 
         public SpanishDatePeriodExtractorConfiguration(IOptionsConfiguration config)

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -1,8 +1,6 @@
 ﻿---
 TillRegex: !simpleRegex
   def: (?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?
-OfPrepositionRegex: !simpleRegex
-  def: do|da|del|de
 AndRegex: !simpleRegex
   def: (?<and>y|y\s*el|--|-|—|——)
 DayRegex: !simpleRegex
@@ -21,6 +19,10 @@ AmPmDescRegex: !nestedRegex
 DescRegex: !nestedRegex
   def: (?<desc>({AmDescRegex}|{PmDescRegex}))
   references: [ AmDescRegex, PmDescRegex ]
+OfPrepositionRegex: !simpleRegex
+  def: (do|da|del|de)
+AfterNextSuffixRegex: !simpleRegex
+  def: \b(que\s+viene|pasad[oa])\b
 RangePrefixRegex: !simpleRegex
   def: ((desde|de|entre)\s+(la(s)?\s+)?)
 # As month number can't be 0, so add (?!\.0\b) to filter out some wrong cases
@@ -28,7 +30,7 @@ TwoDigitYearRegex: !nestedRegex
   def: \b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
-  def: (?<rela>((((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\s+)(semana|semanas|año|mes|días|fin\s+de\s+semana))|(fin\s+de\s+semana))|((fin de semana|semana|semanas|año|mes|días)\s+((que\s+viene)|pasado)))\b
+  def: (?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b
 FullTextYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[\*]
@@ -61,8 +63,8 @@ DayBetweenRegex: !nestedRegex
   def: \b((entre|entre\s+el)\s+)({DayRegex})(\s+{MonthSuffixRegex})?\s*{AndRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)(en\s+|del\s+|de\s+)?{YearRegex})?\b
   references: [ DayRegex, AndRegex, MonthSuffixRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?{RelativeRegex})
-  references: [MonthRegex, RelativeRegex, OfPrepositionRegex]
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))
+  references: [MonthRegex, RelativeRegex, OfPrepositionRegex, AfterNextSuffixRegex]
 MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
   references: [ MonthRegex, YearRegex ]
@@ -90,6 +92,18 @@ QuarterRegexYearFront: !nestedRegex
 AllHalfYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+EarlyPrefixRegex: !nestedRegex
+  def: \b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b
+  references: [OfPrepositionRegex]
+MidPrefixRegex: !simpleRegex
+  # TODO
+  def: ^[.]
+LaterPrefixRegex: !nestedRegex
+  def: \b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b
+  references: [OfPrepositionRegex]
+PrefixPeriodRegex: !nestedRegex
+  def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
+  references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
 PrefixDayRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -448,11 +462,13 @@ SetEachRegex: !nestedRegex
   def: (?<each>({EachExpression})\s*)
   references: [ EachExpression ]
 LaterEarlyPeriodRegex: !nestedRegex
-  def: \b((fines\s+({OfPrepositionRegex}))\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b
-  references: [OneWordPeriodRegex, UnspecificEndOfRangeRegex, OfPrepositionRegex]
-WeekWithWeekDayRangeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(({PrefixPeriodRegex})\s+(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b
+  references: [OneWordPeriodRegex, UnspecificEndOfRangeRegex, PrefixPeriodRegex]
+RelativeWeekRegex: !simpleRegex
+  def: (((la|el)\s+)?(((esta|este|pr[oó]xim[oa]|[uú]ltim(o|as|os))\s+semana(s)?)|(semana(s)?\s+(que\s+viene|pasad[oa]))))
+WeekWithWeekDayRangeRegex: !nestedRegex
+  def: \b((({RelativeWeekRegex})((\s+entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(\s+de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})))|((entre\s+{WeekDayRegex}\s+y\s+{WeekDayRegex})|(de\s+{WeekDayRegex}\s+a\s+{WeekDayRegex})){OfPrepositionRegex}\s+{RelativeWeekRegex})\b
+  references: [RelativeWeekRegex, WeekDayRegex, OfPrepositionRegex]
 GeneralEndingRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -465,9 +481,9 @@ PrefixArticleRegex: !simpleRegex
 OrRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
-YearPlusNumberRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+YearPlusNumberRegex: !nestedRegex
+  def: \b(años?\s+((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
+  references: [ FullTextYearRegex ]
 NumberAsTimeRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -36,10 +36,10 @@ WrittenOneToNineRegex: !simpleRegex
 WrittenOneHundredToNineHundredRegex: !simpleRegex
   def: (cien|ciento|doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s)
 WrittenOneToNinetyNineRegex: !nestedRegex
-  def: (uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+(WrittenOneToNineRegex))?))
+  def: (uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+{WrittenOneToNineRegex})?))
   references: [ WrittenOneToNineRegex ]
 FullTextYearRegex: !nestedRegex
-  def: (((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?(\s+{WrittenOneToNinetyNineRegex})?)
+  def: (((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex})?(\s+{WrittenOneToNinetyNineRegex})?)
   references: [ WrittenOneToNinetyNineRegex, WrittenOneHundredToNineHundredRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
@@ -73,7 +73,7 @@ OneWordPeriodRegex: !nestedRegex
   def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+))|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((la|el)\s+)?((({RelativeRegex}\s+)(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})?)|(semanas|semana|año|mes|días)(\s+{AfterNextSuffixRegex})))
   references: [MonthRegex, RelativeRegex, OfPrepositionRegex, AfterNextSuffixRegex]
 MonthWithYearRegex: !nestedRegex
-  def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
+  def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
   references: [ MonthRegex, YearRegex ]
 MonthNumWithYearRegex: !nestedRegex
   def: ({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex})
@@ -100,13 +100,13 @@ AllHalfYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 EarlyPrefixRegex: !nestedRegex
-  def: \b(?<EarlyPrefix>(comienzos\s+({OfPrepositionRegex})))\b
+  def: \b(?<EarlyPrefix>((comienzos|inicios)\s+({OfPrepositionRegex})))\b
   references: [OfPrepositionRegex]
-MidPrefixRegex: !simpleRegex
-  # TODO
-  def: ^[.]
+MidPrefixRegex: !nestedRegex
+  def: \b(?<MidPrefix>(mediados\s+({OfPrepositionRegex})))\b
+  references: [OfPrepositionRegex]
 LaterPrefixRegex: !nestedRegex
-  def: \b(?<LatePrefix>(fines\s+({OfPrepositionRegex})))\b
+  def: \b(?<LatePrefix>((fines|finales)\s+({OfPrepositionRegex})))\b
   references: [OfPrepositionRegex]
 PrefixPeriodRegex: !nestedRegex
   def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
@@ -118,8 +118,8 @@ CenturySuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 SeasonRegex: !nestedRegex
-  def: \b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente))\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b
-  references: [ YearRegex ]
+  def: \b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente)|{PrefixPeriodRegex})\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+del?|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b
+  references: [ YearRegex, PrefixPeriodRegex ]
 WhichWeekRegex: !simpleRegex
   def: (semana)(\s*)(?<number>\d\d|\d|0\d)
 WeekOfRegex: !nestedRegex
@@ -508,9 +508,9 @@ DecadeRegex: !simpleRegex
 DecadeWithCenturyRegex: !nestedRegex
   def: (los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))
   references: [ WrittenOneHundredToNineHundredRegex, DecadeRegex ]
-RelativeDecadeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+RelativeDecadeRegex: !nestedRegex
+  def: \b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b
+  references: [ RelativeRegex,WrittenOneToNineRegex ]
 ComplexDatePeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -789,13 +789,15 @@ ThisPrefixRegex: !simpleRegex
 RelativeDayRegex: !simpleRegex
   def: (?<relday>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+días)|(días\s+((que\s+viene)|pasado)))\b
 RestOfDateRegex: !simpleRegex
-  def: \bresto\s+((del|de)\s+)?((la|el|est[ae])\s+)?(?<duration>semana|mes|año|decade)(\s+actual)?\b
+  def: \bresto\s+((del|de)\s+)?((la|el|est[ae])\s+)?(?<duration>semana|mes|año|decada)(\s+actual)?\b
 RelativeDurationUnitRegex: !simpleRegex
   # TODO: change to Spanish according to corresponding Regex
   def: ^[\.]
-ReferenceDatePeriodRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+ReferencePrefixRegex: !simpleRegex
+  def: (mism[ao]|aquel)\b
+ReferenceDatePeriodRegex: !nestedRegex
+  def: \b{ReferencePrefixRegex}\s+({DateUnitRegex}|fin\s+de\s+semana)\b
+  references: [ReferencePrefixRegex, DateUnitRegex]
 FromToRegex: !simpleRegex
   # TODO: change to Spanish according to corresponding Regex
   def: \b(from).+(to)\b.+
@@ -831,8 +833,7 @@ YearPeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 FutureSuffixRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(despu[ée]s)\b
 WrittenDecades: !dictionary
   types: [ string, int ]
   # TODO: modify below dictionary according to the counterpart in English

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -31,9 +31,16 @@ TwoDigitYearRegex: !nestedRegex
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
   def: (?<rela>((esta|este|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fin(ales)?\s+de(\s+la)?)?)|(fin(ales)?\s+de(\s+la)?))\b
-FullTextYearRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[\*]
+WrittenOneToNineRegex: !simpleRegex
+  def: (uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)
+WrittenOneHundredToNineHundredRegex: !simpleRegex
+  def: (cien|ciento|doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s)
+WrittenOneToNinetyNineRegex: !nestedRegex
+  def: (uno|un|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+(WrittenOneToNineRegex))?))
+  references: [ WrittenOneToNineRegex ]
+FullTextYearRegex: !nestedRegex
+  def: (((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?(\s+{WrittenOneToNinetyNineRegex})?)
+  references: [ WrittenOneToNinetyNineRegex, WrittenOneHundredToNineHundredRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
@@ -69,7 +76,7 @@ MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|este|esta|[uú]ltim[oa]?)\s+)?({MonthRegex})\s+((de|del|de la)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
   references: [ MonthRegex, YearRegex ]
 MonthNumWithYearRegex: !nestedRegex
-  def: ({YearRegex}(\s*?)[/\-\.](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.](\s*?){YearRegex})
+  def: ({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex})
   references: [ YearRegex, MonthNumRegex ]
 WeekOfMonthRegex: !nestedRegex
   def: (?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima)\s+semana\s+{MonthSuffixRegex})
@@ -497,11 +504,10 @@ CenturyRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 DecadeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
-DecadeWithCenturyRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: (?<decade>diez|veinte|treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)
+DecadeWithCenturyRegex: !nestedRegex
+  def: (los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))
+  references: [ WrittenOneHundredToNineHundredRegex, DecadeRegex ]
 RelativeDecadeRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -503,6 +503,7 @@
   },
   {
     "Input": "Ya no estaré en ene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -515,6 +516,7 @@
   },
   {
     "Input": "Ya no estaré este ene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -527,6 +529,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de ene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -539,6 +542,7 @@
   },
   {
     "Input": "Ya no estaré el mes de ene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -551,6 +555,7 @@
   },
   {
     "Input": "No estuve en ene de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -563,6 +568,7 @@
   },
   {
     "Input": "No estuve ene 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -575,6 +581,7 @@
   },
   {
     "Input": "Ya no estaré en feb",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -587,6 +594,7 @@
   },
   {
     "Input": "Ya no estaré este feb",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -599,6 +607,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de feb",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -611,6 +620,7 @@
   },
   {
     "Input": "Ya no estaré el mes de feb",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -623,6 +633,7 @@
   },
   {
     "Input": "No estuve en feb de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -635,6 +646,7 @@
   },
   {
     "Input": "No estuve feb 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -647,6 +659,7 @@
   },
   {
     "Input": "Ya no estaré en mar",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -659,6 +672,7 @@
   },
   {
     "Input": "Ya no estaré este mar",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -671,6 +685,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de mar",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -683,6 +698,7 @@
   },
   {
     "Input": "Ya no estaré el mes de mar",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -695,6 +711,7 @@
   },
   {
     "Input": "No estuve en mar de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -707,6 +724,7 @@
   },
   {
     "Input": "No estuve mar 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -719,6 +737,7 @@
   },
   {
     "Input": "Ya no estaré en abr",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -731,6 +750,7 @@
   },
   {
     "Input": "Ya no estaré este abr",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -743,6 +763,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de abr",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -755,6 +776,7 @@
   },
   {
     "Input": "Ya no estaré el mes de abr",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -767,6 +789,7 @@
   },
   {
     "Input": "No estuve en abr de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -779,6 +802,7 @@
   },
   {
     "Input": "No estuve abr 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -791,6 +815,7 @@
   },
   {
     "Input": "Ya no estaré en mayo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -803,6 +828,7 @@
   },
   {
     "Input": "Ya no estaré este mayo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -815,6 +841,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de mayo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -827,6 +854,7 @@
   },
   {
     "Input": "Ya no estaré el mes de mayo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -839,6 +867,7 @@
   },
   {
     "Input": "No estuve en mayo de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -851,6 +880,7 @@
   },
   {
     "Input": "No estuve mayo 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -863,6 +893,7 @@
   },
   {
     "Input": "Ya no estaré en jun",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -875,6 +906,7 @@
   },
   {
     "Input": "Ya no estaré este jun",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -887,6 +919,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de jun",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -899,6 +932,7 @@
   },
   {
     "Input": "Ya no estaré el mes de jun",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -911,6 +945,7 @@
   },
   {
     "Input": "No estuve en jun de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -923,6 +958,7 @@
   },
   {
     "Input": "No estuve jun 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -935,6 +971,7 @@
   },
   {
     "Input": "Ya no estaré en jul",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -947,6 +984,7 @@
   },
   {
     "Input": "Ya no estaré este jul",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -959,6 +997,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de jul",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -971,6 +1010,7 @@
   },
   {
     "Input": "Ya no estaré el mes de jul",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -983,6 +1023,7 @@
   },
   {
     "Input": "No estuve en jul de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -995,6 +1036,7 @@
   },
   {
     "Input": "No estuve jul 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1007,6 +1049,7 @@
   },
   {
     "Input": "Ya no estaré en ago",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1019,6 +1062,7 @@
   },
   {
     "Input": "Ya no estaré este ago",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1031,6 +1075,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de ago",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1043,6 +1088,7 @@
   },
   {
     "Input": "Ya no estaré el mes de ago",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1055,6 +1101,7 @@
   },
   {
     "Input": "No estuve en ago de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1067,6 +1114,7 @@
   },
   {
     "Input": "No estuve ago 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1079,6 +1127,7 @@
   },
   {
     "Input": "Ya no estaré en sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1091,6 +1140,7 @@
   },
   {
     "Input": "Ya no estaré este sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1103,6 +1153,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1115,6 +1166,7 @@
   },
   {
     "Input": "Ya no estaré el mes de sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1127,6 +1179,7 @@
   },
   {
     "Input": "No estuve en sept de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1139,6 +1192,7 @@
   },
   {
     "Input": "No estuve sept 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1151,6 +1205,7 @@
   },
   {
     "Input": "Ya no estaré en sep",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1163,6 +1218,7 @@
   },
   {
     "Input": "Ya no estaré este sep",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1175,6 +1231,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de sep",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1187,6 +1244,7 @@
   },
   {
     "Input": "Ya no estaré el mes de sep",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1199,6 +1257,7 @@
   },
   {
     "Input": "No estuve en sep de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1211,6 +1270,7 @@
   },
   {
     "Input": "No estuve sep 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1223,6 +1283,7 @@
   },
   {
     "Input": "Ya no estaré en oct",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1235,6 +1296,7 @@
   },
   {
     "Input": "Ya no estaré este oct",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1247,6 +1309,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de oct",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1259,6 +1322,7 @@
   },
   {
     "Input": "Ya no estaré el mes de oct",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1271,6 +1335,7 @@
   },
   {
     "Input": "No estuve en oct de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1283,6 +1348,7 @@
   },
   {
     "Input": "No estuve oct 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1295,6 +1361,7 @@
   },
   {
     "Input": "Ya no estaré en nov",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1307,6 +1374,7 @@
   },
   {
     "Input": "Ya no estaré este nov",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1319,6 +1387,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de nov",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1331,6 +1400,7 @@
   },
   {
     "Input": "Ya no estaré el mes de nov",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1343,6 +1413,7 @@
   },
   {
     "Input": "No estuve en nov de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1355,6 +1426,7 @@
   },
   {
     "Input": "No estuve nov 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1367,6 +1439,7 @@
   },
   {
     "Input": "Ya no estaré en dic",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1379,6 +1452,7 @@
   },
   {
     "Input": "Ya no estaré este dic",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1391,6 +1465,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de dic",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1403,6 +1478,7 @@
   },
   {
     "Input": "Ya no estaré el mes de dic",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1415,6 +1491,7 @@
   },
   {
     "Input": "No estuve en dic de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1427,6 +1504,7 @@
   },
   {
     "Input": "No estuve dic 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1439,6 +1517,7 @@
   },
   {
     "Input": "Ya no estaré en enero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1451,6 +1530,7 @@
   },
   {
     "Input": "Ya no estaré este enero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1463,6 +1543,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de enero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1475,6 +1556,7 @@
   },
   {
     "Input": "Ya no estaré el mes de enero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1487,6 +1569,7 @@
   },
   {
     "Input": "No estuve en enero de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1499,6 +1582,7 @@
   },
   {
     "Input": "No estuve enero 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1511,6 +1595,7 @@
   },
   {
     "Input": "Ya no estaré en febrero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1523,6 +1608,7 @@
   },
   {
     "Input": "Ya no estaré este febrero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1535,6 +1621,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de febrero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1547,6 +1634,7 @@
   },
   {
     "Input": "Ya no estaré el mes de febrero",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1559,6 +1647,7 @@
   },
   {
     "Input": "No estuve en febrero de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1571,6 +1660,7 @@
   },
   {
     "Input": "No estuve febrero 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1583,6 +1673,7 @@
   },
   {
     "Input": "Ya no estaré en marzo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1595,6 +1686,7 @@
   },
   {
     "Input": "Ya no estaré este marzo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1607,6 +1699,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de marzo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1619,6 +1712,7 @@
   },
   {
     "Input": "Ya no estaré el mes de marzo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1631,6 +1725,7 @@
   },
   {
     "Input": "No estuve en marzo de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1643,6 +1738,7 @@
   },
   {
     "Input": "No estuve marzo 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1655,6 +1751,7 @@
   },
   {
     "Input": "Ya no estaré en junio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1667,6 +1764,7 @@
   },
   {
     "Input": "Ya no estaré este junio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1679,6 +1777,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de junio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1691,6 +1790,7 @@
   },
   {
     "Input": "Ya no estaré el mes de junio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1703,6 +1803,7 @@
   },
   {
     "Input": "No estuve en junio de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1715,6 +1816,7 @@
   },
   {
     "Input": "No estuve junio 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1727,6 +1829,7 @@
   },
   {
     "Input": "Ya no estaré en julio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1739,6 +1842,7 @@
   },
   {
     "Input": "Ya no estaré este julio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1751,6 +1855,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de julio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1763,6 +1868,7 @@
   },
   {
     "Input": "Ya no estaré el mes de julio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1775,6 +1881,7 @@
   },
   {
     "Input": "No estuve en julio de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1787,6 +1894,7 @@
   },
   {
     "Input": "No estuve julio 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1799,6 +1907,7 @@
   },
   {
     "Input": "Ya no estaré en agosto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1811,6 +1920,7 @@
   },
   {
     "Input": "Ya no estaré este agosto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1823,6 +1933,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de agosto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1835,6 +1946,7 @@
   },
   {
     "Input": "Ya no estaré el mes de agosto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1847,6 +1959,7 @@
   },
   {
     "Input": "No estuve en agosto de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1859,6 +1972,7 @@
   },
   {
     "Input": "No estuve agosto 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1871,6 +1985,7 @@
   },
   {
     "Input": "Ya no estaré en septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1883,6 +1998,7 @@
   },
   {
     "Input": "Ya no estaré este septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1895,6 +2011,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1907,6 +2024,7 @@
   },
   {
     "Input": "Ya no estaré el mes de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1919,6 +2037,7 @@
   },
   {
     "Input": "No estuve en septiembre de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1931,6 +2050,7 @@
   },
   {
     "Input": "No estuve septiembre 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1943,6 +2063,7 @@
   },
   {
     "Input": "Ya no estaré en octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1955,6 +2076,7 @@
   },
   {
     "Input": "Ya no estaré este octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1967,6 +2089,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1979,6 +2102,7 @@
   },
   {
     "Input": "Ya no estaré el mes de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -1991,6 +2115,7 @@
   },
   {
     "Input": "No estuve en octubre de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2003,6 +2128,7 @@
   },
   {
     "Input": "No estuve octubre 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2015,6 +2141,7 @@
   },
   {
     "Input": "Ya no estaré en diciembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2027,6 +2154,7 @@
   },
   {
     "Input": "Ya no estaré este diciembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2039,6 +2167,7 @@
   },
   {
     "Input": "Ya no estaré en el mes de diciembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2051,6 +2180,7 @@
   },
   {
     "Input": "Ya no estaré el mes de diciembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2063,6 +2193,7 @@
   },
   {
     "Input": "No estuve en diciembre de 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2075,6 +2206,7 @@
   },
   {
     "Input": "No estuve diciembre 2001",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2087,6 +2219,7 @@
   },
   {
     "Input": "Calendario para el mes de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2099,6 +2232,7 @@
   },
   {
     "Input": "Ya no estaré del 4 al 22 de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2111,6 +2245,7 @@
   },
   {
     "Input": "Ya no estaré de 4-23 del próximo mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2123,6 +2258,7 @@
   },
   {
     "Input": "Ya no estaré desde el 3 hasta el 12 de sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2135,6 +2271,7 @@
   },
   {
     "Input": "Ya no estaré de 4 a 23 del mes que viene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2147,6 +2284,7 @@
   },
   {
     "Input": "Ya no estaré desde 4 hasta 23 de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2159,6 +2297,7 @@
   },
   {
     "Input": "Ya no estaré entre 4 y 22 de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2171,6 +2310,7 @@
   },
   {
     "Input": "Ya no estaré entre el 3 y el 12 de sept jajaja",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2183,6 +2323,7 @@
   },
   {
     "Input": "Ya no estaré entre el 4 de septiembre y el 8 de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2195,6 +2336,7 @@
   },
   {
     "Input": "Ya no estaré entre el 15 y el 19 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2207,6 +2349,7 @@
   },
   {
     "Input": "Ya no estaré entre 15 y 19 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2219,6 +2362,7 @@
   },
   {
     "Input": "Ya no estaré desde el 15 hasta el 19 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2231,6 +2375,7 @@
   },
   {
     "Input": "Ya no estaré del 4 al 22 de enero de 2017",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2243,6 +2388,7 @@
   },
   {
     "Input": "Ya no estaré entre 4-22 de enero de 2017",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2255,6 +2401,7 @@
   },
   {
     "Input": "Ya no estaré esta semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2267,6 +2414,7 @@
   },
   {
     "Input": "Ya no estaré la semana que viene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2279,6 +2427,7 @@
   },
   {
     "Input": "Ya no estaré el último sept",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2291,6 +2440,7 @@
   },
   {
     "Input": "Ya no estaré el próximo junio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2303,6 +2453,7 @@
   },
   {
     "Input": "Ya no estaré en junio 2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2315,6 +2466,7 @@
   },
   {
     "Input": "Ya no estaré en junio del próximo año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2327,6 +2479,7 @@
   },
   {
     "Input": "Ya no estaré este fin de semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2339,6 +2492,7 @@
   },
   {
     "Input": "Ya no estaré la tercera semana de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2351,6 +2505,7 @@
   },
   {
     "Input": "Ya no estaré en la última semana de julio",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2363,6 +2518,7 @@
   },
   {
     "Input": "Programa camping de viernes a domingo",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2375,6 +2531,7 @@
   },
   {
     "Input": "Ya no estaré los 3 días siguientes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2387,6 +2544,7 @@
   },
   {
     "Input": "Ya no estaré en los 3 meses siguientes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2414,6 +2572,7 @@
   },
   {
     "Input": "Ya no estuve en las últimas 3 semanas",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2426,6 +2585,7 @@
   },
   {
     "Input": "Ya no estuve los últimos 3 años",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2438,6 +2598,7 @@
   },
   {
     "Input": "Ya no estuve el año pasado",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2450,6 +2611,7 @@
   },
   {
     "Input": "Ya no estuve el mes pasado",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2462,6 +2624,7 @@
   },
   {
     "Input": "Ya no estuve en las 3 semanas anteriores",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2474,6 +2637,7 @@
   },
   {
     "Input": "últimas semanas",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2486,6 +2650,7 @@
   },
   {
     "Input": "últimos días",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2498,6 +2663,7 @@
   },
   {
     "Input": "Ya no estaré de 2 de oct a 22 de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2510,6 +2676,7 @@
   },
   {
     "Input": "Ya no estaré 12 de ene de 2016-22/2/2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2522,6 +2689,7 @@
   },
   {
     "Input": "Ya no estaré desde 1 ene hasta miércoles 22 de ene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2534,6 +2702,7 @@
   },
   {
     "Input": "Ya no estaré desde hoy hasta mañana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2546,6 +2715,7 @@
   },
   {
     "Input": "Ya no estaré de hoy a 22 de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2558,6 +2728,7 @@
   },
   {
     "Input": "Ya no estaré desde 2 oct hasta pasado mañana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2570,6 +2741,7 @@
   },
   {
     "Input": "Ya no estaré desde hoy hasta próximo sábado",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2582,6 +2754,7 @@
   },
   {
     "Input": "Ya no estaré de este viernes al próximo sábado",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2594,6 +2767,7 @@
   },
   {
     "Input": "Ya no estaré desde 2 oct hasta 22 de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2606,6 +2780,7 @@
   },
   {
     "Input": "Ya no estaré desde 12/8/2015 hasta 22 de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2634,6 +2809,7 @@
   },
   {
     "Input": "Ya no estaré de hoy a mañana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2646,6 +2822,7 @@
   },
   {
     "Input": "Ya no estaré desde este viernes hasta el próximo sábado",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2658,6 +2835,7 @@
   },
   {
     "Input": "Ya no estaré entre 2 de oct y 22 de octubre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2670,6 +2848,7 @@
   },
   {
     "Input": "Ya no estaré 19-20 noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2682,6 +2861,7 @@
   },
   {
     "Input": "Ya no estaré de 19 a 20 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2694,6 +2874,7 @@
   },
   {
     "Input": "Ya no estaré entre 19 y 20 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2706,6 +2887,7 @@
   },
   {
     "Input": "Ya no estaré en el tercer cuarto de 2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2718,6 +2900,7 @@
   },
   {
     "Input": "Ya no estaré el tercer cuarto de este año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2730,6 +2913,7 @@
   },
   {
     "Input": "Ya no estaré tercer cuarto de 2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2742,6 +2926,7 @@
   },
   {
     "Input": "Volveré en el 1º cuarto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2754,6 +2939,7 @@
   },
   {
     "Input": "Ya no estaré en el 3º cuarto",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2766,6 +2952,7 @@
   },
   {
     "Input": "Ya no estaré 3.2015",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2778,6 +2965,7 @@
   },
   {
     "Input": "Ya no estaré 3-2015",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2790,6 +2978,7 @@
   },
   {
     "Input": "Ya no estaré 3/2015",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2802,8 +2991,8 @@
   },
   {
     "Input": "Ya no estaré 3/15",
-    "NotSupported": "dotnet, java",
-    "NotSupportedByDesign": "javascript, python",
+    "Comment": "Won't fix, 3/15 is date not date period",
+    "NotSupported": "dotnet, java, javascript, python",
     "Results": [
       {
         "Text": "3/15",
@@ -2815,6 +3004,7 @@
   },
   {
     "Input": "Ya no estaré en la 3ª semana de 2027",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2827,6 +3017,7 @@
   },
   {
     "Input": "Ya no estaré en la 3ª semana del próximo año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2839,6 +3030,7 @@
   },
   {
     "Input": "Me iré este verano",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2851,6 +3043,7 @@
   },
   {
     "Input": "Me iré la próxima primavera",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2863,6 +3056,7 @@
   },
   {
     "Input": "Me iré en el verano",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2875,6 +3069,7 @@
   },
   {
     "Input": "Me iré en verano",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2887,6 +3082,7 @@
   },
   {
     "Input": "Me iré en verano 2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2899,6 +3095,7 @@
   },
   {
     "Input": "Me iré en el verano de 2016",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2911,6 +3108,7 @@
   },
   {
     "Input": "vacacione en el mes que viene",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2923,6 +3121,7 @@
   },
   {
     "Input": "vacaciones en el próximo mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2935,6 +3134,7 @@
   },
   {
     "Input": "Qué tengo para la semana de 30 de noviembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2947,6 +3147,7 @@
   },
   {
     "Input": "la semana del 15 de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2959,6 +3160,7 @@
   },
   {
     "Input": "semana de 15 septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2971,6 +3173,7 @@
   },
   {
     "Input": "mes del 15 de septiembre",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2983,6 +3186,7 @@
   },
   {
     "Input": "Me iré en el fin de semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -2995,6 +3199,7 @@
   },
   {
     "Input": "Me iré en el resto de la semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3007,6 +3212,7 @@
   },
   {
     "Input": "Me iré resto de la semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3019,6 +3225,7 @@
   },
   {
     "Input": "Me iré en el resto de semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3031,6 +3238,7 @@
   },
   {
     "Input": "Me iré resto de semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3043,6 +3251,7 @@
   },
   {
     "Input": "Me iré en el resto de esta semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3055,6 +3264,7 @@
   },
   {
     "Input": "Me iré en el resto de la semana actual",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3067,6 +3277,7 @@
   },
   {
     "Input": "Me iré en el resto del mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3079,6 +3290,7 @@
   },
   {
     "Input": "Me iré en el resto del año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3091,6 +3303,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para fines de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3103,6 +3316,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para fines de esta semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3115,6 +3329,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para fines de la próxima semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3127,6 +3342,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para fines del próximo año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3139,6 +3355,7 @@
   },
   {
     "Input": "Nos vimos a finales de la semana pasada",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3151,6 +3368,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de este mes",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3163,6 +3381,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de esta semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3175,6 +3394,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de la próxima semana",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3187,6 +3407,7 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos del próximo año",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3199,6 +3420,7 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio entre miércoles y viernes de la próxima semana.",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3211,6 +3433,7 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la próxima semana entre miércoles y viernes.",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3223,6 +3446,7 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la semana pasada de miércoles a viernes.",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3235,6 +3459,7 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para esta semana entre miércoles y viernes.",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3247,7 +3472,7 @@
   },
   {
     "Input": "Ya no estaré en el año 247",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3260,6 +3485,7 @@
   },
   {
     "Input": "en los años 1970",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3272,6 +3498,7 @@
   },
   {
     "Input": "Nació en los años 2000",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3284,7 +3511,7 @@
   },
   {
     "Input": "en la década de 1970",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3297,6 +3524,7 @@
   },
   {
     "Input": "en los años 70",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3309,20 +3537,21 @@
   },
   {
     "Input": "en los 70",
-    "NotSupported": "dotnet, java",
-    "NotSupportedByDesign": "javascript, python",
+    "NotSupported": "java",
+    "Comment": "Won't fix, because 'los 70' has ambiguity, will be extracted as number or datetime",
+    "NotSupported": "javascript, python, dotnet, java",
     "Results": [
       {
         "Text": "los 70",
         "Type": "daterange",
         "Start": 3,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
   {
     "Input": "en la década 40",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3335,73 +3564,74 @@
   },
   {
     "Input": "en los años setenta",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "años setenta",
+        "Text": "los años setenta",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 12
+        "Start": 3,
+        "Length": 16
       }
     ]
   },
   {
     "Input": "en los años mil novecientos sesenta",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "años mil novecientos sesenta",
+        "Text": "los años mil novecientos sesenta",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 28
+        "Start": 3,
+        "Length": 32
       }
     ]
   },
   {
     "Input": "en los años dos mil diez",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "años dos mil diez",
+        "Text": "los años dos mil diez",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 17
+        "Start": 3,
+        "Length": 21
       }
     ]
   },
   {
     "Input": "en los años diez",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "años diez",
+        "Text": "los años diez",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 9
+        "Start": 3,
+        "Length": 13
       }
     ]
   },
   {
     "Input": "en los años dos mil",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "años dos mil",
+        "Text": "los años dos mil",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 12
+        "Start": 3,
+        "Length": 16
       }
     ]
   },
   {
     "Input": "en los noventa",
-    "NotSupported": "dotnet, java",
-    "NotSupportedByDesign": "javascript, python",
+    "NotSupported": "java",
+    "Comment": "Won't fix, because 'los noventa' has ambiguity, will be extracted as number or datetime",
+    "NotSupported": "javascript, python, dotnet, java",
     "Results": [
       {
         "Text": "los noventa",
@@ -3413,7 +3643,7 @@
   },
   {
     "Input": "Ya no estaré de 2 a 7 de feb de dos mil dieciocho",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3426,7 +3656,7 @@
   },
   {
     "Input": "Ya no estaré entre 2 y 7 de feb de dos mil dieciocho",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3439,7 +3669,7 @@
   },
   {
     "Input": "Ya no estaré entre 2-7 de feb de dos mil dieciocho",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3478,7 +3708,7 @@
   },
   {
     "Input": "Ya no estaré en la primera semana de dos mil veintisiete",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3491,7 +3721,7 @@
   },
   {
     "Input": "Ya no estaré en el 1º cuarto de dos mil veinte",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3712,7 +3942,7 @@
   },
   {
     "Input": "Ya no estaré 11 -2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3725,7 +3955,7 @@
   },
   {
     "Input": "Ya no estaré 11- 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3738,7 +3968,7 @@
   },
   {
     "Input": "Ya no estaré 11 / 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3751,7 +3981,7 @@
   },
   {
     "Input": "Ya no estaré 11/2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3764,7 +3994,7 @@
   },
   {
     "Input": "Ya no estaré 11 - 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3777,7 +4007,7 @@
   },
   {
     "Input": "Ya no estaré 11-2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3790,7 +4020,7 @@
   },
   {
     "Input": "Ya no estaré 11. 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3803,7 +4033,7 @@
   },
   {
     "Input": "Ya no estaré 11 .2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3816,20 +4046,20 @@
   },
   {
     "Input": "Ya no estaré 11 . 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
         "Text": "11 . 2016",
         "Type": "daterange",
-        "Start": 12,
+        "Start": 13,
         "Length": 9
       }
     ]
   },
   {
     "Input": "Ya no estaré 11.2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3842,7 +4072,7 @@
   },
   {
     "Input": "Ya no estaré 11~ 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3855,7 +4085,7 @@
   },
   {
     "Input": "Ya no estaré 11 ~2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3868,20 +4098,20 @@
   },
   {
     "Input": "Ya no estaré 11 ~ 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
         "Text": "11 ~ 2016",
         "Type": "daterange",
-        "Start": 12,
+        "Start": 13,
         "Length": 9
       }
     ]
   },
   {
     "Input": "Ya no estaré 11~2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -3537,7 +3537,6 @@
   },
   {
     "Input": "en los 70",
-    "NotSupported": "java",
     "Comment": "Won't fix, because 'los 70' has ambiguity, will be extracted as number or datetime",
     "NotSupported": "javascript, python, dotnet, java",
     "Results": [
@@ -3682,7 +3681,7 @@
   },
   {
     "Input": "Ocurrió en junio de mil novecientos noventa y nueve",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3734,20 +3733,20 @@
   },
   {
     "Input": "En la primavera de mil novecientos setenta y ocho",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "primavera de mil novecientos setenta y ocho",
+        "Text": "la primavera de mil novecientos setenta y ocho",
         "Type": "daterange",
-        "Start": 6,
-        "Length": 43
+        "Start": 3,
+        "Length": 46
       }
     ]
   },
   {
     "Input": "Año dos mil sesenta y siete,",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3760,7 +3759,7 @@
   },
   {
     "Input": "Ya no estaré en dos semanas",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3773,46 +3772,46 @@
   },
   {
     "Input": "Ocurrió en las últimas 2 décadas",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "últimas 2 décadas",
+        "Text": "las últimas 2 décadas",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 17
+        "Start": 11,
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ocurrió en las últimas dos décadas",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "últimas dos décadas",
+        "Text": "las últimas dos décadas",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 19
+        "Start": 11,
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ocurrirá en la próxima década",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "próxima década",
+        "Text": "la próxima década",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 14
+        "Start": 12,
+        "Length": 17
       }
     ]
   },
   {
     "Input": "Ocurrirá en 4 semanas",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3825,7 +3824,7 @@
   },
   {
     "Input": "Ocurrirá 2 días después",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3838,7 +3837,7 @@
   },
   {
     "Input": "Cortana puede buscarnos un tiempo para inicios de la próxima semana",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3851,7 +3850,7 @@
   },
   {
     "Input": "Claro, vamos a hablar por skype a finales de próxima semana",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3864,7 +3863,7 @@
   },
   {
     "Input": "Claro, vamos a hablar por skype a comienzos de próxima semana",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3877,7 +3876,7 @@
   },
   {
     "Input": "Cortana, búscanos un tiempo a finales de marzo",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3890,7 +3889,7 @@
   },
   {
     "Input": "Cortana, búscanos un tiempo a mediados de la próxima semana",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3903,7 +3902,7 @@
   },
   {
     "Input": "cortana puede buscarnos un tiempo para vernos a mediados de marzo",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3916,7 +3915,7 @@
   },
   {
     "Input": "qué tal a mediados de verano?",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3929,7 +3928,7 @@
   },
   {
     "Input": "Yo puedo fijar un tiempo para nosotros a comienzos de la semana que viene",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4124,7 +4123,7 @@
   },
   {
     "Input": "Ya no estaré noviembre 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4137,7 +4136,7 @@
   },
   {
     "Input": "Ya no estaré noviembre , 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4150,11 +4149,11 @@
   },
   {
     "Input": "Ya no estaré nov de 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "nov , 2016",
+        "Text": "nov de 2016",
         "Type": "daterange",
         "Start": 13,
         "Length": 11
@@ -4163,7 +4162,7 @@
   },
   {
     "Input": "Ya no estaré nov, 2016",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4176,7 +4175,7 @@
   },
   {
     "Input": "Ya no estaré entre 1 de enero y 5 de enero",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4189,7 +4188,7 @@
   },
   {
     "Input": "Ya no estaré entre 1 de enero de 2015 y 5 de febrero de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4202,7 +4201,7 @@
   },
   {
     "Input": "Ya no estaré entre 1 de enero de 2015 y feb de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4215,7 +4214,7 @@
   },
   {
     "Input": "Ya no estaré entre 2015 y feb de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4228,7 +4227,7 @@
   },
   {
     "Input": "Ya no estaré desde 1 de feb hasta marzo de 2019",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4241,7 +4240,7 @@
   },
   {
     "Input": "Ya no estaré entre 1 de feb y marzo de 2019",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4254,7 +4253,7 @@
   },
   {
     "Input": "Ya no estaré entre junio de 2015 y mayo de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4267,7 +4266,7 @@
   },
   {
     "Input": "Ya no estaré entre mayo de 2015 y 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4280,7 +4279,7 @@
   },
   {
     "Input": "Ya no estaré desde mayo de 2015 hasta 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4293,7 +4292,7 @@
   },
   {
     "Input": "Ya no estaré entre mayo de 2015 y junio de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4306,7 +4305,7 @@
   },
   {
     "Input": "Ya no estaré entre 2015 y 5 de enero de 2018",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4319,7 +4318,7 @@
   },
   {
     "Input": "Ya no estaré desde 2015 hasta 5 de mayo de 2017",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4332,7 +4331,7 @@
   },
   {
     "Input": "Ya no estaré desde el último lunes de enero hasta 2019",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4345,7 +4344,7 @@
   },
   {
     "Input": "Ya no estaré desde semana 31 hasta semana 35",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4358,7 +4357,7 @@
   },
   {
     "Input": "Ya no estaré entre semana 31 y semana 35",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4384,7 +4383,7 @@
   },
   {
     "Input": "Cuánto es mi bono de enero de 2017?",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4397,7 +4396,7 @@
   },
   {
     "Input": "No estuve allí el mismo mes en que ocurrió eso.",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4410,7 +4409,7 @@
   },
   {
     "Input": "No estuve allí la misma semana en que ocurrió eso.",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -4423,7 +4422,7 @@
   },
   {
     "Input": "No estuve allí aquel año.",
-    "NotSupported": "dotnet, java",
+    "NotSupported": "java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {

--- a/Specs/DateTime/Spanish/DatePeriodExtractor.json
+++ b/Specs/DateTime/Spanish/DatePeriodExtractor.json
@@ -3139,7 +3139,6 @@
   },
   {
     "Input": "Nos vimos a finales de la semana pasada",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3152,7 +3151,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de este mes",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3165,7 +3163,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de esta semana",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3178,7 +3175,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos de la próxima semana",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3191,7 +3187,6 @@
   },
   {
     "Input": "Búscanos un tiempo conveniente para comienzos del próximo año",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3204,7 +3199,6 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio entre miércoles y viernes de la próxima semana.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3217,33 +3211,30 @@
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la próxima semana entre miércoles y viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "próxima semana entre miércoles y viernes",
+        "Text": "la próxima semana entre miércoles y viernes",
         "Type": "daterange",
-        "Start": 64,
-        "Length": 40
+        "Start": 61,
+        "Length": 43
       }
     ]
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para la semana pasada de miércoles a viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
-        "Text": "semana pasada de miércoles a viernes",
+        "Text": "la semana pasada de miércoles a viernes",
         "Type": "daterange",
-        "Start": 64,
-        "Length": 36
+        "Start": 61,
+        "Length": 39
       }
     ]
   },
   {
     "Input": "Cortana, programa una reunión de 25 minutos con Antonio para esta semana entre miércoles y viernes.",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3269,7 +3260,6 @@
   },
   {
     "Input": "en los años 1970",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3282,7 +3272,6 @@
   },
   {
     "Input": "Nació en los años 2000",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
@@ -3308,14 +3297,13 @@
   },
   {
     "Input": "en los años 70",
-    "NotSupported": "dotnet, java",
     "NotSupportedByDesign": "javascript, python",
     "Results": [
       {
         "Text": "años 70",
         "Type": "daterange",
         "Start": 7,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -3328,7 +3316,7 @@
         "Text": "los 70",
         "Type": "daterange",
         "Start": 3,
-        "Length": 6
+        "Length": 7
       }
     ]
   },


### PR DESCRIPTION
DatePeriodExtractor: ❌(19 of 365 still unsupported)

Fix Spanish DatePeriod cases below type.
1.Related date Such as "misma semana"," aquel año" .
2.Daterange about week such as "entre semana 31 y semana 35"
3.noviembre , 2016
4.year range such as "de mil novecientos setenta y ocho"
5.number + $datetype  such as "dos semanas", "últimas 2 décadas"
6.finales de próxima semana,a mediados de la próxima semana