### PR TITLE
[DateTime] Fix wrong recognition for "12:30 December 27"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string CenturySuffixRegex = @"(^century)\b";
       public const string ReferencePrefixRegex = @"(that|same)\b";
       public const string FutureSuffixRegex = @"\b(in\s+the\s+)?(future|hence)\b";
-      public const string DayRegex = @"(the\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)";
+      public const string DayRegex = @"(the\s*)?(?<![:$]\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)";
       public const string ImplicitDayRegex = @"(the\s*)?(?<day>(?:3[0-1]|[0-2]?\d)(?:th|nd|rd|st))\b";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public const string WrittenOneToNineRegex = @"(?:one|two|three|four|five|six|seven|eight|nine)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string CenturySuffixRegex = @"(^century)\b";
       public const string ReferencePrefixRegex = @"(that|same)\b";
       public const string FutureSuffixRegex = @"\b(in\s+the\s+)?(future|hence)\b";
-      public const string DayRegex = @"(the\s*)?(?<![:$]\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)";
+      public const string DayRegex = @"(the\s*)?(?<!(\d+:|\$)\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)";
       public const string ImplicitDayRegex = @"(the\s*)?(?<day>(?:3[0-1]|[0-2]?\d)(?:th|nd|rd|st))\b";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public const string WrittenOneToNineRegex = @"(?:one|two|three|four|five|six|seven|eight|nine)";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -51,7 +51,7 @@ public class EnglishDateTime {
 
     public static final String FutureSuffixRegex = "\\b(in\\s+the\\s+)?(future|hence)\\b";
 
-    public static final String DayRegex = "(the\\s*)?(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)";
+    public static final String DayRegex = "(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)";
 
     public static final String ImplicitDayRegex = "(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b";
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -51,7 +51,7 @@ public class EnglishDateTime {
 
     public static final String FutureSuffixRegex = "\\b(in\\s+the\\s+)?(future|hence)\\b";
 
-    public static final String DayRegex = "(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)";
+    public static final String DayRegex = "(the\\s*)?(?<!(\\d+:|\\$)\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)";
 
     public static final String ImplicitDayRegex = "(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b";
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -25,7 +25,7 @@ export namespace EnglishDateTime {
     export const CenturySuffixRegex = `(^century)\\b`;
     export const ReferencePrefixRegex = `(that|same)\\b`;
     export const FutureSuffixRegex = `\\b(in\\s+the\\s+)?(future|hence)\\b`;
-    export const DayRegex = `(the\\s*)?(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)`;
+    export const DayRegex = `(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)`;
     export const ImplicitDayRegex = `(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b`;
     export const MonthNumRegex = `(?<month>1[0-2]|(0)?[1-9])\\b`;
     export const WrittenOneToNineRegex = `(?:one|two|three|four|five|six|seven|eight|nine)`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -25,7 +25,7 @@ export namespace EnglishDateTime {
     export const CenturySuffixRegex = `(^century)\\b`;
     export const ReferencePrefixRegex = `(that|same)\\b`;
     export const FutureSuffixRegex = `\\b(in\\s+the\\s+)?(future|hence)\\b`;
-    export const DayRegex = `(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)`;
+    export const DayRegex = `(the\\s*)?(?<!(\\d+:|\\$)\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)`;
     export const ImplicitDayRegex = `(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b`;
     export const MonthNumRegex = `(?<month>1[0-2]|(0)?[1-9])\\b`;
     export const WrittenOneToNineRegex = `(?:one|two|three|four|five|six|seven|eight|nine)`;

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -36,7 +36,7 @@ ReferencePrefixRegex: !simpleRegex
 FutureSuffixRegex: !simpleRegex
   def: \b(in\s+the\s+)?(future|hence)\b
 DayRegex: !simpleRegex
-  def: (the\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)
+  def: (the\s*)?(?<![:$]\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)
 ImplicitDayRegex: !simpleRegex
   def: (the\s*)?(?<day>(?:3[0-1]|[0-2]?\d)(?:th|nd|rd|st))\b
 MonthNumRegex: !simpleRegex

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -36,7 +36,7 @@ ReferencePrefixRegex: !simpleRegex
 FutureSuffixRegex: !simpleRegex
   def: \b(in\s+the\s+)?(future|hence)\b
 DayRegex: !simpleRegex
-  def: (the\s*)?(?<![:$]\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)
+  def: (the\s*)?(?<!(\d+:|\$)\s*)(?<=\b)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(?:th|nd|rd|st)?)(?=\b|t)
 ImplicitDayRegex: !simpleRegex
   def: (the\s*)?(?<day>(?:3[0-1]|[0-2]?\d)(?:th|nd|rd|st))\b
 MonthNumRegex: !simpleRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -28,7 +28,7 @@ class EnglishDateTime:
     CenturySuffixRegex = f'(^century)\\b'
     ReferencePrefixRegex = f'(that|same)\\b'
     FutureSuffixRegex = f'\\b(in\\s+the\\s+)?(future|hence)\\b'
-    DayRegex = f'(the\\s*)?(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)'
+    DayRegex = f'(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)'
     ImplicitDayRegex = f'(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b'
     MonthNumRegex = f'(?<month>1[0-2]|(0)?[1-9])\\b'
     WrittenOneToNineRegex = f'(?:one|two|three|four|five|six|seven|eight|nine)'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -28,7 +28,7 @@ class EnglishDateTime:
     CenturySuffixRegex = f'(^century)\\b'
     ReferencePrefixRegex = f'(that|same)\\b'
     FutureSuffixRegex = f'\\b(in\\s+the\\s+)?(future|hence)\\b'
-    DayRegex = f'(the\\s*)?(?<![:$]\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)'
+    DayRegex = f'(the\\s*)?(?<!(\\d+:|\\$)\\s*)(?<=\\b)(?<day>(?:3[0-1]|[1-2]\\d|0?[1-9])(?:th|nd|rd|st)?)(?=\\b|t)'
     ImplicitDayRegex = f'(the\\s*)?(?<day>(?:3[0-1]|[0-2]?\\d)(?:th|nd|rd|st))\\b'
     MonthNumRegex = f'(?<month>1[0-2]|(0)?[1-9])\\b'
     WrittenOneToNineRegex = f'(?:one|two|three|four|five|six|seven|eight|nine)'

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12824,5 +12824,129 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I will be out in 11:30 am to 12:30 december 27th",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "11:30 am to 12:30 december 27th",
+        "Start": 17,
+        "End": 47,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-12-27T11:30,XXXX-12-27T12:30,PT1H)",
+              "type": "datetimerange",
+              "start": "2018-12-27 11:30:00",
+              "end": "2018-12-27 12:30:00"
+            },
+            {
+              "timex": "(XXXX-12-27T11:30,XXXX-12-27T12:30,PT1H)",
+              "type": "datetimerange",
+              "start": "2019-12-27 11:30:00",
+              "end": "2019-12-27 12:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Let's have a meeting in 12:30 december 27th",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "12:30 december 27th",
+        "Start": 24,
+        "End": 42,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27T12:30",
+              "type": "datetime",
+              "value": "2018-12-27 12:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T12:30",
+              "type": "datetime",
+              "value": "2019-12-27 12:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T00:30",
+              "type": "datetime",
+              "value": "2018-12-27 00:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T00:30",
+              "type": "datetime",
+              "value": "2019-12-27 00:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I bought it for $12 December 27",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "december 27",
+        "Start": 20,
+        "End": 30,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2018-12-27"
+            },
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2019-12-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I bought it for $ 12 December 27",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "december 27",
+        "Start": 21,
+        "End": 31,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2018-12-27"
+            },
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2019-12-27"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -12948,5 +12948,33 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Tim says:30 December is OK",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30 december",
+        "Start": 9,
+        "End": 19,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-30",
+              "type": "date",
+              "value": "2018-12-30"
+            },
+            {
+              "timex": "XXXX-12-30",
+              "type": "date",
+              "value": "2019-12-30"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -11115,5 +11115,33 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Tim says:30 December is OK",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30 december",
+        "Start": 9,
+        "End": 19,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-30",
+              "type": "date",
+              "value": "2018-12-30"
+            },
+            {
+              "timex": "XXXX-12-30",
+              "type": "date",
+              "value": "2019-12-30"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -10991,5 +10991,129 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I will be out in 11:30 am to 12:30 december 27th",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "11:30 am to 12:30 december 27th",
+        "Start": 17,
+        "End": 47,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-12-27T11:30,XXXX-12-27T12:30,PT1H)",
+              "type": "datetimerange",
+              "start": "2018-12-27 11:30:00",
+              "end": "2018-12-27 12:30:00"
+            },
+            {
+              "timex": "(XXXX-12-27T11:30,XXXX-12-27T12:30,PT1H)",
+              "type": "datetimerange",
+              "start": "2019-12-27 11:30:00",
+              "end": "2019-12-27 12:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Let's have a meeting in 12:30 december 27th",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "12:30 december 27th",
+        "Start": 24,
+        "End": 42,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27T12:30",
+              "type": "datetime",
+              "value": "2018-12-27 12:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T12:30",
+              "type": "datetime",
+              "value": "2019-12-27 12:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T00:30",
+              "type": "datetime",
+              "value": "2018-12-27 00:30:00"
+            },
+            {
+              "timex": "XXXX-12-27T00:30",
+              "type": "datetime",
+              "value": "2019-12-27 00:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I bought it for $12 December 27",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "december 27",
+        "Start": 20,
+        "End": 30,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2018-12-27"
+            },
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2019-12-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I bought it for $ 12 December 27",
+    "Context": {
+      "ReferenceDateTime": "2019-07-04T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "december 27",
+        "Start": 21,
+        "End": 31,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2018-12-27"
+            },
+            {
+              "timex": "XXXX-12-27",
+              "type": "date",
+              "value": "2019-12-27"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix cases like "11:30 am to 12:30 december 27th", "30 December" would be wrong recognized
Also fix cases like "$12 december 27th"