### PR TITLE
Fix wrongly extracted DateRange in dash-separated sequence

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -301,6 +301,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -301,6 +301,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -214,6 +214,29 @@ namespace Microsoft.Recognizers.Text.DateTime
                     // Possibly include period end only apply for cases like "2014-2018", which are not single year cases
                     metadata.PossiblyIncludePeriodEnd = false;
                 }
+                else
+                {
+                    var yearMatches = this.config.YearRegex.Matches(match.Value);
+                    var allDigitYear = true;
+
+                    foreach (Match yearMatch in yearMatches)
+                    {
+                        if (yearMatch.Length != Constants.FourDigitsYearLength)
+                        {
+                            allDigitYear = false;
+                        }
+                    }
+
+                    // Cases like "2010-2015"
+                    if (allDigitYear)
+                    {
+                        // Filter out cases like "82-2010-2015" or "2010-2015-82" where "2010-2015" should not be extracted as a DateRange
+                        if (HasInvalidDashContext(match, text))
+                        {
+                            continue;
+                        }
+                    }
+                }
 
                 ret.Add(new Token(match.Index, match.Index + match.Length, metadata));
             }
@@ -239,11 +262,20 @@ namespace Microsoft.Recognizers.Text.DateTime
                         }
                     }
 
-                    // handle single year which is surrounded by '-' at both sides, e.g., a single year falls in a GUID
-                    if (match.Length == Constants.FourDigitsYearLength && this.config.YearRegex.IsMatch(match.Value) && InfixBoundaryCheck(match, text))
+                    if (match.Length == Constants.FourDigitsYearLength && this.config.YearRegex.IsMatch(match.Value))
                     {
-                        var substr = text.Substring(match.Index - 1, 6);
-                        if (this.config.IllegalYearRegex.IsMatch(substr))
+                        // handle single year which is surrounded by '-' at both sides, e.g., a single year falls in a GUID
+                        if (InfixBoundaryCheck(match, text))
+                        {
+                            var substr = text.Substring(match.Index - 1, 6);
+                            if (this.config.IllegalYearRegex.IsMatch(substr))
+                            {
+                                continue;
+                            }
+                        }
+
+                        // filter out cases like "82-2010", "2010-82" where "2010" should not be extracted as DateRange
+                        if (HasInvalidDashContext(match, text))
                         {
                             continue;
                         }
@@ -254,6 +286,44 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return ret;
+        }
+
+        private bool HasInvalidDashContext(Match match, string text)
+        {
+            var hasInvalidDashContext = false;
+
+            // Filter out cases like "82-2100" where "2100" should not be extracted as a DateRange
+            // Filter out cases like "82-2010-2015" where "2010-2015" should not be extracted as a DateRange
+            if (HasDashPrefix(match, text, out int dashPrefixIndex))
+            {
+                if (HasDigitNumberBeforeDash(text, dashPrefixIndex, out int numberStartIndex))
+                {
+                    var digitNumberStr = text.Substring(numberStartIndex, match.Index - 1 - numberStartIndex);
+
+                    if (!this.config.MonthNumRegex.IsExactMatch(digitNumberStr, trim: true))
+                    {
+                        hasInvalidDashContext = true;
+                    }
+                }
+            }
+
+            // Filter out cases like "2100-82" where "2100" should not be extracted as a DateRange
+            // Filter out cases like "2010-2015-82" where "2010-2015" should not be extracted as a DateRange
+            if (HasDashSuffix(match, text, out int dashSuffixIndex))
+            {
+                if (HasDigitNumberAfterDash(text, dashSuffixIndex, out int numberEndIndex))
+                {
+                    var numberStartIndex = match.Index + match.Length + 1;
+                    var digitNumberStr = text.Substring(numberStartIndex, numberEndIndex - numberStartIndex);
+
+                    if (!this.config.MonthNumRegex.IsExactMatch(digitNumberStr, trim: true))
+                    {
+                        hasInvalidDashContext = true;
+                    }
+                }
+            }
+
+            return hasInvalidDashContext;
         }
 
         // Complex cases refer to the combination of daterange and datepoint
@@ -456,6 +526,127 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return isMatchInfixOfSource;
+        }
+
+        private bool IsDigitChar(char ch)
+        {
+            return ch >= '0' && ch <= '9';
+        }
+
+        private bool HasDashPrefix(Match match, string source, out int dashPrefixIndex)
+        {
+            bool hasDashPrefix = false;
+            dashPrefixIndex = -1;
+
+            for (var i = match.Index - 1; i >= 0; i--)
+            {
+                if (source[i] != ' ' && source[i] != '-')
+                {
+                    break;
+                }
+                else if (source[i] == '-')
+                {
+                    hasDashPrefix = true;
+                    dashPrefixIndex = i;
+                    break;
+                }
+            }
+
+            return hasDashPrefix;
+        }
+
+        private bool HasDigitNumberBeforeDash(string source, int dashPrefixIndex, out int numberStartIndex)
+        {
+            bool hasDigitNumberBeforeDash = false;
+            numberStartIndex = -1;
+
+            for (var i = dashPrefixIndex - 1; i >= 0; i--)
+            {
+                if (source[i] == ' ')
+                {
+                    continue;
+                }
+
+                if (IsDigitChar(source[i]))
+                {
+                    hasDigitNumberBeforeDash = true;
+                }
+
+                if (!IsDigitChar(source[i]))
+                {
+                    if (hasDigitNumberBeforeDash)
+                    {
+                        numberStartIndex = i + 1;
+                    }
+
+                    break;
+                }
+            }
+
+            if (hasDigitNumberBeforeDash && numberStartIndex == -1)
+            {
+                numberStartIndex = 0;
+            }
+
+            return hasDigitNumberBeforeDash;
+        }
+
+        private bool HasDashSuffix(Match match, string source, out int dashSuffixIndex)
+        {
+            bool hasDashSuffix = false;
+            dashSuffixIndex = -1;
+
+            for (var i = match.Index + match.Length; i < source.Length; i++)
+            {
+                if (source[i] != ' ' && source[i] != '-')
+                {
+                    break;
+                }
+                else if (source[i] == '-')
+                {
+                    hasDashSuffix = true;
+                    dashSuffixIndex = i;
+                    break;
+                }
+            }
+
+            return hasDashSuffix;
+        }
+
+        private bool HasDigitNumberAfterDash(string source, int dashSuffixIndex, out int numberEndIndex)
+        {
+            bool hasDigitNumberAfterDash = false;
+            numberEndIndex = -1;
+
+            for (var i = dashSuffixIndex + 1; i < source.Length; i++)
+            {
+                if (source[i] == ' ')
+                {
+                    continue;
+                }
+
+                if (IsDigitChar(source[i]))
+                {
+                    hasDigitNumberAfterDash = true;
+                }
+
+                if (!IsDigitChar(source[i]))
+                {
+                    if (hasDigitNumberAfterDash)
+                    {
+                        numberEndIndex = i;
+                    }
+
+                    break;
+                }
+            }
+
+            if (hasDigitNumberAfterDash && numberEndIndex == -1)
+            {
+                numberEndIndex = source.Length;
+            }
+
+            return hasDigitNumberAfterDash;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -288,6 +288,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             return ret;
         }
 
+        // This method is to detect the invalid dash context
+        // Some match with invalid dash context might be false positives
+        // For example, it can be part of the phone number like "Tel: 138-2010-2015"
         private bool HasInvalidDashContext(Match match, string text)
         {
             var hasInvalidDashContext = false;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex CenturySuffixRegex { get; }
 
+        Regex MonthNumRegex { get; }
+
         IDateExtractor DatePointExtractor { get; }
 
         IExtractor CardinalExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -284,6 +284,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -257,6 +257,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -338,6 +338,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -264,6 +264,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -266,6 +266,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         Regex IDatePeriodExtractorConfiguration.CenturySuffixRegex => CenturySuffixRegex;
 
+        Regex IDatePeriodExtractorConfiguration.MonthNumRegex => MonthNumRegex;
+
         string[] IDatePeriodExtractorConfiguration.DurationDateRestrictions => DateTimeDefinitions.DurationDateRestrictions;
 
         public bool GetFromTokenIndex(string text, out int index)

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -234,7 +234,7 @@ export namespace EnglishDateTime {
 	export const RestOfDateTimeRegex = `\\brest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<unit>day)\\b`;
 	export const MealTimeRegex = `\\b(at\\s+)?(?<mealTime>lunchtime)\\b`;
 	export const NumberEndingPattern = `^(\\s+(?<meeting>meeting|appointment|conference|call|skype call)\\s+to\\s+(?<newTime>${PeriodHourNumRegex}|${HourRegex})((\\.)?$|(\\.,|,|!|\\?)))`;
-	export const OneOnOneRegex = `\\b(1\\s*:\\s*1)|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b`;
+	export const OneOnOneRegex = `\\b(1\\s*:\\s*1(?!\\d))|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b`;
 	export const LaterEarlyPeriodRegex = `\\b((${PrefixPeriodRegex})\\s*\\b\\s*(?<suffix>${OneWordPeriodRegex})|(${UnspecificEndOfRangeRegex}))\\b`;
 	export const WeekWithWeekDayRangeRegex = `\\b((?<week>(${NextPrefixRegex}|${PreviousPrefixRegex}|this)\\s+week)((\\s+between\\s+${WeekDayRegex}\\s+and\\s+${WeekDayRegex})|(\\s+from\\s+${WeekDayRegex}\\s+to\\s+${WeekDayRegex})))\\b`;
 	export const GeneralEndingRegex = `^\\s*((\\.,)|\\.|,|!|\\?)?\\s*$`;

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10121,31 +10121,6 @@
     ] 
   },
   {
-    "Input": "Is this a valid date? 12-2015",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [
-      {
-        "Text": "12-2015",
-        "Start": 22,
-        "End": 28,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2015-12",
-              "type": "daterange",
-              "start": "2015-12-01",
-              "end": "2016-01-01"
-            }
-          ]
-        }
-      }
-    ] 
-  },
-  {
     "Input": "Is this a valid date? 32-2015",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10119,5 +10119,111 @@
         }
       }
     ] 
+  },
+  {
+    "Input": "Is this a valid date? 12-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12-2015",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 32-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 32 - 2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-12",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "2015-12",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015 - 32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: +86 138-2010-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: +86 2010-2015-86",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: 000 111 82-2100",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10121,6 +10121,31 @@
     ] 
   },
   {
+    "Input": "Is this a valid date? 12-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12-2015",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
     "Input": "Is this a valid date? 32-2015",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8940,31 +8940,6 @@
     "Results": [] 
   },
   {
-    "Input": "Is this a valid date? 12-2015",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [
-      {
-        "Text": "12-2015",
-        "Start": 22,
-        "End": 28,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2015-12",
-              "type": "daterange",
-              "start": "2015-12-01",
-              "end": "2016-01-01"
-            }
-          ]
-        }
-      }
-    ] 
-  },
-  {
     "Input": "Is this a valid date? 32-2015",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8856,5 +8856,193 @@
         }
       }
     ] 
+  },
+  {
+    "Input": "Is this a valid date? 12-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12-2015",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 32-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 32 - 2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-12",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "2015-12",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015 - 32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 12-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12-2015",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 32-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 32 - 2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-12",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "2015-12",
+        "Start": 22,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015-12",
+              "type": "daterange",
+              "start": "2015-12-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ] 
+  },
+  {
+    "Input": "Is this a valid date? 2015-32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Is this a valid date? 2015 - 32",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: +86 138-2010-2015",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: +86 2010-2015-86",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
+  },
+  {
+    "Input": "Tel: 000 111 82-2100",
+    "Context": {
+      "ReferenceDateTime": "2019-02-27T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [] 
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8940,63 +8940,6 @@
     "Results": [] 
   },
   {
-    "Input": "Is this a valid date? 32-2015",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [] 
-  },
-  {
-    "Input": "Is this a valid date? 32 - 2015",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [] 
-  },
-  {
-    "Input": "Is this a valid date? 2015-12",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [
-      {
-        "Text": "2015-12",
-        "Start": 22,
-        "End": 28,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2015-12",
-              "type": "daterange",
-              "start": "2015-12-01",
-              "end": "2016-01-01"
-            }
-          ]
-        }
-      }
-    ] 
-  },
-  {
-    "Input": "Is this a valid date? 2015-32",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [] 
-  },
-  {
-    "Input": "Is this a valid date? 2015 - 32",
-    "Context": {
-      "ReferenceDateTime": "2019-02-27T00:00:00"
-    },
-    "NotSupported": "javascript, java, python",
-    "Results": [] 
-  },
-  {
     "Input": "Tel: +86 138-2010-2015",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -665,6 +665,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "Results": []
   },
   {

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -665,24 +665,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Results": [
-      {
-        "Text": "2017",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2017",
-              "type": "daterange",
-              "start": "2017-01-01",
-              "end": "2018-01-01"
-            }
-          ]
-        },
-        "Start": 0,
-        "Length": 4
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "add yoga to personal calendar on monday and wednesday at 3pm",


### PR DESCRIPTION
Cases fixed in this PR include:
"2100" in "Tel: 000 111 82-2100"
"2010-2015" in "Tel: +86 138-2010-2015"

Support for Javascript, Java and Python would be in the upcoming PRs