### PR TITLE
[.NET] DateTime suggested solution for BaseDateTimePeriodParser

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -732,42 +732,27 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Parse "pm"
-            string matchPmStr = string.Empty, matchAmStr = string.Empty, descStr = string.Empty;
-            string matchPmStr1 = string.Empty, matchAmStr1 = string.Empty, descStr1 = string.Empty;
-            var matchPmStrGroup = match.Groups[Constants.PmGroupName];
-            var matchAmStrGroup = match.Groups[Constants.AmGroupName];
+            string descStr = string.Empty, beginDescStr = string.Empty, endDescStr = string.Empty;
+            var matchPmStr = match.Groups[Constants.PmGroupName].Value;
+            var matchAmStr = match.Groups[Constants.AmGroupName].Value;
             var descStrGroup = match.Groups[Constants.DescGroupName];
-            if (matchPmStrGroup.Captures.Count > 0)
+
+            if (descStrGroup.Captures.Count > 1)
             {
-                matchPmStr = matchPmStrGroup.Captures[0].Value;
-                if (matchPmStrGroup.Captures.Count > 1)
-                {
-                    matchPmStr1 = matchPmStrGroup.Captures[1].Value;
-                }
+                // first particle am/pm in patterns like "between 8am and 2pm"
+                beginDescStr = descStrGroup.Captures[0].Value;
+
+                // second particle am/pm
+                endDescStr = descStrGroup.Captures[1].Value;
+            }
+            else if (descStrGroup.Captures.Count > 0)
+            {
+                descStr = descStrGroup.Value;
             }
 
-            if (matchAmStrGroup.Captures.Count > 0)
+            if (descStrGroup.Captures.Count > 1)
             {
-                matchAmStr = matchAmStrGroup.Captures[0].Value;
-                if (matchAmStrGroup.Captures.Count > 1)
-                {
-                    matchAmStr1 = matchAmStrGroup.Captures[1].Value;
-                }
-            }
-
-            if (descStrGroup.Captures.Count > 0)
-            {
-                descStr = descStrGroup.Captures[0].Value;
-
-                if (descStrGroup.Captures.Count > 1)
-                {
-                    descStr1 = descStrGroup.Captures[1].Value;
-                }
-            }
-
-            if (matchPmStrGroup.Captures.Count > 1 || matchAmStrGroup.Captures.Count > 1 || descStrGroup.Captures.Count > 1)
-            {
-                if (!string.IsNullOrEmpty(matchAmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("a")))
+                if (!string.IsNullOrEmpty(beginDescStr) && beginDescStr.StartsWith("a"))
                 {
                     if (beginHour >= Constants.HalfDayHourCount)
                     {
@@ -776,22 +761,17 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     hasAm = true;
                 }
-                else if (!string.IsNullOrEmpty(matchPmStr) || (!string.IsNullOrEmpty(descStr) && descStr.StartsWith("p")))
+                else if (!string.IsNullOrEmpty(beginDescStr) && beginDescStr.StartsWith("p"))
                 {
                     if (beginHour < Constants.HalfDayHourCount)
                     {
                         beginHour += Constants.HalfDayHourCount;
                     }
 
-                    if (endHour < Constants.HalfDayHourCount)
-                    {
-                        endHour += Constants.HalfDayHourCount;
-                    }
-
                     hasPm = true;
                 }
 
-                if (!string.IsNullOrEmpty(matchAmStr1) || (!string.IsNullOrEmpty(descStr1) && descStr1.StartsWith("a")))
+                if (!string.IsNullOrEmpty(endDescStr) && endDescStr.StartsWith("a"))
                 {
                     if (endHour >= Constants.HalfDayHourCount)
                     {
@@ -800,7 +780,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     hasAm = true;
                 }
-                else if (!string.IsNullOrEmpty(matchPmStr1) || (!string.IsNullOrEmpty(descStr1) && descStr1.StartsWith("p")))
+                else if (!string.IsNullOrEmpty(endDescStr) && endDescStr.StartsWith("p"))
                 {
                     if (endHour < Constants.HalfDayHourCount)
                     {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -732,27 +732,15 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Parse "pm"
-            string descStr = string.Empty, beginDescStr = string.Empty, endDescStr = string.Empty;
             var matchPmStr = match.Groups[Constants.PmGroupName].Value;
             var matchAmStr = match.Groups[Constants.AmGroupName].Value;
-            var descStrGroup = match.Groups[Constants.DescGroupName];
+            var descStr = match.Groups[Constants.DescGroupName].Value;
+            var beginDescStr = match.Groups[Constants.LeftAmPmGroupName].Value;
+            var endDescStr = match.Groups[Constants.RightAmPmGroupName].Value;
 
-            if (descStrGroup.Captures.Count > 1)
+            if (!string.IsNullOrEmpty(beginDescStr) && !string.IsNullOrEmpty(endDescStr))
             {
-                // first particle am/pm in patterns like "between 8am and 2pm"
-                beginDescStr = descStrGroup.Captures[0].Value;
-
-                // second particle am/pm
-                endDescStr = descStrGroup.Captures[1].Value;
-            }
-            else if (descStrGroup.Captures.Count > 0)
-            {
-                descStr = descStrGroup.Value;
-            }
-
-            if (descStrGroup.Captures.Count > 1)
-            {
-                if (!string.IsNullOrEmpty(beginDescStr) && beginDescStr.StartsWith("a"))
+                if (beginDescStr.StartsWith("a"))
                 {
                     if (beginHour >= Constants.HalfDayHourCount)
                     {
@@ -761,7 +749,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     hasAm = true;
                 }
-                else if (!string.IsNullOrEmpty(beginDescStr) && beginDescStr.StartsWith("p"))
+                else if (beginDescStr.StartsWith("p"))
                 {
                     if (beginHour < Constants.HalfDayHourCount)
                     {
@@ -780,7 +768,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     hasAm = true;
                 }
-                else if (!string.IsNullOrEmpty(endDescStr) && endDescStr.StartsWith("p"))
+                else if (endDescStr.StartsWith("p"))
                 {
                     if (endHour < Constants.HalfDayHourCount)
                     {

--- a/Specs/DateTime/English/DateTimePeriodParser.json
+++ b/Specs/DateTime/English/DateTimePeriodParser.json
@@ -2378,7 +2378,7 @@
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "on Friday next week between 8am and 2pm",
@@ -2404,7 +2404,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "between half past seven and 4pm of tomorrow",

--- a/Specs/DateTime/English/DateTimePeriodParser.json
+++ b/Specs/DateTime/English/DateTimePeriodParser.json
@@ -2372,5 +2372,57 @@
         "Length": 29
       }
     ]
+  },
+  {
+    "Input": "Can you schedule us on Friday next week between 8am and 2pm?",
+    "Context": {
+      "ReferenceDateTime": "2017-11-09T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "on Friday next week between 8am and 2pm",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2017-11-17T08,2017-11-17T14,PT6H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-17 08:00:00",
+            "endDateTime": "2017-11-17 14:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-17 08:00:00",
+            "endDateTime": "2017-11-17 14:00:00"
+          }
+        },
+        "Start": 20,
+        "Length": 39
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out between half past seven and 4pm of tomorrow",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "between half past seven and 4pm of tomorrow",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 07:30:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-08 07:30:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          }
+        },
+        "Start": 12,
+        "Length": 43
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Italian/DateTimePeriodParser.json
+++ b/Specs/DateTime/Italian/DateTimePeriodParser.json
@@ -186,7 +186,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "python,javascript,python",
     "Results": [
       {
@@ -1565,7 +1564,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "python,javascript,python",
     "Results": [
       {

--- a/Specs/DateTime/Spanish/DateTimePeriodParser.json
+++ b/Specs/DateTime/Spanish/DateTimePeriodParser.json
@@ -176,6 +176,8 @@
   },
   {
     "Input": "Estaré afuera de siete y media a 4pm mañana",
+    "NotSupported": "python, javascript, java",
+    "Comment": "Timex is incorrectly resolved to PT8H, code needs to be updated to match C# in #1736",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },

--- a/Specs/DateTime/Spanish/DateTimePeriodParser.json
+++ b/Specs/DateTime/Spanish/DateTimePeriodParser.json
@@ -184,7 +184,7 @@
         "Text": "de siete y media a 4pm mañana",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H)",
+          "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
           "FutureResolution": {
             "startDateTime": "2016-11-08 07:30:00",
             "endDateTime": "2016-11-08 16:00:00"


### PR DESCRIPTION
The modification in ParseTimePeriod serves to correctly address cases such as "on Dec 9th between 8am and 2pm" so that both particles 'am' and 'pm' are extracted and associated to the corresponding time entities (originally only one particle was extracted and associated to both times causing errors in cases where the two particles differ)

The modification in MergeTwoTimePoints serves to take into account minutes when calculating the duration so that for example "from half past seven to 4pm of tomorrow" returns 'PT8H30M' (the original output was 'PT8H').
Spanish case is an example of this point it was returning PT8H instead of the correct PT8H30M