### PR TITLE
Support for "this calendar year" and similar

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -318,6 +318,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"secs", 1 },
             { @"sec", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"lente", @"SP" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(((?<special>calendar|fiscal|school)\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b";
+      public const string SpecialYearPrefixes = @"(calendar|(?<special>fiscal|school))";
+      public static readonly string OneWordPeriodRegex = $@"\b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(({SpecialYearPrefixes}\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b";
       public static readonly string WeekOfYearRegex = $@"\b(?<woy>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week(\s+of)?\s+({YearRegex}|{RelativeRegex}\s+year))\b";
@@ -257,8 +258,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string DurationConnectorRegex = @"^\s*(?<connector>\s+|and|,)\s*$";
       public const string PrefixArticleRegex = @"\bthe\s+";
       public const string OrRegex = @"\s*((\b|,\s*)(or|and)\b|,)\s*";
-      public const string SpecialYear = @"\b((((?<special>calendar|fiscal|school)\s+)?year)|(?<special>cy|fy|sy))";
-      public static readonly string YearPlusNumberRegex = $@"\b({SpecialYear}\s+((?<year>(\d{{3,4}}))|{YearSuffix}))\b";
+      public static readonly string SpecialYearTermsRegex = $@"\b((({SpecialYearPrefixes}\s+)?year)|(cy|(?<special>fy|sy)))";
+      public static readonly string YearPlusNumberRegex = $@"\b({SpecialYearTermsRegex}\s*((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(before|no later than|by|after)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+at)\s*$";
@@ -328,10 +329,8 @@ namespace Microsoft.Recognizers.Definitions.English
         };
       public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
         {
-            { @"calendar", @" " },
             { @"fiscal", @"FY" },
             { @"school", @"SY" },
-            { @"cy", @" " },
             { @"fy", @"FY" },
             { @"sy", @"SY" }
         };

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|year)(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b";
+      public static readonly string OneWordPeriodRegex = $@"\b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(((?<special>calendar|fiscal|school)\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b";
       public static readonly string WeekOfYearRegex = $@"\b(?<woy>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+week(\s+of)?\s+({YearRegex}|{RelativeRegex}\s+year))\b";
@@ -257,7 +257,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string DurationConnectorRegex = @"^\s*(?<connector>\s+|and|,)\s*$";
       public const string PrefixArticleRegex = @"\bthe\s+";
       public const string OrRegex = @"\s*((\b|,\s*)(or|and)\b|,)\s*";
-      public static readonly string YearPlusNumberRegex = $@"\b(year\s+((?<year>(\d{{3,4}}))|{FullTextYearRegex}))\b";
+      public const string SpecialYear = @"\b((((?<special>calendar|fiscal|school)\s+)?year)|(?<special>cy|fy|sy))";
+      public static readonly string YearPlusNumberRegex = $@"\b({SpecialYear}\s+((?<year>(\d{{3,4}}))|{YearSuffix}))\b";
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(before|no later than|by|after)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+at)\s*$";
@@ -324,6 +325,15 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"second", 1 },
             { @"secs", 1 },
             { @"sec", 1 }
+        };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"calendar", @" " },
+            { @"fiscal", @"FY" },
+            { @"school", @"SY" },
+            { @"cy", @" " },
+            { @"fy", @"FY" },
+            { @"sy", @"SY" }
         };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -299,6 +299,10 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"secs", 1 },
             { @"sec", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"printemps", @"SP" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -290,6 +290,10 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"sekunde", 1 },
             { @"sek", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"spring", @"SP" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
@@ -289,6 +289,10 @@ namespace Microsoft.Recognizers.Definitions.Italian
             { @"secs", 1 },
             { @"sec", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"primavera", @"SP" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -241,6 +241,10 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { @"segs", 1 },
             { @"seg", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"primavera", @"SP" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -260,6 +260,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"segs", 1 },
             { @"seg", 1 }
         };
+      public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
+        {
+            { @"", @"" }
+        };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
             { @"primavera", @"SP" },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public static readonly int MaxTwoDigitYearFutureNum = int.Parse(BaseDateTime.MaxTwoDigitYearFutureNum);
         public static readonly int MinTwoDigitYearPastNum = int.Parse(BaseDateTime.MinTwoDigitYearPastNum);
+        public static readonly System.DateTime InvalidDate = default(System.DateTime);
 
         // Timex non-constant
         public static readonly string[] DatePeriodTimexSplitter = { ",", "(", ")" };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             WrittenDecades = config.WrittenDecades;
             Numbers = config.Numbers;
             SpecialDecadeCases = config.SpecialDecadeCases;
@@ -216,6 +217,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             WrittenDecades = config.WrittenDecades;
             Numbers = config.Numbers;
             SpecialDecadeCases = config.SpecialDecadeCases;
@@ -216,6 +217,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             WrittenDecades = config.WrittenDecades;
             SpecialDecadeCases = config.SpecialDecadeCases;
         }
@@ -204,6 +205,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             WrittenDecades = config.WrittenDecades;
             Numbers = config.Numbers;
             SpecialDecadeCases = config.SpecialDecadeCases;
@@ -200,6 +201,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             WrittenDecades = config.WrittenDecades;
             SpecialDecadeCases = config.SpecialDecadeCases;
         }
@@ -199,6 +200,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public virtual IImmutableDictionary<string, string> SeasonMap { get; protected set; }
 
+        public virtual IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; protected set; }
+
         public virtual IImmutableDictionary<string, string> UnitMap { get; protected set; }
 
         public virtual IImmutableDictionary<string, int> CardinalMap { get; protected set; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1004,6 +1004,28 @@ namespace Microsoft.Recognizers.Text.DateTime
                         var date = referenceDate.AddYears(swift);
                         year = date.Year;
 
+                        if (!string.IsNullOrEmpty(match.Groups["special"].Value))
+                        {
+                            var specialYearTimex = this.config.SpecialYearPrefixesMap[match.Groups["special"].Value.ToLowerInvariant()];
+
+                            if (!string.IsNullOrWhiteSpace(specialYearTimex))
+                            {
+                                swift = this.config.GetSwiftYear(trimmedText);
+                                if (swift < -1)
+                                {
+                                    ret.Timex = Constants.TimexFuzzyYear + specialYearTimex;
+                                }
+                                else
+                                {
+                                    var yearStr = year.ToString("D4");
+                                    ret.Timex = yearStr + specialYearTimex;
+                                }
+
+                                ret.Success = true;
+                                return ret;
+                            }
+                        }
+
                         var beginDate = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
                         var endDate = inclusiveEndPeriod ?
                             DateObject.MinValue.SafeCreateFromValue(year, 12, 31) :
@@ -1236,6 +1258,18 @@ namespace Microsoft.Recognizers.Text.DateTime
                     if (exactMatch.Success)
                     {
                         year = config.DateExtractor.GetYearFromText(exactMatch.Match);
+                        if (!string.IsNullOrEmpty(exactMatch.Groups["special"].Value))
+                        {
+                            var specialYearTimex = this.config.SpecialYearPrefixesMap[exactMatch.Groups["special"].Value.ToLowerInvariant()];
+
+                            if (!string.IsNullOrWhiteSpace(specialYearTimex))
+                            {
+                                var yearStr = year.ToString("D4");
+                                ret.Timex = yearStr + specialYearTimex;
+                                ret.Success = true;
+                                return ret;
+                            }
+                        }
                     }
                 }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1008,9 +1008,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                         {
                             var specialYearPrefixes = this.config.SpecialYearPrefixesMap[match.Groups["special"].Value.ToLowerInvariant()];
                             swift = this.config.GetSwiftYear(trimmedText);
-                            ret.Timex = swift < -1 ?
-                                TimexUtility.GenerateYearTimex(specialTimex: specialYearPrefixes) :
-                                TimexUtility.GenerateYearTimex(date, specialYearPrefixes);
+                            date = swift < -1 ? Constants.InvalidDate : date;
+                            ret.Timex = TimexUtility.GenerateYearTimex(date, specialYearPrefixes);
                             ret.Success = true;
                             return ret;
                         }
@@ -1250,7 +1249,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (!string.IsNullOrEmpty(exactMatch.Groups["special"].Value))
                         {
                             var specialYearPrefixes = this.config.SpecialYearPrefixesMap[exactMatch.Groups["special"].Value.ToLowerInvariant()];
-                            ret.Timex = year.ToString("D4") + specialYearPrefixes;
+                            ret.Timex = TimexUtility.GenerateYearTimex(year, specialYearPrefixes);
                             ret.Success = true;
                             return ret;
                         }
@@ -1265,7 +1264,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1).AddDays(-1) :
                         DateObject.MinValue.SafeCreateFromValue(year + 1, 1, 1);
 
-                    ret.Timex = year.ToString("D4");
+                    ret.Timex = TimexUtility.GenerateYearTimex(year);
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDay, endDay);
                     ret.Success = true;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1007,23 +1007,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (!string.IsNullOrEmpty(match.Groups["special"].Value))
                         {
                             var specialYearTimex = this.config.SpecialYearPrefixesMap[match.Groups["special"].Value.ToLowerInvariant()];
-
-                            if (!string.IsNullOrWhiteSpace(specialYearTimex))
-                            {
-                                swift = this.config.GetSwiftYear(trimmedText);
-                                if (swift < -1)
-                                {
-                                    ret.Timex = Constants.TimexFuzzyYear + specialYearTimex;
-                                }
-                                else
-                                {
-                                    var yearStr = year.ToString("D4");
-                                    ret.Timex = yearStr + specialYearTimex;
-                                }
-
-                                ret.Success = true;
-                                return ret;
-                            }
+                            swift = this.config.GetSwiftYear(trimmedText);
+                            ret.Timex = swift < -1 ?
+                                TimexUtility.GenerateYearTimex() + specialYearTimex :
+                                TimexUtility.GenerateYearTimex(date) + specialYearTimex;
+                            ret.Success = true;
+                            return ret;
                         }
 
                         var beginDate = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
@@ -1261,14 +1250,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (!string.IsNullOrEmpty(exactMatch.Groups["special"].Value))
                         {
                             var specialYearTimex = this.config.SpecialYearPrefixesMap[exactMatch.Groups["special"].Value.ToLowerInvariant()];
-
-                            if (!string.IsNullOrWhiteSpace(specialYearTimex))
-                            {
-                                var yearStr = year.ToString("D4");
-                                ret.Timex = yearStr + specialYearTimex;
-                                ret.Success = true;
-                                return ret;
-                            }
+                            ret.Timex = year.ToString("D4") + specialYearTimex;
+                            ret.Success = true;
+                            return ret;
                         }
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1006,11 +1006,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                         if (!string.IsNullOrEmpty(match.Groups["special"].Value))
                         {
-                            var specialYearTimex = this.config.SpecialYearPrefixesMap[match.Groups["special"].Value.ToLowerInvariant()];
+                            var specialYearPrefixes = this.config.SpecialYearPrefixesMap[match.Groups["special"].Value.ToLowerInvariant()];
                             swift = this.config.GetSwiftYear(trimmedText);
                             ret.Timex = swift < -1 ?
-                                TimexUtility.GenerateYearTimex() + specialYearTimex :
-                                TimexUtility.GenerateYearTimex(date) + specialYearTimex;
+                                TimexUtility.GenerateYearTimex(specialTimex: specialYearPrefixes) :
+                                TimexUtility.GenerateYearTimex(date, specialYearPrefixes);
                             ret.Success = true;
                             return ret;
                         }
@@ -1249,8 +1249,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                         year = config.DateExtractor.GetYearFromText(exactMatch.Match);
                         if (!string.IsNullOrEmpty(exactMatch.Groups["special"].Value))
                         {
-                            var specialYearTimex = this.config.SpecialYearPrefixesMap[exactMatch.Groups["special"].Value.ToLowerInvariant()];
-                            ret.Timex = year.ToString("D4") + specialYearTimex;
+                            var specialYearPrefixes = this.config.SpecialYearPrefixesMap[exactMatch.Groups["special"].Value.ToLowerInvariant()];
+                            ret.Timex = year.ToString("D4") + specialYearPrefixes;
                             ret.Success = true;
                             return ret;
                         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IImmutableDictionary<string, string> SeasonMap { get; }
 
+        IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> CardinalMap { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IImmutableDictionary<string, string> SeasonMap { get; }
 
+        IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
+
         IImmutableDictionary<string, int> WrittenDecades { get; }
 
         IImmutableDictionary<string, int> Numbers { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             Numbers = config.Numbers;
             WrittenDecades = config.WrittenDecades;
             SpecialDecadeCases = config.SpecialDecadeCases;
@@ -202,6 +203,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
             SeasonMap = DateTimeDefinitions.SeasonMap.ToImmutableDictionary();
+            SpecialYearPrefixesMap = DateTimeDefinitions.SpecialYearPrefixesMap.ToImmutableDictionary();
             CardinalMap = DateTimeDefinitions.CardinalMap.ToImmutableDictionary();
             DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
             MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DayOfMonth = config.DayOfMonth;
             MonthOfYear = config.MonthOfYear;
             SeasonMap = config.SeasonMap;
+            SpecialYearPrefixesMap = config.SpecialYearPrefixesMap;
             Numbers = config.Numbers;
             WrittenDecades = config.WrittenDecades;
             SpecialDecadeCases = config.SpecialDecadeCases;
@@ -201,6 +202,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IImmutableDictionary<string, int> MonthOfYear { get; }
 
         public IImmutableDictionary<string, string> SeasonMap { get; }
+
+        public IImmutableDictionary<string, string> SpecialYearPrefixesMap { get; }
 
         public IImmutableDictionary<string, int> WrittenDecades { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -121,9 +121,15 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
         }
 
-        public static string GenerateYearTimex(DateObject date = default(DateObject))
+        public static string GenerateYearTimex(DateObject date = default(DateObject), string specialTimex = null)
         {
-            return date.IsDefaultValue() ? Constants.TimexFuzzyYear : $"{date.Year:D4}";
+            var yearTimex = date.IsDefaultValue() ? Constants.TimexFuzzyYear : $"{date.Year:D4}";
+            if (specialTimex != null)
+            {
+                yearTimex += specialTimex;
+            }
+
+            return yearTimex;
         }
 
         public static string GenerateDurationTimex(double number, string unitStr, bool isLessThanDay)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -121,15 +121,16 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
         }
 
-        public static string GenerateYearTimex(DateObject date = default(DateObject), string specialTimex = null)
+        public static string GenerateYearTimex(DateObject date = default(DateObject), string specialYearPrefixes = null)
         {
             var yearTimex = date.IsDefaultValue() ? Constants.TimexFuzzyYear : $"{date.Year:D4}";
-            if (specialTimex != null)
-            {
-                yearTimex += specialTimex;
-            }
+            return specialYearPrefixes == null ? yearTimex : specialYearPrefixes + yearTimex;
+        }
 
-            return yearTimex;
+        public static string GenerateYearTimex(int year, string specialYearPrefixes = null)
+        {
+            var yearTimex = DateTimeFormatUtil.LuisDate(year);
+            return specialYearPrefixes == null ? yearTimex : specialYearPrefixes + yearTimex;
         }
 
         public static string GenerateDurationTimex(double number, string unitStr, bool isLessThanDay)

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -681,6 +681,11 @@ UnitValueMap: !dictionary
     seconde: 1
     secs: 1
     sec: 1
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -122,7 +122,7 @@ MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|year)(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b
+  def: \b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(((?<special>calendar|fiscal|school)\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
@@ -611,9 +611,11 @@ PrefixArticleRegex: !simpleRegex
   def: \bthe\s+
 OrRegex: !simpleRegex
   def: \s*((\b|,\s*)(or|and)\b|,)\s*
+SpecialYear: !simpleRegex
+  def: \b((((?<special>calendar|fiscal|school)\s+)?year)|(?<special>cy|fy|sy))
 YearPlusNumberRegex: !nestedRegex
-  def: \b(year\s+((?<year>(\d{3,4}))|{FullTextYearRegex}))\b
-  references: [ FullTextYearRegex ]
+  def: \b({SpecialYear}\s+((?<year>(\d{3,4}))|{YearSuffix}))\b
+  references: [ YearSuffix, SpecialYear ]
 NumberAsTimeRegex: !nestedRegex
   def: \b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b
   references: [ WrittenTimeRegex, PeriodHourNumRegex, BaseDateTime.HourRegex ]
@@ -702,6 +704,15 @@ UnitValueMap: !dictionary
     second: 1
     secs: 1
     sec: 1
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    calendar: ' '
+    fiscal: FY
+    school: SY
+    cy: ' '
+    fy: FY
+    sy: SY
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -121,9 +121,11 @@ BetweenRegex: !nestedRegex
 MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex ]
+SpecialYearPrefixes: !simpleRegex
+  def: (calendar|(?<special>fiscal|school))
 OneWordPeriodRegex: !nestedRegex
-  def: \b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(((?<special>calendar|fiscal|school)\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b
-  references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
+  def: \b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?(?<month>apr(il)?|aug(ust)?|dec(ember)?|feb(ruary)?|jan(uary)?|july?|june?|mar(ch)?|may|nov(ember)?|oct(ober)?|sept(ember)?|sept?))|(month|year) to date|({RelativeRegex}\s+)?(my\s+)?(week(end)?|month|(({SpecialYearPrefixes}\s+)?year))(?!((\s+of)?\s+\d+|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b
+  references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex, SpecialYearPrefixes ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
   references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex ]
@@ -611,11 +613,12 @@ PrefixArticleRegex: !simpleRegex
   def: \bthe\s+
 OrRegex: !simpleRegex
   def: \s*((\b|,\s*)(or|and)\b|,)\s*
-SpecialYear: !simpleRegex
-  def: \b((((?<special>calendar|fiscal|school)\s+)?year)|(?<special>cy|fy|sy))
+SpecialYearTermsRegex: !nestedRegex
+  def: \b((({SpecialYearPrefixes}\s+)?year)|(cy|(?<special>fy|sy)))
+  references: [ SpecialYearPrefixes ]
 YearPlusNumberRegex: !nestedRegex
-  def: \b({SpecialYear}\s+((?<year>(\d{3,4}))|{YearSuffix}))\b
-  references: [ YearSuffix, SpecialYear ]
+  def: \b({SpecialYearTermsRegex}\s*((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
+  references: [ FullTextYearRegex, SpecialYearTermsRegex ]
 NumberAsTimeRegex: !nestedRegex
   def: \b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b
   references: [ WrittenTimeRegex, PeriodHourNumRegex, BaseDateTime.HourRegex ]
@@ -707,10 +710,8 @@ UnitValueMap: !dictionary
 SpecialYearPrefixesMap: !dictionary
   types: [ string, string ]
   entries:
-    calendar: ' '
     fiscal: FY
     school: SY
-    cy: ' '
     fy: FY
     sy: SY
 SeasonMap: !dictionary

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -631,6 +631,11 @@ UnitValueMap: !dictionary
     seconde: 1
     secs: 1
     sec: 1
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -604,6 +604,11 @@ UnitValueMap: !dictionary
     sekunde: 1
     sek: 1
 
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Italian/Italian-DateTime.yaml
+++ b/Patterns/Italian/Italian-DateTime.yaml
@@ -610,6 +610,11 @@ UnitValueMap: !dictionary
     secondo: 1
     secs: 1
     sec: 1
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -544,6 +544,11 @@ UnitValueMap: !dictionary
     segundo: 1
     segs: 1
     seg: 1
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -585,6 +585,11 @@ UnitValueMap: !dictionary
     segundo: 1
     segs: 1
     seg: 1
+# TODO: modify below regex according to the counterpart in English
+SpecialYearPrefixesMap: !dictionary
+  types: [ string, string ]
+  entries:
+    '': ''
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12100,7 +12100,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019SY",
+              "timex": "SY2019",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12124,7 +12124,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018FY",
+              "timex": "FY2018",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12173,7 +12173,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008FY",
+              "timex": "FY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12197,7 +12197,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008SY",
+              "timex": "SY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12271,7 +12271,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008SY",
+              "timex": "SY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12295,7 +12295,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXXFY",
+              "timex": "FYXXXX",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -12319,7 +12319,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018SY",
+              "timex": "SY2018",
               "type": "daterange",
               "value": "not resolved"
             }

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12084,5 +12084,224 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I have a lot of gains in this school year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "this school year",
+        "Start": 25,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I got a lot of gains in last fiscal year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "last fiscal year",
+        "Start": 24,
+        "End": 39,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018FY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I have a lot of gains in this calendar year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "this calendar year",
+        "Start": 25,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the fiscal year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "fiscal year 2008",
+        "Start": 18,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008FY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the school year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "school year 2008",
+        "Start": 18,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the calendar year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "calendar year 2008",
+        "Start": 18,
+        "End": 35,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008",
+              "type": "daterange",
+              "start": "2008-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the cy 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "cy 2008",
+        "Start": 18,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008",
+              "type": "daterange",
+              "start": "2008-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the sy 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "sy 2008",
+        "Start": 18,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in fiscal year",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "fiscal year",
+        "Start": 14,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXXFY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12303,5 +12303,54 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Show sales in the sy18",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "sy18",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the cy18",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "cy18",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "type": "daterange",
+              "start": "2018-01-01",
+              "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -10257,5 +10257,224 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I have a lot of gains in this school year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "this school year",
+        "Start": 25,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I got a lot of gains in last fiscal year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "last fiscal year",
+        "Start": 24,
+        "End": 39,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018FY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I have a lot of gains in this calendar year.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "this calendar year",
+        "Start": 25,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the fiscal year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "fiscal year 2008",
+        "Start": 18,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008FY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the school year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "school year 2008",
+        "Start": 18,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the calendar year 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "calendar year 2008",
+        "Start": 18,
+        "End": 35,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008",
+              "type": "daterange",
+              "start": "2008-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the cy 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "cy 2008",
+        "Start": 18,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008",
+              "type": "daterange",
+              "start": "2008-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the sy 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "sy 2008",
+        "Start": 18,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2008SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in fiscal year",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "fiscal year",
+        "Start": 14,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXXFY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -10273,7 +10273,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019SY",
+              "timex": "SY2019",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10297,7 +10297,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018FY",
+              "timex": "FY2018",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10346,7 +10346,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008FY",
+              "timex": "FY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10370,7 +10370,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008SY",
+              "timex": "SY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10444,7 +10444,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2008SY",
+              "timex": "SY2008",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10468,7 +10468,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXXFY",
+              "timex": "FYXXXX",
               "type": "daterange",
               "value": "not resolved"
             }
@@ -10492,7 +10492,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018SY",
+              "timex": "SY2018",
               "type": "daterange",
               "value": "not resolved"
             }

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -10476,5 +10476,54 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Show sales in the sy18",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "sy18",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018SY",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the cy18",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "cy18",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "type": "daterange",
+              "start": "2018-01-01",
+              "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix issue #1627. Includes, for example":
"this/last calendar/fiscal/school year"
"calendar year 2018"
"cy 2018"
"FY19"

Currently only in .NET