### PR TITLE
[Python] Add pre-push hook

### DIFF
--- a/Python/.pre-commit-config.yaml
+++ b/Python/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+default_stages: [push]
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+    - id: flake8
+
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: master
+    hooks:
+    - id: autopep8

--- a/Python/build.ci.cmd
+++ b/Python/build.ci.cmd
@@ -1,11 +1,19 @@
 ECHO ==============================PYTHON BUILD/TEST START==============================
 
+ECHO # Installing Requirements
+
+CALL pip install -r .\requirements.txt
+
+CALL pre-commit install --hook-type pre-push
+
 pushd libraries\resource-generator
+
 
 REM Dependencies
 ECHO.
 ECHO # Installing Resource Generator Dependencies
 CALL pip install -r .\requirements.txt
+
 
 REM Build Resources
 ECHO.

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,0 +1,5 @@
+emoji
+grapheme
+pre-commit
+autopep8
+flake8

--- a/Python/tests/requirements.txt
+++ b/Python/tests/requirements.txt
@@ -1,4 +1,2 @@
 pytest-cov
 pytest>=3.2.0
-emoji
-grapheme


### PR DESCRIPTION
## Issue
There are many files that do not comply with [PEP 8](https://www.python.org/dev/peps/pep-0008/) on the Python side.

## Proposal
We suggest adding [autopep8 ](https://pypi.org/project/autopep8/) and [flake8](http://flake8.pycqa.org/en/latest/) to the repository. This tool lets us easily fix style errors by just running a command. 

## How to
We used [pre-commit](https://pre-commit.com/) to create a pre-push hook, and using the resources provided by pre-commit: [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) and [autopep8](https://github.com/pre-commit/mirrors-autopep8).

## Changes
1. Move `requirements.txt` to the root of the Python folders
2. Add autopep8, flake8 and pre-commit to the `requirements.txt`
3. Add `.pre-commit-config.yaml` to define the pre-push hook
4. Add to `build.ci.cmd` the installing of the hook

## Console outputs
If there are linting issues in .py files:
![imagen](https://user-images.githubusercontent.com/22912283/60037208-527a2a00-9687-11e9-8ed3-e398d661fbce.png)

If there are no linting issues in .py files:
![imagen](https://user-images.githubusercontent.com/22912283/60036840-886ade80-9686-11e9-84b2-07274ed3f3f8.png)

If there are no python files staged: 
![imagen](https://user-images.githubusercontent.com/22912283/60037182-3f675a00-9687-11e9-9f25-9464c9d0b1c9.png)


## Notes
1. Existing collaborators would need to either run the build.ci.cmd script or manually install the dependencies and the pre-commit script. The first option will of course handle everything automatically. 
2. We will have to fix all non-complying files inside the repository.
3. The hook will be triggered every time someone pushes to the repository. However it will only be executed for python files.
