### PR TITLE
Fix cases like "thursday morning est" where timezone is tagged, but not parsed in resolution

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new DutchDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new DutchTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new DutchTimeZoneExtractorConfiguration(this));
         }
 
         public string TokenBeforeDate { get; }
@@ -147,6 +148,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         // TODO: these three methods are the same in DatePeriod, should be abstracted
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = DutchTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -84,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(this));
         }
 
         public IEnumerable<Regex> SimpleCasesRegex => SimpleCases;
@@ -147,6 +148,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         // TODO: these three methods are the same in DatePeriod, should be abstracted
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = EnglishTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = EnglishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -84,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeAltExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimeAltExtractor.cs
@@ -234,6 +234,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static void ApplyMetadata(List<ExtractResult> ers, Dictionary<string, object> metadata, string parentText)
         {
+            // Share the timeZone info
+            var metaDataOrigin = ers[0].Data as Dictionary<string, object>;
+            if (metaDataOrigin != null && metaDataOrigin.ContainsKey(Constants.SYS_DATETIME_TIMEZONE))
+            {
+                metadata.Add(Constants.SYS_DATETIME_TIMEZONE, metaDataOrigin[Constants.SYS_DATETIME_TIMEZONE]);
+            }
+
             // The first extract results don't need any context
             var metadataWithoutConext = CreateMetadata(ers[0].Type, parentText, contextEr: null);
             ers[0].Data = MergeMetadata(ers[0].Data, metadataWithoutConext);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -37,7 +37,14 @@ namespace Microsoft.Recognizers.Text.DateTime
             tokens.AddRange(MatchDateWithPeriodPrefix(text, reference, new List<ExtractResult>(dateErs)));
             tokens.AddRange(MergeDateWithTimePeriodSuffix(text, new List<ExtractResult>(dateErs), new List<ExtractResult>(timeErs)));
 
-            return Token.MergeAllTokens(tokens, text, ExtractorName);
+            var ers = Token.MergeAllTokens(tokens, text, ExtractorName);
+
+            if ((this.config.Options & DateTimeOptions.EnablePreview) != 0)
+            {
+                ers = TimeZoneUtility.MergeTimeZones(ers, config.TimeZoneExtractor.Extract(text, reference), text);
+            }
+
+            return ers;
         }
 
         private static bool MatchPrefixRegexInSegment(string beforeStr, Match match)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor TimePeriodExtractor { get; }
 
+        IDateTimeExtractor TimeZoneExtractor { get; }
+
         bool GetFromTokenIndex(string text, out int index);
 
         bool HasConnectorToken(string text);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(this));
         }
 
         public IEnumerable<Regex> SimpleCasesRegex => SimpleCases;
@@ -125,6 +126,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         Regex IDateTimePeriodExtractorConfiguration.PrefixDayRegex => PrefixDayRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = FrenchTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = FrenchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -84,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new GermanDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new GermanTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new GermanTimeZoneExtractorConfiguration(this));
         }
 
         public IEnumerable<Regex> SimpleCasesRegex => SimpleCases;
@@ -154,6 +155,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         // TODO: these three methods are the same in DatePeriod, should be abstracted
         public bool GetFromTokenIndex(string text, out int index)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = GermanTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = GermanTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -84,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new ItalianDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new ItalianTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new ItalianTimeZoneExtractorConfiguration(this));
         }
 
         public IEnumerable<Regex> SimpleCasesRegex => SimpleCases;
@@ -140,6 +141,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         Regex IDateTimePeriodExtractorConfiguration.PrefixDayRegex => PrefixDayRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
             DateTimeParser = config.DateTimeParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = ItalianTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = ItalianTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -84,6 +85,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeParser DurationParser { get; }
 
+        IDateTimeParser TimeZoneParser { get; }
+
         Regex PureNumberFromToRegex { get; }
 
         Regex PureNumberBetweenAndRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new PortugueseDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new PortugueseTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new PortugueseTimeZoneExtractorConfiguration(this));
         }
 
         public string TokenBeforeDate { get; }
@@ -81,6 +82,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public IEnumerable<Regex> SimpleCasesRegex => new[]
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             DateTimeParser = config.DateTimeParser;
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = PortugueseTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = PortugueseTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -73,6 +74,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             SingleDateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(this));
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));
             TimePeriodExtractor = new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration(this));
+            TimeZoneExtractor = new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(this));
         }
 
         public string TokenBeforeDate { get; }
@@ -98,6 +99,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimePeriodExtractor { get; }
+
+        public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public IEnumerable<Regex> SimpleCasesRegex => new[]
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DateTimeParser = config.DateTimeParser;
             TimePeriodParser = config.TimePeriodParser;
             DurationParser = config.DurationParser;
+            TimeZoneParser = config.TimeZoneParser;
 
             PureNumberFromToRegex = SpanishTimePeriodExtractorConfiguration.PureNumFromTo;
             PureNumberBetweenAndRegex = SpanishTimePeriodExtractorConfiguration.PureNumBetweenAnd;
@@ -70,6 +71,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser TimeZoneParser { get; }
 
         public Regex PureNumberFromToRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
@@ -32,6 +32,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                             };
                         }
                     }
+
+                    if (er.IsOverlap(timeZoneEr))
+                    {
+                        er.Data = new Dictionary<string, object>()
+                            {
+                                { Constants.SYS_DATETIME_TIMEZONE, timeZoneEr },
+                            };
+                    }
                 }
             }
 
@@ -41,6 +49,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         public static bool ShouldResolveTimeZone(ExtractResult er, DateTimeOptions options)
         {
             var enablePreview = (options & DateTimeOptions.EnablePreview) != 0;
+            if (!enablePreview)
+            {
+                return enablePreview;
+            }
+
             var hasTimeZoneData = false;
 
             if (er.Data is Dictionary<string, object>)
@@ -53,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            return enablePreview && hasTimeZoneData;
+            return hasTimeZoneData;
         }
 
         public static StringMatcher BuildMatcherFromLists(params List<string>[] collections)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         }
                     }
 
+                    // Make sure timezone info propagates to longer span entity.
                     if (er.IsOverlap(timeZoneEr))
                     {
                         er.Data = new Dictionary<string, object>()

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -9916,5 +9916,57 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Please book 30min with Bob on Thursday morning EST.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-12T12:00:00"
+    },
+    "NotSupported": "python, javascript, java",
+    "Results": [
+      {
+        "Text": "30min",
+        "Start": 12,
+        "End": 16,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT30M",
+              "type": "duration",
+              "value": "1800"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "thursday morning est",
+        "Start": 30,
+        "End": 49,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-4TMO",
+              "type": "datetimerange",
+              "timezone": "UTC-05:00",
+              "timezoneText": "est",
+              "utcOffsetMins": "-300",
+              "start": "2019-06-06 08:00:00",
+              "end": "2019-06-06 12:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-4TMO",
+              "type": "datetimerange",
+              "timezone": "UTC-05:00",
+              "timezoneText": "est",
+              "utcOffsetMins": "-300",
+              "start": "2019-06-13 08:00:00",
+              "end": "2019-06-13 12:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Modify the method that DatetimePeriod handling the timeZone to same method as TimePeriod. 
This PR replaces #1611.