### PR TITLE
Update TimexResolver to equate Timex "XXXX-WXX-7" as Sunday

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -43,6 +43,26 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_Date_Sunday()
+        {
+            var today = new System.DateTime(2019, 4, 23, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-7" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-WXX-7", resolution.Values[0].Timex);
+            Assert.AreEqual("date", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-21", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+
+            Assert.AreEqual("XXXX-WXX-7", resolution.Values[1].Timex);
+            Assert.AreEqual("date", resolution.Values[1].Type);
+            Assert.AreEqual("2019-04-28", resolution.Values[1].Value);
+            Assert.IsNull(resolution.Values[1].Start);
+            Assert.IsNull(resolution.Values[1].End);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_DateTime_Wednesday_4()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
-                var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
+                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
                 var result = TimexDateHelpers.DateOfLastDay(day, date);
                 return TimexValue.DateValue(new TimexProperty
                 {
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
-                var day = timex.DayOfWeek == 7 ? DayOfWeek.Monday : (DayOfWeek)timex.DayOfWeek;
+                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
                 var result = TimexDateHelpers.DateOfNextDay(day, date);
                 return TimexValue.DateValue(new TimexProperty
                 {


### PR DESCRIPTION
.NET's TimexResolver is resolving Date types of Sunday as Monday, this change updates the DayOfWeek to use when encountering the "XXXX-WXX-7" Timex expression.

This issue was previously closed but the behavior still exists: [https://github.com/Microsoft/Recognizers-Text/issues/688](https://github.com/Microsoft/Recognizers-Text/issues/688)