### PR TITLE
Revise JavaScript baseDatePeriod, issue #1442

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -588,8 +588,8 @@ export class BaseDatePeriodParser implements IDateTimeParser {
             swift = this.config.getSwiftDayOrMonth(trimedText);
             if (this.config.isWeekOnly(trimedText)) {
                 let monday = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Monday), 7 * swift);
-
-                result.timex = `${DateTimeFormatUtil.toString(monday.getFullYear(), 4)}-W${DateTimeFormatUtil.toString(DateUtils.getWeekNumber(monday).weekNo, 2)}`;
+                
+                result.timex = `${DateTimeFormatUtil.toString(DateUtils.getWeekNumber(monday).year, 4)}-W${DateTimeFormatUtil.toString(DateUtils.getWeekNumber(monday).weekNo, 2)}`;
 
                 let beginDate = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Monday), 7 * swift);
                 let endDate = this.inclusiveEndPeriod

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -487,7 +487,7 @@ export class DateUtils {
     
         // Store the millisecond value of the target date
         let firstThursday = target.valueOf();
-    
+        let theThursday = new Date(firstThursday);
         // Set the target to the first thursday of the year
         // First set the target to january first
         target.setMonth(0, 1);
@@ -499,7 +499,8 @@ export class DateUtils {
         // The weeknumber is the number of weeks between the 
         // first thursday of the year and the thursday in the target week
         let weekNo = 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000); // 604800000 = 7 * 24 * 3600 * 1000
-        return { weekNo: weekNo, year: referenceDate.getUTCFullYear() }
+
+        return { weekNo: weekNo, year: theThursday.getFullYear() }
     }
 
     static minValue(): Date {


### PR DESCRIPTION
Issue #1442 is caused by detecting the Monday in that week. According to ISO-8601, it should be Thursday.