### PR TITLE
[.NET] Turkish Numbers (Percent) support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
@@ -90,8 +90,10 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+,)))\d+,\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string DoubleAllFloatRegex = $@"((?<=\b){AllFloatRegex}(?=\b))";
       public const string ConnectorRegex = @"(?<spacer>ve)";
-      public static readonly string NumberWithPrefixPercentage = $@"(%|(eksi\s)?yüzde\s)({BaseNumbers.NumberReplaceToken}|{AllIntRegex})";
-      public static readonly string NumberWithSuffixPercentage = $@"(((({TensNumberIntegerRegex}\s)?(birin|ikinin|üçün|dördün|beşin|altının|yedinin|sekizin|dokuzun)|onun|yirminin|otuzun|kırkın|ellinin|altmışın|yetmişin|seksenin|doksanın)\s(yüzdesi))|(\d*(1'in|2'nin|3'ün|4'ün|5'in|6'nın|7'nin|8'in|9'un|10'un|20'nin|30'un|40'ın|50'nin|60'ın|70'in|80'in|90'ın)\s(yüzdesi)))";
+      public const string NumberWithSuffixPercentage = @"(((({TensNumberIntegerRegex}\s)?(birin|ikinin|üçün|dördün|beşin|altının|yedinin|sekizin|dokuzun)|onun|yirminin|otuzun|kırkın|ellinin|altmışın|yetmişin|seksenin|doksanın)\s(yüzdesi))|(\d*(1'in|2'nin|3'ün|4'ün|5'in|6'nın|7'nin|8'in|9'un|10'un|20'nin|30'un|40'ın|50'nin|60'ın|70'in|80'in|90'ın)\s(yüzdesi)))";
+      public const string FractionNumberWithSuffixPercentage = @"(\d+,\d+((1|5|8|70|80)'i|(2|7|20|50)'si|(3|4|100)'ü|6'sı|(9|10|30)'u|(40|60|90)'ı))";
+      public static readonly string NumberWithPrefixPercentage = $@"(%|eksi\syüzde\s|yüzde\s)({BaseNumbers.NumberReplaceToken}|{AllIntRegex})";
+      public static readonly string NumberWithPrepositionPercentage = $@"({BaseNumbers.NumberReplaceToken})\s*(üzerinden)\s*({BaseNumbers.NumberReplaceToken})";
       public const string TillRegex = @"(-|—|——|–|~)";
       public const string MoreRegex = @"(büyük(tür)?|(?<!<|=)>)";
       public const string LessRegex = @"(küçük(tür)?|(?<!>|=)<)";

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -309,13 +309,11 @@ namespace Microsoft.Recognizers.Text.Number
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new TurkishNumberParserConfiguration()),
                     Turkish.OrdinalExtractor.GetInstance()));
 
-            /*TO DO Uncomment once the PercentModel test passes */
-
-            /*RegisterModel<PercentModel>(
+            RegisterModel<PercentModel>(
                 Culture.Turkish,
                 (options) => new PercentModel(
                     AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new TurkishNumberParserConfiguration()),
-                    new Turkish.PercentageExtractor(options)));*/
+                    new Turkish.PercentageExtractor(options)));
         }
 
         private static List<ModelResult> RecognizeByModel(Func<NumberRecognizer, IModel> getModelFunc, string query, NumberOptions options)

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/DoubleExtractor.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class DoubleExtractor : BaseNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<string, DoubleExtractor> Instances =
             new ConcurrentDictionary<string, DoubleExtractor>();
 
@@ -17,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/FractionExtractor.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class FractionExtractor : BaseNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<(NumberOptions, string), FractionExtractor> Instances =
             new ConcurrentDictionary<(NumberOptions, string), FractionExtractor>();
 
@@ -19,19 +21,19 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.TURKISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/IntegerExtractor.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class IntegerExtractor : BaseNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances =
             new ConcurrentDictionary<string, IntegerExtractor>();
 
@@ -17,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.NegativeAllIntRegexWithLocks, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.NegativeAllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/MergedNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/MergedNumberExtractor.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     internal class MergedNumberExtractor : BaseMergedNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), MergedNumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), MergedNumberExtractor>();
 
@@ -14,9 +16,9 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
         {
             NumberExtractor = Turkish.NumberExtractor.GetInstance(mode, options);
             RoundNumberIntegerRegexWithLocks =
-                new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexOptions.Singleline);
+                new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
             ConnectorRegex =
-                new Regex(NumbersDefinitions.ConnectorRegex, RegexOptions.Singleline);
+                new Regex(NumbersDefinitions.ConnectorRegex, RegexFlags);
         }
 
         public sealed override BaseNumberExtractor NumberExtractor { get; set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberExtractor.cs
@@ -8,14 +8,16 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class NumberExtractor : BaseNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor>();
 
         private NumberExtractor(NumberMode mode, NumberOptions options)
         {
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexOptions.Singleline);
+            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexOptions.Singleline);
+            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             Options = options;
 
@@ -59,7 +61,7 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexOptions.Singleline), new Regex(item.Value, RegexOptions.Singleline));
+                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
             : base(
                   NumberExtractor.GetInstance(),
@@ -19,57 +21,57 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/OrdinalExtractor.cs
@@ -9,30 +9,32 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class OrdinalExtractor : BaseNumberExtractor
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         private static readonly ConcurrentDictionary<string, OrdinalExtractor> Instances =
             new ConcurrentDictionary<string, OrdinalExtractor>();
 
         private OrdinalExtractor(NumberOptions options)
             : base(options)
         {
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexOptions.Singleline);
+            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalTurkishRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.OrdinalTurkishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberOrdinalRegex, RegexOptions.Singleline),
+                    new Regex(NumbersDefinitions.RoundNumberOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.TURKISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/PercentageExtractor.cs
@@ -19,11 +19,17 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 
         protected override ImmutableHashSet<Regex> InitRegexes()
         {
-            var regexStrs = new HashSet<string>
+            HashSet<string> regexStrs = new HashSet<string>
             {
-                NumbersDefinitions.NumberWithPrefixPercentage,
                 NumbersDefinitions.NumberWithSuffixPercentage,
+                NumbersDefinitions.NumberWithPrefixPercentage,
             };
+
+            if ((Options & NumberOptions.PercentageMode) != 0)
+            {
+                regexStrs.Add(NumbersDefinitions.FractionNumberWithSuffixPercentage);
+                regexStrs.Add(NumbersDefinitions.NumberWithPrepositionPercentage);
+            }
 
             return BuildRegexes(regexStrs);
         }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class TurkishNumberParserConfiguration : BaseNumberParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public TurkishNumberParserConfiguration()
             : this(new CultureInfo(Culture.Turkish))
         {
@@ -34,10 +36,10 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexOptions.Singleline);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexOptions.Singleline);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexOptions.Singleline);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexOptions.Singleline);
+            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 {
     public class TurkishNumberRangeParserConfiguration : INumberRangeParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public TurkishNumberRangeParserConfiguration()
             : this(new CultureInfo(Culture.Turkish))
         {
@@ -18,8 +20,8 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             NumberExtractor = Turkish.NumberExtractor.GetInstance();
             OrdinalExtractor = Turkish.OrdinalExtractor.GetInstance();
             NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration());
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexOptions.Singleline);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexOptions.Singleline);
+            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/Patterns/Turkish/Turkish-Numbers.yaml
+++ b/Patterns/Turkish/Turkish-Numbers.yaml
@@ -183,13 +183,17 @@ DoubleAllFloatRegex: !nestedRegex
   references: [ AllFloatRegex ]
 ConnectorRegex: !simpleRegex
     def: (?<spacer>ve)
-# Percentage Regex
-NumberWithPrefixPercentage: !nestedRegex
-  def: (%|(eksi\s)?yüzde\s)({BaseNumbers.NumberReplaceToken}|{AllIntRegex})
-  references: [ BaseNumbers.NumberReplaceToken, AllIntRegex ]
-NumberWithSuffixPercentage: !nestedRegex
+#Percentage Regex
+NumberWithSuffixPercentage: !simpleRegex
   def: (((({TensNumberIntegerRegex}\s)?(birin|ikinin|üçün|dördün|beşin|altının|yedinin|sekizin|dokuzun)|onun|yirminin|otuzun|kırkın|ellinin|altmışın|yetmişin|seksenin|doksanın)\s(yüzdesi))|(\d*(1'in|2'nin|3'ün|4'ün|5'in|6'nın|7'nin|8'in|9'un|10'un|20'nin|30'un|40'ın|50'nin|60'ın|70'in|80'in|90'ın)\s(yüzdesi)))
-  references: [ TensNumberIntegerRegex ]
+FractionNumberWithSuffixPercentage: !simpleRegex
+  def: (\d+,\d+((1|5|8|70|80)'i|(2|7|20|50)'si|(3|4|100)'ü|6'sı|(9|10|30)'u|(40|60|90)'ı))
+NumberWithPrefixPercentage: !nestedRegex
+  def: (%|eksi\syüzde\s|yüzde\s)({BaseNumbers.NumberReplaceToken}|{AllIntRegex})
+  references: [ BaseNumbers.NumberReplaceToken, AllIntRegex ]
+NumberWithPrepositionPercentage: !nestedRegex
+  def: ({BaseNumbers.NumberReplaceToken})\s*(üzerinden)\s*({BaseNumbers.NumberReplaceToken})
+  references: [ BaseNumbers.NumberReplaceToken ]
 # NumberRange Regex
 TillRegex: !simpleRegex
   def: (-|—|——|–|~)

--- a/Specs/Number/Turkish/PercentModel.json
+++ b/Specs/Number/Turkish/PercentModel.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "%100",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -17,7 +16,6 @@
   },
   {
     "Input": "yüzde 100",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -33,7 +31,6 @@
   },
   {
     "Input": "yüzde 240",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -49,7 +46,6 @@
   },
   {
     "Input": "yüzde yirmi",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -65,7 +61,6 @@
   },
   {
     "Input": "yüzde otuz",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -81,7 +76,6 @@
   },
   {
     "Input": "yüzde yüz",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -161,7 +155,6 @@
   },
   {
     "Input": "yüzde 10",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {

--- a/Specs/Number/Turkish/PercentModel.json
+++ b/Specs/Number/Turkish/PercentModel.json
@@ -90,21 +90,6 @@
     ]
   },
   {
-    "Input": "yüzde yirmi",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "yüzde yirmi",
-        "TypeName": "percentage",
-        "Resolution": {
-          "value": "20%"
-        },
-        "Start": 0,
-        "End": 10
-      }
-    ]
-  },
-  {
     "Input": "yüzde 10",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -162,21 +147,6 @@
         },
         "Start": 0,
         "End": 8
-      }
-    ]
-  },
-  {
-    "Input": "yüzde 10",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "yüzde 10",
-        "TypeName": "percentage",
-        "Resolution": {
-          "value": "10%"
-        },
-        "Start": 0,
-        "End": 7
       }
     ]
   },

--- a/Specs/Number/Turkish/PercentModel.json
+++ b/Specs/Number/Turkish/PercentModel.json
@@ -90,50 +90,47 @@
     ]
   },
   {
-    "Input": "yirminin yüzdesi",
-    "NotSupported": "dotnet",
+    "Input": "yüzde yirmi",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "yirminin yüzdesi",
+        "Text": "yüzde yirmi",
         "TypeName": "percentage",
         "Resolution": {
           "value": "20%"
         },
         "Start": 0,
-        "End": 15
+        "End": 10
       }
     ]
   },
   {
-    "Input": "10'un yüzdesi",
-    "NotSupported": "dotnet",
+    "Input": "yüzde 10",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "10'un yüzdesi",
+        "Text": "yüzde 10",
         "TypeName": "percentage",
         "Resolution": {
           "value": "10%"
         },
         "Start": 0,
-        "End": 12
+        "End": 7
       }
     ]
   },
   {
-    "Input": "yirmi ikinin yüzdesi",
-    "NotSupported": "dotnet",
+    "Input": "yüzde yirmi iki",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "yirmi ikinin yüzdesi",
+        "Text": "yüzde yirmi iki",
         "TypeName": "percentage",
         "Resolution": {
           "value": "22%"
         },
         "Start": 0,
-        "End": 19
+        "End": 14
       }
     ]
   },
@@ -150,6 +147,21 @@
         },
         "Start": 0,
         "End": 13
+      }
+    ]
+  },
+  {
+    "Input": "yüzde 210",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "yüzde 210",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "210%"
+        },
+        "Start": 0,
+        "End": 8
       }
     ]
   },


### PR DESCRIPTION
Follow up to #1653. 
9 passes 2 skips.

Issues: 
- written negative percentage, "-5%" actual "5%"
"minus five" is captured by BaseNumbers, but in Turkish, the order is different "eksi yüzde beş" directly translates to "minus percent five" since minus sign does not come before the number directly but comes before the number with percent,  it is not resolved. 

Explanation of modified localization: 
NumberWithSuffixPercentage can only be used with a (Num+Suffix)(Percent+Suffix), e.g. 210'un yüzdesi (per cent of 210). However, "yüzde 210" has the same meaning and more common than "210'un yüzdesi". Also, "yüzdesi" is mostly used as "percentage" and used with nouns more frequently than numbers, e.g. "kütle yüzdesi" (meaning "mass percentage").

