### PR TITLE
Fix  wrong recognition for  "from three thirty to four thirty"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -639,7 +639,7 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"inaugurationday", new string[] { @"inaugurationday" } },
             { @"groundhougday", new string[] { @"groundhougday" } },
             { @"valentinesday", new string[] { @"valentinesday" } },
-            { @"stpatrickday", new string[] { @"stpatrickday", @"stpatricksday", "stpatrick" } },
+            { @"stpatrickday", new string[] { @"stpatrickday", @"stpatricksday", @"stpatrick" } },
             { @"aprilfools", new string[] { @"aprilfools" } },
             { @"stgeorgeday", new string[] { @"stgeorgeday" } },
             { @"mayday", new string[] { @"mayday", @"intlworkersday", @"internationalworkersday" } },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -368,13 +368,25 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     var yearMatches = this.config.YearRegex.Matches(match.Value);
                     var allDigitYear = true;
+                    var isValidYear = true;
 
                     foreach (Match yearMatch in yearMatches)
                     {
-                        if (yearMatch.Length != Constants.FourDigitsYearLength)
+                        var year = config.DatePointExtractor.GetYearFromText(yearMatch);
+                        if (!(year >= Constants.MinYearNum && year <= Constants.MaxYearNum))
+                        {
+                            isValidYear = false;
+                            break;
+                        }
+                        else if (yearMatch.Length != Constants.FourDigitsYearLength)
                         {
                             allDigitYear = false;
                         }
+                    }
+
+                    if (!isValidYear)
+                    {
+                        continue;
                     }
 
                     // Cases like "2010-2015"

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
@@ -401,6 +401,21 @@ public class BaseDatePeriodExtractor implements IDateTimeExtractor {
                 }
                 // Possibly include period end only apply for cases like "2014-2018", which are not single year cases
                 metadata.setPossiblyIncludePeriodEnd(false);
+            } else {
+                Match[] yearMatches = RegExpUtility.getMatches(config.getYearRegex(), match.value);
+                boolean isValidYear = true;
+                for (Match yearMatch : yearMatches) {
+                    int year = ((BaseDateExtractor)config.getDatePointExtractor()).getYearFromText(yearMatch);
+                    if (!(year >= Constants.MinYearNum && year <= Constants.MaxYearNum)) {
+                        isValidYear = false;
+                        break;
+                    }
+                }
+
+                if (!isValidYear) {
+                    continue;
+                }
+
             }
 
             results.add(new Token(match.index, match.index + match.length, metadata));

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12447,5 +12447,65 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Let's play basketball from three thirty to four thirty",
+    "Context": {
+      "ReferenceDateTime": "2019-06-28T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from three thirty to four thirty",
+        "Start": 22,
+        "End": 53,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T03:30,T04:30,PT1H)",
+              "type": "timerange",
+              "start": "03:30:00",
+              "end": "04:30:00"
+            },
+            {
+              "timex": "(T15:30,T16:30,PT1H)",
+              "type": "timerange",
+              "start": "15:30:00",
+              "end": "16:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Let's play basketball from two thirty to two forty five",
+    "Context": {
+      "ReferenceDateTime": "2019-06-28T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from two thirty to two forty five",
+        "Start": 22,
+        "End": 54,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T02:30,T02:45,PT15M)",
+              "type": "timerange",
+              "start": "02:30:00",
+              "end": "02:45:00"
+            },
+            {
+              "timex": "(T14:30,T14:45,PT15M)",
+              "type": "timerange",
+              "start": "14:30:00",
+              "end": "14:45:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -10614,5 +10614,65 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Let's play basketball from three thirty to four thirty",
+    "Context": {
+      "ReferenceDateTime": "2019-06-28T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from three thirty to four thirty",
+        "Start": 22,
+        "End": 53,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T03:30,T04:30,PT1H)",
+              "type": "timerange",
+              "start": "03:30:00",
+              "end": "04:30:00"
+            },
+            {
+              "timex": "(T15:30,T16:30,PT1H)",
+              "type": "timerange",
+              "start": "15:30:00",
+              "end": "16:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Let's play basketball from two thirty to two forty five",
+    "Context": {
+      "ReferenceDateTime": "2019-06-28T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from two thirty to two forty five",
+        "Start": 22,
+        "End": 54,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T02:30,T02:45,PT15M)",
+              "type": "timerange",
+              "start": "02:30:00",
+              "end": "02:45:00"
+            },
+            {
+              "timex": "(T14:30,T14:45,PT15M)",
+              "type": "timerange",
+              "start": "14:30:00",
+              "end": "14:45:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix cases like "from three thirty to four thirty"  which would be wrong extracted in DatePeriodExtractor.
**NOTE**: This PR is a temporary fix, and MatchYearPeriod code will be refactored later.