### PR TITLE
Fix bug related to wrong recognition when there are more than one time phrases present

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Definitions.French
 		public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(le\s+)?(?<cardinal>premier|1er|duexi[èe]me|2|troisi[èe]me|3|quatri[èe]me|4|cinqi[èe]me|5)\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
 		public const string RelativeWeekDayRegex = @"^[.]";
 		public const string NumberEndingPattern = @"^[.]";
-		public static readonly string SpecialDate = $@"(?<=\b([àa]|au|le)\s+){DayRegex}\b";
+		public static readonly string SpecialDate = $@"(?<=\b([àa]|au|le)\s+){DayRegex}(?!:)\b";
 		public static readonly string DateYearRegex = $@"(?<year>{YearRegex}|{TwoDigitYearRegex})";
 		public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{MonthRegex}\s*[/\\\.\-]?\s*{DayRegex}\b";
 		public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s+){MonthRegex}\s*[\.\-]?\s*{DateYearRegex}\b";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeExtractor.cs
@@ -145,10 +145,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                         var begin = ers[i].Start ?? 0;
                         var end = (ers[j].Start ?? 0) + (ers[j].Length ?? 0);
                         ret.Add(new Token(begin, end));
+                        i = j + 1;
+                        continue;
                     }
-
-                    i = j + 1;
-                    continue;
                 }
 
                 i = j;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDateTimeExtractor.java
@@ -264,10 +264,9 @@ public class BaseDateTimeExtractor implements IDateTimeExtractor {
                     int begin = ersI.getStart();
                     int end = ersJ.getStart() + ersJ.getLength();
                     ret.add(new Token(begin, end));
+                    i = j + 1;
+                    continue;
                 }
-
-                i = j + 1;
-                continue;
             }
             i = j;
         }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -783,7 +783,7 @@ public class EnglishDateTime {
             .replace("{PeriodHourNumRegex}", PeriodHourNumRegex)
             .replace("{HourRegex}", HourRegex);
 
-    public static final String OneOnOneRegex = "\\b(1\\s*:\\s*1)|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b";
+    public static final String OneOnOneRegex = "\\b(1\\s*:\\s*1(?!\\d))|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b";
 
     public static final String LaterEarlyPeriodRegex = "\\b(({PrefixPeriodRegex})\\s*\\b\\s*(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\\b"
             .replace("{PrefixPeriodRegex}", PrefixPeriodRegex)

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
@@ -190,7 +190,7 @@ public class FrenchDateTime {
 
     public static final String NumberEndingPattern = "^[.]";
 
-    public static final String SpecialDate = "(?<=\\b([àa]|au|le)\\s+){DayRegex}\\b"
+    public static final String SpecialDate = "(?<=\\b([àa]|au|le)\\s+){DayRegex}(?!:)\\b"
             .replace("{DayRegex}", DayRegex);
 
     public static final String DateYearRegex = "(?<year>{YearRegex}|{TwoDigitYearRegex})"

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
@@ -80,9 +80,9 @@ export class BaseDateTimeExtractor implements IDateTimeExtractor {
                     let begin = ers[i].start;
                     let end = ers[j].start + ers[j].length;
                     tokens.push(new Token(begin, end));
+                    i = j + 1;
+                    continue;
                 }
-                i = j + 1;
-                continue;
             }
             i = j;
         }

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -234,7 +234,7 @@ export namespace EnglishDateTime {
 	export const RestOfDateTimeRegex = `\\brest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<unit>day)\\b`;
 	export const MealTimeRegex = `\\b(at\\s+)?(?<mealTime>lunchtime)\\b`;
 	export const NumberEndingPattern = `^(\\s+(?<meeting>meeting|appointment|conference|call|skype call)\\s+to\\s+(?<newTime>${PeriodHourNumRegex}|${HourRegex})((\\.)?$|(\\.,|,|!|\\?)))`;
-	export const OneOnOneRegex = `\\b(1\\s*:\\s*1)|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b`;
+	export const OneOnOneRegex = `\\b(1\\s*:\\s*1(?!\\d))|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b`;
 	export const LaterEarlyPeriodRegex = `\\b((${PrefixPeriodRegex})\\s*\\b\\s*(?<suffix>${OneWordPeriodRegex})|(${UnspecificEndOfRangeRegex}))\\b`;
 	export const WeekWithWeekDayRangeRegex = `\\b((?<week>(${NextPrefixRegex}|${PreviousPrefixRegex}|this)\\s+week)((\\s+between\\s+${WeekDayRegex}\\s+and\\s+${WeekDayRegex})|(\\s+from\\s+${WeekDayRegex}\\s+to\\s+${WeekDayRegex})))\\b`;
 	export const GeneralEndingRegex = `^\\s*((\\.,)|\\.|,|!|\\?)?\\s*$`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/frenchDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/frenchDateTime.ts
@@ -64,7 +64,7 @@ export namespace FrenchDateTime {
 	export const WeekDayOfMonthRegex = `(?<wom>(le\\s+)?(?<cardinal>premier|1er|duexi[èe]me|2|troisi[èe]me|3|quatri[èe]me|4|cinqi[èe]me|5)\\s+${WeekDayRegex}\\s+${MonthSuffixRegex})`;
 	export const RelativeWeekDayRegex = `^[.]`;
 	export const NumberEndingPattern = `^[.]`;
-	export const SpecialDate = `(?<=\\b([àa]|au|le)\\s+)${DayRegex}\\b`;
+	export const SpecialDate = `(?<=\\b([àa]|au|le)\\s+)${DayRegex}(?!:)\\b`;
 	export const DateYearRegex = `(?<year>${YearRegex}|${TwoDigitYearRegex})`;
 	export const DateExtractor1 = `\\b(${WeekDayRegex}(\\s+|\\s*,\\s*))?${MonthRegex}\\s*[/\\\\\\.\\-]?\\s*${DayRegex}\\b`;
 	export const DateExtractor2 = `\\b(${WeekDayRegex}(\\s+|\\s*,\\s*))?${DayRegex}(\\s+|\\s*,\\s*|\\s+)${MonthRegex}\\s*[\\.\\-]?\\s*${DateYearRegex}\\b`;

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -147,7 +147,7 @@ NumberEndingPattern: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 SpecialDate: !nestedRegex
-  def: (?<=\b([àa]|au|le)\s+){DayRegex}\b
+  def: (?<=\b([àa]|au|le)\s+){DayRegex}(?!:)\b
   references: [ DayRegex ]
 DateYearRegex: !nestedRegex
   def: (?<year>{YearRegex}|{TwoDigitYearRegex})

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_datetime.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_datetime.py
@@ -150,8 +150,8 @@ class BaseDateTimeExtractor(DateTimeExtractor):
                     begin = ers[i].start
                     end = ers[j].start + ers[j].length
                     tokens.append(Token(begin, end))
-                i = j + 1
-                continue
+                    i = j + 1
+                    continue
             i = j
 
         tokens = list(map(lambda x: self.verify_end_token(source, x), tokens))

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -235,7 +235,7 @@ class EnglishDateTime:
     RestOfDateTimeRegex = f'\\brest\\s+(of\\s+)?((the|my|this|current)\\s+)?(?<unit>day)\\b'
     MealTimeRegex = f'\\b(at\\s+)?(?<mealTime>lunchtime)\\b'
     NumberEndingPattern = f'^(\\s+(?<meeting>meeting|appointment|conference|call|skype call)\\s+to\\s+(?<newTime>{PeriodHourNumRegex}|{HourRegex})((\\.)?$|(\\.,|,|!|\\?)))'
-    OneOnOneRegex = f'\\b(1\\s*:\\s*1)|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b'
+    OneOnOneRegex = f'\\b(1\\s*:\\s*1(?!\\d))|(one (on )?one|one\\s*-\\s*one|one\\s*:\\s*one)\\b'
     LaterEarlyPeriodRegex = f'\\b(({PrefixPeriodRegex})\\s*\\b\\s*(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\\b'
     WeekWithWeekDayRangeRegex = f'\\b((?<week>({NextPrefixRegex}|{PreviousPrefixRegex}|this)\\s+week)((\\s+between\\s+{WeekDayRegex}\\s+and\\s+{WeekDayRegex})|(\\s+from\\s+{WeekDayRegex}\\s+to\\s+{WeekDayRegex})))\\b'
     GeneralEndingRegex = f'^\\s*((\\.,)|\\.|,|!|\\?)?\\s*$'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/french_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/french_date_time.py
@@ -65,7 +65,7 @@ class FrenchDateTime:
     WeekDayOfMonthRegex = f'(?<wom>(le\\s+)?(?<cardinal>premier|1er|duexi[èe]me|2|troisi[èe]me|3|quatri[èe]me|4|cinqi[èe]me|5)\\s+{WeekDayRegex}\\s+{MonthSuffixRegex})'
     RelativeWeekDayRegex = f'^[.]'
     NumberEndingPattern = f'^[.]'
-    SpecialDate = f'(?<=\\b([àa]|au|le)\\s+){DayRegex}\\b'
+    SpecialDate = f'(?<=\\b([àa]|au|le)\\s+){DayRegex}(?!:)\\b'
     DateYearRegex = f'(?<year>{YearRegex}|{TwoDigitYearRegex})'
     DateExtractor1 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?{MonthRegex}\\s*[/\\\\\\.\\-]?\\s*{DayRegex}\\b'
     DateExtractor2 = f'\\b({WeekDayRegex}(\\s+|\\s*,\\s*))?{DayRegex}(\\s+|\\s*,\\s*|\\s+){MonthRegex}\\s*[\\.\\-]?\\s*{DateYearRegex}\\b'

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10125,7 +10125,7 @@
     "Context": {
       "ReferenceDateTime": "2019-02-28T00:00:00"
     },
-    "NotSupported": "javascript, java, python",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "january 18, 2019",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -10119,5 +10119,44 @@
         }
       }
     ] 
+  },
+  {
+    "Input": "Your renewal will be January 18, 2019.  You have until then to add the paid support. @Cortana, Please schedule a Skype call at 3pm today.",
+    "Context": {
+      "ReferenceDateTime": "2019-02-28T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "january 18, 2019",
+        "Start": 21,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-01-18",
+              "type": "date",
+              "value": "2019-01-18"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "3pm today",
+        "Start": 127,
+        "End": 135,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-28T15",
+              "type": "datetime",
+              "value": "2019-02-28 15:00:00"
+            }
+          ]
+        }
+      }
+    ] 
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8862,7 +8862,7 @@
     "Context": {
       "ReferenceDateTime": "2019-02-28T00:00:00"
     },
-    "NotSupported": "javascript, java, python",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "january 18, 2019",

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -8856,5 +8856,44 @@
         }
       }
     ] 
+  },
+  {
+    "Input": "Your renewal will be January 18, 2019.  You have until then to add the paid support. @Cortana, Please schedule a Skype call at 3pm today.",
+    "Context": {
+      "ReferenceDateTime": "2019-02-28T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "january 18, 2019",
+        "Start": 21,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-01-18",
+              "type": "date",
+              "value": "2019-01-18"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "3pm today",
+        "Start": 127,
+        "End": 135,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-28T15",
+              "type": "datetime",
+              "value": "2019-02-28 15:00:00"
+            }
+          ]
+        }
+      }
+    ] 
   }
 ]


### PR DESCRIPTION
For example, "Your renewal will be January 18, 2019.  You have until then to add the paid support. @Cortana, Please schedule a Skype call at 3pm today."
woud return:  "January 18, 2019"; "3pm"; "today", where "January 18, 2019" and "3pm today" are expected.

The fix applies to .Net and Java.

Javascript and Python has another issue when recognize "You have until then to add the paid support. @Cortana, Please schedule a Skype call at 3pm today.". The fix for Javascript and Python would be available in upcoming PRs.