### PR TITLE
Make Azure DevOps build process fail on StyleCop issues

### DIFF
--- a/.NET/Build.cmd
+++ b/.NET/Build.cmd
@@ -2,4 +2,4 @@
 
 REM This is only used for local build. It executes the same build and test scripts than the CI server.
 
-build.ci.cmd & tests.ci.cmd
+build.ci.cmd && tests.ci.cmd


### PR DESCRIPTION
## Bug
When creating a pull request that inadvertently included StyleCop issues we found that the AzureDevOps build would not fail but the AppVeyor one did.

## Solution
In the `Build.cmd` file we changed the `&` operand to `&&` because while `&` runs the second script without taking into consideration the outcome of the first one, with `&&` we make sure that the first script runs ok before running the second one.
We got to this solution after making a couple tests on AzureDevOp. If instead of running the original `Build.cmd` script from a single task we ran the `build.ci.cmd` and `tests.ci.cmd` scripts separately in two different tasks, it would work as expected. With this, we realized the issue was that even if the build script failed, the `tests.ci.cmd` script would run and would end up throwing a succesful output. When separating them, the failure of build.ci.cmd would prevent the tests from running and would make the  the whole process fail.

## Screenshots
### Running the scripts on different tasks
Configuration:
![imagen](https://user-images.githubusercontent.com/22912283/53590053-aa88a000-3b6f-11e9-849b-6688300e6499.png)

Output:
![imagen](https://user-images.githubusercontent.com/22912283/53589962-7a410180-3b6f-11e9-9d24-78a5e05d0398.png)

### Running the scripts on the same task (but with the new `Build.cmd` script)
Configuration:
![imagen](https://user-images.githubusercontent.com/22912283/53590183-f8050d00-3b6f-11e9-874a-77b5351d058c.png)

Code: 
`build.ci.cmd && tests.ci.cmd`

Output:
![imagen](https://user-images.githubusercontent.com/22912283/53590008-947adf80-3b6f-11e9-9772-9e96e016947d.png)
