### PR TITLE
[Python] Include Grapheme as a dependency in recognizers_choice

### DIFF
--- a/Python/libraries/recognizers-choice/setup.py
+++ b/Python/libraries/recognizers-choice/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 NAME = 'recognizers-text-choice'
 VERSION = '1.0.0.a0'
-REQUIRES = ['recognizers-text', 'regex']
+REQUIRES = ['recognizers-text', 'regex', 'grapheme']
 
 setup(
     name=NAME,

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,5 +1,4 @@
 emoji
-grapheme
 pre-commit==1.16.1
 autopep8
 flake8


### PR DESCRIPTION
### Description
This PR will resolve issue [#1739](https://github.com/microsoft/Recognizers-Text/issues/1739).
### Changes made

- Remove _Grapheme_ dependency from the _requirements.txt_

- Add  _Grapheme_ dependency into _setup.py_
## Testing

- Add the following import _from recognizers_choice import ChoiceRecognizer_ into the _test_runner_choice_

- Run _pip install -e .\libraries\recognizers-choice_ to install the choice library among with the  missing _Grapheme_ dependency

- Run _pytests test_runner_choice_ from the tests folder 

You can find the whole process in the image below:
![image](https://user-images.githubusercontent.com/42946515/61975505-adbd7600-afbf-11e9-9d22-b1ac79826e08.png)
