### PR TITLE
[Python] Timex migration – Tests classes

### DIFF
--- a/Python/libraries/datatypes-timex-expression/CreatePackage.cmd
+++ b/Python/libraries/datatypes-timex-expression/CreatePackage.cmd
@@ -1,15 +1,15 @@
 @echo off
-echo *** Building Microsoft.Recognizers.Text.Timex
+echo *** Building Microsoft.Recognizers.Text.DataTypes.TimexExpression
 setlocal
 setlocal enabledelayedexpansion
 setlocal enableextensions
 
 if not exist ..\dist mkdir ..\dist
-if exist ..\dist\Microsoft.Recognizers.Text.Timex*.whl erase /s ..\dist\Microsoft.Recognizers.Text.Timex*.whl
+if exist ..\dist\Microsoft.Recognizers.Text.DataTypes.TimexExpression*.whl erase /s ..\dist\Microsoft.Recognizers.Text.DataTypes.TimexExpression*.whl
 python setup.py bdist_wheel -d ..\dist\
 
 set error=%errorlevel%
-set packageName=Microsoft.Recognizers.Text.Timex
+set packageName=Microsoft.Recognizers.Text.DataTypes.TimexExpression
 if %error% NEQ 0 (
 	echo *** Failed to build %packageName%
 	exit /b %error%

--- a/Python/tests/datatypes/test_time.py
+++ b/Python/tests/datatypes/test_time.py
@@ -1,0 +1,15 @@
+from datatypes_timex_expression import Time
+
+
+def test_datatypes_time_constructor():
+    time = Time(23, 45, 32)
+
+    assert time.hour is 23
+    assert time.minute is 45
+    assert time.second is 32
+
+
+def test_datatypes_time_gettime():
+    time = Time(23, 45, 32)
+
+    assert time.get_time() == 85532000

--- a/Python/tests/datatypes/test_timex.py
+++ b/Python/tests/datatypes/test_timex.py
@@ -1,0 +1,88 @@
+from datatypes_timex_expression import Timex, datetime, Time
+
+
+def test_datatypes_timex_fromdate():
+    assert Timex.from_date(datetime(2017, 12, 5)).timex_value() == '2017-12-05'
+
+
+def test_datatypes_timex_fromdatetime():
+    assert Timex.from_date_time(datetime(2017, 12, 5, 23, 57, 35)).timex_value() == '2017-12-05T23:57:35'
+
+
+def test_datatypes_timex_roundtrip_date():
+    roundtrip('2017-09-27')
+    roundtrip('XXXX-WXX-3')
+    roundtrip('XXXX-12-05')
+
+
+def test_datatypes_timex_roundtrip_time():
+    roundtrip('T17:30:45')
+    roundtrip('T05:06:07')
+    roundtrip('T17:30')
+    roundtrip('T23')
+
+
+def test_datatypes_timex_roundtrip_duration():
+    roundtrip('P50Y')
+    roundtrip('P6M')
+    roundtrip('P3W')
+    roundtrip('P5D')
+    roundtrip('PT16H')
+    roundtrip('PT32M')
+    roundtrip('PT20S')
+
+
+def test_datatypes_timex_roundtrip_now():
+    roundtrip('PRESENT_REF')
+
+
+def test_datatypes_timex_roundtrip_datetime():
+    roundtrip('2017')
+    roundtrip('SU')
+    roundtrip('2017-WI')
+    roundtrip('2017-09')
+    roundtrip('2017-W37')
+    roundtrip('2017-W37-WE')
+    roundtrip('XXXX-05')
+
+
+def test_datatypes_timex_roundtrip_daterange_start_end_duration():
+    roundtrip('(XXXX-WXX-3,XXXX-WXX-6,P3D)')
+    roundtrip('(XXXX-01-01,XXXX-08-05,P216D)')
+    roundtrip('(2017-01-01,2017-08-05,P216D)')
+    roundtrip('(2016-01-01,2016-08-05,P217D)')
+
+
+def test_datatypes_timex_roundtrip_timerange():
+    roundtrip('TEV')
+
+
+def test_datatypes_timex_roundtrip_timerange_start_end_duration():
+    roundtrip('(T16,T19,PT3H)')
+
+
+def test_datatypes_timex_roundtrip_datetimerange():
+    roundtrip('2017-09-27TEV')
+
+
+def test_datatypes_timex_roundtrip_datetimerange_start_end_duration():
+    roundtrip('(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)')
+    roundtrip('(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)')
+
+
+def test_datatypes_timex_tostring():
+    assert Timex('XXXX-05-05').to_string() == '5th May'
+
+
+def test_datatypes_timex_tonaturallanguage():
+    today = datetime(2017, 10, 16)
+    Timex('2017-10-17').to_natural_language(today)
+    assert 'tomorrow' == Timex('2017-10-17').to_natural_language(today)
+
+
+def test_datatypes_timex_fromtime():
+    assert Timex.from_time(Time(23, 59, 30)).timex_value() == 'T23:59:30'
+
+
+def roundtrip(timex):
+    assert timex == Timex(timex).timex_value()

--- a/Python/tests/datatypes/test_timex_convert.py
+++ b/Python/tests/datatypes/test_timex_convert.py
@@ -1,0 +1,179 @@
+from datatypes_timex_expression import TimexConvert, Timex
+
+
+def test_timex_convert_complete_date():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="2017-05-29")) == "29th May 2017"
+
+
+def test_timex_convert_month_and_day_of_month():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-01-05")) == "5th January"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-02-05")) == "5th Februrary"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-03-05")) == "5th March"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-04-05")) == "5th April"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-05-05")) == "5th May"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-06-05")) == "5th June"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-07-05")) == "5th July"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-08-05")) == "5th August"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-09-05")) == "5th September"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-10-05")) == "5th October"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-11-05")) == "5th November"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-12-05")) == "5th December"
+
+
+def test_timex_convert_month_and_day_of_month_with_correct_abbreviation():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-06-01")) == "1st June"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-06-02")) == "2nd June"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-06-03")) == "3rd June"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-06-04")) == "4th June"
+
+
+def test_timex_convert_day_of_week():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-1")) == "Monday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-2")) == "Tuesday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-3")) == "Wednesday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-4")) == "Thursday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-5")) == "Friday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-6")) == "Saturday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-7")) == "Sunday"
+
+
+def test_timex_convert_time():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T17:30:05")) == "5:30:05PM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T02:30:30")) == "2:30:30AM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T00:30:30")) == "12:30:30AM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T12:30:30")) == "12:30:30PM"
+
+
+def test_timex_convert_hour_and_minute():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T17:30")) == "5:30PM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T17:00")) == "5PM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T01:30")) == "1:30AM"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="T01:00")) == "1AM"
+
+
+def test_timex_convert_now():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PRESENT_REF")) == "now"
+
+
+def test_timex_convert_full_datetime():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="1984-01-03T18:30:45")) == "6:30:45PM 3rd January 1984"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="2000-01-01T00")) == "midnight 1st January 2000"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="1967-05-29T19:30:00")) == "7:30PM 29th May 1967"
+
+
+def test_timex_convert_particular_time_on_particular_day_of_week():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-3T16")) == "4PM Wednesday"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-5T18:30")) == "6:30PM Friday"
+
+
+def test_timex_convert_year():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="2016")) == " 2016"
+
+
+def test_timex_convert_year_season():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="1999-SU")) == "summer 1999"
+
+
+def test_timex_convert_season():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="SU")) == "summer "
+    assert TimexConvert.convert_timex_to_string(Timex(timex="WI")) == "winter "
+
+
+def test_timex_convert_month():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-01")) == "January"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-05")) == "May"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-12")) == "December"
+
+
+def test_timex_convert_month_and_year():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="2018-05")) == "May2018"
+
+
+def test_timex_convert_week_of_month():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-01-W01")) == "firstweek of January"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-08-W03")) == "thirdweek of August"
+
+
+def test_timex_convert_part_of_the_day():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TDT")) == "daytime"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TNI")) == "night"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TMO")) == "morning"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TAF")) == "afternoon"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TEV")) == "evening"
+
+
+def test_timex_convert_friday_evening():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-5TEV")) == "Friday evening"
+
+
+def test_timex_convert_date_and_part_of_day():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="2017-09-07TNI")) == "7th September 2017 night"
+
+# def test_timex_convert_last_5_minutes():
+
+# def test_timex_convert_wednesday_to_saturdays():
+
+
+def test_timex_convert_years():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P2Y")) == "2 years"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P1Y")) == "1 year"
+
+
+def test_timex_convert_weeks():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P6W")) == "6 weeks"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P9.5W")) == "9.5 weeks"
+
+
+def test_timex_convert_days():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P5D")) == "5 days"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P1D")) == "1 day"
+
+
+def test_timex_convert_hours():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PT5H")) == "5 hours"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PT1H")) == "1 hour"
+
+
+def test_timex_convert_minutes():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PT30M")) == "30 minutes"
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PT1M")) == "1 minute"
+
+
+def test_timex_convert_seconds():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="PT45S")) == "45 seconds"
+
+
+def test_timex_convert_every_2days():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P2D")) == "2 days"
+
+
+def test_timex_convert_every_week():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P1W")) == "1 week"
+
+
+def test_timex_convert_every_October():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-10")) == "October"
+
+
+def test_timex_convert_every_Sunday():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="XXXX-WXX-7")) == "Sunday"
+
+
+def test_timex_convert_every_Day():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P1D")) == "1 day"
+
+
+def test_timex_convert_every_Year():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="P1Y")) == "1 year"
+
+
+def test_timex_convert_every_spring():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="SP")) == "spring "
+
+
+def test_timex_convert_every_winter():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="WI")) == "winter "
+
+
+def test_timex_convert_every_evening():
+    assert TimexConvert.convert_timex_to_string(Timex(timex="TEV")) == "evening"

--- a/Python/tests/datatypes/test_timex_date_helpers.py
+++ b/Python/tests/datatypes/test_timex_date_helpers.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+from datatypes_timex_expression import TimexDateHelpers, Constants
+
+
+def test_datatypes_datehelpers_tomorrow():
+    assert TimexDateHelpers.tomorrow(datetime(2016, 12, 31)) == datetime(2017, 1, 1)
+    assert TimexDateHelpers.tomorrow(datetime(2017, 1, 1)) == datetime(2017, 1, 2)
+    assert TimexDateHelpers.tomorrow(datetime(2017, 2, 28)) == datetime(2017, 3, 1)
+    assert TimexDateHelpers.tomorrow(datetime(2016, 2, 28)) == datetime(2016, 2, 29)
+
+
+def test_datatypes_datehelpers_yesterday():
+    assert TimexDateHelpers.yesterday(datetime(2017, 1, 1)) == datetime(2016, 12, 31)
+    assert TimexDateHelpers.yesterday(datetime(2017, 1, 2)) == datetime(2017, 1, 1)
+    assert TimexDateHelpers.yesterday(datetime(2017, 3, 1)) == datetime(2017, 2, 28)
+    assert TimexDateHelpers.yesterday(datetime(2016, 2, 29)) == datetime(2016, 2, 28)
+
+
+def test_datatypes_datehelpers_datepartequals():
+    assert TimexDateHelpers.date_part_equal(datetime(2017, 5, 29), datetime(2017, 5, 29)) is True
+    assert TimexDateHelpers.date_part_equal(datetime(2017, 5, 29, 19, 30, 0), datetime(2017, 5, 29)) is False
+    assert TimexDateHelpers.date_part_equal(datetime(2017, 5, 29), datetime(2017, 11, 15)) is False
+
+
+def test_datatypes_datehelpers_isnextweek():
+    today = datetime(2017, 9, 25)
+
+    assert TimexDateHelpers.is_next_week(datetime(2017, 10, 4), today) is True
+    assert TimexDateHelpers.is_next_week(datetime(2017, 9, 27), today) is False
+    assert TimexDateHelpers.is_next_week(today, today) is False
+
+
+def test_datatypes_datehelpers_islastweek():
+    today = datetime(2017, 9, 25)
+
+    assert TimexDateHelpers.is_last_week(datetime(2017, 9, 20), today) is True
+    assert TimexDateHelpers.is_last_week(datetime(2017, 9, 4), today) is False
+    assert TimexDateHelpers.is_last_week(today, today) is False
+
+
+def test_datatypes_datehelpers_weekofyear():
+    assert TimexDateHelpers.week_of_year(datetime(2017, 1, 1)) == 1
+    assert TimexDateHelpers.week_of_year(datetime(2017, 1, 2)) == 2
+    assert TimexDateHelpers.week_of_year(datetime(2017, 2, 23)) == 9
+    assert TimexDateHelpers.week_of_year(datetime(2017, 3, 15)) == 12
+    assert TimexDateHelpers.week_of_year(datetime(2017, 9, 25)) == 40
+    assert TimexDateHelpers.week_of_year(datetime(2017, 12, 31)) == 53
+    assert TimexDateHelpers.week_of_year(datetime(2018, 1, 1)) == 1
+    assert TimexDateHelpers.week_of_year(datetime(2018, 1, 2)) == 1
+    assert TimexDateHelpers.week_of_year(datetime(2018, 1, 7)) == 1
+    assert TimexDateHelpers.week_of_year(datetime(2018, 1, 8)) == 2
+
+
+def test_datatypes_datehelpers_invariance():
+    d = datetime(2017, 8, 25)
+    before = d
+
+    TimexDateHelpers.tomorrow(d)
+    TimexDateHelpers.yesterday(d)
+    TimexDateHelpers.date_part_equal(datetime.now(), d)
+    TimexDateHelpers.date_part_equal(d, datetime.now())
+    TimexDateHelpers.is_next_week(d, datetime.now())
+    TimexDateHelpers.is_next_week(datetime.now(), d)
+    TimexDateHelpers.is_last_week(datetime.now(), d)
+    TimexDateHelpers.week_of_year(d)
+
+    after = d
+    assert after is before
+
+
+def test_datatypes_datehelpers_dateoflastday_friday_lastweek():
+    day = Constants.DAYS['FRIDAY']
+    date = datetime(2017, 9, 28)
+
+    assert datetime(2017, 9, 22) == TimexDateHelpers.date_of_last_day(day, date)
+
+
+def test_datatypes_datehelpers_dateofnextday_wednesday_nextweek():
+    day = Constants.DAYS['WEDNESDAY']
+    date = datetime(2017, 9, 28)
+
+    assert datetime(2017, 10, 4) == TimexDateHelpers.date_of_next_day(day, date)
+
+
+def test_datatypes_datehelpers_dateofnextday_today():
+    day = Constants.DAYS['THURSDAY']
+    date = datetime(2017, 9, 28)
+
+    assert date != TimexDateHelpers.date_of_next_day(day, date)
+
+
+def test_datatypes_datehelpers_datesmatchingday():
+    day = Constants.DAYS['THURSDAY']
+    start = datetime(2017, 3, 1)
+    end = datetime(2017, 4, 1)
+    result = TimexDateHelpers.dates_matching_day(day, start, end)
+
+    assert len(result) == 5
+    assert result[0] == datetime(2017, 3, 2)
+    assert result[1] == datetime(2017, 3, 9)
+    assert result[2] == datetime(2017, 3, 16)
+    assert result[3] == datetime(2017, 3, 23)
+    assert result[4] == datetime(2017, 3, 30)

--- a/Python/tests/datatypes/test_timex_format.py
+++ b/Python/tests/datatypes/test_timex_format.py
@@ -1,0 +1,52 @@
+from datatypes_timex_expression import Timex
+
+
+def test_datatypes_format_date():
+    assert '2017-09-27' == Timex(year=2017, month=9, day_of_month=27).timex_value()
+    assert 'XXXX-WXX-3' == Timex(day_of_week=3).timex_value()
+    assert 'XXXX-12-05' == Timex(month=12, day_of_month=5).timex_value()
+
+
+def test_datatypes_format_time():
+    assert 'T17:30:45' == Timex(hour=17, minute=30, second=45).timex_value()
+    assert 'T05:06:07' == Timex(hour=5, minute=6, second=7).timex_value()
+    assert 'T17:30' == Timex(hour=17, minute=30, second=0).timex_value()
+    assert 'T23' == Timex(hour=23, minute=0, second=0).timex_value()
+
+
+def test_datatypes_format_duration():
+    assert 'P50Y' == Timex(years=50).timex_value()
+    assert 'P6M' == Timex(months=6).timex_value()
+    assert 'P3W' == Timex(weeks=3).timex_value()
+    assert 'P5D' == Timex(days=5).timex_value()
+    assert 'PT16H' == Timex(hours=16).timex_value()
+    assert 'PT32M' == Timex(minutes=32).timex_value()
+    assert 'PT20S' == Timex(seconds=20).timex_value()
+
+
+def test_datatypes_format_present():
+    assert Timex(now=True).timex_value() == 'PRESENT_REF'
+
+
+def test_datatypes_format_datetime():
+    assert Timex(hour=4, minute=0, second=0, day_of_week=3).timex_value() == 'XXXX-WXX-3T04'
+    assert Timex(year=2017, month=9, day_of_month=27, hour=11, minute=41, second=30).timex_value() == '2017-09-27T11:41:30'
+
+
+def test_datatypes_format_daterange():
+
+    assert Timex(year=2017).timex_value() == '2017'
+    assert Timex(season='SU').timex_value() == 'SU'
+    assert Timex(year=2017, season='WI').timex_value() == '2017-WI'
+    assert Timex(year=2017, month=9).timex_value() == '2017-09'
+    assert Timex(year=2017, week_of_year=37).timex_value() == '2017-W37'
+    assert Timex(year=2017, week_of_year=37, weekend=True).timex_value() == '2017-W37-WE'
+    assert Timex(month=5).timex_value() == 'XXXX-05'
+
+
+def test_datatypes_format_timerange():
+    assert Timex(part_of_day='EV').timex_value() == 'TEV'
+
+
+def test_datatypes_format_datetimerange():
+    assert Timex(year=2017, month=9, day_of_month=27, part_of_day='EV').timex_value() == '2017-09-27TEV'

--- a/Python/tests/datatypes/test_timex_helpers.py
+++ b/Python/tests/datatypes/test_timex_helpers.py
@@ -1,0 +1,71 @@
+from datatypes_timex_expression import Timex, TimexHelpers, datetime, Time
+
+
+def test_datatypes_helpers_expanddatetimerange_short():
+    timex = Timex(timex='(2017-09-27,2017-09-29,P2D)')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == '2017-09-27'
+    assert range.end.timex_value() == '2017-09-29'
+
+
+def test_datatypes_helpers_expanddatetimerange_long():
+    timex = Timex(timex='(2006-01-01,2008-06-01,P882D)')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == '2006-01-01'
+    assert range.end.timex_value() == '2008-06-01'
+
+
+def test_datatypes_gelpers_expanddatetimerange_include_time():
+    timex = Timex(timex='(2017-10-10T16:02:04,2017-10-10T16:07:04,PT5M)')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == '2017-10-10T16:02:04'
+    assert range.end.timex_value() == '2017-10-10T16:07:04'
+
+
+def test_datatypes_helpers_expanddatetimerange_month():
+    timex = Timex(timex='2017-05')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == '2017-05-01'
+    assert range.end.timex_value() == '2017-06-01'
+
+
+def test_datatypes_helpers_expanddatetimerange_year():
+    timex = Timex(timex='1999')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == '1999-01-01'
+    assert range.end.timex_value() == '2000-01-01'
+
+
+def test_datatypes_helpers_expandtimerange():
+    timex = Timex(timex='(T14,T16,PT2H)')
+    range = TimexHelpers.expand_datetime_range(timex)
+
+    assert range.start.timex_value() == 'T14'
+    assert range.end.timex_value() == 'T16'
+
+
+def test_datatypes_helpers_daterangefromtimex():
+    timex = Timex(timex='(2017-09-27,2017-09-29,P2D)')
+    range = TimexHelpers.daterange_from_timex(timex)
+
+    assert range.start == datetime(2017, 9, 27).date()
+    assert range.end == datetime(2017, 9, 29).date()
+
+
+def test__datatypes_helpers_datefromtimex():
+    timex = Timex(timex='2017-09-27')
+    date = TimexHelpers.date_from_timex(timex)
+
+    assert date == datetime(2017, 9, 27).date()
+
+
+def test_datatypes_helpers_timefromtimex():
+    timex = Timex(timex='T00:05:00')
+    time = TimexHelpers.time_from_timex(timex)
+
+    assert time.get_time() == Time(0, 5, 0).get_time()

--- a/Python/tests/datatypes/test_timex_parsing.py
+++ b/Python/tests/datatypes/test_timex_parsing.py
@@ -1,0 +1,1024 @@
+from datatypes_timex_expression import Timex, Constants
+
+
+def test_timex_parsing_complete_date():
+    timex = Timex(timex='2017-05-29')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DEFINITE,
+        Constants.TIMEX_TYPES_DATE}
+    assert timex.year == 2017
+    assert timex.month == 5
+    assert timex.day_of_month == 29
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_timex_parsing_month_and_ady_of_month():
+    timex = Timex(timex='XXXX-12-05')
+    assert timex.types == {Constants.TIMEX_TYPES_DATE}
+    assert timex.year is None
+    assert timex.month == 12
+    assert timex.day_of_month == 5
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_day_of_week():
+    timex = Timex(timex='XXXX-WXX-3')
+    assert timex.types == {Constants.TIMEX_TYPES_DATE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week == 3
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_hours_minutes_and_seconds():
+    timex = Timex(timex='T17:30:05')
+    assert timex.types == {Constants.TIMEX_TYPES_TIME}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 17
+    assert timex.minute == 30
+    assert timex.second == 5
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_hours_and_minutes():
+    timex = Timex(timex='T17:30')
+    assert timex.types == {Constants.TIMEX_TYPES_TIME}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 17
+    assert timex.minute == 30
+    assert timex.second == 0
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_hours():
+    timex = Timex(timex='T17')
+    assert timex.types == {Constants.TIMEX_TYPES_TIME}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 17
+    assert timex.minute == 0
+    assert timex.second == 0
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_now():
+    timex = Timex(timex='PRESENT_REF')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_PRESENT,
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DATETIME}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is True
+
+
+def test_datatypes_parsing_full_datetime():
+    timex = Timex(timex='1984-01-03T18:30:45')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DEFINITE,
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DATETIME}
+    assert timex.year == 1984
+    assert timex.month == 1
+    assert timex.day_of_month == 3
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 18
+    assert timex.minute == 30
+    assert timex.second == 45
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_paricular_time_on_particular_day_of_week():
+    timex = Timex(timex='XXXX-WXX-3T16')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_DATETIME}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week == 3
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 16
+    assert timex.minute == 0
+    assert timex.second == 0
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_year():
+    timex = Timex(timex='2016')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 2016
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_summer_of_1999():
+    timex = Timex(timex='1999-SU')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 1999
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season == 'SU'
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_year_and_week():
+    timex = Timex(timex='2017-W37')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 2017
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year == 37
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_Parsing_SeasonSummer():
+    timex = Timex(timex='SU')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season == 'SU'
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_season_winter():
+    timex = Timex(timex='WI')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season == 'WI'
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_year_and_weekend():
+    timex = Timex(timex='2017-W37-WE')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 2017
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year == 37
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is True
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_may():
+    timex = Timex(timex='XXXX-05')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month == 5
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_july_2020():
+    timex = Timex(timex='2020-07')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 2020
+    assert timex.month == 7
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_week_of_month():
+    timex = Timex(timex='XXXX-01-W01')
+    assert timex.types == {Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month == 1
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month == 1
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_wednesday_to_saturday():
+    timex = Timex(timex='(XXXX-WXX-3,XXXX-WXX-6,P3D)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week == 3
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days == 3
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_jan_1_to_aug_5():
+    timex = Timex(timex='(XXXX-01-01,XXXX-08-05,P216D)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month == 1
+    assert timex.day_of_month == 1
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days == 216
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_jan_1_to_aug_5_year_2015():
+    timex = Timex(timex='(2015-01-01,2015-08-05,P216D)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DEFINITE,
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year == 2015
+    assert timex.month == 1
+    assert timex.day_of_month == 1
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days == 216
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_dayTime():
+    timex = Timex(timex='TDT')
+    assert timex.types == {Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'DT'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_nighttime():
+    timex = Timex(timex='TNI')
+    assert timex.types == {Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'NI'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_morning():
+    timex = Timex(timex='TMO')
+    assert timex.types == {Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'MO'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_afternoon():
+    timex = Timex(timex='TAF')
+    assert timex.types == {Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'AF'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_evening():
+    timex = Timex(timex='TEV')
+    assert timex.types == {Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'EV'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_timerange_430pm_to_445pm():
+    timex = Timex(timex='(T16:30,T16:45,PT15M)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_TIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 16
+    assert timex.minute == 30
+    assert timex.second == 0
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes == 15
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_datetimerange():
+    timex = Timex(timex='XXXX-WXX-5TEV')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIMERANGE,
+        Constants.TIMEX_TYPES_DATETIMERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week == 5
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'EV'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_lastnight():
+    timex = Timex(timex='2017-09-07TNI')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DEFINITE,
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIMERANGE,
+        Constants.TIMEX_TYPES_DATETIMERANGE}
+    assert timex.year == 2017
+    assert timex.month == 9
+    assert timex.day_of_month == 7
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day == 'NI'
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_last_5_minutes():
+    timex = Timex(timex='(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIMERANGE,
+        Constants.TIMEX_TYPES_DATETIMERANGE,
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DATETIME,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_DATERANGE,
+        Constants.TIMEX_TYPES_DEFINITE}
+    assert timex.year == 2017
+    assert timex.month == 9
+    assert timex.day_of_month == 8
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 21
+    assert timex.minute == 19
+    assert timex.second == 29
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes == 5
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_wed_4PM_to_sat_3PM():
+    timex = Timex(timex='(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)')
+    assert timex.types == {
+        Constants.TIMEX_TYPES_DATE,
+        Constants.TIMEX_TYPES_TIMERANGE,
+        Constants.TIMEX_TYPES_DATETIMERANGE,
+        Constants.TIMEX_TYPES_TIME,
+        Constants.TIMEX_TYPES_DATETIME,
+        Constants.TIMEX_TYPES_DURATION,
+        Constants.TIMEX_TYPES_DATERANGE}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week == 3
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour == 16
+    assert timex.minute == 0
+    assert timex.second == 0
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours == 71
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_years():
+    timex = Timex(timex='P2Y')
+#   assert timex.types == { Constants.TIMEX_TYPES_DURATION }
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years == 2
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_months():
+    timex = Timex(timex='P4M')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months == 4
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_weeks():
+    timex = Timex(timex='P6W')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks == 6
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_weeks_floating_point():
+    timex = Timex(timex='P2.5W')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks == 2.5
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_days():
+    timex = Timex(timex='P1D')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days == 1
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_parsing_duration_hours():
+    timex = Timex(timex='PT5H')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours == 5
+    assert timex.minutes is None
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_Parsing_DurationMinutes():
+    timex = Timex(timex='PT30M')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes == 30
+    assert timex.seconds is None
+    assert timex.now is False
+
+
+def test_datatypes_Parsing_DurationSeconds():
+    timex = Timex(timex='PT45S')
+    assert timex.types == {Constants.TIMEX_TYPES_DURATION}
+    assert timex.year is None
+    assert timex.month is None
+    assert timex.day_of_month is None
+    assert timex.day_of_week is None
+    assert timex.week_of_year is None
+    assert timex.week_of_month is None
+    assert timex.season is None
+    assert timex.hour is None
+    assert timex.minute is None
+    assert timex.second is None
+    assert timex.weekend is False
+    assert timex.part_of_day is None
+    assert timex.years is None
+    assert timex.months is None
+    assert timex.weeks is None
+    assert timex.days is None
+    assert timex.hours is None
+    assert timex.minutes is None
+    assert timex.seconds == 45
+    assert timex.now is False

--- a/Python/tests/datatypes/test_timex_range_resolver.py
+++ b/Python/tests/datatypes/test_timex_range_resolver.py
@@ -1,0 +1,252 @@
+from datatypes_timex_expression import Timex, TimexRangeResolver, TimexCreator
+
+
+def test_datatypes_rangeresolve_daterange_definite():
+    eval_constraints_and_candidates(['2017-09-28'], [Timex(year=2017, month=9, day_of_month=27, days=2).timex_value()], ['2017-09-28'])
+
+
+def test_datatypes_rangeresolve_daterange_definite_constraints_as_timex():
+    candidates = ['2017-09-28']
+    constraints = ['(2017-09-27,2017-09-29,P2d)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-28'])
+
+
+def test_datatypes_rangeresolve_daterange_month_and_date():
+    candidates = ["XXXX-05-29"]
+    constraints = [Timex(year=2006, month=1, day_of_month=1, years=2).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['2006-05-29', '2007-05-29'])
+
+
+def test_datatypes_rangeresolve_daterange_saturdays_in_september():
+    candidates = ['XXXX-WXX-6']
+    constraints = ['2017-09']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-02', '2017-09-09', '2017-09-16', '2017-09-23', '2017-09-30'])
+
+
+def test_datatypes_rangeresolve_daterange_saturdays_in_september_expressed_as_range():
+    candidates = ['XXXX-WXX-6']
+    constraints = ['(2017-09-01,2017-10-01,P30D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-02', '2017-09-09', '2017-09-16', '2017-09-23', '2017-09-30'])
+
+
+def test_datatypes_rangeresolve_daterange_year():
+    candidates = ['XXXX-05-29']
+    constraints = ['2018']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-05-29'])
+
+
+def test_datatypes_rangeresolve_daterange_expressed_as_range():
+    candidates = ['XXXX-05-29']
+    constraints = ['(2018-01-01,2019-01-01,P365D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-05-29'])
+
+
+def test_datatypes_rangeresolve_daterange__multiple_constraints():
+    candidates = ['XXXX-WXX-3']
+    constraints = ['(2017-09-01,2017-09-08,P7D)', '(2017-10-01,2017-10-08,P7D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-06', '2017-10-04'])
+
+
+def test_datatypes_rangeresolve_daterange__multiple_candidates_with_multiple_constraints():
+    candidates = ['XXXX-WXX-2', 'XXXX-WXX-4']
+    constraints = ["(2017-09-01,2017-09-08,P7D)",
+                   "(2017-10-01,2017-10-08,P7D)"]
+    eval_constraints_and_candidates(candidates, constraints, ["2017-09-05", "2017-09-07", "2017-10-03", "2017-10-05"])
+
+
+def test_datatypes_rangeresolve_daterange_multiple_overlapping_constraints():
+    candidates = ["XXXX-WXX-3"]
+    constraints = ["(2017-09-03,2017-09-07,P4D)",
+                   "(2017-09-01,2017-09-08,P7D)",
+                   "(2017-09-01,2017-09-16,P15D)"]
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-06'])
+
+
+def test_datatypes_rangeresolve_timerange_time_within_range():
+    candidates = ['T16']
+    constraints = [Timex(hour=14, hours=4).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['T16'])
+
+
+def test_datatypes_rangeresolve_timerange_multiple_times_within_range():
+    candidates = ["T12", "T16", "T16:30", "T17", "T18"]
+    constraints = [Timex(hour=14, minute=0, second=0, hours=4).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['T16', 'T16:30', 'T17'])
+
+
+def test_DataTypes_RangeResolve_timerange_time_with_overlapping_ranges():
+    candidates = ['T19']
+    constraints = [Timex(hour=16, minute=0, second=0, hours=4).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['T19'])
+
+    constraints.append(Timex(hour=14, minute=0, second=0, hours=4).timex_value())
+
+    eval_constraints_and_candidates(candidates, constraints, [])
+
+    candidates = ['T17']
+    eval_constraints_and_candidates(candidates, constraints, ['T17'])
+
+
+def test_DataTypes_RangeResolve_multiple_times_with_overlapping_range():
+    candidates = ["T19", "T19:30"]
+    constraints = [Timex(hour=16, minute=0, second=0, hours=4).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ["T19", "T19:30"])
+
+    constraints.append(Timex(hour=14, minute=0, second=0, hours=4).timex_value())
+
+    eval_constraints_and_candidates(candidates, constraints, [])
+
+    candidates = ["T17", "T17:30", "T19"]
+    eval_constraints_and_candidates(candidates, constraints, ["T17", "T17:30"])
+
+
+def test_DataTypes_RangeResolve_filter_duplicate():
+    candidates = ["T16", "T16", "T16"]
+    constraints = [Timex(hour=16, minute=0, second=0, hours=4).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['T16'])
+
+
+def test_DataTypes_RangeResolve_carry_through_time_definite():
+    candidates = ['2017-09-28T18:30:01']
+    constraints = [Timex(year=2017, month=9, day_of_month=27, days=2).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-28T18:30:01'])
+
+
+def test_DataTypes_RangeResolve_carry_through_time_definite_constrainst_expressed_as_timex():
+    candidates = ['2017-09-28T18:30:01']
+    constraints = ['(2017-09-27,2017-09-29,P2D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-28T18:30:01'])
+
+
+def test_DataTypes_RangeResolve_carry_through_time_month_and_date():
+    candidates = ['XXXX-05-29T19:30']
+    constraints = [Timex(year=2006, month=1, day_of_month=1, years=2).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['2006-05-29T19:30', '2007-05-29T19:30'])
+
+
+def test_DataTypes_RangeResolve_carry_through_time_month_and_date_conditiona():
+    candidates = ['XXXX-05-29T19:30']
+    constraints = ['(2006-01-01,2008-06-01,P882D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2006-05-29T19:30', '2007-05-29T19:30', '2008-05-29T19:30'])
+
+
+def test_DataTypes_RangeResolve_carry_through_time_Saturdays_in_September():
+    candidates = ['XXXX-WXX-6T01:00:00']
+    constraints = ['(2017-09-01,2017-10-01,P30D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-02T01', '2017-09-09T01', '2017-09-16T01', '2017-09-23T01', '2017-09-30T01'])
+
+
+def test_DataTypes_RangeResolve__carry_through_time_multiple_constraints():
+    candidates = ['XXXX-WXX-3T01:02']
+    constraints = ['(2017-09-01,2017-09-08,P7D)', '(2017-10-01,2017-10-08,P7D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-09-06T01:02', '2017-10-04T01:02'])
+
+
+def test_DataTypes_RangeResolve_combined_daterange_and_timerange_next_week_and_any_time():
+    candidates = ['XXXX-WXX-3T04', 'XXXX-WXX-3T16']
+    constraints = [Timex(year=2017, month=10, day_of_month=5, days=7).timex_value(),
+                   Timex(hour=0, minute=0, second=0, hours=24).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['2017-10-11T04', '2017-10-11T16'])
+
+
+def test_DataTypes_RangeResolve_combined_daterange_and_timerange_next_week_and_business_hours():
+    candidates = ['XXXX-WXX-3T04', 'XXXX-WXX-3T16']
+    constraints = [Timex(year=2017, month=10, day_of_month=5, days=7).timex_value(),
+                   Timex(hour=12, minute=0, second=0, hours=8).timex_value()]
+    eval_constraints_and_candidates(candidates, constraints, ['2017-10-11T16'])
+
+
+def test_DataTypes_RangeResolve_adding_times_add_specific_time_to_date():
+    constraints = ['2017', 'T19:30:00']
+    candidates = ['XXXX-05-29']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-05-29T19:30'])
+
+
+def test_DataTypes_RangeResolve_adding_times_add_specific_time_to_date_2():
+    constraints = ['2017', 'T19:30:00', 'T20:01:01']
+    candidates = ['XXXX-05-29']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-05-29T19:30', '2017-05-29T20:01:01'])
+
+
+def test_DataTypes_RangeResolve_duration_specific_datetime():
+    constraints = ['2017-12-05T19:30:00']
+    candidates = ['PT5M']
+    eval_constraints_and_candidates(candidates, constraints, ['2017-12-05T19:35'])
+
+
+def test_DataTypes_RangeResolve_duration_specific_time():
+    constraints = ['T19:30:00']
+    candidates = ['PT5M']
+    eval_constraints_and_candidates(candidates, constraints, ['T19:35'])
+
+
+def test_DataTypes_RangeResolve_duration_no_constraints():
+    constraints = []
+    candidates = ['PT5M']
+    eval_constraints_and_candidates(candidates, constraints, [])
+
+
+def test_DataTypes_RangeResolve_duration_no_time_component():
+    constraints = [Timex(year=2017, month=10, day_of_month=5, days=7).timex_value()]
+    candidates = ['PT5M']
+    eval_constraints_and_candidates(candidates, constraints, [])
+
+
+def test_DataTypes_RangeResolve_dateranges():
+    candidates = ['XXXX-WXX-7']
+    constraints = ['(2018-06-04,2018-06-11,P7D)', '(2018-06-11,2018-06-18,P7D)', TimexCreator.EVENING]
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10T16', '2018-06-17T16'])
+
+
+def test_DataTypes_RangeResolve_dateranges_no_time_constraint():
+    candidates = ['XXXX-WXX-7TEV']
+    constraints = ['(2018-06-04,2018-06-11,P7D)', '(2018-06-11,2018-06-18,P7D)']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10TEV', '2018-06-17TEV'])
+
+
+def test_DataTypes_RangeResolve_dateranges_overlapping_constraint_1():
+    candidates = ['XXXX-WXX-7TEV']
+    constraints = ['(2018-06-04,2018-06-11,P7D)',
+                   '(2018-06-11,2018-06-18,P7D)',
+                   '(T18,T22,PT4H)']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10T18',
+                                                              '2018-06-17T18'])
+
+
+def test_DataTypes_RangeResolve_dateranges_overlapping_constraint_2():
+    candidates = ['XXXX-WXX-7TEV']
+    constraints = ['(2018-06-04,2018-06-11,P7D)',
+                   '(2018-06-11,2018-06-18,P7D)',
+                   '(T15,T19,PT4H)']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10T16',
+                                                              '2018-06-17T16'])
+
+
+def test_DataTypes_RangeResolve_dateranges_non_overlapping_constraint():
+    candidates = ['XXXX-WXX-7TEV']
+    constraints = ['(2018-06-04,2018-06-11,P7D)',
+                   '(2018-06-11,2018-06-18,P7D)',
+                   '(T18,T22,PT4H)']
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10T18',
+                                                              '2018-06-17T18'])
+
+
+def test_DataTypes_RangeResolve_dateranges_non_overlapping_constraint():
+    candidates = ['XXXX-WXX-7TEV']
+    constraints = ['(2018-06-04,2018-06-11,P7D)',
+                   '(2018-06-11,2018-06-18,P7D)',
+                   TimexCreator.EVENING]
+    eval_constraints_and_candidates(candidates, constraints, ['2018-06-10T16',
+                                                              '2018-06-17T16'])
+
+
+def eval_constraints_and_candidates(candidates, constraints, results):
+    result = TimexRangeResolver.evaluate(candidates, constraints)
+    map_results_to_timex_value = list(map(lambda t: t.timex_value(), result))
+
+    if not results:
+        assert map_results_to_timex_value == []
+    for r in results:
+        assert r in map_results_to_timex_value
+
+    assert len(map_results_to_timex_value) == len(results)

--- a/Python/tests/datatypes/test_timex_relative_convert.py
+++ b/Python/tests/datatypes/test_timex_relative_convert.py
@@ -1,0 +1,274 @@
+from datatypes_timex_expression import Timex, datetime, TimexRelativeConvert
+
+
+def test_datatypes_relativeconvert_date_today():
+    timex = Timex(timex='2017-09-25')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'today'
+
+
+def test_datatypes_relativeconvert_date_tomorrow():
+    timex = Timex(timex='2017-09-23')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'tomorrow'
+
+
+def test_datatypes_relativeconvert_date_tomorrow_cross_year_month_boundary():
+    timex = Timex(timex='2018-01-01')
+    today = datetime(2017, 12, 31)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'tomorrow'
+
+
+def test_datatypes_relativeconvert_date_yesterday():
+    timex = Timex(timex='2017-09-21')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'yesterday'
+
+
+def test_datatypes_relativeconvert_date_yesterday_cross_year_month_boundary():
+    timex = Timex(timex='2017-12-31')
+    today = datetime(2018, 1, 1)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'yesterday'
+
+
+def test_datatypes_relativeconvert_date_this_week():
+    timex = Timex(timex='2017-10-18')
+    today = datetime(2017, 10, 16)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this Wednesday'
+
+
+def test_datatypes_relativeconvert_date_this_week_cross_year_month_boundary():
+    timex = Timex(timex='2017-11-03')
+    today = datetime(2017, 10, 31)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this Friday'
+
+
+def test_datatypes_relativeconvert_date_next_week():
+    timex = Timex(timex='2017-09-27')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next Wednesday'
+
+
+def test_datatypes_relativeconvert_date_next_week_cross_year_month_boundary():
+    timex = Timex(timex='2018-01-05')
+    today = datetime(2017, 12, 28)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next Friday'
+
+
+def test_datatypes_relativeconvert_date_last_week():
+    timex = Timex(timex='2017-09-14')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last Thursday'
+
+
+def test_datatypes_relativeconvert_date_last_week_cross_year_month_boundary():
+    timex = Timex(timex='2017-12-25')
+    today = datetime(2018, 1, 4)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last Monday'
+
+
+def test_datatypes_relativeconvert_date_this_week_2():
+    timex = Timex(timex='2017-10-25')
+    today = datetime(2017, 9, 9)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == '25th October 2017'
+
+
+def test_datatypes_relativeconvert_date_next_week_2():
+    timex = Timex(timex='2017-10-04')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == '4th October 2017'
+
+
+def test_datatypes_relativeconvert_date_last_week_2():
+    timex = Timex(timex='2017-09-07')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == '7th September 2017'
+
+
+def test_datatypes_relativeconvert_datetime_today():
+    timex = Timex(timex='2017-09-25T16:00:00')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'today 4PM'
+
+
+def test_datatypes_relativeconvert_datetime_tomorrow():
+    timex = Timex(timex='2017-09-23T16:00:00')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'tomorrow 4PM'
+
+
+def test_datatypes_relativeconvert_datetime_yesterday():
+    timex = Timex(timex='2017-09-21T16:00:00')
+    today = datetime(2017, 9, 22)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'yesterday 4PM'
+
+
+def test_datatypes_relativeconvert_daterange_this_week():
+    timex = Timex(timex='2017-W40')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this week'
+
+
+def test_datatypes_relativeconvert_daterange_next_week():
+    timex = Timex(timex='2017-W41')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next week'
+
+
+def test_datatypes_relativeconvert_daterange_last_week():
+    timex = Timex(timex='2017-W39')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last week'
+
+
+def test_datatypes_relativeconvert_daterange_this_week_2():
+    timex = Timex(timex='2017-W41')
+    today = datetime(2017, 10, 4)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this week'
+
+
+def test_datatypes_relativeconvert_daterange_next_week_2():
+    timex = Timex(timex='2017-W42')
+    today = datetime(2017, 10, 4)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next week'
+
+
+def test_datatypes_relativeconvert_daterange_last_week_2():
+    timex = Timex(timex='2017-W40')
+    today = datetime(2017, 10, 4)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last week'
+
+
+def test_datatypes_relativeconvert_daterange_this_weekend():
+    timex = Timex(timex='2017-W40-WE')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this weekend'
+
+
+def test_datatypes_relativeconvert_daterange_next_weekend():
+    timex = Timex(timex='2017-W41-WE')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next weekend'
+
+
+def test_datatypes_relativeconvert_daterange_last_weekend():
+    timex = Timex(timex='2017-W39-WE')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last weekend'
+
+
+def test_datatypes_relativeconvert_daterange_this_month():
+    timex = Timex(timex='2017-09')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this month'
+
+
+def test_datatypes_relativeconvert_daterange_next_month():
+    timex = Timex(timex='2017-10')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next month'
+
+
+def test_datatypes_relativeconvert_daterange_last_month():
+    timex = Timex(timex='2017-08')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last month'
+
+
+def test_datatypes_relativeconvert_daterange_this_year():
+    timex = Timex(timex='2017')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this year'
+
+
+def test_datatypes_relativeconvert_daterange_next_year():
+    timex = Timex(timex='2018')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next year'
+
+
+def test_datatypes_relativeconvert_daterange_last_year():
+    timex = Timex(timex='2016')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last year'
+
+
+def test_datatypes_relativeconvert_season_next_summer():
+    timex = Timex(timex='2018-SU')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next summer'
+
+
+def test_datatypes_relativeconvert_season_last_summer():
+    timex = Timex(timex='2016-SU')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'last summer'
+
+
+def test_datatypes_relativeconvert_partofday_this_evening():
+    timex = Timex(timex='2017-09-25TEV')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'this evening'
+
+
+def test_datatypes_relativeconvert_partofday_tonight():
+    timex = Timex(timex='2017-09-25TNI')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'tonight'
+
+
+def test_datatypes_relativeconvert_partofday_tomorrow_morning():
+    timex = Timex(timex='2017-09-26TMO')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'tomorrow morning'
+
+
+def test_datatypes_relativeconvert_partofday_yesterday_afternoon():
+    timex = Timex(timex='2017-09-24TAF')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'yesterday afternoon'
+
+
+def test_datatypes_relativeconvert_partofday_next_wednesday_evening():
+    timex = Timex(timex='2017-10-04TEV')
+    today = datetime(2017, 9, 25)
+
+    assert TimexRelativeConvert.convert_timex_to_string_relative(timex, today) == 'next Wednesday evening'

--- a/Python/tests/datatypes/test_timex_resolver.py
+++ b/Python/tests/datatypes/test_timex_resolver.py
@@ -1,0 +1,354 @@
+from datatypes_timex_expression import Timex, datetime, TimexResolver
+
+
+def test_datatypes_resolver_date_definite():
+    today = datetime(2017, 9, 26, 15, 30, 0)
+    resolution = TimexResolver.resolve(["2017-09-28"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2017-09-28"
+    assert resolution.values[0].type == "date"
+    assert resolution.values[0].value == "2017-09-28"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_date_saturday():
+    today = datetime(2017, 9, 26, 15, 30, 0)
+    resolution = TimexResolver.resolve(["XXXX-WXX-6"], today)
+
+    assert len(resolution.values) == 2
+    assert resolution.values[0].timex == "XXXX-WXX-6"
+    assert resolution.values[0].type == "date"
+    assert resolution.values[0].value == "2017-09-23"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+    assert resolution.values[1].timex == "XXXX-WXX-6"
+    assert resolution.values[1].type == "date"
+    assert resolution.values[1].value == "2017-09-30"
+    assert resolution.values[1].start is None
+    assert resolution.values[1].end is None
+
+
+def test_datatypes_resolver_date_sunday():
+    today = datetime(2019, 4, 23, 15, 30, 0)
+    resolution = TimexResolver.resolve(["XXXX-WXX-7"], today)
+
+    assert len(resolution.values) == 2
+    assert resolution.values[0].timex == "XXXX-WXX-7"
+    assert resolution.values[0].type == "date"
+    assert resolution.values[0].value == "2019-04-21"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+    assert resolution.values[1].timex == "XXXX-WXX-7"
+    assert resolution.values[1].type == "date"
+    assert resolution.values[1].value == "2019-04-28"
+    assert resolution.values[1].start is None
+    assert resolution.values[1].end is None
+
+
+def test_datatypes_resolver_date_wednesday_4():
+    today = datetime(2017, 9, 28, 15, 30, 0)
+    resolution = TimexResolver.resolve(["XXXX-WXX-3T04", "XXXX-WXX-3T16"], today)
+
+    assert len(resolution.values) == 4
+    assert resolution.values[0].timex == "XXXX-WXX-3T04"
+    assert resolution.values[0].type == "datetime"
+    assert resolution.values[0].value == "2017-09-27 04:00:00"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+    assert resolution.values[1].timex == "XXXX-WXX-3T04"
+    assert resolution.values[1].type == "datetime"
+    assert resolution.values[1].value == "2017-10-04 04:00:00"
+    assert resolution.values[1].start is None
+    assert resolution.values[1].end is None
+
+    assert resolution.values[2].timex == "XXXX-WXX-3T16"
+    assert resolution.values[2].type == "datetime"
+    assert resolution.values[2].value == "2017-09-27 16:00:00"
+    assert resolution.values[2].start is None
+    assert resolution.values[2].end is None
+
+    assert resolution.values[3].timex == "XXXX-WXX-3T16"
+    assert resolution.values[3].type == "datetime"
+    assert resolution.values[3].value == "2017-10-04 16:00:00"
+    assert resolution.values[3].start is None
+    assert resolution.values[3].end is None
+
+
+def test_datatypes_resolver_datetime_wednesday_4_am():
+    today = datetime(2017, 9, 7)
+    resolution = TimexResolver.resolve(["2017-10-11T04"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2017-10-11T04"
+    assert resolution.values[0].type == "datetime"
+    assert resolution.values[0].value == "2017-10-11 04:00:00"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_2years():
+    today = datetime(2017, 9, 7)
+    resolution = TimexResolver.resolve(["P2Y"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "P2Y"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "63072000"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_6month():
+    today = datetime(2017, 9, 7)
+    resolution = TimexResolver.resolve(["P6M"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "P6M"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "15552000"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_3weeks():
+    resolution = TimexResolver.resolve(["P3W"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "P3W"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "1814400"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_5days():
+    resolution = TimexResolver.resolve(["P5D"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "P5D"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "432000"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_8hours():
+    resolution = TimexResolver.resolve(["PT8H"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "PT8H"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "28800"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_15minutes():
+    resolution = TimexResolver.resolve(["PT15M"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "PT15M"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "900"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_duration_10seconds():
+    resolution = TimexResolver.resolve(["PT10S"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "PT10S"
+    assert resolution.values[0].type == "duration"
+    assert resolution.values[0].value == "10"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_dateRange_september():
+    today = datetime(2017, 9, 28)
+    resolution = TimexResolver.resolve(["XXXX-09"], today)
+
+    assert len(resolution.values) == 2
+    assert resolution.values[0].timex == "XXXX-09"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2016-09-01"
+    assert resolution.values[0].end == "2016-10-01"
+    assert resolution.values[0].value is None
+
+    assert resolution.values[1].timex == "XXXX-09"
+    assert resolution.values[1].type == "daterange"
+    assert resolution.values[1].start == "2017-09-01"
+    assert resolution.values[1].end == "2017-10-01"
+    assert resolution.values[1].value is None
+
+
+def test_datatypes_resolver_dateRange_winter():
+    resolution = TimexResolver.resolve(["WI"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "WI"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].value == "not resolved"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_dateRange_last_week():
+    today = datetime(2017, 4, 30)
+    resolution = TimexResolver.resolve(["2019-W17"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2019-W17"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2019-04-22"
+    assert resolution.values[0].end == "2019-04-29"
+
+
+def test_datatypes_resolver_dateRange_last_month():
+    today = datetime(2017, 4, 30)
+    resolution = TimexResolver.resolve(["2019-03"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2019-03"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2019-03-01"
+    assert resolution.values[0].end == "2019-04-01"
+
+
+def test_datatypes_resolver_dateRange_last_year():
+    today = datetime(2017, 4, 30)
+    resolution = TimexResolver.resolve(["2018"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2018"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2018-01-01"
+    assert resolution.values[0].end == "2019-01-01"
+
+
+def test_datatypes_resolver_dateRange_last_three_weeks():
+    today = datetime(2017, 4, 30)
+    resolution = TimexResolver.resolve(["(2019-04-10,2019-05-01,P3W)"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "(2019-04-10,2019-05-01,P3W)"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2019-04-10"
+    assert resolution.values[0].end == "2019-05-01"
+
+
+def test_datatypes_resolver_timeRange_4am_to_8pm():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["(T04,T20,PT16H)"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "(T04,T20,PT16H)"
+    assert resolution.values[0].type == "timerange"
+    assert resolution.values[0].start == "04:00:00"
+    assert resolution.values[0].end == "20:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_timeRange_morning():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["TMO"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "TMO"
+    assert resolution.values[0].type == "timerange"
+    assert resolution.values[0].start == "08:00:00"
+    assert resolution.values[0].end == "12:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_timeRange_afternoon():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["TAF"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "TAF"
+    assert resolution.values[0].type == "timerange"
+    assert resolution.values[0].start == "12:00:00"
+    assert resolution.values[0].end == "16:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_timeRange_evening():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["TEV"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "TEV"
+    assert resolution.values[0].type == "timerange"
+    assert resolution.values[0].start == "16:00:00"
+    assert resolution.values[0].end == "20:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_dateTimeRange_this_morning():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["2017-10-07TMO"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2017-10-07TMO"
+    assert resolution.values[0].type == "datetimerange"
+    assert resolution.values[0].start == "2017-10-07 08:00:00"
+    assert resolution.values[0].end == "2017-10-07 12:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_dateTimeRange_tonight():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["2018-03-18TNI"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2018-03-18TNI"
+    assert resolution.values[0].type == "datetimerange"
+    assert resolution.values[0].start == "2018-03-18 20:00:00"
+    assert resolution.values[0].end == "2018-03-18 24:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_dateTimeRange_next_monday_4am_to_next_thursday_3pm():
+    today = datetime.now()
+    resolution = TimexResolver.resolve(["(2017-10-09T04,2017-10-12T15,PT83H)"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "(2017-10-09T04,2017-10-12T15,PT83H)"
+    assert resolution.values[0].type == "datetimerange"
+    assert resolution.values[0].start == "2017-10-09 04:00:00"
+    assert resolution.values[0].end == "2017-10-12 15:00:00"
+    assert resolution.values[0].value is None
+
+
+def test_datatypes_resolver_time_4am():
+    resolution = TimexResolver.resolve(["T04"])
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "T04"
+    assert resolution.values[0].type == "time"
+    assert resolution.values[0].value == "04:00:00"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+
+
+def test_datatypes_resolver_time_4_oclock():
+    resolution = TimexResolver.resolve(["T04", "T16"])
+
+    assert len(resolution.values) == 2
+    assert resolution.values[0].timex == "T04"
+    assert resolution.values[0].type == "time"
+    assert resolution.values[0].value == "04:00:00"
+    assert resolution.values[0].start is None
+    assert resolution.values[0].end is None
+    assert resolution.values[1].timex == "T16"
+    assert resolution.values[1].type == "time"
+    assert resolution.values[1].value == "16:00:00"
+    assert resolution.values[1].start is None
+    assert resolution.values[1].end is None


### PR DESCRIPTION
Merge after #1708 

### **Timex migration – Tests classes**
### Description
Based on Microsoft.Recognizers.Text.DataTypes.DataDrivenTests, we migrated the following tests modules: _TestTime_, _TestTimex_, _TestTimexConvert_, _TestTimexDateHelpers_, _TestTimexFormat_, _TestTimexHelpers_, _TestTimexParsing_, _TestTimexRangeResolve_, _TestTimexRelativeConvert_, and _TestTimexResolver_.

### Changes made
The following tests modules were migrated inside `tests/datatypes` folder: 
- test_time
- test_timex
- test_timex_convert
- test_timex_date_helpers
- test_timex_format
- test_timex_helpers
- test_timex_parsing
- test_timex_range_resolver
- test_timex_relative_convert
- test_timex_resolver

The whole migration includes **217 tests**. Considering these changes, the project's tree folder will be something like this:
![image](https://user-images.githubusercontent.com/42946515/61078656-7c597d80-a3f7-11e9-9f25-11cd3762bd58.png)
### Testing
Below, you can find all the tests running successfully. 
![image](https://user-images.githubusercontent.com/42946515/61082364-b75faf00-a3ff-11e9-91a0-776d657f44a9.png)
