### PR TITLE
[.NET] Add unit "'" filter in English and Italian

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -799,5 +799,9 @@ namespace Microsoft.Recognizers.Definitions.English
             @"dram",
             @"lbs"
         };
+      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
+        {
+            { @"\bm\b", @"((('|’)\s*m)|(m\s*('|’)))" }
+        };
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersWithUnitDefinitions.cs
@@ -528,5 +528,9 @@ namespace Microsoft.Recognizers.Definitions.Italian
             @"g",
             @"oz"
         };
+      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
+        {
+            { @"\bl\b", @"l\s*('|’)" }
+        };
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.English;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.English;
 
@@ -28,6 +29,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
             this.BuildPrefix = NumbersWithUnitDefinitions.BuildPrefix;
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
             this.ConnectorToken = string.Empty;
+
+            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.AmbiguityFiltersDict);
         }
 
         public abstract string ExtractType { get; }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.Italian;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number.Italian;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
@@ -27,6 +28,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
             this.BuildPrefix = NumbersWithUnitDefinitions.BuildPrefix;
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
+
+            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.AmbiguityFiltersDict);
         }
 
         public abstract string ExtractType { get; }

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -889,4 +889,8 @@ AmbiguousWeightUnitList: !list
     - stone
     - dram
     - lbs
+AmbiguityFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    \bm\b: ((('|’)\s*m)|(m\s*('|’)))
 ...

--- a/Patterns/Italian/Italian-NumbersWithUnit.yaml
+++ b/Patterns/Italian/Italian-NumbersWithUnit.yaml
@@ -616,4 +616,8 @@ AmbiguousWeightUnitList: !list
   entries:
     - g
     - oz
+AmbiguityFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    \bl\b: l\s*('|’)
 ...

--- a/Specs/NumberWithUnit/English/DimensionModel.json
+++ b/Specs/NumberWithUnit/English/DimensionModel.json
@@ -809,5 +809,10 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I ' m tired",
+    "NotSupported": "javascript, python, java",
+    "Results": []
   }
 ]

--- a/Specs/NumberWithUnit/Italian/DimensionModel.json
+++ b/Specs/NumberWithUnit/Italian/DimensionModel.json
@@ -141,7 +141,6 @@
   },
   {
     "Input": "` ` l'amministrazione non vuole sorprese, ' ' osserva jack zaves , che , come direttore dei servizi di carburante delle compagnie aeree americane, compra circa 2,4 miliardi di galloni di carburante per aerei all'anno.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "python,javascript,python",
     "Results": [
       {
@@ -520,7 +519,6 @@
   },
   {
     "Input": "lo svincolo con l'autostrada 35 e l'autostrada 115 per Lindsay e Peterborough (uscita 436) si trova a 500 metri ad est di Bennett Road.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "python,javascript,python",
     "Results": [
       {
@@ -634,5 +632,37 @@
     "Input": "l ' autostrada",
     "NotSupported": "javascript, python, java",
     "Results": []
+  },
+  {
+    "Input": "Ci sono 20 l d'acqua qui.",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "20 l",
+        "Start": 8,
+        "End": 11,
+        "TypeName": "dimension",
+        "Resolution": {
+          "unit": "Litro",
+          "value": "20"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ci sono 10l d'acqua qui.",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "10l",
+        "Start": 8,
+        "End": 10,
+        "TypeName": "dimension",
+        "Resolution": {
+          "unit": "Litro",
+          "value": "10"
+        }
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Italian/DimensionModel.json
+++ b/Specs/NumberWithUnit/Italian/DimensionModel.json
@@ -624,5 +624,15 @@
         }
       }
     ]
+  },
+  {
+    "Input": "l'amministrazione",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "l ' autostrada",
+    "NotSupported": "javascript, python, java",
+    "Results": []
   }
 ]


### PR DESCRIPTION
Add AmbiguityFiltersDict contains "'" filter in English and Italian.
Fix cases like "i ' m tried", 'm' should not be recognized.