### PR TITLE
Fix build script for code signing (indentation now causes build break)

### DIFF
--- a/.NET/buildtools/updateAssemblyInfo.ps1
+++ b/.NET/buildtools/updateAssemblyInfo.ps1
@@ -34,7 +34,7 @@ function UpdateAssemblyInfo()
 function AddCodeSign()
 {
 
-    $csAppend = "`r`n[assembly: AssemblyKeyFileAttribute(@`"" + ($PSScriptRoot + "\35MSSharedLib1024.snk") + "`")] `r`n [assembly: AssemblyDelaySignAttribute(true)]"
+    $csAppend = "`r`n[assembly: AssemblyKeyFileAttribute(@`"" + ($PSScriptRoot + "\35MSSharedLib1024.snk") + "`")]`r`n[assembly: AssemblyDelaySignAttribute(true)]"
     #Write-Host ("CSAppend:" + $csAppend)
     $fileContent = $fileContent + $csAppend
     return $fileContent


### PR DESCRIPTION
Code signing script introduces indentation inconsistency, which leads to build breaks as we now treat warnings as errors in the build.