### PR TITLE
Revise relative week parsing to use ISO 8601 standard

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateTimeFormatUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateTimeFormatUtil.cs
@@ -242,8 +242,9 @@ namespace Microsoft.Recognizers.Text.DateTime
         public static string ToIsoWeekTimex(DateObject date)
         {
             var cal = DateTimeFormatInfo.InvariantInfo.Calendar;
+            var thursday = cal.AddDays(date, DayOfWeek.Thursday - cal.GetDayOfWeek(date));
 
-            return $"{date.Year:D4}-W{cal.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday):D2}";
+            return $"{thursday.Year:D4}-W{cal.GetWeekOfYear(thursday, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday):D2}";
         }
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
@@ -662,9 +662,9 @@ public class BaseDatePeriodParser implements IDateTimeParser {
                 swift = this.config.getSwiftDayOrMonth(trimmedText);
 
                 if (this.config.isWeekOnly(trimmedText)) {
-                    LocalDateTime monday = DateUtil.thisDate(referenceDate, DayOfWeek.MONDAY.getValue()).plusDays(Constants.WeekDayCount * swift);
+                    LocalDateTime thursday = DateUtil.thisDate(referenceDate, DayOfWeek.THURSDAY.getValue()).plusDays(Constants.WeekDayCount * swift);
 
-                    ret.setTimex(isRef ? TimexUtility.generateWeekTimex() : TimexUtility.generateWeekTimex(monday));
+                    ret.setTimex(isRef ? TimexUtility.generateWeekTimex() : TimexUtility.generateWeekTimex(thursday));
 
                     LocalDateTime beginDate = DateUtil.thisDate(referenceDate, DayOfWeek.MONDAY.getValue()).plusDays(Constants.WeekDayCount * swift);
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -478,7 +478,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
     }
 
     private isPresent(swift: number): boolean{
-        return swift == 0;
+        return swift === 0;
     }
 
     protected parseOneWordPeriod(source: string, referenceDate: Date): DateTimeResolutionResult {
@@ -588,8 +588,9 @@ export class BaseDatePeriodParser implements IDateTimeParser {
             swift = this.config.getSwiftDayOrMonth(trimedText);
             if (this.config.isWeekOnly(trimedText)) {
                 let monday = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Monday), 7 * swift);
+                let weekNumber = DateUtils.getWeekNumber(monday);
 
-                result.timex = `${DateTimeFormatUtil.toString(monday.getFullYear(), 4)}-W${DateTimeFormatUtil.toString(DateUtils.getWeekNumber(monday).weekNo, 2)}`;
+                result.timex = `${DateTimeFormatUtil.toString(weekNumber.year, 4)}-W${DateTimeFormatUtil.toString(weekNumber.weekNo, 2)}`;
 
                 let beginDate = DateUtils.addDays(DateUtils.this(referenceDate, DayOfWeek.Monday), 7 * swift);
                 let endDate = this.inclusiveEndPeriod
@@ -1029,7 +1030,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         if (!numberStr) {
             quarterNum = this.config.cardinalMap.get(cardinalStr);
         } else {
-            quarterNum = parseInt(numberStr)
+            quarterNum = parseInt(numberStr);
         }
 
         let beginDate = DateUtils.safeCreateDateResolveOverflow(year, (quarterNum - 1) * Constants.SemesterMonthCount, 1);
@@ -1071,7 +1072,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         if (!numberStr) {
             quarterNum = this.config.cardinalMap.get(cardinalStr);
         } else {
-            quarterNum = parseInt(numberStr)
+            quarterNum = parseInt(numberStr);
         }
 
         let beginDate = DateUtils.safeCreateDateResolveOverflow(year, (quarterNum - 1) * Constants.TrimesterMonthCount, 1);
@@ -1136,7 +1137,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         let firstDay = DateUtils.safeCreateFromValue(DateUtils.minValue(), year, 0, 1);
         let firstThursday = DateUtils.this(firstDay, DayOfWeek.Thursday);
         let firstWeek = DateUtils.getWeekNumber(firstThursday).weekNo;
-        if (firstWeek == 1) {
+        if (firstWeek === 1) {
             num -= 1;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -487,7 +487,7 @@ export class DateUtils {
     
         // Store the millisecond value of the target date
         let firstThursday = target.valueOf();
-        let targetThursday = new Date(firstThursday);
+        let thursday = new Date(firstThursday);
     
         // Set the target to the first thursday of the year
         // First set the target to january first
@@ -500,7 +500,7 @@ export class DateUtils {
         // The weeknumber is the number of weeks between the 
         // first thursday of the year and the thursday in the target week
         let weekNo = 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000); // 604800000 = 7 * 24 * 3600 * 1000
-        return { weekNo: weekNo, year: targetThursday.getUTCFullYear() }
+        return { weekNo: weekNo, year: thursday.getFullYear() }
     }
 
     static minValue(): Date {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -487,6 +487,7 @@ export class DateUtils {
     
         // Store the millisecond value of the target date
         let firstThursday = target.valueOf();
+        let targetThursday = new Date(firstThursday);
     
         // Set the target to the first thursday of the year
         // First set the target to january first
@@ -499,7 +500,7 @@ export class DateUtils {
         // The weeknumber is the number of weeks between the 
         // first thursday of the year and the thursday in the target week
         let weekNo = 1 + Math.ceil((firstThursday - target.valueOf()) / 604800000); // 604800000 = 7 * 24 * 3600 * 1000
-        return { weekNo: weekNo, year: referenceDate.getUTCFullYear() }
+        return { weekNo: weekNo, year: targetThursday.getUTCFullYear() }
     }
 
     static minValue(): Date {

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -807,7 +807,7 @@ class BaseDatePeriodParser(DateTimeParser):
 
             if self.config.is_week_only(trimmed_source):
                 thursday = DateUtils.this(reference, DayOfWeek.Thursday) + datedelta(days=7 * swift)
-                result.timex = f'{thursday.year:04d}-W{thursday.isocalendar()[1]:02d}'
+                result.timex = f'{thursday.year:04d}-W{DateUtils.week_of_year(thursday):02d}'
                 begin_date = DateUtils.this(reference, DayOfWeek.Monday) + datedelta(days=7 * swift)
                 end_date = DateUtils.this(reference, DayOfWeek.Sunday) + datedelta(days=7 * swift)
                 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -806,8 +806,8 @@ class BaseDatePeriodParser(DateTimeParser):
             swift = self.config.get_swift_day_or_month(trimmed_source)
 
             if self.config.is_week_only(trimmed_source):
-                monday = DateUtils.this(reference, DayOfWeek.Monday) + datedelta(days=7 * swift)
-                result.timex = f'{year:04d}-W{monday.isocalendar()[1]:02d}'
+                thursday = DateUtils.this(reference, DayOfWeek.Thursday) + datedelta(days=7 * swift)
+                result.timex = f'{thursday.year:04d}-W{thursday.isocalendar()[1]:02d}'
                 begin_date = DateUtils.this(reference, DayOfWeek.Monday) + datedelta(days=7 * swift)
                 end_date = DateUtils.this(reference, DayOfWeek.Sunday) + datedelta(days=7 * swift)
                 

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -735,7 +735,7 @@
     ]
   },
   {
-    "Input": "this week",
+    "Input": "The union suspended strike action this week.",
     "Context": {
       "ReferenceDateTime": "2026-01-01T00:00:00"
     },
@@ -754,7 +754,7 @@
             "endDate": "2026-01-05"
           }
         },
-        "Start": 0,
+        "Start": 34,
         "Length": 9
       }
     ]

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -5522,13 +5522,13 @@
     ]
   },
   {
-    "Input": "This week belongs to 19.",
+    "Input": "The U.S. government is still in suspension this week.",
     "Context": {
       "ReferenceDateTime": "2019-01-01T00:00:00"
     },
     "Results": [
       {
-        "Text": "This week",
+        "Text": "this week",
         "Type": "daterange",
         "Value": {
           "Timex": "2019-W01",
@@ -5541,19 +5541,19 @@
             "endDate": "2019-01-07"
           }
         },
-        "Start": 0,
+        "Start": 43,
         "Length": 9
       }
     ]
   },
   {
-    "Input": "This week belongs to 16.",
+    "Input": "Mr Werner unveiled his new strategy this week.",
     "Context": {
       "ReferenceDateTime": "2017-01-01T00:00:00"
     },
     "Results": [
       {
-        "Text": "This week",
+        "Text": "this week",
         "Type": "daterange",
         "Value": {
           "Timex": "2016-W52",
@@ -5566,19 +5566,19 @@
             "endDate": "2017-01-02"
           }
         },
-        "Start": 0,
+        "Start": 36,
         "Length": 9
       }
     ]
   },
   {
-    "Input": "Week belongs to 15.",
+    "Input": "There is no big news this week.",
     "Context": {
       "ReferenceDateTime": "2016-01-01T00:00:00"
     },
     "Results": [
       {
-        "Text": "Week",
+        "Text": "this week",
         "Type": "daterange",
         "Value": {
           "Timex": "2015-W53",
@@ -5591,19 +5591,19 @@
             "endDate": "2016-01-04"
           }
         },
-        "Start": 0,
-        "Length": 4
+        "Start": 21,
+        "Length": 9
       }
     ]
   },
   {
-    "Input": "This week belongs to 26",
+    "Input": "week",
     "Context": {
       "ReferenceDateTime": "2026-01-01T00:00:00"
     },
     "Results": [
       {
-        "Text": "This week",
+        "Text": "week",
         "Type": "daterange",
         "Value": {
           "Timex": "2026-W01",
@@ -5617,7 +5617,7 @@
           }
         },
         "Start": 0,
-        "Length": 9
+        "Length": 4
       }
     ]
   }

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -737,21 +737,21 @@
   {
     "Input": "this week",
     "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
+      "ReferenceDateTime": "2026-01-01T00:00:00"
     },
     "Results": [
       {
         "Text": "this week",
         "Type": "daterange",
         "Value": {
-          "Timex": "2016-W45",
+          "Timex": "2026-W01",
           "FutureResolution": {
-            "startDate": "2016-11-07",
-            "endDate": "2016-11-14"
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
           },
           "PastResolution": {
-            "startDate": "2016-11-07",
-            "endDate": "2016-11-14"
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
           }
         },
         "Start": 0,
@@ -5593,31 +5593,6 @@
         },
         "Start": 21,
         "Length": 9
-      }
-    ]
-  },
-  {
-    "Input": "week",
-    "Context": {
-      "ReferenceDateTime": "2026-01-01T00:00:00"
-    },
-    "Results": [
-      {
-        "Text": "week",
-        "Type": "daterange",
-        "Value": {
-          "Timex": "2026-W01",
-          "FutureResolution": {
-            "startDate": "2025-12-29",
-            "endDate": "2026-01-05"
-          },
-          "PastResolution": {
-            "startDate": "2025-12-29",
-            "endDate": "2026-01-05"
-          }
-        },
-        "Start": 0,
-        "Length": 4
       }
     ]
   }

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -5520,5 +5520,105 @@
         "Length": 19
       }
     ]
+  },
+  {
+    "Input": "This week belongs to 19.",
+    "Context": {
+      "ReferenceDateTime": "2019-01-01T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "This week",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2019-W01",
+          "FutureResolution": {
+            "startDate": "2018-12-31",
+            "endDate": "2019-01-07"
+          },
+          "PastResolution": {
+            "startDate": "2018-12-31",
+            "endDate": "2019-01-07"
+          }
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "This week belongs to 16.",
+    "Context": {
+      "ReferenceDateTime": "2017-01-01T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "This week",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W52",
+          "FutureResolution": {
+            "startDate": "2016-12-26",
+            "endDate": "2017-01-02"
+          },
+          "PastResolution": {
+            "startDate": "2016-12-26",
+            "endDate": "2017-01-02"
+          }
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Week belongs to 15.",
+    "Context": {
+      "ReferenceDateTime": "2016-01-01T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "Week",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2015-W53",
+          "FutureResolution": {
+            "startDate": "2015-12-28",
+            "endDate": "2016-01-04"
+          },
+          "PastResolution": {
+            "startDate": "2015-12-28",
+            "endDate": "2016-01-04"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "This week belongs to 26",
+    "Context": {
+      "ReferenceDateTime": "2026-01-01T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "This week",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2026-W01",
+          "FutureResolution": {
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
+          },
+          "PastResolution": {
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
+          }
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Revise JavaScript baseDatePeriod to use ISO standard. [Issue #1442](https://github.com/Microsoft/Recognizers-Text/issues/1442)

