### PR TITLE
Add Ordinal attributes into other languages

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
@@ -368,7 +368,11 @@ namespace Microsoft.Recognizers.Definitions.Italian
 			{ @"b", 1000000000 },
 			{ @"t", 1000000000000 }
 		};
-		public static readonly Dictionary<string, string> RelativeReferenceMap = new Dictionary<string, string>
+		public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
+		{
+			{ @"", @"" }
+		};
+		public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
 		{
 			{ @"", @"" }
 		};

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
@@ -193,7 +193,11 @@ namespace Microsoft.Recognizers.Definitions.Japanese
 		public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2}|{OneNumberRangeLessRegex3}|{OneNumberRangeLessRegex4})\s*(と|は|((と)?同時に)|((と)?そして)|が|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2}|{OneNumberRangeMoreRegex3}|{OneNumberRangeMoreRegex4})";
 		public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)";
 		public const string AmbiguousFractionConnectorsRegex = @"^[.]";
-		public static readonly Dictionary<string, string> RelativeReferenceMap = new Dictionary<string, string>
+		public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
+		{
+			{ @"", @"" }
+		};
+		public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
 		{
 			{ @"", @"" }
 		};

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -175,7 +175,11 @@ namespace Microsoft.Recognizers.Definitions.Korean
 		public const string MoreOrEqualSuffix = @"\s*(이상)";
 		public static readonly string LessOrEqual = $@"(({LessRegex}\s*(거나)?\s*{EqualRegex}))";
 		public const string LessOrEqualSuffix = @"\s*(이상)";
-		public static readonly Dictionary<string, string> RelativeReferenceMap = new Dictionary<string, string>
+		public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
+		{
+			{ @"", @"" }
+		};
+		public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
 		{
 			{ @"", @"" }
 		};

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Korean.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Korean.cs
@@ -27,5 +27,12 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         {
             TestNumber();
         }
+
+        [DataSource("Microsoft.VisualStudio.TestTools.DataSource.CSV", "OrdinalModel-Korean.csv", "OrdinalModel-Korean#csv", DataAccessMethod.Sequential)]
+        [TestMethod]
+        public void OrdinalModel()
+        {
+            TestNumber();
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
@@ -370,17 +370,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                     {
                         Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value], GetMessage(TestSpec));
                     }
-
-                    //only English has "offset" and "relativeTo" attributes now
-                    if (expected.Resolution.ContainsKey(ResolutionKey.Offset))
-                    {
-                        Assert.AreEqual(expected.Resolution[ResolutionKey.Offset], actual.Resolution[ResolutionKey.Offset], GetMessage(TestSpec));
-                    }
-
-                    if (expected.Resolution.ContainsKey(ResolutionKey.RelativeTo))
-                    {
-                        Assert.AreEqual(expected.Resolution[ResolutionKey.RelativeTo], actual.Resolution[ResolutionKey.RelativeTo], GetMessage(TestSpec));
-                    }
+                    
+                    Assert.AreEqual(expected.Resolution[ResolutionKey.Offset], actual.Resolution[ResolutionKey.Offset], GetMessage(TestSpec));
+                    Assert.AreEqual(expected.Resolution[ResolutionKey.RelativeTo], actual.Resolution[ResolutionKey.RelativeTo], GetMessage(TestSpec));
                 }
                 else
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Recognizers.Text.Number.Italian
 
             this.CardinalNumberMap = NumbersDefinitions.CardinalNumberMap.ToImmutableDictionary();
             this.OrdinalNumberMap = NumberMapGenerator.InitOrdinalNumberMap(NumbersDefinitions.OrdinalNumberMap, NumbersDefinitions.PrefixCardinalMap, NumbersDefinitions.SuffixOrdinalMap);
-            this.RelativeReferenceMap = NumbersDefinitions.RelativeReferenceMap.ToImmutableDictionary();
+            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
             this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
             CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
             OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            RelativeReferenceMap = NumbersDefinitions.RelativeReferenceMap.ToImmutableDictionary();
+            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
             ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
             FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 
             CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
             OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            RelativeReferenceMap = NumbersDefinitions.RelativeReferenceMap.ToImmutableDictionary();
+            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
             ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
             RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Recognizers.Text.Number
                 var type = string.Empty;
 
                 // for ordinal and ordinal.relative
-                // Only support "subtype" for English for now
-                if (ModelTypeName.Equals(Constants.MODEL_ORDINAL) && extractorType.Contains(Constants.ENGLISH))
+                // Only support "ordinal.relative" for English for now
+                if (ModelTypeName.Equals(Constants.MODEL_ORDINAL))
                 {
                     if (o.Metadata != null && o.Metadata.IsOrdinalRelative)
                     {

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -89,6 +89,24 @@ namespace Microsoft.Recognizers.Text.Number
                 ret.Text = extResult.Text.ToLowerInvariant();
             }
 
+            // Add "offset" and "relativeTo" for ordinal
+            if (!string.IsNullOrEmpty(ret.Type) && ret.Type.Contains(Constants.MODEL_ORDINAL))
+            {
+                if (Config.RelativeReferenceOffsetMap.ContainsKey(extResult.Text) &&
+                    Config.RelativeReferenceRelativeToMap.ContainsKey(extResult.Text))
+                {
+                    ret.Metadata.Offset = Config.RelativeReferenceOffsetMap[extResult.Text];
+                    ret.Metadata.RelativeTo = Config.RelativeReferenceRelativeToMap[extResult.Text];
+                }
+                else
+                {
+                    ret.Metadata.Offset = ret.ResolutionStr;
+
+                    // Every ordinal number is relative to the start
+                    ret.Metadata.RelativeTo = Constants.RELATIVE_START;
+                }
+            }
+
             return ret;
         }
 
@@ -141,6 +159,7 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             result.ResolutionStr = result.Value.ToString();
+
             return result;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Recognizers.Text.Number
                 Data = extResult.Data,
                 Text = extResult.Text,
                 Type = extResult.Type,
+                Metadata = extResult.Metadata,
             };
 
             if (Config.CultureInfo.Name == "zh-CN")
@@ -307,6 +308,7 @@ namespace Microsoft.Recognizers.Text.Number
                 Length = extResult.Length,
                 Text = extResult.Text,
                 Type = extResult.Type,
+                Metadata = extResult.Metadata,
             };
 
             var resultText = extResult.Text;

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             // Add "offset" and "relativeTo" for ordinal
+            // only support in English now, other languages will be empty string
             if (!string.IsNullOrEmpty(ret.Type) && ret.Type.Contains(Constants.MODEL_ORDINAL))
             {
                 if (Config.RelativeReferenceOffsetMap.ContainsKey(extResult.Text) &&
@@ -170,7 +171,8 @@ namespace Microsoft.Recognizers.Text.Number
                     ret.Metadata.Offset = Config.RelativeReferenceOffsetMap[extResult.Text];
                     ret.Metadata.RelativeTo = Config.RelativeReferenceRelativeToMap[extResult.Text];
                 }
-                else
+                else if (!Config.RelativeReferenceRelativeToMap.ContainsKey(string.Empty) &&
+                    !Config.RelativeReferenceRelativeToMap.ContainsKey(string.Empty))
                 {
                     ret.Metadata.Offset = ret.ResolutionStr;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -162,7 +162,6 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             // Add "offset" and "relativeTo" for ordinal
-            // only support in English now, other languages will be empty string
             if (!string.IsNullOrEmpty(ret.Type) && ret.Type.Contains(Constants.MODEL_ORDINAL))
             {
                 if (Config.RelativeReferenceOffsetMap.ContainsKey(extResult.Text) &&
@@ -171,8 +170,7 @@ namespace Microsoft.Recognizers.Text.Number
                     ret.Metadata.Offset = Config.RelativeReferenceOffsetMap[extResult.Text];
                     ret.Metadata.RelativeTo = Config.RelativeReferenceRelativeToMap[extResult.Text];
                 }
-                else if (!Config.RelativeReferenceRelativeToMap.ContainsKey(string.Empty) &&
-                    !Config.RelativeReferenceRelativeToMap.ContainsKey(string.Empty))
+                else
                 {
                     ret.Metadata.Offset = ret.ResolutionStr;
 

--- a/.NET/Microsoft.Recognizers.Text/Extractors/Metadata.cs
+++ b/.NET/Microsoft.Recognizers.Text/Extractors/Metadata.cs
@@ -13,7 +13,7 @@
         // For Ordinal
         public bool IsOrdinalRelative { get; set; } = false;
 
-        public string Offset { get; set; } = null;
+        public string Offset { get; set; } = string.Empty;
 
         public string RelativeTo { get; set; } = string.Empty;
     }

--- a/JavaScript/packages/recognizers-number/src/resources/japaneseNumeric.ts
+++ b/JavaScript/packages/recognizers-number/src/resources/japaneseNumeric.ts
@@ -109,5 +109,6 @@ export namespace JapaneseNumeric {
 	export const TwoNumberRangeRegex3 = `(${OneNumberRangeLessRegex1}|${OneNumberRangeLessRegex2}|${OneNumberRangeLessRegex3}|${OneNumberRangeLessRegex4})\\s*(と|は|((と)?同時に)|((と)?そして)|が|，|、|,)?\\s*(${OneNumberRangeMoreRegex1}|${OneNumberRangeMoreRegex2}|${OneNumberRangeMoreRegex3}|${OneNumberRangeMoreRegex4})`;
 	export const TwoNumberRangeRegex4 = `(?<number1>((?!((，(?!\\d+))|(,(?!\\d+))|。)).)+)\\s*${TillRegex}\\s*(?<number2>((?!((，(?!\\d+))|(,(?!\\d+))|。)).)+)`;
 	export const AmbiguousFractionConnectorsRegex = `^[.]`;
-	export const RelativeReferenceMap: ReadonlyMap<string, string> = new Map<string, string>([["", ""]]);
+	export const RelativeReferenceOffsetMap: ReadonlyMap<string, string> = new Map<string, string>([["", ""]]);
+	export const RelativeReferenceRelativeToMap: ReadonlyMap<string, string> = new Map<string, string>([["", ""]]);
 }

--- a/Patterns/Italian/Italian-Numbers.yaml
+++ b/Patterns/Italian/Italian-Numbers.yaml
@@ -442,7 +442,12 @@ RoundNumberMap: !dictionary
     g: 1000000000
     b: 1000000000
     t: 1000000000000
-RelativeReferenceMap: !dictionary
+RelativeReferenceOffsetMap: !dictionary
+  types: [ string, string ]
+# TODO: modify below regex according to the counterpart in English
+  entries:
+    '': ''
+RelativeReferenceRelativeToMap: !dictionary
   types: [ string, string ]
 # TODO: modify below regex according to the counterpart in English
   entries:

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -331,7 +331,12 @@ TwoNumberRangeRegex4: !nestedRegex
 AmbiguousFractionConnectorsRegex: !simpleRegex
 # TODO: modify below regex according to the counterpart in English
   def: ^[.]
-RelativeReferenceMap: !dictionary
+RelativeReferenceOffsetMap: !dictionary
+  types: [ string, string ]
+# TODO: modify below regex according to the counterpart in English
+  entries:
+    '': ''
+RelativeReferenceRelativeToMap: !dictionary
   types: [ string, string ]
 # TODO: modify below regex according to the counterpart in English
   entries:

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -279,7 +279,12 @@ LessOrEqual: !nestedRegex
 LessOrEqualSuffix: !simpleRegex
   def: \s*(이상)
 
-RelativeReferenceMap: !dictionary
+RelativeReferenceOffsetMap: !dictionary
+  types: [ string, string ]
+# TODO: modify below regex according to the counterpart in English
+  entries:
+    '': ''
+RelativeReferenceRelativeToMap: !dictionary
   types: [ string, string ]
 # TODO: modify below regex according to the counterpart in English
   entries:

--- a/Python/libraries/recognizers-number/recognizers_number/resources/japanese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/japanese_numeric.py
@@ -161,5 +161,6 @@ class JapaneseNumeric:
     TwoNumberRangeRegex3 = f'({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2}|{OneNumberRangeLessRegex3}|{OneNumberRangeLessRegex4})\\s*(と|は|((と)?同時に)|((と)?そして)|が|，|、|,)?\\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2}|{OneNumberRangeMoreRegex3}|{OneNumberRangeMoreRegex4})'
     TwoNumberRangeRegex4 = f'(?<number1>((?!((，(?!\\d+))|(,(?!\\d+))|。)).)+)\\s*{TillRegex}\\s*(?<number2>((?!((，(?!\\d+))|(,(?!\\d+))|。)).)+)'
     AmbiguousFractionConnectorsRegex = f'^[.]'
-    RelativeReferenceMap = dict([("", "")])
+    RelativeReferenceOffsetMap = dict([("", "")])
+    RelativeReferenceRelativeToMap = dict([("", "")])
 # pylint: enable=line-too-long

--- a/Specs/Number/Chinese/OrdinalModel.json
+++ b/Specs/Number/Chinese/OrdinalModel.json
@@ -6,7 +6,9 @@
         "Text": "第二百五十",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 4
@@ -20,7 +22,9 @@
         "Text": "第250",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -34,7 +38,9 @@
         "Text": "第一",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 1
@@ -43,7 +49,9 @@
         "Text": "第二",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 3,
         "End": 4
@@ -52,7 +60,9 @@
         "Text": "第三",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 6,
         "End": 7
@@ -61,7 +71,9 @@
         "Text": "第四",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4"
+          "value": "4",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 9,
         "End": 10
@@ -75,7 +87,9 @@
         "Text": "第十四",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "14"
+          "value": "14",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -89,7 +103,9 @@
         "Text": "第三",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 1
@@ -104,7 +120,9 @@
         "Text": "第3万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30000"
+          "value": "30000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -119,7 +137,9 @@
         "Text": "第三万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30000"
+          "value": "30000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2

--- a/Specs/Number/Chinese/OrdinalModel.json
+++ b/Specs/Number/Chinese/OrdinalModel.json
@@ -7,8 +7,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 4
@@ -23,8 +23,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -39,8 +39,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 1
@@ -50,8 +50,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 3,
         "End": 4
@@ -61,8 +61,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 6,
         "End": 7
@@ -72,8 +72,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4",
+          "relativeTo":"start"
         },
         "Start": 9,
         "End": 10
@@ -88,8 +88,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "14",
-          "offset":"",
-          "relativeTo":""
+          "offset":"14",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -104,8 +104,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 1
@@ -121,8 +121,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -138,8 +138,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2

--- a/Specs/Number/Dutch/OrdinalModel.json
+++ b/Specs/Number/Dutch/OrdinalModel.json
@@ -6,7 +6,9 @@
         "Text": "drie biljoenste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -25,7 +27,9 @@
         "Text": "honderd biljoenste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000000"
+          "value": "100000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -38,7 +42,9 @@
         "Text": "11e",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -51,7 +57,9 @@
         "Text": "derde",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -64,7 +72,9 @@
         "Text": "30ste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -77,7 +87,9 @@
         "Text": "tweede",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -90,7 +102,9 @@
         "Text": "elfde",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -103,7 +117,9 @@
         "Text": "nulde",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "0"
+          "value": "0",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -116,7 +132,9 @@
         "Text": "twintigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -129,7 +147,9 @@
         "Text": "vijfendertigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "35"
+          "value": "35",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -142,7 +162,9 @@
         "Text": "eenentwintigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -155,7 +177,9 @@
         "Text": "honderdvijfentwintigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -168,7 +192,9 @@
         "Text": "biljoenste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000000000000"
+          "value": "1000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -181,7 +207,9 @@
         "Text": "eerste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -194,7 +222,9 @@
         "Text": "tweehonderdste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -207,7 +237,9 @@
         "Text": "eerste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -221,7 +253,9 @@
         "Text": "honderdachtste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "108"
+          "value": "108",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -234,7 +268,9 @@
         "Text": "honderdenachtste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "108"
+          "value": "108",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -247,7 +283,9 @@
         "Text": "tweeduizend zestiende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2016"
+          "value": "2016",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -260,7 +298,9 @@
         "Text": "tweeduizend en zestiende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2016"
+          "value": "2016",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -273,7 +313,9 @@
         "Text": "zeventien miljoenste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "17000000"
+          "value": "17000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -286,7 +328,9 @@
         "Text": "vier miljoenste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4000000"
+          "value": "4000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -299,7 +343,9 @@
         "Text": "vier miljoen vierhonderdduizendste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4400000"
+          "value": "4400000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -312,7 +358,9 @@
         "Text": "drieduizend tweehonderdtwintigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3220"
+          "value": "3220",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -326,7 +374,9 @@
         "Text": "honderdvijfendertigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "135"
+          "value": "135",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -339,7 +389,9 @@
         "Text": "honderdentweede",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "102"
+          "value": "102",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -352,7 +404,9 @@
         "Text": "drieduizendste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000"
+          "value": "3000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -366,7 +420,9 @@
         "Text": "honderdeende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "101"
+          "value": "101",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -381,7 +437,9 @@
         "Text": "honderdeneende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "101"
+          "value": "101",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -396,7 +454,9 @@
         "Text": "honderdeerste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "101"
+          "value": "101",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -410,7 +470,9 @@
         "Text": "duizendeende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1001"
+          "value": "1001",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -425,7 +487,9 @@
         "Text": "duizendeerste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1001"
+          "value": "1001",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -438,7 +502,9 @@
         "Text": "achthonderdzevende",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "807"
+          "value": "807",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],
@@ -451,7 +517,9 @@
         "Text": "driehonderdachtste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "308"
+          "value": "308",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ],

--- a/Specs/Number/Dutch/OrdinalModel.json
+++ b/Specs/Number/Dutch/OrdinalModel.json
@@ -7,8 +7,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -28,8 +28,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000000000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -43,8 +43,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         }
       }
     ],
@@ -58,8 +58,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         }
       }
     ],
@@ -73,8 +73,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30",
+          "relativeTo":"start"
         }
       }
     ],
@@ -88,8 +88,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         }
       }
     ],
@@ -103,8 +103,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         }
       }
     ],
@@ -118,8 +118,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "0",
-          "offset":"",
-          "relativeTo":""
+          "offset":"0",
+          "relativeTo":"start"
         }
       }
     ],
@@ -133,8 +133,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"",
-          "relativeTo":""
+          "offset":"20",
+          "relativeTo":"start"
         }
       }
     ],
@@ -148,8 +148,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "35",
-          "offset":"",
-          "relativeTo":""
+          "offset":"35",
+          "relativeTo":"start"
         }
       }
     ],
@@ -163,8 +163,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         }
       }
     ],
@@ -178,8 +178,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         }
       }
     ],
@@ -193,8 +193,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1000000000000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -208,8 +208,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         }
       }
     ],
@@ -223,8 +223,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"",
-          "relativeTo":""
+          "offset":"200",
+          "relativeTo":"start"
         }
       }
     ],
@@ -238,8 +238,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         }
       }
     ],
@@ -254,8 +254,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "108",
-          "offset":"",
-          "relativeTo":""
+          "offset":"108",
+          "relativeTo":"start"
         }
       }
     ],
@@ -269,8 +269,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "108",
-          "offset":"",
-          "relativeTo":""
+          "offset":"108",
+          "relativeTo":"start"
         }
       }
     ],
@@ -284,8 +284,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2016",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2016",
+          "relativeTo":"start"
         }
       }
     ],
@@ -299,8 +299,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2016",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2016",
+          "relativeTo":"start"
         }
       }
     ],
@@ -314,8 +314,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "17000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"17000000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -329,8 +329,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4000000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -344,8 +344,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4400000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4400000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -359,8 +359,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3220",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3220",
+          "relativeTo":"start"
         }
       }
     ],
@@ -375,8 +375,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "135",
-          "offset":"",
-          "relativeTo":""
+          "offset":"135",
+          "relativeTo":"start"
         }
       }
     ],
@@ -390,8 +390,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "102",
-          "offset":"",
-          "relativeTo":""
+          "offset":"102",
+          "relativeTo":"start"
         }
       }
     ],
@@ -405,8 +405,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000",
+          "relativeTo":"start"
         }
       }
     ],
@@ -421,8 +421,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "101",
-          "offset":"",
-          "relativeTo":""
+          "offset":"101",
+          "relativeTo":"start"
         }
       }
     ],
@@ -438,8 +438,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "101",
-          "offset":"",
-          "relativeTo":""
+          "offset":"101",
+          "relativeTo":"start"
         }
       }
     ],
@@ -455,8 +455,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "101",
-          "offset":"",
-          "relativeTo":""
+          "offset":"101",
+          "relativeTo":"start"
         }
       }
     ],
@@ -471,8 +471,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1001",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1001",
+          "relativeTo":"start"
         }
       }
     ],
@@ -488,8 +488,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1001",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1001",
+          "relativeTo":"start"
         }
       }
     ],
@@ -503,8 +503,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "807",
-          "offset":"",
-          "relativeTo":""
+          "offset":"807",
+          "relativeTo":"start"
         }
       }
     ],
@@ -518,8 +518,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "308",
-          "offset":"",
-          "relativeTo":""
+          "offset":"308",
+          "relativeTo":"start"
         }
       }
     ],

--- a/Specs/Number/French/OrdinalModel.json
+++ b/Specs/Number/French/OrdinalModel.json
@@ -7,8 +7,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -23,8 +23,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 16
@@ -43,8 +43,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 4
@@ -59,8 +59,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 13
@@ -75,8 +75,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "9000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"9000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 16
@@ -91,8 +91,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "22",
-          "offset":"",
-          "relativeTo":""
+          "offset":"22",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -107,8 +107,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -123,8 +123,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "155",
-          "offset":"",
-          "relativeTo":""
+          "offset":"155",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -139,8 +139,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "255",
-          "offset":"",
-          "relativeTo":""
+          "offset":"255",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -155,8 +155,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "500000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"500000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 8
@@ -171,8 +171,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -187,8 +187,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 6
@@ -203,8 +203,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"",
-          "relativeTo":""
+          "offset":"20",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 8
@@ -219,8 +219,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"",
-          "relativeTo":""
+          "offset":"25",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -235,8 +235,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "80",
-          "offset":"",
-          "relativeTo":""
+          "offset":"80",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 9
@@ -251,8 +251,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"",
-          "relativeTo":""
+          "offset":"200",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 12
@@ -267,8 +267,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 19
@@ -283,8 +283,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 19
@@ -299,8 +299,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "70",
-          "offset":"",
-          "relativeTo":""
+          "offset":"70",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -315,8 +315,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "80",
-          "offset":"",
-          "relativeTo":""
+          "offset":"80",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -331,8 +331,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "78",
-          "offset":"",
-          "relativeTo":""
+          "offset":"78",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 16
@@ -347,8 +347,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "92",
-          "offset":"",
-          "relativeTo":""
+          "offset":"92",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -363,8 +363,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "322",
-          "offset":"",
-          "relativeTo":""
+          "offset":"322",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 23
@@ -379,8 +379,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "9992",
-          "offset":"",
-          "relativeTo":""
+          "offset":"9992",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 44

--- a/Specs/Number/French/OrdinalModel.json
+++ b/Specs/Number/French/OrdinalModel.json
@@ -6,7 +6,9 @@
         "Text": "tierce",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -20,7 +22,9 @@
         "Text": "trois billionieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 16
@@ -38,7 +42,9 @@
         "Text": "11eme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 4
@@ -52,7 +58,9 @@
         "Text": "trois millieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000"
+          "value": "3000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 13
@@ -66,7 +74,9 @@
         "Text": "neuf milliardieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "9000000000"
+          "value": "9000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 16
@@ -80,7 +90,9 @@
         "Text": "22e",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "22"
+          "value": "22",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -94,7 +106,9 @@
         "Text": "30e",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -108,7 +122,9 @@
         "Text": "155e",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "155"
+          "value": "155",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -122,7 +138,9 @@
         "Text": "255eme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "255"
+          "value": "255",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -136,7 +154,9 @@
         "Text": "500000eme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "500000"
+          "value": "500000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 8
@@ -150,7 +170,9 @@
         "Text": "2eme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -164,7 +186,9 @@
         "Text": "onzieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 6
@@ -178,7 +202,9 @@
         "Text": "vingtieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 8
@@ -192,7 +218,9 @@
         "Text": "vingt-cinquieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -206,7 +234,9 @@
         "Text": "octantieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "80"
+          "value": "80",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 9
@@ -220,7 +250,9 @@
         "Text": "deux centieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 12
@@ -234,7 +266,9 @@
         "Text": "cent vingt cinquieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 19
@@ -248,7 +282,9 @@
         "Text": "cent vingt-cinquieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 19
@@ -262,7 +298,9 @@
         "Text": "soixante-dixieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "70"
+          "value": "70",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -276,7 +314,9 @@
         "Text": "quatre-vingtieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "80"
+          "value": "80",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -290,7 +330,9 @@
         "Text": "septante-huitieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "78"
+          "value": "78",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 16
@@ -304,7 +346,9 @@
         "Text": "nonante-deuxieme",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "92"
+          "value": "92",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -318,7 +362,9 @@
         "Text": "trois cent vingt seconde",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "322"
+          "value": "322",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 23
@@ -332,7 +378,9 @@
         "Text": "neuf mille neuf cent quatre-vingt-dix seconde",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "9992"
+          "value": "9992",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 44

--- a/Specs/Number/German/OrdinalModel.json
+++ b/Specs/Number/German/OrdinalModel.json
@@ -8,8 +8,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -25,8 +25,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 6
@@ -42,8 +42,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"",
-          "relativeTo":""
+          "offset":"25",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 17
@@ -59,8 +59,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "131",
-          "offset":"",
-          "relativeTo":""
+          "offset":"131",
+          "relativeTo":"start"
         },
         "Start": 12,
         "End": 37
@@ -76,8 +76,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 8,
         "End": 13
@@ -93,8 +93,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 18,
         "End": 22
@@ -110,8 +110,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4",
+          "relativeTo":"start"
         },
         "Start": 29,
         "End": 33
@@ -127,8 +127,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 20,
         "End": 23
@@ -138,8 +138,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "12",
-          "offset":"",
-          "relativeTo":""
+          "offset":"12",
+          "relativeTo":"start"
         },
         "Start": 33,
         "End": 39
@@ -155,8 +155,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 9,
         "End": 14
@@ -166,8 +166,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 28,
         "End": 34
@@ -177,8 +177,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4",
+          "relativeTo":"start"
         },
         "Start": 45,
         "End": 51
@@ -188,8 +188,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 58,
         "End": 64
@@ -205,8 +205,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -216,8 +216,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 47,
         "End": 53
@@ -233,8 +233,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1000",
+          "relativeTo":"start"
         },
         "Start": 20,
         "End": 29
@@ -251,8 +251,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 192,
         "End": 196
@@ -262,8 +262,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 242,
         "End": 242
@@ -273,8 +273,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "74",
-          "offset":"",
-          "relativeTo":""
+          "offset":"74",
+          "relativeTo":"start"
         },
         "Start": 346,
         "End": 347
@@ -284,8 +284,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 453,
         "End": 453
@@ -295,8 +295,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "6",
-          "offset":"",
-          "relativeTo":""
+          "offset":"6",
+          "relativeTo":"start"
         },
         "Start": 459,
         "End": 459
@@ -306,8 +306,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "8",
-          "offset":"",
-          "relativeTo":""
+          "offset":"8",
+          "relativeTo":"start"
         },
         "Start": 465,
         "End": 468
@@ -317,8 +317,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "13",
-          "offset":"",
-          "relativeTo":""
+          "offset":"13",
+          "relativeTo":"start"
         },
         "Start": 552,
         "End": 553
@@ -334,8 +334,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 17,
         "End": 17
@@ -351,8 +351,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 17,
         "End": 22
@@ -368,8 +368,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "27",
-          "offset":"",
-          "relativeTo":""
+          "offset":"27",
+          "relativeTo":"start"
         },
         "Start": 7,
         "End": 26
@@ -385,8 +385,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1000000000",
+          "relativeTo":"start"
         },
         "Start": 26,
         "End": 37
@@ -402,8 +402,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -413,8 +413,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 8,
         "End": 14
@@ -424,8 +424,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "8",
-          "offset":"",
-          "relativeTo":""
+          "offset":"8",
+          "relativeTo":"start"
         },
         "Start": 17,
         "End": 22
@@ -435,8 +435,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 53,
         "End": 59
@@ -446,8 +446,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "7",
-          "offset":"",
-          "relativeTo":""
+          "offset":"7",
+          "relativeTo":"start"
         },
         "Start": 78,
         "End": 83
@@ -457,8 +457,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "27",
-          "offset":"",
-          "relativeTo":""
+          "offset":"27",
+          "relativeTo":"start"
         },
         "Start": 109,
         "End": 128
@@ -468,8 +468,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "9",
-          "offset":"",
-          "relativeTo":""
+          "offset":"9",
+          "relativeTo":"start"
         },
         "Start": 150,
         "End": 156
@@ -485,8 +485,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 4,
         "End": 8
@@ -496,8 +496,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "70",
-          "offset":"",
-          "relativeTo":""
+          "offset":"70",
+          "relativeTo":"start"
         },
         "Start": 91,
         "End": 100
@@ -513,8 +513,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 24,
         "End": 28
@@ -535,8 +535,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 5,
         "End": 11
@@ -552,8 +552,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100",
+          "relativeTo":"start"
         },
         "Start": 4,
         "End": 14
@@ -569,8 +569,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000000",
+          "relativeTo":"start"
         },
         "Start": 80,
         "End": 101
@@ -580,8 +580,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "300000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"300000000000",
+          "relativeTo":"start"
         },
         "Start": 121,
         "End": 143
@@ -597,8 +597,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000",
+          "relativeTo":"start"
         },
         "Start": 80,
         "End": 100
@@ -608,8 +608,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "300000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"300000000",
+          "relativeTo":"start"
         },
         "Start": 120,
         "End": 141
@@ -625,8 +625,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000000000",
+          "relativeTo":"start"
         },
         "Start": 80,
         "End": 100
@@ -636,8 +636,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "300000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"300000000000000",
+          "relativeTo":"start"
         },
         "Start": 120,
         "End": 141
@@ -653,8 +653,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 37,
         "End": 43
@@ -664,8 +664,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 70,
         "End": 76
@@ -681,8 +681,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000",
+          "relativeTo":"start"
         },
         "Start": 13,
         "End": 32

--- a/Specs/Number/German/OrdinalModel.json
+++ b/Specs/Number/German/OrdinalModel.json
@@ -7,7 +7,9 @@
         "Text": "erster",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -22,7 +24,9 @@
         "Text": "zweiter",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 6
@@ -37,7 +41,9 @@
         "Text": "fünfundzwanzigster",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 17
@@ -52,7 +58,9 @@
         "Text": "einhunderteinunddreißigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "131"
+          "value": "131",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 12,
         "End": 37
@@ -67,7 +75,9 @@
         "Text": "erster",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 8,
         "End": 13
@@ -82,7 +92,9 @@
         "Text": "dritt",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 18,
         "End": 22
@@ -97,7 +109,9 @@
         "Text": "viert",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4"
+          "value": "4",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 29,
         "End": 33
@@ -112,7 +126,9 @@
         "Text": "elft",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 20,
         "End": 23
@@ -121,7 +137,9 @@
         "Text": "zwoelft",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "12"
+          "value": "12",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 33,
         "End": 39
@@ -136,7 +154,9 @@
         "Text": "zuerst",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 9,
         "End": 14
@@ -145,7 +165,9 @@
         "Text": "zweiter",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 28,
         "End": 34
@@ -154,7 +176,9 @@
         "Text": "vierter",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4"
+          "value": "4",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 45,
         "End": 51
@@ -163,7 +187,9 @@
         "Text": "dritten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 58,
         "End": 64
@@ -178,7 +204,9 @@
         "Text": "zuerst",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -187,7 +215,9 @@
         "Text": "dritten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 47,
         "End": 53
@@ -202,7 +232,9 @@
         "Text": "tausendste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000"
+          "value": "1000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 20,
         "End": 29
@@ -218,7 +250,9 @@
         "Text": "erste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 192,
         "End": 196
@@ -227,7 +261,9 @@
         "Text": "3",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 242,
         "End": 242
@@ -236,7 +272,9 @@
         "Text": "74",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "74"
+          "value": "74",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 346,
         "End": 347
@@ -245,7 +283,9 @@
         "Text": "2",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 453,
         "End": 453
@@ -254,7 +294,9 @@
         "Text": "6",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "6"
+          "value": "6",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 459,
         "End": 459
@@ -263,7 +305,9 @@
         "Text": "acht",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "8"
+          "value": "8",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 465,
         "End": 468
@@ -272,7 +316,9 @@
         "Text": "13",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "13"
+          "value": "13",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 552,
         "End": 553
@@ -287,7 +333,9 @@
         "Text": "3",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 17,
         "End": 17
@@ -302,7 +350,9 @@
         "Text": "dritte",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 17,
         "End": 22
@@ -317,7 +367,9 @@
         "Text": "siebenundzwanzigster",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "27"
+          "value": "27",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 7,
         "End": 26
@@ -332,7 +384,9 @@
         "Text": "milliardsten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000000000"
+          "value": "1000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 26,
         "End": 37
@@ -347,7 +401,9 @@
         "Text": "erster",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -356,7 +412,9 @@
         "Text": "zweiter",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 8,
         "End": 14
@@ -365,7 +423,9 @@
         "Text": "achter",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "8"
+          "value": "8",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 17,
         "End": 22
@@ -374,7 +434,9 @@
         "Text": "dritten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 53,
         "End": 59
@@ -383,7 +445,9 @@
         "Text": "siebte",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "7"
+          "value": "7",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 78,
         "End": 83
@@ -392,7 +456,9 @@
         "Text": "siebenundzwanzigsten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "27"
+          "value": "27",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 109,
         "End": 128
@@ -401,7 +467,9 @@
         "Text": "neunten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "9"
+          "value": "9",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 150,
         "End": 156
@@ -416,7 +484,9 @@
         "Text": "erste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 4,
         "End": 8
@@ -425,7 +495,9 @@
         "Text": "siebzigste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "70"
+          "value": "70",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 91,
         "End": 100
@@ -440,7 +512,9 @@
         "Text": "erste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 24,
         "End": 28
@@ -460,7 +534,9 @@
         "Text": "zweiten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 5,
         "End": 11
@@ -475,7 +551,9 @@
         "Text": "hundertsten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100"
+          "value": "100",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 4,
         "End": 14
@@ -490,7 +568,9 @@
         "Text": "einhundert milliardste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000"
+          "value": "100000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 80,
         "End": 101
@@ -499,7 +579,9 @@
         "Text": "dreihundert milliardste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "300000000000"
+          "value": "300000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 121,
         "End": 143
@@ -514,7 +596,9 @@
         "Text": "einhundert millionste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000"
+          "value": "100000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 80,
         "End": 100
@@ -523,7 +607,9 @@
         "Text": "dreihundert millionste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "300000000"
+          "value": "300000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 120,
         "End": 141
@@ -538,7 +624,9 @@
         "Text": "einhundert billionste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000000"
+          "value": "100000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 80,
         "End": 100
@@ -547,7 +635,9 @@
         "Text": "dreihundert billionste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "300000000000000"
+          "value": "300000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 120,
         "End": 141
@@ -562,7 +652,9 @@
         "Text": "dritten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 37,
         "End": 43
@@ -571,7 +663,9 @@
         "Text": "dritten",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 70,
         "End": 76
@@ -586,7 +680,9 @@
         "Text": "einhunderttausendste",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000"
+          "value": "100000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 13,
         "End": 32

--- a/Specs/Number/Italian/OrdinalModel.json
+++ b/Specs/Number/Italian/OrdinalModel.json
@@ -9,8 +9,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -25,8 +25,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -41,8 +41,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -57,8 +57,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         }
       }
     ]
@@ -73,8 +73,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         }
       }
     ]
@@ -89,8 +89,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30",
+          "relativeTo":"start"
         }
       }
     ]
@@ -105,8 +105,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         }
       }
     ]
@@ -121,8 +121,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         }
       }
     ]
@@ -137,8 +137,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"",
-          "relativeTo":""
+          "offset":"20",
+          "relativeTo":"start"
         }
       }
     ]
@@ -153,8 +153,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"",
-          "relativeTo":""
+          "offset":"25",
+          "relativeTo":"start"
         }
       }
     ]
@@ -169,8 +169,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         }
       }
     ]
@@ -185,8 +185,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         }
       }
     ]
@@ -201,8 +201,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"",
-          "relativeTo":""
+          "offset":"200",
+          "relativeTo":"start"
         }
       }
     ]
@@ -217,8 +217,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         }
       }
     ]

--- a/Specs/Number/Italian/OrdinalModel.json
+++ b/Specs/Number/Italian/OrdinalModel.json
@@ -8,7 +8,9 @@
         "Text": "tre trilionesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -22,7 +24,9 @@
         "Text": "trilionesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000000000000"
+          "value": "1000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -36,7 +40,9 @@
         "Text": "cento trilioni",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000000"
+          "value": "100000000000000",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -50,7 +56,9 @@
         "Text": "11th",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -64,7 +72,9 @@
         "Text": "21st",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -78,7 +88,9 @@
         "Text": "30th",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -92,7 +104,9 @@
         "Text": "2nd",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -106,7 +120,9 @@
         "Text": "undicesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -120,7 +136,9 @@
         "Text": "ventesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -134,7 +152,9 @@
         "Text": "venticinquesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -148,7 +168,9 @@
         "Text": "ventunesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -162,7 +184,9 @@
         "Text": "centoventicinquensimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -176,7 +200,9 @@
         "Text": "duecentesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]
@@ -190,7 +216,9 @@
         "Text": "prima",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         }
       }
     ]

--- a/Specs/Number/Japanese/OrdinalModel.json
+++ b/Specs/Number/Japanese/OrdinalModel.json
@@ -7,7 +7,9 @@
         "Text": "だい12",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "12"
+          "value": "12",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -22,7 +24,9 @@
         "Text": "第二百五十",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 4
@@ -37,7 +41,9 @@
         "Text": "だい二百五十",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -52,7 +58,9 @@
         "Text": "第250",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -67,7 +75,9 @@
         "Text": "だい250",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "250"
+          "value": "250",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 4
@@ -82,7 +92,9 @@
         "Text": "だい一億",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000"
+          "value": "100000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -97,7 +109,9 @@
         "Text": "第一億",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000"
+          "value": "100000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -112,7 +126,9 @@
         "Text": "だい一万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "10000"
+          "value": "10000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -121,7 +137,9 @@
         "Text": "だい十万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000"
+          "value": "100000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 5,
         "End": 8
@@ -136,7 +154,9 @@
         "Text": "第一",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 1
@@ -145,7 +165,9 @@
         "Text": "第二",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 3,
         "End": 4
@@ -154,7 +176,9 @@
         "Text": "第三",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 6,
         "End": 7
@@ -163,7 +187,9 @@
         "Text": "第四",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4"
+          "value": "4",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 9,
         "End": 10
@@ -178,7 +204,9 @@
         "Text": "第1",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 1
@@ -187,7 +215,9 @@
         "Text": "第2",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 3,
         "End": 4
@@ -196,7 +226,9 @@
         "Text": "第3",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3"
+          "value": "3",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 6,
         "End": 7
@@ -205,7 +237,9 @@
         "Text": "第4",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "4"
+          "value": "4",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 9,
         "End": 10
@@ -220,7 +254,9 @@
         "Text": "第3万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30000"
+          "value": "30000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -235,7 +271,9 @@
         "Text": "第三万",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30000"
+          "value": "30000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2

--- a/Specs/Number/Japanese/OrdinalModel.json
+++ b/Specs/Number/Japanese/OrdinalModel.json
@@ -8,8 +8,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "12",
-          "offset":"",
-          "relativeTo":""
+          "offset":"12",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -25,8 +25,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 4
@@ -42,8 +42,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -59,8 +59,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -76,8 +76,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "250",
-          "offset":"",
-          "relativeTo":""
+          "offset":"250",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 4
@@ -93,8 +93,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -110,8 +110,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -127,8 +127,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "10000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"10000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -138,8 +138,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000",
+          "relativeTo":"start"
         },
         "Start": 5,
         "End": 8
@@ -155,8 +155,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 1
@@ -166,8 +166,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 3,
         "End": 4
@@ -177,8 +177,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 6,
         "End": 7
@@ -188,8 +188,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4",
+          "relativeTo":"start"
         },
         "Start": 9,
         "End": 10
@@ -205,8 +205,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 1
@@ -216,8 +216,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 3,
         "End": 4
@@ -227,8 +227,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3",
+          "relativeTo":"start"
         },
         "Start": 6,
         "End": 7
@@ -238,8 +238,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "4",
-          "offset":"",
-          "relativeTo":""
+          "offset":"4",
+          "relativeTo":"start"
         },
         "Start": 9,
         "End": 10
@@ -255,8 +255,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -272,8 +272,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2

--- a/Specs/Number/Korean/OrdinalModel.json
+++ b/Specs/Number/Korean/OrdinalModel.json
@@ -7,7 +7,9 @@
         "Text": "3조 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"3000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -20,7 +22,9 @@
         "Text": "조 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000000000000"
+          "value": "1000000000000",
+          "offset":"1000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -33,7 +37,9 @@
         "Text": "백조 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000000"
+          "value": "100000000000000",
+          "offset":"100000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -46,7 +52,9 @@
         "Text": "열한 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"11",
+          "relativeTo":"start"
         }
       }
     ]
@@ -59,7 +67,9 @@
         "Text": "스물한 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"21",
+          "relativeTo":"start"
         }
       }
     ]
@@ -72,7 +82,9 @@
         "Text": "서른 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"30",
+          "relativeTo":"start"
         }
       }
     ]
@@ -85,7 +97,9 @@
         "Text": "두 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"2",
+          "relativeTo":"start"
         }
       }
     ]
@@ -98,7 +112,9 @@
         "Text": "스무 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"20",
+          "relativeTo":"start"
         }
       }
     ]
@@ -111,7 +127,9 @@
         "Text": "스물다섯 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"25",
+          "relativeTo":"start"
         }
       }
     ]
@@ -124,7 +142,9 @@
         "Text": "백스물다섯 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"125",
+          "relativeTo":"start"
         }
       }
     ]
@@ -137,7 +157,9 @@
         "Text": "백이십오 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"125",
+          "relativeTo":"start"
         }
       }
     ]
@@ -150,7 +172,9 @@
         "Text": "조번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1000000000000"
+          "value": "1000000000000",
+          "offset":"1000000000000",
+          "relativeTo":"start"
         }
       }
     ]
@@ -163,7 +187,9 @@
         "Text": "이십일조 삼백이십이 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21000000000322"
+          "value": "21000000000322",
+          "offset":"21000000000322",
+          "relativeTo":"start"
         }
       }
     ]
@@ -176,7 +202,9 @@
         "Text": "이백 번째",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"200",
+          "relativeTo":"start"
         }
       }
     ]
@@ -189,7 +217,9 @@
         "Text": "일등",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"1",
+          "relativeTo":"start"
         }
       }
     ]

--- a/Specs/Number/Portuguese/OrdinalModel.json
+++ b/Specs/Number/Portuguese/OrdinalModel.json
@@ -7,8 +7,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "7",
-          "offset":"",
-          "relativeTo":""
+          "offset":"7",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 5
@@ -23,8 +23,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "47",
-          "offset":"",
-          "relativeTo":""
+          "offset":"47",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 18
@@ -39,8 +39,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 31
@@ -55,8 +55,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 45
@@ -71,8 +71,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "52347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"52347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 57
@@ -87,8 +87,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1523",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1523",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 39
@@ -103,8 +103,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"",
-          "relativeTo":""
+          "offset":"25",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -119,8 +119,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 16
@@ -135,8 +135,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 24
@@ -151,8 +151,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"",
-          "relativeTo":""
+          "offset":"200",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 10
@@ -167,8 +167,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -183,8 +183,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -199,8 +199,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 1
@@ -215,8 +215,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 7
@@ -231,8 +231,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -247,8 +247,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"",
-          "relativeTo":""
+          "offset":"20",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 7
@@ -263,8 +263,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 8
@@ -279,8 +279,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "22000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"22000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 20
@@ -295,8 +295,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 72
@@ -311,8 +311,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 85
@@ -327,8 +327,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3524694673",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3524694673",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 117

--- a/Specs/Number/Portuguese/OrdinalModel.json
+++ b/Specs/Number/Portuguese/OrdinalModel.json
@@ -6,7 +6,9 @@
         "Text": "setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "7"
+          "value": "7",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 5
@@ -20,7 +22,9 @@
         "Text": "quadragesimo setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "47"
+          "value": "47",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 18
@@ -34,7 +38,9 @@
         "Text": "tricentésimo quadragésima sétima",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "347"
+          "value": "347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 31
@@ -48,7 +54,9 @@
         "Text": "dois milesimo tricentesimo quadragesimo setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2347"
+          "value": "2347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 45
@@ -62,7 +70,9 @@
         "Text": "cinquenta e dois milesimo tricentesimo quadragesimo setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "52347"
+          "value": "52347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 57
@@ -76,7 +86,9 @@
         "Text": "milesimo quingentesimo vigesimo terceiro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1523"
+          "value": "1523",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 39
@@ -90,7 +102,9 @@
         "Text": "vigesimo quinto",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -104,7 +118,9 @@
         "Text": "vigesimo primeiro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 16
@@ -118,7 +134,9 @@
         "Text": "centesimo vigesimo quinto",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 24
@@ -132,7 +150,9 @@
         "Text": "ducentesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 10
@@ -146,7 +166,9 @@
         "Text": "21o",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -160,7 +182,9 @@
         "Text": "30a",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -174,7 +198,9 @@
         "Text": "2a",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 1
@@ -188,7 +214,9 @@
         "Text": "undecimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 7
@@ -202,7 +230,9 @@
         "Text": "décimo primeiro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -216,7 +246,9 @@
         "Text": "vigesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 7
@@ -230,7 +262,9 @@
         "Text": "centesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100"
+          "value": "100",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 8
@@ -244,7 +278,9 @@
         "Text": "vinte e dois milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "22000"
+          "value": "22000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 20
@@ -258,7 +294,9 @@
         "Text": "quatrocentos e cinquenta e dois milesimo tricentesimo quadragesimo setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "452347"
+          "value": "452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 72
@@ -272,7 +310,9 @@
         "Text": "três milhões quatrocentos e cinquenta e dois milésimo tricentesimo quadragesimo setimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3452347"
+          "value": "3452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 85
@@ -286,7 +326,9 @@
         "Text": "tres mil quinhentos e vinte e quatro milhoes seiscentos e noventa e quatro milesimo sexcentesimo septuagesimo terceiro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3524694673"
+          "value": "3524694673",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 117

--- a/Specs/Number/Spanish/OrdinalModel.json
+++ b/Specs/Number/Spanish/OrdinalModel.json
@@ -6,7 +6,9 @@
         "Text": "tresmillonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000"
+          "value": "3000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -20,7 +22,9 @@
         "Text": "dos mil millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2000000000"
+          "value": "2000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 18
@@ -34,7 +38,9 @@
         "Text": "septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "7"
+          "value": "7",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 6
@@ -48,7 +54,9 @@
         "Text": "cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "47"
+          "value": "47",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 19
@@ -62,7 +70,9 @@
         "Text": "tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "347"
+          "value": "347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 32
@@ -76,7 +86,9 @@
         "Text": "dosmilesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2347"
+          "value": "2347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 44
@@ -90,7 +102,9 @@
         "Text": "cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "52347"
+          "value": "52347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 57
@@ -104,7 +118,9 @@
         "Text": "cuatrocientos cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "452347"
+          "value": "452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 71
@@ -118,7 +134,9 @@
         "Text": "tresmillonesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000007"
+          "value": "3000007",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 22
@@ -132,7 +150,9 @@
         "Text": "tresmillonesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000047"
+          "value": "3000047",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 35
@@ -146,7 +166,9 @@
         "Text": "tresmillonesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000347"
+          "value": "3000347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 48
@@ -160,7 +182,9 @@
         "Text": "tres millones dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3002347"
+          "value": "3002347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 59
@@ -174,7 +198,9 @@
         "Text": "tres millones cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3052347"
+          "value": "3052347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 71
@@ -188,7 +214,9 @@
         "Text": "tres millones cuatrocientos cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3452347"
+          "value": "3452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 85
@@ -202,7 +230,9 @@
         "Text": "trece millones cuatrocientos cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "13452347"
+          "value": "13452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 86
@@ -216,7 +246,9 @@
         "Text": "quinientos trece millones cuatrocientos cincuenta y dos milesimo tricentesimo cuadragesimo septimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513452347"
+          "value": "513452347",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 97
@@ -230,7 +262,9 @@
         "Text": "quinientos trece millones cuatrocientos cincuenta y dos milesimo tricentesimo cuadragesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513452340"
+          "value": "513452340",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 89
@@ -244,7 +278,9 @@
         "Text": "quinientos trece millones cuatrocientos cincuenta y dos milesimo tricentesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513452300"
+          "value": "513452300",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 76
@@ -258,7 +294,9 @@
         "Text": "quinientos trece millones cuatrocientos cincuenta y dos milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513452000"
+          "value": "513452000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 63
@@ -272,7 +310,9 @@
         "Text": "quinientos trece millones cuatrocientos cincuenta milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513450000"
+          "value": "513450000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 57
@@ -286,7 +326,9 @@
         "Text": "quinientos trece millones cuatrocientos milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513400000"
+          "value": "513400000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 47
@@ -300,7 +342,9 @@
         "Text": "quinientos trece millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "513000000"
+          "value": "513000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 27
@@ -314,7 +358,9 @@
         "Text": "quinientos diez millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "510000000"
+          "value": "510000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 26
@@ -328,7 +374,9 @@
         "Text": "quinientosmillonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "500000000"
+          "value": "500000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 20
@@ -342,7 +390,9 @@
         "Text": "milesimo quingentesimo vigesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1523"
+          "value": "1523",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 38
@@ -356,7 +406,9 @@
         "Text": "tres billones cuatrocientos cincuenta y cinco mil doscientos veintiocho millones quinientos cincuenta y seis milesimo octingentesimo trigesimo segundo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3455228556832"
+          "value": "3455228556832",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 149
@@ -370,7 +422,9 @@
         "Text": "tres billones cuatrocientos cincuenta y cinco mil doscientos veintiocho millones quinientos cincuenta y seis milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3455228556000"
+          "value": "3455228556000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 116
@@ -384,7 +438,9 @@
         "Text": "tres billones cuatrocientos cincuenta y cinco mil doscientos veintiocho millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3455228000000"
+          "value": "3455228000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 82
@@ -398,7 +454,9 @@
         "Text": "tres billones cuatrocientos cincuenta y cinco mil millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3455000000000"
+          "value": "3455000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 60
@@ -412,7 +470,9 @@
         "Text": "tresbillonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -426,7 +486,9 @@
         "Text": "vigesimo quinto",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "25"
+          "value": "25",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 14
@@ -440,7 +502,9 @@
         "Text": "vigesimo primero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -454,7 +518,9 @@
         "Text": "centesimo vigesimo quinto",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "125"
+          "value": "125",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 24
@@ -468,7 +534,9 @@
         "Text": "ducentesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "200"
+          "value": "200",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 10
@@ -482,7 +550,9 @@
         "Text": "tres mil quinientos veinticuatro millones seiscientos noventa y cuatro milesimo sexcentesimo septuagesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3524694673"
+          "value": "3524694673",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 112
@@ -496,7 +566,9 @@
         "Text": "tres mil quinientos veinticuatro millones seiscientos noventa y cuatro milesimo sexcentesimo septuagesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3524694670"
+          "value": "3524694670",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 104
@@ -510,7 +582,9 @@
         "Text": "tres mil quinientos veinticuatro millones seiscientos noventa y cuatro milesimo sexcentesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3524694600"
+          "value": "3524694600",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 91
@@ -524,7 +598,9 @@
         "Text": "tres mil quinientos veinticuatro millones seiscientos milesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3524600000"
+          "value": "3524600000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 61
@@ -538,7 +614,9 @@
         "Text": "tres mil millonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000"
+          "value": "3000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 19
@@ -552,7 +630,9 @@
         "Text": "tres mil millonesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000003"
+          "value": "3000000003",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 27
@@ -566,7 +646,9 @@
         "Text": "tres mil millonesimo septuagesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000073"
+          "value": "3000000073",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 40
@@ -580,7 +662,9 @@
         "Text": "tres mil millonesimo sexcentesimo septuagesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000673"
+          "value": "3000000673",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 53
@@ -594,7 +678,9 @@
         "Text": "tres mil millones cuatro milesimo sexcentesimo septuagesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000004673"
+          "value": "3000004673",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 66
@@ -608,7 +694,9 @@
         "Text": "tres mil veinticuatro millones seiscientos noventa y cuatro milesimo sexcentesimo septuagesimo tercero",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3024694673"
+          "value": "3024694673",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 101
@@ -622,7 +710,9 @@
         "Text": "11mo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -636,7 +726,9 @@
         "Text": "11vo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -650,7 +742,9 @@
         "Text": "12vo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "12"
+          "value": "12",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -664,7 +758,9 @@
         "Text": "111ro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "111"
+          "value": "111",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 4
@@ -678,7 +774,9 @@
         "Text": "21ro",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "21"
+          "value": "21",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -692,7 +790,9 @@
         "Text": "30ma",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "30"
+          "value": "30",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 3
@@ -706,7 +806,9 @@
         "Text": "2da",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "2"
+          "value": "2",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 2
@@ -720,7 +822,9 @@
         "Text": "undecimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "11"
+          "value": "11",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 7
@@ -734,7 +838,9 @@
         "Text": "veintidosmilesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "22000"
+          "value": "22000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 16
@@ -748,7 +854,9 @@
         "Text": "cincuenta y cinco billones quinientos cincuenta y cinco mil quinientos cincuenta y cinco millones quinientos cincuenta y cinco milesimo quingentesimo quincuagesimo quinto",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "55555555555555"
+          "value": "55555555555555",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 169
@@ -762,7 +870,9 @@
         "Text": "vigesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "20"
+          "value": "20",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 7
@@ -776,7 +886,9 @@
         "Text": "centesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100"
+          "value": "100",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 8
@@ -790,7 +902,9 @@
         "Text": "tres billonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -804,7 +918,9 @@
         "Text": "tres billonesima",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "3000000000000"
+          "value": "3000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -818,7 +934,9 @@
         "Text": "cien billonesimo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "100000000000000"
+          "value": "100000000000000",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 15
@@ -832,7 +950,9 @@
         "Text": "primer",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "1"
+          "value": "1",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 3,
         "End": 8
@@ -846,7 +966,9 @@
         "Text": "decimoctavo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "18"
+          "value": "18",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 0,
         "End": 10
@@ -855,7 +977,9 @@
         "Text": "décimo octavo",
         "TypeName": "ordinal",
         "Resolution": {
-          "value": "18"
+          "value": "18",
+          "offset":"",
+          "relativeTo":""
         },
         "Start": 14,
         "End": 26

--- a/Specs/Number/Spanish/OrdinalModel.json
+++ b/Specs/Number/Spanish/OrdinalModel.json
@@ -7,8 +7,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -23,8 +23,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 18
@@ -39,8 +39,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "7",
-          "offset":"",
-          "relativeTo":""
+          "offset":"7",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 6
@@ -55,8 +55,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "47",
-          "offset":"",
-          "relativeTo":""
+          "offset":"47",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 19
@@ -71,8 +71,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 32
@@ -87,8 +87,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 44
@@ -103,8 +103,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "52347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"52347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 57
@@ -119,8 +119,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 71
@@ -135,8 +135,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000007",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000007",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 22
@@ -151,8 +151,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000047",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000047",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 35
@@ -167,8 +167,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 48
@@ -183,8 +183,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3002347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3002347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 59
@@ -199,8 +199,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3052347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3052347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 71
@@ -215,8 +215,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 85
@@ -231,8 +231,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "13452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"13452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 86
@@ -247,8 +247,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513452347",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513452347",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 97
@@ -263,8 +263,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513452340",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513452340",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 89
@@ -279,8 +279,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513452300",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513452300",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 76
@@ -295,8 +295,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513452000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513452000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 63
@@ -311,8 +311,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513450000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513450000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 57
@@ -327,8 +327,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513400000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513400000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 47
@@ -343,8 +343,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "513000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"513000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 27
@@ -359,8 +359,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "510000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"510000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 26
@@ -375,8 +375,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "500000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"500000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 20
@@ -391,8 +391,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1523",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1523",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 38
@@ -407,8 +407,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3455228556832",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3455228556832",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 149
@@ -423,8 +423,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3455228556000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3455228556000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 116
@@ -439,8 +439,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3455228000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3455228000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 82
@@ -455,8 +455,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3455000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3455000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 60
@@ -471,8 +471,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -487,8 +487,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"",
-          "relativeTo":""
+          "offset":"25",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 14
@@ -503,8 +503,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -519,8 +519,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"",
-          "relativeTo":""
+          "offset":"125",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 24
@@ -535,8 +535,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"",
-          "relativeTo":""
+          "offset":"200",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 10
@@ -551,8 +551,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3524694673",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3524694673",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 112
@@ -567,8 +567,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3524694670",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3524694670",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 104
@@ -583,8 +583,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3524694600",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3524694600",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 91
@@ -599,8 +599,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3524600000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3524600000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 61
@@ -615,8 +615,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 19
@@ -631,8 +631,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000003",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000003",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 27
@@ -647,8 +647,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000073",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000073",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 40
@@ -663,8 +663,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000673",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000673",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 53
@@ -679,8 +679,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000004673",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000004673",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 66
@@ -695,8 +695,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3024694673",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3024694673",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 101
@@ -711,8 +711,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -727,8 +727,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -743,8 +743,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "12",
-          "offset":"",
-          "relativeTo":""
+          "offset":"12",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -759,8 +759,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "111",
-          "offset":"",
-          "relativeTo":""
+          "offset":"111",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 4
@@ -775,8 +775,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"",
-          "relativeTo":""
+          "offset":"21",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -791,8 +791,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"",
-          "relativeTo":""
+          "offset":"30",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 3
@@ -807,8 +807,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"",
-          "relativeTo":""
+          "offset":"2",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 2
@@ -823,8 +823,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"",
-          "relativeTo":""
+          "offset":"11",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 7
@@ -839,8 +839,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "22000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"22000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 16
@@ -855,8 +855,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "55555555555555",
-          "offset":"",
-          "relativeTo":""
+          "offset":"55555555555555",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 169
@@ -871,8 +871,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"",
-          "relativeTo":""
+          "offset":"20",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 7
@@ -887,8 +887,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 8
@@ -903,8 +903,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -919,8 +919,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"3000000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -935,8 +935,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000000",
-          "offset":"",
-          "relativeTo":""
+          "offset":"100000000000000",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 15
@@ -951,8 +951,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"",
-          "relativeTo":""
+          "offset":"1",
+          "relativeTo":"start"
         },
         "Start": 3,
         "End": 8
@@ -967,8 +967,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "18",
-          "offset":"",
-          "relativeTo":""
+          "offset":"18",
+          "relativeTo":"start"
         },
         "Start": 0,
         "End": 10
@@ -978,8 +978,8 @@
         "TypeName": "ordinal",
         "Resolution": {
           "value": "18",
-          "offset":"",
-          "relativeTo":""
+          "offset":"18",
+          "relativeTo":"start"
         },
         "Start": 14,
         "End": 26


### PR DESCRIPTION
add "relativeTo" and "offset" into other languages as well.
Their values will be an empty string in other languages(expect English).
English totally support this function now.