### PR TITLE
Moving nuget package definitions to use <license> tag

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Choice/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.Choice/CreatePackage.cmd
@@ -13,7 +13,7 @@ if exist ..\nuget\Microsoft.Recognizers.Text.Choice*.nupkg erase /s ..\nuget\Mic
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.Choice.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Choice.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.Choice.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.Choice.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.Choice

--- a/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Microsoft.Recognizers.Text.Choice.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.Choice provides recognition of Boolean (yes/no) answers expressed in English, Portuguese, Spanish, and Japanese. As well as base classes to support lists of alternative choices.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/CreatePackage.cmd
@@ -12,7 +12,7 @@ if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text.DataTypes.TimexExpression*.nupkg erase /s ..\nuget\Microsoft.Recognizers.Text.DataTypes.TimexExpression*.nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.DataTypes.TimexExpression.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.DataTypes.TimexExpression.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.DataTypes.TimexExpression.nuspec -symbols -properties version=%numberVersion% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.DataTypes.TimexExpression.nuspec -symbols -properties version=%numberVersion% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.DataTypes.TimexExpression

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.DataTypes.TimexExpression provides parsing and evaluation of TIMEX expressions.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text.DateTime/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/CreatePackage.cmd
@@ -15,7 +15,7 @@ for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set numberWithUnit=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.DateTime.dll).FileVersionInfo.FileVersion"') do set version=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.DateTime.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number%;numberWithUnit=%numberWithUnit% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.DateTime.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number%;numberWithUnit=%numberWithUnit% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.DateTime

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Microsoft.Recognizers.Text.DateTime.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.DateTime provides robust recognition and resolution of Date and Time expressed in English, Spanish, French, Portuguese, and Chinese.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text.Number/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.Number/CreatePackage.cmd
@@ -13,7 +13,7 @@ if exist ..\nuget\Microsoft.Recognizers.Text.Number*.nupkg erase /s ..\nuget\Mic
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.Number.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.Number.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.Number.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.Number

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.Number provides robust recognition and resolution of numbers expressed in English, Spanish, French, Portuguese, Chinese, German, Dutch, and Japanese.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/CreatePackage.cmd
@@ -14,7 +14,7 @@ if exist ..\nuget\Microsoft.Recognizers.Text.NumberWithUnit*nupkg erase /s ..\nu
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Number.dll).FileVersionInfo.FileVersion"') do set number=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.NumberWithUnit.dll).FileVersionInfo.FileVersion"') do set version=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.NumberWithUnit.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.NumberWithUnit.nuspec -symbols -properties version=%version%;basic=%basic%;number=%number% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.NumberWithUnit

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Microsoft.Recognizers.Text.NumberWithUnit.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.NumberWithUnit provides robust recognition and resolution of numbers with units expressed in English, Spanish, French, Portuguese, Chinese, German, and Dutch.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text.Sequence/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/CreatePackage.cmd
@@ -13,7 +13,7 @@ if exist ..\nuget\Microsoft.Recognizers.Text.Sequence*.nupkg erase /s ..\nuget\M
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.Sequence.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basic=%%v
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.Sequence.dll).FileVersionInfo.FileVersion"') do set numberVersion=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.Sequence.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.Sequence.nuspec -symbols -properties version=%numberVersion%;basic=%basic% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text.Sequence

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Microsoft.Recognizers.Text.Sequence.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text.Sequence provides robust recognition and resolution of series entities like phone numbers and IP addresses.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Microsoft.Recognizers.Text/CreatePackage.cmd
+++ b/.NET/Microsoft.Recognizers.Text/CreatePackage.cmd
@@ -12,7 +12,7 @@ if not exist ..\nuget mkdir ..\nuget
 if exist ..\nuget\Microsoft.Recognizers.Text*.nupkg erase /s ..\nuget\Microsoft.Recognizers.Text*.nupkg
 "%MSBuildDir%\MSBuild\15.0\Bin\MSBuild.exe" /property:Configuration=release Microsoft.Recognizers.Text.csproj
 for /f %%v in ('powershell -noprofile "(Get-Command .\bin\release\netstandard2.0\Microsoft.Recognizers.Text.dll).FileVersionInfo.FileVersion"') do set basicVersion=%%v
-..\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack Microsoft.Recognizers.Text.nuspec -symbols -properties version=%basicVersion% -OutputDirectory ..\nuget
+..\buildtools\NuGet.exe pack Microsoft.Recognizers.Text.nuspec -symbols -properties version=%basicVersion% -OutputDirectory ..\nuget
 
 set error=%errorlevel%
 set packageName=Microsoft.Recognizers.Text

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Microsoft.Recognizers.Text provides base classes for robust recognition and resolution of text entities.</description>
-    <licenseUrl>https://github.com/Microsoft/Recognizers-Text/blob/master/LICENSE</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/Microsoft/Recognizers-Text</projectUrl>
     <iconUrl>http://docs.botframework.com/images/bot_icon.png</iconUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/.NET/Recognizers-Text.ruleset
+++ b/.NET/Recognizers-Text.ruleset
@@ -14,7 +14,7 @@
     <Rule Id="CS0108" Action="Error" />
     <Rule Id="CS0109" Action="Error" />
     <Rule Id="CS0114" Action="Error" />
-    <Rule Id="CS0162" Action="Error" />
+    <Rule Id="CS0162" Action="Warning" />
     <Rule Id="CS0164" Action="Error" />
     <Rule Id="CS0168" Action="Error" />
     <Rule Id="CS0183" Action="Error" />
@@ -355,6 +355,9 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic.Features" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic.Features">
     <Rule Id="IDE0043" Action="Error" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1707" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="Error" />
     <Rule Id="SA0002" Action="Error" />
@@ -476,7 +479,7 @@
     <Rule Id="SA1505" Action="Error" />
     <Rule Id="SA1506" Action="Error" />
     <Rule Id="SA1507" Action="Error" />
-    <Rule Id="SA1508" Action="Error" />
+    <Rule Id="SA1508" Action="None" />
     <Rule Id="SA1509" Action="Error" />
     <Rule Id="SA1510" Action="Error" />
     <Rule Id="SA1511" Action="Error" />


### PR DESCRIPTION
`<licenseUrl>`  will be deprecated - https://docs.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#license-url-deprecation