### PR TITLE
[.NET] Standardizing config in DateTime and introducing it in Numbers

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
@@ -21,16 +21,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
 
         public TestDateTimeRecognizerInitialization()
         {
-            var config = new BaseDateTimeOptionsConfiguration();
-            var configEnableDmy = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true);
+            var defaultConfig = new BaseDateTimeOptionsConfiguration(Culture.English, DateTimeOptions.None, false);
+            var dmyConfig = new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, DateTimeOptions.None, true);
 
             defaultEnglishControlModel = new DateTimeModel(
-                    new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(config)),
-                    new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(config)));
+                    new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(defaultConfig)),
+                    new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(defaultConfig)));
 
             otherEnglishControlModel = new DateTimeModel(
-                    new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(configEnableDmy)),
-                    new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(configEnableDmy)));
+                    new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(dmyConfig)),
+                    new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(dmyConfig)));
         }
 
         [TestMethod]

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTimeRecognizerInitialization.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
 
         public TestDateTimeRecognizerInitialization()
         {
-            var config = new BaseOptionsConfiguration();
-            var configEnableDmy = new BaseOptionsConfiguration(DateTimeOptions.None, true);
+            var config = new BaseDateTimeOptionsConfiguration();
+            var configEnableDmy = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true);
 
             defaultEnglishControlModel = new DateTimeModel(
                     new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(config)),

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
@@ -28,11 +28,11 @@ namespace Microsoft.Recognizers.Text.Number.Tests
 
         public ImmutableDictionary<string, string> RelativeReferenceRelativeToMap { get; private set; }
 
+        public INumberOptionsConfiguration Config { get; }
+
         public ImmutableDictionary<string, long> OrdinalNumberMap { get; }
 
         public ImmutableDictionary<string, long> RoundNumberMap { get; }
-
-        public NumberOptions Options { get; }
 
         public CultureInfo CultureInfo { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerInitialization.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumberRecognizerInitialization.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         public TestNumberRecognizerInitialization()
         {
             controlModel = new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number,
+                                                          new EnglishNumberParserConfiguration(new BaseNumberOptionsConfiguration(EnglishCulture))),
                     NumberExtractor.GetInstance(NumberMode.PureNumber));
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestParserFactory.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestParserFactory.cs
@@ -5,7 +5,9 @@ using Microsoft.Recognizers.Text.Number.German;
 using Microsoft.Recognizers.Text.Number.Italian;
 using Microsoft.Recognizers.Text.Number.Japanese;
 using Microsoft.Recognizers.Text.Number.Korean;
+using Microsoft.Recognizers.Text.Number.Portuguese;
 using Microsoft.Recognizers.Text.Number.Spanish;
+using Microsoft.Recognizers.Text.Number.Turkish;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.Number.Tests
@@ -16,55 +18,79 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void TestEnglishParser()
         {
-            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration());
-            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new EnglishNumberParserConfiguration());
-            IParser parserPercentaje = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new EnglishNumberParserConfiguration());
+            var config = new EnglishNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.English));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parserPercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parserNumber is BaseNumberParser);
             Assert.IsTrue(parserCardinal is BaseNumberParser);
-            Assert.IsTrue(parserPercentaje is BasePercentageParser);
+            Assert.IsTrue(parserPercentage is BasePercentageParser);
         }
 
         [TestMethod]
         public void TestSpanishParser()
         {
-            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration());
-            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new SpanishNumberParserConfiguration());
-            IParser parserPercentaje = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new SpanishNumberParserConfiguration());
+            var config = new SpanishNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Spanish));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parserPercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parserNumber is BaseNumberParser);
             Assert.IsTrue(parserCardinal is BaseNumberParser);
-            Assert.IsTrue(parserPercentaje is BasePercentageParser);
+            Assert.IsTrue(parserPercentage is BasePercentageParser);
+        }
+
+        [TestMethod]
+        public void TestPortugueseParser()
+        {
+            var config = new PortugueseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Portuguese));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parserPercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
+
+            Assert.IsTrue(parserNumber is BaseNumberParser);
+            Assert.IsTrue(parserCardinal is BaseNumberParser);
+            Assert.IsTrue(parserPercentage is BasePercentageParser);
         }
 
         [TestMethod]
         public void TestChineseParser()
         {
-            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration());
-            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new ChineseNumberParserConfiguration());
-            IParser parserPercentaje = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ChineseNumberParserConfiguration());
+            var config = new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parserPercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parserNumber is BaseCJKNumberParser);
             Assert.IsTrue(parserCardinal is BaseCJKNumberParser);
-            Assert.IsTrue(parserPercentaje is BaseCJKNumberParser);
+            Assert.IsTrue(parserPercentage is BaseCJKNumberParser);
         }
 
         [TestMethod]
         public void TestJapaneseParser()
         {
-            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration());
-            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new JapaneseNumberParserConfiguration());
-            IParser parserPercentaje = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new JapaneseNumberParserConfiguration());
+            var config = new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Japanese));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parserCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parserPercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parserNumber is BaseCJKNumberParser);
             Assert.IsTrue(parserCardinal is BaseCJKNumberParser);
-            Assert.IsTrue(parserPercentaje is BaseCJKNumberParser);
+            Assert.IsTrue(parserPercentage is BaseCJKNumberParser);
         }
 
         [TestMethod]
         public void TestKoreanParser()
         {
-            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new KoreanNumberParserConfiguration());
+            var config = new KoreanNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Korean));
+
+            IParser parserNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
 
             Assert.IsTrue(parserNumber is BaseCJKNumberParser);
         }
@@ -72,9 +98,11 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void TestFrenchParser()
         {
-            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration());
-            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new FrenchNumberParserConfiguration());
-            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration());
+            var config = new FrenchNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.French));
+
+            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parseNumber is BaseNumberParser);
             Assert.IsTrue(parseCardinal is BaseNumberParser);
@@ -84,9 +112,11 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void TestGermanParser()
         {
-            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration());
-            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new GermanNumberParserConfiguration());
-            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new GermanNumberParserConfiguration());
+            var config = new GermanNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.German));
+
+            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parseNumber is BaseNumberParser);
             Assert.IsTrue(parseCardinal is BaseNumberParser);
@@ -96,9 +126,25 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         [TestMethod]
         public void TestItalianParser()
         {
-            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ItalianNumberParserConfiguration());
-            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, new ItalianNumberParserConfiguration());
-            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ItalianNumberParserConfiguration());
+            var config = new ItalianNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Italian));
+
+            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
+
+            Assert.IsTrue(parseNumber is BaseNumberParser);
+            Assert.IsTrue(parseCardinal is BaseNumberParser);
+            Assert.IsTrue(parsePercentage is BasePercentageParser);
+        }
+
+        [TestMethod]
+        public void TestTurkishParser()
+        {
+            var config = new TurkishNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Turkish));
+
+            IParser parseNumber = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, config);
+            IParser parseCardinal = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Cardinal, config);
+            IParser parsePercentage = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, config);
 
             Assert.IsTrue(parseNumber is BaseNumberParser);
             Assert.IsTrue(parseCardinal is BaseNumberParser);

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         {
             var culture = TestUtils.GetCulture(context.FullyQualifiedTestClassName);
             var extractorName = TestUtils.GetExtractor(context.TestName);
+
             switch (culture)
             {
                 case Culture.English:
@@ -168,6 +169,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
         {
             var culture = TestUtils.GetCulture(context.FullyQualifiedTestClassName);
             var parserName = TestUtils.GetParser(context.TestName);
+
             switch (culture)
             {
                 case Culture.English:
@@ -199,7 +201,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetDutchExtractor(DateTimeExtractors extractorName)
         {
-            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true);
+            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(Culture.Dutch, DateTimeOptions.None, dmyDateFormat: true);
+            var dmySkipConfig = new BaseDateTimeOptionsConfiguration(Culture.Dutch, DateTimeOptions.SkipFromToMerge, true);
 
             switch (extractorName)
             {
@@ -226,7 +229,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(enableDmyConfig));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(dmySkipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Dutch not supported");
@@ -234,7 +237,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetDutchParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new DutchCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true));
+            var commonConfiguration = new DutchCommonDateTimeParserConfiguration(
+                new BaseDateTimeOptionsConfiguration(Culture.Dutch, DateTimeOptions.None, dmyDateFormat: true));
 
             switch (parserName)
             {
@@ -259,7 +263,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new DutchSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true)));
+                    return new BaseMergedDateTimeParser(new DutchMergedParserConfiguration(commonConfiguration));
             }
 
             throw new Exception($"Parser '{parserName}' for Dutch not supported");
@@ -267,8 +271,10 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetEnglishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
-            var previewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview);
+            var config = new BaseDateTimeOptionsConfiguration(Culture.English);
+            var previewConfig = new BaseDateTimeOptionsConfiguration(Culture.English, DateTimeOptions.EnablePreview);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.English, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -294,7 +300,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(skipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for English not supported");
@@ -302,7 +308,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetEnglishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.English));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -326,7 +333,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new EnglishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(commonConfiguration));
             }
 
             throw new Exception($"Parser '{parserName}' for English not supported");
@@ -334,8 +341,10 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetEnglishOthersExtractor(DateTimeExtractors extractorName)
         {
-            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true);
-            var enableDmyPreviewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview, true);
+            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, DateTimeOptions.None, true);
+            var enableDmyPreviewConfig = new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, DateTimeOptions.EnablePreview, true);
+            var enableDmySkipConfig = new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, DateTimeOptions.SkipFromToMerge, true);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -361,7 +370,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(enableDmyConfig));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge, true)));
+                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(enableDmySkipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for English-Others not supported");
@@ -369,7 +378,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetEnglishOthersParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true));
+            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(
+                new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, DateTimeOptions.None, true));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -393,7 +404,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new EnglishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(commonConfiguration));
             }
 
             throw new Exception($"Parser '{parserName}' for English-Others not supported");
@@ -401,6 +412,10 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetChineseExtractor(DateTimeExtractors extractorName)
         {
+
+            var defaultConfig = new BaseDateTimeOptionsConfiguration(Culture.Chinese, DateTimeOptions.None);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.Chinese, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -418,13 +433,13 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Duration:
                     return new DateTime.Chinese.ChineseDurationExtractorConfiguration();
                 case DateTimeExtractors.Holiday:
-                    return new BaseHolidayExtractor(new DateTime.Chinese.ChineseHolidayExtractorConfiguration());
+                    return new BaseHolidayExtractor(new DateTime.Chinese.ChineseHolidayExtractorConfiguration(defaultConfig));
                 case DateTimeExtractors.Set:
                     return new DateTime.Chinese.ChineseSetExtractorConfiguration();
                 case DateTimeExtractors.Merged:
-                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(DateTimeOptions.None);
+                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(defaultConfig);
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge);
+                    return new DateTime.Chinese.ChineseMergedExtractorConfiguration(skipConfig);
             }
 
             throw new Exception($"Extractor '{extractorName}' for Chinese not supported");
@@ -432,29 +447,30 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetChineseParser(DateTimeParsers parserName)
         {
-            // var commonConfiguration = new EnglishCommonDateTimeParserConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Chinese, DateTimeOptions.None);
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
-                    return new DateTime.Chinese.ChineseDateParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Time:
-                    return new DateTime.Chinese.ChineseTimeParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseTimeParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DatePeriod:
-                    return new DateTime.Chinese.ChineseDatePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDatePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.TimePeriod:
-                    return new DateTime.Chinese.ChineseTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DateTime:
-                    return new DateTime.Chinese.ChineseDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DateTimePeriod:
-                    return new DateTime.Chinese.ChineseDateTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDateTimePeriodParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Duration:
-                    return new DateTime.Chinese.ChineseDurationParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseDurationParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Holiday:
-                    return new DateTime.Chinese.ChineseHolidayParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseHolidayParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Set:
-                    return new DateTime.Chinese.ChineseSetParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new DateTime.Chinese.ChineseSetParserConfiguration(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Merged:
-                    return new FullDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration());
+                    return new FullDateTimeParser(new DateTime.Chinese.ChineseDateTimeParserConfiguration(config));
             }
 
             throw new Exception($"Parser '{parserName}' for Chinese not supported");
@@ -462,6 +478,10 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetJapaneseExtractor(DateTimeExtractors extractorName)
         {
+
+            var defaultConfig = new BaseDateTimeOptionsConfiguration(Culture.Japanese, DateTimeOptions.None);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.Japanese, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -479,13 +499,13 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Duration:
                     return new DateTime.Japanese.JapaneseDurationExtractorConfiguration();
                 case DateTimeExtractors.Holiday:
-                    return new BaseHolidayExtractor(new DateTime.Japanese.JapaneseHolidayExtractorConfiguration());
+                    return new BaseHolidayExtractor(new DateTime.Japanese.JapaneseHolidayExtractorConfiguration(defaultConfig));
                 case DateTimeExtractors.Set:
                     return new DateTime.Japanese.JapaneseSetExtractorConfiguration();
                 case DateTimeExtractors.Merged:
-                    return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(DateTimeOptions.None);
+                    return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(defaultConfig);
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge);
+                    return new DateTime.Japanese.JapaneseMergedExtractorConfiguration(skipConfig);
             }
 
             throw new Exception($"Extractor '{extractorName}' for Japanese not supported");
@@ -493,28 +513,31 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetJapaneseParser(DateTimeParsers parserName)
         {
+
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Japanese, DateTimeOptions.None);
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
-                    return new DateTime.Japanese.JapaneseDateParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseDateParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Time:
-                    return new DateTime.Japanese.JapaneseTimeParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseTimeParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DatePeriod:
-                    return new DateTime.Japanese.JapaneseDatePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseDatePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.TimePeriod:
-                    return new DateTime.Japanese.JapaneseTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DateTime:
-                    return new DateTime.Japanese.JapaneseDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.DateTimePeriod:
-                    return new DateTime.Japanese.JapaneseDateTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseDateTimePeriodParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Duration:
-                    return new DateTime.Japanese.JapaneseDurationParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseDurationParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Holiday:
-                    return new DateTime.Japanese.JapaneseHolidayParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseHolidayParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Set:
-                    return new DateTime.Japanese.JapaneseSetParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new DateTime.Japanese.JapaneseSetParserConfiguration(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
                 case DateTimeParsers.Merged:
-                    return new FullDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration());
+                    return new FullDateTimeParser(new DateTime.Japanese.JapaneseDateTimeParserConfiguration(config));
             }
 
             throw new Exception($"Parser '{parserName}' for Japanese not supported");
@@ -522,7 +545,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetSpanishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None);
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Spanish, DateTimeOptions.None);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -544,7 +568,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new SpanishSetExtractorConfiguration(config));
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
+                    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(config));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Spanish not supported");
@@ -552,7 +576,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetSpanishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Spanish));
 
             switch (parserName)
             {
@@ -583,7 +607,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetPortugueseExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Portuguese);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -605,7 +630,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new PortugueseSetExtractorConfiguration(config));
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedDateTimeExtractor(new PortugueseMergedExtractorConfiguration(DateTimeOptions.None));
+                    return new BaseMergedDateTimeExtractor(new PortugueseMergedExtractorConfiguration(config));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Portuguese not supported");
@@ -613,7 +638,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetPortugueseParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new PortugueseCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new PortugueseCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Portuguese));
 
             switch (parserName)
             {
@@ -644,7 +669,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetFrenchExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration(Culture.French);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.French, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -666,9 +693,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new FrenchSetExtractorConfiguration(config));
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.None));
+                    return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+                    return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(skipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for French not supported");
@@ -676,7 +703,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetFrenchParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.French));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -706,7 +734,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetGermanExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration(Culture.German);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.German, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -728,9 +758,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Set:
                     return new BaseSetExtractor(new GermanSetExtractorConfiguration(config));
                 case DateTimeExtractors.Merged:
-                    return new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(DateTimeOptions.None));
+                    return new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+                    return new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(skipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for German not supported");
@@ -738,7 +768,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetGermanParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new GermanCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new GermanCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.German));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -768,7 +799,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetItalianExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Italian);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -802,7 +834,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetItalianParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new ItalianCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new ItalianCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Italian));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -832,8 +865,9 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetTurkishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseDateTimeOptionsConfiguration();
-            var previewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview);
+            var config = new BaseDateTimeOptionsConfiguration(Culture.Turkish);
+            var skipConfig = new BaseDateTimeOptionsConfiguration(Culture.Turkish, DateTimeOptions.SkipFromToMerge);
+
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -857,7 +891,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(skipConfig));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Turkish not supported");
@@ -865,7 +899,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetTurkishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new TurkishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
+            var commonConfiguration = new TurkishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Turkish));
+
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -887,7 +922,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new TurkishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new TurkishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new TurkishMergedParserConfiguration(commonConfiguration));
             }
 
             throw new Exception($"Parser '{parserName}' for Turkish not supported");

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestHelpers.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetDutchExtractor(DateTimeExtractors extractorName)
         {
-            var enableDmyConfig = new BaseOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true);
+            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true);
 
             switch (extractorName)
             {
@@ -226,7 +226,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(enableDmyConfig));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(new BaseOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Dutch not supported");
@@ -234,7 +234,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetDutchParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new DutchCommonDateTimeParserConfiguration(new BaseOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true));
+            var commonConfiguration = new DutchCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true));
 
             switch (parserName)
             {
@@ -259,7 +259,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new DutchSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new DutchMergedParserConfiguration(new BaseOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true)));
+                    return new BaseMergedDateTimeParser(new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, dmyDateFormat: true)));
             }
 
             throw new Exception($"Parser '{parserName}' for Dutch not supported");
@@ -267,8 +267,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetEnglishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
-            var previewConfig = new BaseOptionsConfiguration(DateTimeOptions.EnablePreview);
+            var config = new BaseDateTimeOptionsConfiguration();
+            var previewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview);
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -294,7 +294,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
             }
 
             throw new Exception($"Extractor '{extractorName}' for English not supported");
@@ -302,7 +302,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetEnglishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -326,7 +326,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new EnglishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
             }
 
             throw new Exception($"Parser '{parserName}' for English not supported");
@@ -334,8 +334,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetEnglishOthersExtractor(DateTimeExtractors extractorName)
         {
-            var enableDmyConfig = new BaseOptionsConfiguration(DateTimeOptions.None, true);
-            var enableDmyPreviewConfig = new BaseOptionsConfiguration(DateTimeOptions.EnablePreview, true);
+            var enableDmyConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true);
+            var enableDmyPreviewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview, true);
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -361,7 +361,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(enableDmyConfig));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseOptionsConfiguration(DateTimeOptions.SkipFromToMerge, true)));
+                    return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge, true)));
             }
 
             throw new Exception($"Extractor '{extractorName}' for English-Others not supported");
@@ -369,7 +369,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetEnglishOthersParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseOptionsConfiguration(DateTimeOptions.None, true));
+            var commonConfiguration = new EnglishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.None, true));
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -393,7 +393,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new EnglishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
             }
 
             throw new Exception($"Parser '{parserName}' for English-Others not supported");
@@ -522,7 +522,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetSpanishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration(DateTimeOptions.None);
+            var config = new BaseDateTimeOptionsConfiguration(DateTimeOptions.None);
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -552,7 +552,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetSpanishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new SpanishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
 
             switch (parserName)
             {
@@ -583,7 +583,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetPortugueseExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration();
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -613,7 +613,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetPortugueseParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new PortugueseCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new PortugueseCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
 
             switch (parserName)
             {
@@ -644,7 +644,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetFrenchExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration();
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -676,7 +676,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetFrenchParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new FrenchCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -706,7 +706,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetGermanExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration();
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -738,7 +738,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetGermanParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new GermanCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new GermanCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -768,7 +768,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetItalianExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
+            var config = new BaseDateTimeOptionsConfiguration();
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -802,7 +802,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetItalianParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new ItalianCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new ItalianCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -832,8 +832,8 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeExtractor GetTurkishExtractor(DateTimeExtractors extractorName)
         {
-            var config = new BaseOptionsConfiguration();
-            var previewConfig = new BaseOptionsConfiguration(DateTimeOptions.EnablePreview);
+            var config = new BaseDateTimeOptionsConfiguration();
+            var previewConfig = new BaseDateTimeOptionsConfiguration(DateTimeOptions.EnablePreview);
             switch (extractorName)
             {
                 case DateTimeExtractors.Date:
@@ -857,7 +857,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeExtractors.Merged:
                     return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(config));
                 case DateTimeExtractors.MergedSkipFromTo:
-                    return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(new BaseOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
+                    return new BaseMergedDateTimeExtractor(new TurkishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(DateTimeOptions.SkipFromToMerge)));
             }
 
             throw new Exception($"Extractor '{extractorName}' for Turkish not supported");
@@ -865,7 +865,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
 
         public static IDateTimeParser GetTurkishParser(DateTimeParsers parserName)
         {
-            var commonConfiguration = new TurkishCommonDateTimeParserConfiguration(new BaseOptionsConfiguration());
+            var commonConfiguration = new TurkishCommonDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration());
             switch (parserName)
             {
                 case DateTimeParsers.Date:
@@ -887,7 +887,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                 case DateTimeParsers.Set:
                     return new BaseSetParser(new TurkishSetParserConfiguration(commonConfiguration));
                 case DateTimeParsers.Merged:
-                    return new BaseMergedDateTimeParser(new TurkishMergedParserConfiguration(new BaseOptionsConfiguration()));
+                    return new BaseMergedDateTimeParser(new TurkishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration()));
             }
 
             throw new Exception($"Parser '{parserName}' for Turkish not supported");

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
-        public static readonly IParser NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+        public static readonly IParser NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese)));
 
         public static readonly Regex[] DateRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ChineseHolidayExtractorConfiguration()
-            : base()
+        public ChineseHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class ChineseHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class ChineseHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
 
         public static readonly Regex LunarHolidayRegex = new Regex(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -26,14 +26,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private static readonly ChineseDateTimePeriodExtractorConfiguration DateTimePeriodExtractor = new ChineseDateTimePeriodExtractorConfiguration();
         private static readonly ChineseDurationExtractorConfiguration DurationExtractor = new ChineseDurationExtractorConfiguration();
         private static readonly ChineseSetExtractorConfiguration SetExtractor = new ChineseSetExtractorConfiguration();
-        private static readonly BaseHolidayExtractor HolidayExtractor = new BaseHolidayExtractor(new ChineseHolidayExtractorConfiguration());
 
-        private readonly DateTimeOptions options;
+        private readonly IDateTimeOptionsConfiguration config;
 
-        public ChineseMergedExtractorConfiguration(DateTimeOptions options)
+        public ChineseMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
         {
-            this.options = options;
+            this.config = config;
+
+            HolidayExtractor = new BaseHolidayExtractor(new ChineseHolidayExtractorConfiguration(config));
         }
+
+        private BaseHolidayExtractor HolidayExtractor { get; }
 
         public List<ExtractResult> Extract(string text)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             integerExtractor = new IntegerExtractor();
             ordinalExtractor = new OrdinalExtractor();
             durationExtractor = new ChineseDurationExtractorConfiguration();
-            numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+            numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(configuration.Culture)));
         }
 
         public ParseResult Parse(ExtractResult extResult)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Chinese;
 using DateObject = System.DateTime;
@@ -16,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese)));
 
         private static readonly IDateTimeExtractor DurationExtractor = new ChineseDurationExtractorConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private readonly IExtractor integerExtractor = new IntegerExtractor();
 
-        private readonly IParser numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+        private readonly IParser numberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.Chinese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
-    public class ChineseDateTimeParserConfiguration : BaseOptionsConfiguration, IFullDateTimeParserConfiguration
+    public class ChineseDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IFullDateTimeParserConfiguration
     {
         public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
             : base(options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParserConfiguration.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class ChineseDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IFullDateTimeParserConfiguration
     {
-        public ChineseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
-            : base(options)
+        public ChineseDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             DateExtractor = new ChineseDateExtractorConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         private static readonly IExtractor CardinalExtractor = new CardinalExtractor();
 
         private static readonly IParser CardinalParser = AgnosticNumberParserFactory.GetParser(
-            AgnosticNumberParserType.Cardinal, new ChineseNumberParserConfiguration());
+            AgnosticNumberParserType.Cardinal, new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseHolidayParserConfiguration.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Chinese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseDateTimeOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseDateTimeOptionsConfiguration.cs
@@ -1,14 +1,14 @@
 ﻿namespace Microsoft.Recognizers.Text.DateTime
 {
-    public class BaseOptionsConfiguration : IOptionsConfiguration
+    public class BaseDateTimeOptionsConfiguration : IDateTimeOptionsConfiguration
     {
-        public BaseOptionsConfiguration(DateTimeOptions options = DateTimeOptions.None, bool dmyDateFormat = false)
+        public BaseDateTimeOptionsConfiguration(DateTimeOptions options = DateTimeOptions.None, bool dmyDateFormat = false)
         {
             Options = options;
             DmyDateFormat = dmyDateFormat;
         }
 
-        public BaseOptionsConfiguration(IOptionsConfiguration config)
+        public BaseDateTimeOptionsConfiguration(IDateTimeOptionsConfiguration config)
         {
             Options = config.Options;
             DmyDateFormat = config.DmyDateFormat;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseDateTimeOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/BaseDateTimeOptionsConfiguration.cs
@@ -2,14 +2,16 @@
 {
     public class BaseDateTimeOptionsConfiguration : IDateTimeOptionsConfiguration
     {
-        public BaseDateTimeOptionsConfiguration(DateTimeOptions options = DateTimeOptions.None, bool dmyDateFormat = false)
+        public BaseDateTimeOptionsConfiguration(string culture, DateTimeOptions options = DateTimeOptions.None, bool dmyDateFormat = false)
         {
+            Culture = culture;
             Options = options;
             DmyDateFormat = dmyDateFormat;
         }
 
         public BaseDateTimeOptionsConfiguration(IDateTimeOptionsConfiguration config)
         {
+            Culture = config.Culture;
             Options = config.Options;
             DmyDateFormat = config.DmyDateFormat;
         }
@@ -17,5 +19,8 @@
         public DateTimeOptions Options { get; }
 
         public bool DmyDateFormat { get; }
+
+        public string Culture { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/IDateTimeOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/IDateTimeOptionsConfiguration.cs
@@ -1,6 +1,8 @@
-﻿namespace Microsoft.Recognizers.Text.DateTime
+﻿using Microsoft.Recognizers.Text.Config;
+
+namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimeOptionsConfiguration
+    public interface IDateTimeOptionsConfiguration : IConfiguration
     {
         DateTimeOptions Options { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Config/IDateTimeOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Config/IDateTimeOptionsConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IOptionsConfiguration
+    public interface IDateTimeOptionsConfiguration
     {
         DateTimeOptions Options { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -50,17 +50,17 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Culture.English,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new EnglishMergedParserConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: false))),
+                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: false))),
                     new BaseMergedDateTimeExtractor(
-                        new EnglishMergedExtractorConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: false)))));
+                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: false)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.EnglishOthers,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new EnglishMergedParserConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: true))),
+                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: true))),
                     new BaseMergedDateTimeExtractor(
-                        new EnglishMergedExtractorConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: true)))));
+                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: true)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.Chinese,
@@ -72,28 +72,28 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Culture.Spanish,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new SpanishMergedParserConfiguration(new BaseOptionsConfiguration(options))),
+                        new SpanishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
                     new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(options))));
 
             RegisterModel<DateTimeModel>(
                 Culture.French,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new FrenchMergedParserConfiguration(new BaseOptionsConfiguration(options))),
+                        new FrenchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
                     new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(options))));
 
             RegisterModel<DateTimeModel>(
                 Culture.Portuguese,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new PortugueseMergedParserConfiguration(new BaseOptionsConfiguration(options))),
+                        new PortugueseMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
                     new BaseMergedDateTimeExtractor(new PortugueseMergedExtractorConfiguration(options))));
 
             RegisterModel<DateTimeModel>(
                 Culture.German,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new GermanMergedParserConfiguration(new BaseOptionsConfiguration(options))),
+                        new GermanMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
                     new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(options))));
 
             // TODO to be uncommented when all tests for Dutch are green.

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -50,51 +50,56 @@ namespace Microsoft.Recognizers.Text.DateTime
                 Culture.English,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: false))),
+                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.English, options, dmyDateFormat: false))),
                     new BaseMergedDateTimeExtractor(
-                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: false)))));
+                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.English, options, dmyDateFormat: false)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.EnglishOthers,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: true))),
+                        new EnglishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, options, dmyDateFormat: true))),
                     new BaseMergedDateTimeExtractor(
-                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(options, dmyDateFormat: true)))));
+                        new EnglishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.EnglishOthers, options, dmyDateFormat: true)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.Chinese,
                 options => new DateTimeModel(
-                    new FullDateTimeParser(new ChineseDateTimeParserConfiguration(options)),
-                    new ChineseMergedExtractorConfiguration(options)));
+                    new FullDateTimeParser(
+                        new ChineseDateTimeParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Chinese, options))),
+                    new ChineseMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Chinese, options))));
 
             RegisterModel<DateTimeModel>(
                 Culture.Spanish,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new SpanishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
-                    new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(options))));
+                        new SpanishMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Spanish, options))),
+                    new BaseMergedDateTimeExtractor(
+                        new SpanishMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Spanish, options)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.French,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new FrenchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
-                    new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(options))));
+                        new FrenchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.French, options))),
+                    new BaseMergedDateTimeExtractor(
+                        new FrenchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.French, options)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.Portuguese,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new PortugueseMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
-                    new BaseMergedDateTimeExtractor(new PortugueseMergedExtractorConfiguration(options))));
+                        new PortugueseMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Portuguese, options))),
+                    new BaseMergedDateTimeExtractor(
+                        new PortugueseMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Portuguese, options)))));
 
             RegisterModel<DateTimeModel>(
                 Culture.German,
                 options => new DateTimeModel(
                     new BaseMergedDateTimeParser(
-                        new GermanMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(options))),
-                    new BaseMergedDateTimeExtractor(new GermanMergedExtractorConfiguration(options))));
+                        new GermanMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.German, options))),
+                    new BaseMergedDateTimeExtractor(
+                        new GermanMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.German, options)))));
 
             // TODO to be uncommented when all tests for Dutch are green.
             // RegisterModel<DateTimeModel>(

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Dutch.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
             UtilityConfiguration = new DutchDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class DutchDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthNumRegex =
             new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
@@ -119,7 +119,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
-        public DutchDateExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class DutchDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // Base regexes
         public static readonly Regex TillRegex =
@@ -236,7 +236,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             ReferenceDatePeriodRegex,
         };
 
-        public DutchDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             CardinalExtractor = Number.Dutch.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.Dutch.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class DutchDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public DutchDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class DutchDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Dutch.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
+    public class DutchDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex AmDescRegex =
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd,
         };
 
-        public DutchDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class DutchDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchDurationExtractorConfiguration(IOptionsConfiguration config)
+        public DutchDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.Dutch.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class DutchHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public DutchHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class DutchMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchMergedExtractorConfiguration(IOptionsConfiguration config)
+        public DutchMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class DutchSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchSetExtractorConfiguration(IOptionsConfiguration config)
+        public DutchSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class DutchTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchTimeExtractorConfiguration(IOptionsConfiguration config)
+        public DutchTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class DutchTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public DutchTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeZoneExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class DutchTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex DirectUtcRegex =
             new Regex(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public static readonly List<string> AmbiguousTimezoneList = TimeZoneDefinitions.AmbiguousTimezoneList.ToList();
 
-        public DutchTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public DutchTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             if ((Options & DateTimeOptions.EnablePreview) != 0)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             OrdinalExtractor = Number.Dutch.OrdinalExtractor.GetInstance();
 
             TimeZoneParser = new BaseTimeZoneParser();
-            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new DutchDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new DutchTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new DutchDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchCommonDateTimeParserConfiguration : BaseDateParserConfiguration, ICommonDateTimeParserConfiguration
     {
-        public DutchCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public DutchCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new DutchDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class DutchDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         public DutchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class DutchDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex NextPrefixRegex =
             new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class DutchDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
             new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Dutch;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class DutchDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class DutchDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public DutchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public DutchHolidayParserConfiguration(IOptionsConfiguration config)
+        public DutchHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = DutchHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchMergedParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public sealed class DutchMergedParserConfiguration : DutchCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public DutchMergedParserConfiguration(IOptionsConfiguration config)
+        public DutchMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = DutchMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class DutchSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public DutchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class DutchTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimePeriodParserConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
-    public class DutchTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class DutchTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public DutchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.English.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));
             UtilityConfiguration = new EnglishDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class EnglishDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
 
         public static readonly Regex MonthRegex =
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
-        public EnglishDateExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class EnglishDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // Base regexes
         public static readonly Regex TillRegex =
@@ -236,7 +236,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             ReferenceDatePeriodRegex,
         };
 
-        public EnglishDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.English.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class EnglishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public EnglishDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class EnglishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
+    public class EnglishDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private static readonly Regex MiddlePauseRegex =
             new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
-        public EnglishDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class EnglishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishDurationExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.English.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class EnglishHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class EnglishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishMergedExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class EnglishSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishSetExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class EnglishTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -122,7 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishTimeExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class EnglishTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class EnglishTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex DirectUtcRegex =
             new Regex(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public static readonly List<string> AmbiguousTimezoneList = TimeZoneDefinitions.AmbiguousTimezoneList.ToList();
 
-        public EnglishTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public EnglishTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             if ((Options & DateTimeOptions.EnablePreview) != 0)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishCommonDateTimeParserConfiguration : BaseDateParserConfiguration, ICommonDateTimeParserConfiguration
     {
-        public EnglishCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public EnglishCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new EnglishDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishCommonDateTimeParserConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             OrdinalExtractor = Number.English.OrdinalExtractor.GetInstance();
 
             TimeZoneParser = new BaseTimeZoneParser();
-            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new EnglishDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new EnglishTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class EnglishDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class EnglishDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex PreviousPrefixRegex =
             new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class EnglishDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
              new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.English;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class EnglishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class EnglishDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public EnglishDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
-using System.Linq;
+
 using Microsoft.Recognizers.Definitions.English;
 using DateObject = System.DateTime;
 
@@ -10,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public EnglishHolidayParserConfiguration(IOptionsConfiguration config)
+        public EnglishHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = EnglishHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public sealed class EnglishMergedParserConfiguration : EnglishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public EnglishMergedParserConfiguration(IOptionsConfiguration config)
+        public EnglishMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = EnglishMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class EnglishSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public EnglishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class EnglishTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.English
 {
-    public class EnglishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class EnglishTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public EnglishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateExtractorConfiguration : IOptionsConfiguration
+    public interface IDateExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         IEnumerable<Regex> DateRegexList { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDatePeriodExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDatePeriodExtractorConfiguration : IOptionsConfiguration
+    public interface IDatePeriodExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         IEnumerable<Regex> SimpleCasesRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimeExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimeExtractorConfiguration : IOptionsConfiguration
+    public interface IDateTimeExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         Regex NowRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateTimePeriodExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimePeriodExtractorConfiguration : IOptionsConfiguration
+    public interface IDateTimePeriodExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDurationExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDurationExtractorConfiguration : IOptionsConfiguration
+    public interface IDurationExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         Regex FollowedUnit { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IHolidayExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IHolidayExtractorConfiguration : IOptionsConfiguration
+    public interface IHolidayExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         IEnumerable<Regex> HolidayRegexes { get; }
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IMergedExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IMergedExtractorConfiguration : IOptionsConfiguration
+    public interface IMergedExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ISetExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ISetExtractorConfiguration : IOptionsConfiguration
+    public interface ISetExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         Regex LastRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimeExtractorConfiguration : IOptionsConfiguration
+    public interface ITimeExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         IDateTimeExtractor TimeZoneExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimePeriodExtractorConfiguration : IOptionsConfiguration
+    public interface ITimePeriodExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeZoneExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimeZoneExtractorConfiguration : IOptionsConfiguration
+    public interface ITimeZoneExtractorConfiguration : IDateTimeOptionsConfiguration
     {
         Regex DirectUtcRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class FrenchDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
@@ -133,7 +133,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchDateExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.French.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         {
             IntegerExtractor = Number.French.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.French.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class FrenchDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
 
@@ -216,7 +216,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             RelativeDecadeRegex,
         };
 
-        public FrenchDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             CardinalExtractor = Number.French.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.French.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class FrenchDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public FrenchDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class FrenchDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         // à - time at which, en - length of time, dans - amount of time
         public static readonly Regex PrepositionRegex =
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.French.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
+    public class FrenchDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
             new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         private static readonly Regex TimeFollowedUnit =
             new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
-        public FrenchDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class FrenchDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchDurationExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.French.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class FrenchHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class FrenchMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         // avant - 'before'
         public static readonly Regex BeforeRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchMergedExtractorConfiguration(DateTimeOptions options)
-            : base(options)
+        public FrenchMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class FrenchSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchSetExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class FrenchTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------
@@ -123,7 +123,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchTimeExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class FrenchTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         private static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex2, RegexFlags);
 
-        public FrenchTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeZoneExtractorConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class FrenchTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
-        public FrenchTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public FrenchTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public FrenchCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public FrenchCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchCommonDateTimeParserConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             IntegerExtractor = Number.French.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.French.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class FrenchDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         public FrenchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class FrenchDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         // @TODO move to resources - French - relative
         public static readonly Regex NextPrefixRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class FrenchDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
             new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.French;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class FrenchDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class FrenchDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public FrenchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchHolidayParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public class FrenchHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public FrenchHolidayParserConfiguration(IOptionsConfiguration config)
+        public FrenchHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = FrenchHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchMergedParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 {
     public sealed class FrenchMergedParserConfiguration : FrenchCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public FrenchMergedParserConfiguration(IOptionsConfiguration config)
+        public FrenchMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = FrenchMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class FrenchSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public FrenchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class FrenchTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         public FrenchTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
-    public class FrenchTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class FrenchTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public FrenchTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
            : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             IntegerExtractor = Number.German.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.German.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
             UtilityConfiguration = new GermanDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class GermanDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanDateExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.German.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class GermanDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
         public static readonly Regex TillRegex =
@@ -192,7 +192,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             RelativeDecadeRegex,
         };
 
-        public GermanDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new GermanDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             CardinalExtractor = Number.German.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.German.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class GermanDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public GermanDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new GermanDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class GermanDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.German.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
+    public class GermanDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
@@ -70,7 +70,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         private static readonly Regex MiddlePauseRegex =
             new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
-        public GermanDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class GermanDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanDurationExtractorConfiguration(IOptionsConfiguration config)
+        public GermanDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.German.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class GermanHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public GermanHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class GermanMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanMergedExtractorConfiguration(DateTimeOptions options)
-            : base(options)
+        public GermanMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             DateExtractor = new BaseDateExtractor(new GermanDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new GermanTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class GermanSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanSetExtractorConfiguration(IOptionsConfiguration config)
+        public GermanSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class GermanTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanTimeExtractorConfiguration(IOptionsConfiguration config)
+        public GermanTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class GermanTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public GermanTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeZoneExtractorConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class GermanTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
-        public GermanTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public GermanTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             IntegerExtractor = Number.German.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.German.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new GermanDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new GermanTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new GermanDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public GermanCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public GermanCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new GermanDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class GermanDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         public GermanDateParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class GermanDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex NextPrefixRegex =
             new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class GermanDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class GermanDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class GermanDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public GermanDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public GermanHolidayParserConfiguration(IOptionsConfiguration config)
+        public GermanHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = GermanHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanMergedParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public sealed class GermanMergedParserConfiguration : GermanCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public GermanMergedParserConfiguration(IOptionsConfiguration config)
+        public GermanMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = GermanMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class GermanSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public GermanSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class GermanTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         private static readonly Regex TimeSuffixFull =
             new Regex(DateTimeDefinitions.TimeSuffixFull, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
-    public class GermanTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class GermanTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public GermanTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             IntegerExtractor = Number.Italian.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Italian.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));
             UtilityConfiguration = new ItalianDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class ItalianDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianDateExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Italian.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class ItalianDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
 
@@ -227,7 +227,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             ReferenceDatePeriodRegex,
         };
 
-        public ItalianDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new ItalianDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             CardinalExtractor = Number.Italian.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.Italian.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class ItalianDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public ItalianDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new ItalianDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class ItalianDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
 
         // à - time at which, en - length of time, dans - amount of time
@@ -67,7 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Italian.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
+    public class ItalianDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex SuffixRegex =
             new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
@@ -76,7 +76,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private static readonly Regex TimeFollowedUnit =
             new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
-        public ItalianDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class ItalianDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -56,7 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianDurationExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.Italian.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class ItalianHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class ItalianMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags); // avant - 'before'
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianMergedExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new ItalianDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class ItalianSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianSetExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class ItalianTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianTimeExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
            : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class ItalianTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex2, RegexFlags);
 
-        public ItalianTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeZoneExtractorConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    public class ItalianTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
-        public ItalianTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public ItalianTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             IntegerExtractor = Number.Italian.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Italian.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new ItalianDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new ItalianTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new ItalianDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public ItalianCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public ItalianCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new ItalianDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class ItalianDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public ItalianDateParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             DateTokenPrefix = DateTimeDefinitions.DateTokenPrefix;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public ItalianDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             CardinalExtractor = config.CardinalExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class ItalianDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex UpcomingPrefixRegex =
             new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public ItalianDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class ItalianDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Italian;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class ItalianDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public ItalianDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
             DateExtractor = config.DateExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public ItalianDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             CardinalExtractor = config.CardinalExtractor;
             NumberParser = config.NumberParser;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class ItalianDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public ItalianDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config.Options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianHolidayParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianHolidayParserConfiguration(IOptionsConfiguration config)
+        public ItalianHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public sealed class ItalianMergedParserConfiguration : ItalianCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public ItalianMergedParserConfiguration(IOptionsConfiguration options)
+        public ItalianMergedParserConfiguration(IDateTimeOptionsConfiguration options)
             : base(options)
         {
             BeforeRegex = ItalianMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianMergedParserConfiguration.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public sealed class ItalianMergedParserConfiguration : ItalianCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public ItalianMergedParserConfiguration(IDateTimeOptionsConfiguration options)
-            : base(options)
+        public ItalianMergedParserConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             BeforeRegex = ItalianMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = ItalianMergedExtractorConfiguration.AfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public ItalianSetParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class ItalianSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public ItalianSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config.Options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             new Regex(DateTimeDefinitions.NightRegex, RegexOptions.Singleline);
 
         public ItalianTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             TimeTokenPrefix = DateTimeDefinitions.TimeTokenPrefix;
             AtRegex = ItalianTimeExtractorConfiguration.AtRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class ItalianTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         private static readonly Regex LunchRegex =
             new Regex(DateTimeDefinitions.LunchRegex, RegexOptions.Singleline);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public ItalianTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
-            : base(config.Options)
+            : base(config)
         {
             TimeExtractor = config.TimeExtractor;
             IntegerExtractor = config.IntegerExtractor;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
-    public class ItalianTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class ItalianTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public ItalianTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config.Options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public JapaneseHolidayExtractorConfiguration()
-            : base()
+        public JapaneseHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class JapaneseHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class JapaneseHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex LunarHolidayRegex =
             new Regex(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
@@ -39,14 +39,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private static readonly JapaneseSetExtractorConfiguration SetExtractor = new JapaneseSetExtractorConfiguration();
 
-        private static readonly BaseHolidayExtractor HolidayExtractor = new BaseHolidayExtractor(new JapaneseHolidayExtractorConfiguration());
+        private readonly IDateTimeOptionsConfiguration config;
 
-        private readonly DateTimeOptions options;
-
-        public JapaneseMergedExtractorConfiguration(DateTimeOptions options)
+        public JapaneseMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
         {
-            this.options = options;
+            this.config = config;
+
+            HolidayExtractor = new BaseHolidayExtractor(new JapaneseHolidayExtractorConfiguration(config));
         }
+
+        private BaseHolidayExtractor HolidayExtractor { get; }
 
         public List<ExtractResult> Extract(string text)
         {
@@ -236,5 +238,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 }
             }
         }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             config = configuration;
             integerExtractor = new IntegerExtractor();
             durationExtractor = new JapaneseDurationExtractorConfiguration();
-            numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+            numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public ParseResult Parse(ExtractResult extResult)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Japanese)));
 
         private static readonly IDateTimeExtractor DurationExtractor = new JapaneseDurationExtractorConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private readonly IExtractor integerExtractor = new IntegerExtractor();
 
-        private readonly IParser numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+        private readonly IParser numberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Japanese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
-    public class JapaneseDateTimeParserConfiguration : BaseOptionsConfiguration, IFullDateTimeParserConfiguration
+    public class JapaneseDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IFullDateTimeParserConfiguration
     {
         public JapaneseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
                 : base(options)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParserConfiguration.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
     public class JapaneseDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IFullDateTimeParserConfiguration
     {
-        public JapaneseDateTimeParserConfiguration(DateTimeOptions options = DateTimeOptions.None)
-                : base(options)
+        public JapaneseDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
+                : base(config)
         {
             DateExtractor = new JapaneseDateExtractorConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         private static readonly IExtractor CardinalExtractor = new CardinalExtractor();
 
         private static readonly IParser CardinalParser = AgnosticNumberParserFactory.GetParser(
-            AgnosticNumberParserType.Cardinal, new JapaneseNumberParserConfiguration());
+            AgnosticNumberParserType.Cardinal, new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Japanese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseHolidayParserConfiguration.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private static readonly IExtractor IntegerExtractor = new IntegerExtractor();
 
-        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+        private static readonly IParser IntegerParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(new BaseNumberOptionsConfiguration(Culture.Japanese)));
 
         private readonly IFullDateTimeParserConfiguration config;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var referenceDate = reference;
 
             object value = null;
-            if (er.Type.Equals(ParserName))
+            if (er.Type.Equals(ParserName, StringComparison.Ordinal))
             {
                 var innerResult = ParseBasicRegexMatch(er.Text, referenceDate);
                 if (!innerResult.Success)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParserConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public abstract class BaseDateParserConfiguration : BaseOptionsConfiguration, ICommonDateTimeParserConfiguration
+    public abstract class BaseDateParserConfiguration : BaseDateTimeOptionsConfiguration, ICommonDateTimeParserConfiguration
     {
-        protected BaseDateParserConfiguration(IOptionsConfiguration config)
+        protected BaseDateParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParserConfiguration.cs
@@ -8,9 +8,9 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public abstract class BaseHolidayParserConfiguration : BaseOptionsConfiguration, IHolidayParserConfiguration
+    public abstract class BaseHolidayParserConfiguration : BaseDateTimeOptionsConfiguration, IHolidayParserConfiguration
     {
-        protected BaseHolidayParserConfiguration(IOptionsConfiguration config)
+        protected BaseHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
                 : base(config)
         {
             this.VariableHolidaysTimexDictionary = BaseDateTime.VariableHolidaysTimexDictionary.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ICommonDateTimeParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ICommonDateTimeParserConfiguration : IOptionsConfiguration
+    public interface ICommonDateTimeParserConfiguration : IDateTimeOptionsConfiguration
     {
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateParserConfiguration : IOptionsConfiguration
+    public interface IDateParserConfiguration : IDateTimeOptionsConfiguration
     {
         string DateTokenPrefix { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDatePeriodParserConfiguration : ISimpleDatePeriodParserConfiguration, IOptionsConfiguration
+    public interface IDatePeriodParserConfiguration : ISimpleDatePeriodParserConfiguration, IDateTimeOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimeParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimeParserConfiguration : IOptionsConfiguration
+    public interface IDateTimeParserConfiguration : IDateTimeOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDateTimePeriodParserConfiguration : IOptionsConfiguration
+    public interface IDateTimePeriodParserConfiguration : IDateTimeOptionsConfiguration
     {
         string TokenBeforeDate { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IDurationParserConfiguration : IOptionsConfiguration
+    public interface IDurationParserConfiguration : IDateTimeOptionsConfiguration
     {
         IExtractor CardinalExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IFullDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IFullDateTimeParserConfiguration.cs
@@ -4,7 +4,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IFullDateTimeParserConfiguration : ISimpleDatePeriodParserConfiguration, IOptionsConfiguration
+    public interface IFullDateTimeParserConfiguration : ISimpleDatePeriodParserConfiguration, IDateTimeOptionsConfiguration
     {
         int TwoNumYear { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IHolidayParserConfiguration.cs
@@ -6,7 +6,7 @@ using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface IHolidayParserConfiguration : IOptionsConfiguration
+    public interface IHolidayParserConfiguration : IDateTimeOptionsConfiguration
     {
         IImmutableDictionary<string, string> VariableHolidaysTimexDictionary { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ISetParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ISetParserConfiguration : IOptionsConfiguration
+    public interface ISetParserConfiguration : IDateTimeOptionsConfiguration
     {
         IDateTimeExtractor DurationExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimeParserConfiguration : IOptionsConfiguration
+    public interface ITimeParserConfiguration : IDateTimeOptionsConfiguration
     {
         string TimeTokenPrefix { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/ITimePeriodParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime
 {
-    public interface ITimePeriodParserConfiguration : IOptionsConfiguration
+    public interface ITimePeriodParserConfiguration : IDateTimeOptionsConfiguration
     {
         IDateTimeExtractor TimeExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -11,7 +11,7 @@ using Microsoft.Recognizers.Text.Number.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class PortugueseDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseDateExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Portuguese.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
             UtilityConfiguration = new PortugueseDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class PortugueseDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
         public static readonly Regex TillRegex =
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             RelativeDecadeRegex,
         };
 
-        public PortugueseDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             CardinalExtractor = Number.Portuguese.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.Portuguese.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class PortugueseDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public PortugueseDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class PortugueseDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration, IDateTimePeriodExtractorConfiguration
+    public class PortugueseDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex NumberCombinedWithUnit =
             new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         private static readonly Regex BetweenRegex =
             new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
-        public PortugueseDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDurationExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class PortugueseDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex UnitRegex =
             new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseDurationExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.Portuguese.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class PortugueseHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex[] HolidayRegexList =
         {
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class PortugueseMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseMergedExtractorConfiguration(DateTimeOptions options)
-            : base(options)
+        public PortugueseMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new PortugueseTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class PortugueseSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseSetExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Portuguese;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class PortugueseTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -111,7 +111,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseTimeExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class PortugueseTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
@@ -56,7 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         private static readonly Regex BetweenRegex =
             new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
-        public PortugueseTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeZoneExtractorConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    internal class PortugueseTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    internal class PortugueseTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
-        public PortugueseTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public PortugueseTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             IntegerExtractor = Number.Portuguese.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Portuguese.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new PortugueseDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new PortugueseTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new PortugueseDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public PortugueseCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public PortugueseCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new PortugueseDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class PortugueseDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class PortugueseDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         // TODO: config this according to English
         public static readonly Regex NextPrefixRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class PortugueseDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class PortugueseDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public PortugueseDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class PortugueseDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public PortugueseDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public PortugueseHolidayParserConfiguration(IOptionsConfiguration config)
+        public PortugueseHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = PortugueseHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseMergedParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public sealed class PortugueseMergedParserConfiguration : PortugueseCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public PortugueseMergedParserConfiguration(IOptionsConfiguration config)
+        public PortugueseMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = PortugueseMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class PortugueseSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public PortugueseSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class PortugueseTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         public PortugueseTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
-    public class PortugueseTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class PortugueseTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public PortugueseTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             IntegerExtractor = Number.Spanish.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Spanish.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -11,7 +11,7 @@ using Microsoft.Recognizers.Text.Number.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class SpanishDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
             new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishDateExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Spanish.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Number.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class SpanishDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // base regexes
         public static readonly Regex TillRegex =
@@ -201,7 +201,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             ReferenceDatePeriodRegex,
         };
 
-        public SpanishDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             CardinalExtractor = Number.Spanish.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.Spanish.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class SpanishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public SpanishDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class SpanishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -66,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Spanish.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
+    public class SpanishDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex NumberCombinedWithUnit =
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex BetweenRegex =
             new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
-        public SpanishDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class SpanishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex UnitRegex =
             new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishDurationExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.Spanish.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class SpanishHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex[] HolidayRegexList =
         {
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishMergedExtractorConfiguration(DateTimeOptions options)
-            : base(options)
+        public SpanishMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
+            : base(config)
         {
             DateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class SpanishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class SpanishSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
@@ -33,7 +33,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishSetExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class SpanishTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -109,7 +109,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishTimeExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class SpanishTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
@@ -56,7 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex BetweenRegex =
             new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
-        public SpanishTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeZoneExtractorConfiguration.cs
@@ -5,9 +5,9 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    internal class SpanishTimeZoneExtractorConfiguration : BaseOptionsConfiguration, ITimeZoneExtractorConfiguration
+    internal class SpanishTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
-        public SpanishTimeZoneExtractorConfiguration(IOptionsConfiguration config)
+        public SpanishTimeZoneExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishCommonDateTimeParserConfiguration : BaseDateParserConfiguration
     {
-        public SpanishCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public SpanishCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishCommonDateTimeParserConfiguration.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             IntegerExtractor = Number.Spanish.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Spanish.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new SpanishDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new SpanishTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class SpanishDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Definitions.Spanish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class SpanishDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         // TODO: config this according to English
         public static readonly Regex NextPrefixRegex =

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class SpanishDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class SpanishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class SpanishDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public SpanishDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public SpanishHolidayParserConfiguration(IOptionsConfiguration config)
+        public SpanishHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = SpanishHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public SpanishMergedParserConfiguration(IOptionsConfiguration config)
+        public SpanishMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class SpanishSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public SpanishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimeParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class SpanishTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         public SpanishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
-    public class SpanishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class SpanishTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public SpanishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -10,7 +10,7 @@ using Microsoft.Recognizers.Text.Number.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateExtractorConfiguration : BaseOptionsConfiguration, IDateExtractorConfiguration
+    public class TurkishDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
 
         public static readonly Regex MonthRegex =
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
-        public TurkishDateExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Turkish.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             IntegerExtractor = Number.Turkish.IntegerExtractor.GetInstance();
             OrdinalExtractor = Number.Turkish.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DurationExtractor = new BaseDurationExtractor(new TurkishDurationExtractorConfiguration(this));
             UtilityConfiguration = new TurkishDatetimeUtilityConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             CardinalExtractor = Number.Turkish.CardinalExtractor.GetInstance();
             OrdinalExtractor = Number.Turkish.OrdinalExtractor.GetInstance();
             DurationExtractor = new BaseDurationExtractor(new TurkishDurationExtractorConfiguration(this));
-            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
         }
 
         public IDateExtractor DatePointExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
@@ -8,7 +8,7 @@ using Microsoft.Recognizers.Text.Number.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDatePeriodExtractorConfiguration : BaseOptionsConfiguration, IDatePeriodExtractorConfiguration
+    public class TurkishDatePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodExtractorConfiguration
     {
         // Base regexes
         public static readonly Regex TillRegex =
@@ -236,7 +236,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             ReferenceDatePeriodRegex,
         };
 
-        public TurkishDatePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDatePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DatePointExtractor = new BaseDateExtractor(new TurkishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeAltExtractorConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateTimeAltExtractorConfiguration : BaseOptionsConfiguration, IDateTimeAltExtractorConfiguration
+    public class TurkishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
             new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
@@ -42,7 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private static readonly Regex DayRegex =
             new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public TurkishDateTimeAltExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new TurkishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateTimeExtractorConfiguration : BaseOptionsConfiguration, IDateTimeExtractorConfiguration
+    public class TurkishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
             new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishDateTimeExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             IntegerExtractor = Number.Turkish.IntegerExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimePeriodExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateTimePeriodExtractorConfiguration : BaseOptionsConfiguration,
+    public class TurkishDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration,
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
@@ -73,7 +73,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private static readonly Regex MiddlePauseRegex =
             new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
-        public TurkishDateTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDurationExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDurationExtractorConfiguration : BaseOptionsConfiguration, IDurationExtractorConfiguration
+    public class TurkishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishDurationExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             CardinalExtractor = Number.Turkish.CardinalExtractor.GetInstance();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishHolidayExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishHolidayExtractorConfiguration : BaseOptionsConfiguration, IHolidayExtractorConfiguration
+    public class TurkishHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishHolidayExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishHolidayExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishMergedExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.Matcher;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishMergedExtractorConfiguration : BaseOptionsConfiguration, IMergedExtractorConfiguration
+    public class TurkishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
             new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishMergedExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishMergedExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DateExtractor = new BaseDateExtractor(new TurkishDateExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishSetExtractorConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishSetExtractorConfiguration : BaseOptionsConfiguration, ISetExtractorConfiguration
+    public class TurkishSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
             new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishSetExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new TurkishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishTimeExtractorConfiguration : BaseOptionsConfiguration, ITimeExtractorConfiguration
+    public class TurkishTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeExtractorConfiguration
     {
         // part 1: smallest component
         // --------------------------------------
@@ -122,7 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishTimeExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             DurationExtractor = new BaseDurationExtractor(new TurkishDurationExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishTimePeriodExtractorConfiguration : BaseOptionsConfiguration, ITimePeriodExtractorConfiguration
+    public class TurkishTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
             new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishTimePeriodExtractorConfiguration(IOptionsConfiguration config)
+        public TurkishTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishCommonDateTimeParserConfiguration.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             OrdinalExtractor = Number.Turkish.OrdinalExtractor.GetInstance();
 
             TimeZoneParser = new BaseTimeZoneParser();
-            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(new BaseNumberOptionsConfiguration(config.Culture)));
             DateExtractor = new BaseDateExtractor(new TurkishDateExtractorConfiguration(this));
             TimeExtractor = new BaseTimeExtractor(new TurkishTimeExtractorConfiguration(this));
             DateTimeExtractor = new BaseDateTimeExtractor(new TurkishDateTimeExtractorConfiguration(this));

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishCommonDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishCommonDateTimeParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
     public class TurkishCommonDateTimeParserConfiguration : BaseDateParserConfiguration, ICommonDateTimeParserConfiguration
     {
-        public TurkishCommonDateTimeParserConfiguration(IOptionsConfiguration config)
+        public TurkishCommonDateTimeParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             UtilityConfiguration = new TurkishDatetimeUtilityConfiguration();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateParserConfiguration : BaseOptionsConfiguration, IDateParserConfiguration
+    public class TurkishDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
@@ -7,7 +7,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDatePeriodParserConfiguration : BaseOptionsConfiguration, IDatePeriodParserConfiguration
+    public class TurkishDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex PreviousPrefixRegex =
             new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimeParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateTimeParserConfiguration : BaseOptionsConfiguration, IDateTimeParserConfiguration
+    public class TurkishDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
              new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Recognizers.Definitions.Turkish;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDateTimePeriodParserConfiguration : BaseOptionsConfiguration, IDateTimePeriodParserConfiguration
+    public class TurkishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
             new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDurationParserConfiguration.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishDurationParserConfiguration : BaseOptionsConfiguration, IDurationParserConfiguration
+    public class TurkishDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
         public TurkishDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishHolidayParserConfiguration.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
+
 using Microsoft.Recognizers.Definitions.Turkish;
 using DateObject = System.DateTime;
 
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
     public class TurkishHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
-        public TurkishHolidayParserConfiguration(IOptionsConfiguration config)
+        public TurkishHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             this.HolidayRegexList = TurkishHolidayExtractorConfiguration.HolidayRegexList;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishMergedParserConfiguration.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
     public sealed class TurkishMergedParserConfiguration : TurkishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        public TurkishMergedParserConfiguration(IOptionsConfiguration config)
+        public TurkishMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = TurkishMergedExtractorConfiguration.BeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishSetParserConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishSetParserConfiguration : BaseOptionsConfiguration, ISetParserConfiguration
+    public class TurkishSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
         public TurkishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimeParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishTimeParserConfiguration : BaseOptionsConfiguration, ITimeParserConfiguration
+    public class TurkishTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimePeriodParserConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Turkish
 {
-    public class TurkishTimePeriodParserConfiguration : BaseOptionsConfiguration, ITimePeriodParserConfiguration
+    public class TurkishTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodParserConfiguration
     {
         public TurkishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/CardinalExtractor.cs
@@ -1,12 +1,14 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Number.Config;
+
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
         // CardinalExtractor = Int + Double
-        public CardinalExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
+        public CardinalExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Chinese;
+using Microsoft.Recognizers.Text.Number.Config;
 
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
@@ -10,7 +11,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public IntegerExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
+        public IntegerExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var regexes = new Dictionary<Regex, TypeTag>()
             {
@@ -48,7 +49,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
             switch (mode)
             {
-                case ChineseNumberExtractorMode.Default:
+                case CJKNumberExtractorMode.Default:
                     // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "四" from "四川"
                     regexes.Add(
@@ -56,7 +57,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE));
                     break;
 
-                case ChineseNumberExtractorMode.ExtractAll:
+                case CJKNumberExtractorMode.ExtractAll:
                     // 一百五十五, 负一亿三百二十二, "四" from "四川".
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
@@ -1,29 +1,14 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Number.Config;
+
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
-    /// <summary>
-    /// These modes only apply to ChineseNumberExtractor.
-    /// The default more utilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese ideograms.
-    /// ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
-    /// </summary>
-    public enum ChineseNumberExtractorMode
-    {
-        /// <summary>
-        /// Number extraction with an allow list that filters what numbers to extract.
-        /// </summary>
-        Default,
-
-        /// <summary>
-        /// Extract all number-related terms aggressively.
-        /// </summary>
-        ExtractAll,
-    }
 
     public class NumberExtractor : BaseNumberExtractor
     {
-        public NumberExtractor(ChineseNumberExtractorMode mode = ChineseNumberExtractorMode.Default)
+        public NumberExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 {
     public class NumberRangeExtractor : BaseNumberRangeExtractor
     {
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new ChineseNumberParserConfiguration()), options: options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new ChineseNumberParserConfiguration(config)), config)
         {
             var regexes = new Dictionary<Regex, string>()
             {

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
@@ -9,85 +9,62 @@ using Microsoft.Recognizers.Definitions.Chinese;
 namespace Microsoft.Recognizers.Text.Number.Chinese
 {
 
-    public class ChineseNumberParserConfiguration : ICJKNumberParserConfiguration
+    public class ChineseNumberParserConfiguration : BaseNumberParserConfiguration, ICJKNumberParserConfiguration
     {
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ChineseNumberParserConfiguration()
-               : this(new CultureInfo(Culture.Chinese))
+        public ChineseNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
+            this.LangMarker = NumbersDefinitions.LangMarker;
+            this.CultureInfo = new CultureInfo(config.Culture);
+            this.Config = config;
 
-        public ChineseNumberParserConfiguration(CultureInfo ci)
-        {
-            LangMarker = NumbersDefinitions.LangMarker;
-            CultureInfo = ci;
-            IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
-            IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
+            this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
+            this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 
-            DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
-            FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
-            NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
-            HalfADozenText = NumbersDefinitions.HalfADozenText;
-            WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
-            ZeroChar = NumbersDefinitions.ZeroChar;
-            PairChar = NumbersDefinitions.PairChar;
+            this.DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
+            this.FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
+            this.NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
+            this.HalfADozenText = NumbersDefinitions.HalfADozenText;
+            this.WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
+            this.ZeroChar = NumbersDefinitions.ZeroChar;
+            this.PairChar = NumbersDefinitions.PairChar;
 
-            WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
-            WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
-            WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
-            WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
 
-            CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
-            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
-            RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
-            ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
-            RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
-            FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
-            TratoSimMap = NumbersDefinitions.TratoSimMap.ToImmutableDictionary();
-            UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
-            RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
-            TenChars = NumbersDefinitions.TenChars.ToImmutableList();
+            this.CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
+            this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
+            this.ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
+            this.RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
+            this.FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
+            this.TratoSimMap = NumbersDefinitions.TratoSimMap.ToImmutableDictionary();
+            this.UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
+            this.RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
+            this.TenChars = NumbersDefinitions.TenChars.ToImmutableList();
 
-            HalfADozenRegex = null;
+            this.HalfADozenRegex = null;
 
             // @TODO Change init to follow design in other languages
-            DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
-            FractionPrepositionRegex = null;
+            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
+            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.FractionPrepositionRegex = null;
         }
-
-        public NumberOptions Options { get; }
-
-        public CultureInfo CultureInfo { get; private set; }
-
-        public char DecimalSeparatorChar { get; private set; }
-
-        public Regex DigitalNumberRegex { get; private set; }
-
-        public Regex FractionPrepositionRegex { get; }
-
-        public string FractionMarkerToken { get; private set; }
-
-        public Regex HalfADozenRegex { get; private set; }
-
-        public string HalfADozenText { get; private set; }
-
-        public string LangMarker { get; private set; }
-
-        public char NonDecimalSeparatorChar { get; private set; }
 
         public string NonDecimalSeparatorText { get; private set; }
 
@@ -105,12 +82,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
         public Regex FracSplitRegex { get; private set; }
 
-        public Regex NegativeNumberSignRegex { get; private set; }
-
-        public bool IsCompoundNumberLanguage { get; private set; }
-
-        public bool IsMultiDecimalSeparatorCulture { get; private set; }
-
         public Regex PointRegex { get; private set; }
 
         public Regex SpeGetNumberRegex { get; private set; }
@@ -118,18 +89,6 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
         public Regex PairRegex { get; private set; }
 
         public Regex RoundNumberIntegerRegex { get; private set; }
-
-        public ImmutableDictionary<string, long> OrdinalNumberMap { get; private set; }
-
-        public ImmutableDictionary<string, string> RelativeReferenceMap { get; private set; }
-
-        public ImmutableDictionary<string, string> RelativeReferenceOffsetMap { get; private set; }
-
-        public ImmutableDictionary<string, string> RelativeReferenceRelativeToMap { get; private set; }
-
-        public ImmutableDictionary<string, long> CardinalNumberMap { get; private set; }
-
-        public ImmutableDictionary<string, long> RoundNumberMap { get; private set; }
 
         public ImmutableDictionary<char, double> ZeroToNineMap { get; private set; }
 
@@ -145,28 +104,18 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
         public ImmutableList<char> TenChars { get; private set; }
 
-        public string WordSeparatorToken { get; private set; }
-
-        public IEnumerable<string> WrittenDecimalSeparatorTexts { get; private set; }
-
-        public IEnumerable<string> WrittenGroupSeparatorTexts { get; private set; }
-
-        public IEnumerable<string> WrittenIntegerSeparatorTexts { get; private set; }
-
-        public IEnumerable<string> WrittenFractionSeparatorTexts { get; private set; }
-
-        public IEnumerable<string> NormalizeTokenSet(IEnumerable<string> tokens, ParseResult context)
+        public override IEnumerable<string> NormalizeTokenSet(IEnumerable<string> tokens, ParseResult context)
         {
             return tokens;
         }
 
-        public long ResolveCompositeNumber(string numberStr)
+        public override long ResolveCompositeNumber(string numberStr)
         {
             return 0;
         }
 
         // Handle cases like "last", "next one", "previous one"
-        public string ResolveSpecificString(string numberStr)
+        public override string ResolveSpecificString(string numberStr)
         {
             if (this.RelativeReferenceMap.ContainsKey(numberStr))
             {

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
@@ -9,18 +9,13 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ChineseNumberRangeParserConfiguration()
-           : this(new CultureInfo(Culture.Chinese))
+        public ChineseNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public ChineseNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = new NumberExtractor();
             OrdinalExtractor = new OrdinalExtractor();
-            NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration());
+            NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/Config/BaseNumberOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Config/BaseNumberOptionsConfiguration.cs
@@ -1,0 +1,26 @@
+﻿namespace Microsoft.Recognizers.Text.Number
+{
+    public class BaseNumberOptionsConfiguration : INumberOptionsConfiguration
+    {
+        public BaseNumberOptionsConfiguration(string culture, NumberOptions options = NumberOptions.None, NumberMode mode = NumberMode.Default)
+        {
+            Culture = culture;
+            Options = options;
+            Mode = mode;
+        }
+
+        public BaseNumberOptionsConfiguration(INumberOptionsConfiguration config)
+        {
+            Culture = config.Culture;
+            Options = config.Options;
+            Mode = config.Mode;
+        }
+
+        public NumberOptions Options { get; }
+
+        public NumberMode Mode { get; }
+
+        public string Culture { get; }
+
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/Config/CJKNumberExtractorMode.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Config/CJKNumberExtractorMode.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.Recognizers.Text.Number.Config
+{
+
+    /// <summary>
+    /// These modes only apply to CJK NumberExtractors.
+    /// The default mode utilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese/Japanese ideograms.
+    /// ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
+    /// </summary>
+    public enum CJKNumberExtractorMode
+    {
+        /// <summary>
+        /// Number extraction with an allow list that filters what numbers to extract.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Extract all number-related terms aggressively.
+        /// </summary>
+        ExtractAll,
+    }
+
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/Config/INumberOptionsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Config/INumberOptionsConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Recognizers.Text.Config;
+
+namespace Microsoft.Recognizers.Text.Number
+{
+    public interface INumberOptionsConfiguration : IConfiguration
+    {
+        NumberOptions Options { get; }
+
+        NumberMode Mode { get; }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
@@ -11,9 +11,13 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), new BaseNumberParser(new DutchNumberParserConfiguration()), options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(NumberExtractor.GetInstance(),
+                   OrdinalExtractor.GetInstance(),
+                   new BaseNumberParser(new DutchNumberParserConfiguration(config)),
+                   config)
         {
+
             var regexes = new Dictionary<Regex, string>()
             {
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
@@ -10,21 +10,12 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchNumberParserConfiguration(NumberOptions options)
-            : this()
+        public DutchNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-            this.Options = options;
-        }
-
-        public DutchNumberParserConfiguration()
-            : this(new CultureInfo(Culture.Dutch))
-        {
-        }
-
-        public DutchNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
@@ -9,20 +9,15 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public DutchNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Dutch))
+        public DutchNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public DutchNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = Dutch.NumberExtractor.GetInstance();
             OrdinalExtractor = Dutch.OrdinalExtractor.GetInstance();
 
             // @TODO Change init to follow design in other languages
-            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberRangeExtractor.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Recognizers.Text.Number.English
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
             : base(
                   NumberExtractor.GetInstance(),
                   OrdinalExtractor.GetInstance(),
-                  new BaseNumberParser(new EnglishNumberParserConfiguration()),
-                  options)
+                  new BaseNumberParser(new EnglishNumberParserConfiguration(config)),
+                  config)
         {
             var regexes = new Dictionary<Regex, string>()
             {

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -10,21 +11,21 @@ namespace Microsoft.Recognizers.Text.Number.English
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishNumberParserConfiguration(NumberOptions options)
-            : this()
+        public EnglishNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-            this.Options = options;
-        }
 
-        public EnglishNumberParserConfiguration()
-            : this(new CultureInfo(Culture.English))
-        {
-        }
-
-        public EnglishNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+
+            // @TODO Temporary workaround
+            var culture = config.Culture;
+            if (culture.IndexOf("*", StringComparison.Ordinal) != -1)
+            {
+                culture = config.Culture.Replace("*", "us");
+            }
+
+            this.CultureInfo = new CultureInfo(culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberRangeParserConfiguration.cs
@@ -8,18 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.English
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public EnglishNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.English))
+        public EnglishNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public EnglishNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = English.NumberExtractor.GetInstance();
             OrdinalExtractor = English.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Recognizers.Text.Number
         public static readonly Regex CurrencyRegex =
             new Regex(BaseNumbers.CurrencyRegex, RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 
+        private static Dictionary<string, List<ExtractResult>> cache = new Dictionary<string, List<ExtractResult>>();
+
         protected BaseNumberExtractor(NumberOptions options = NumberOptions.None)
         {
             Options = options;
@@ -34,6 +36,12 @@ namespace Microsoft.Recognizers.Text.Number
 
         public virtual List<ExtractResult> Extract(string source)
         {
+
+            if (cache.Keys.Contains(ExtractType + Options + source))
+            {
+                return cache[ExtractType + Options + source];
+            }
+
             if (string.IsNullOrEmpty(source))
             {
                 return new List<ExtractResult>();
@@ -93,7 +101,7 @@ namespace Microsoft.Recognizers.Text.Number
                                 if (match.Success)
                                 {
                                     start = match.Index;
-                                    length = length + match.Length;
+                                    length += match.Length;
                                     substr = match.Value + substr;
                                 }
                             }
@@ -129,6 +137,8 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             result = FilterAmbiguity(result, source);
+
+            // cache.Add(ExtractType + Options + source, result);
 
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Recognizers.Text.Number
         public static readonly Regex CurrencyRegex =
             new Regex(BaseNumbers.CurrencyRegex, RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 
-        private static Dictionary<string, List<ExtractResult>> cache = new Dictionary<string, List<ExtractResult>>();
-
         protected BaseNumberExtractor(NumberOptions options = NumberOptions.None)
         {
             Options = options;
@@ -36,11 +34,6 @@ namespace Microsoft.Recognizers.Text.Number
 
         public virtual List<ExtractResult> Extract(string source)
         {
-
-            if (cache.Keys.Contains(ExtractType + Options + source))
-            {
-                return cache[ExtractType + Options + source];
-            }
 
             if (string.IsNullOrEmpty(source))
             {
@@ -137,8 +130,6 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             result = FilterAmbiguity(result, source);
-
-            // cache.Add(ExtractType + Options + source, result);
 
             return result;
         }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
@@ -14,19 +14,19 @@ namespace Microsoft.Recognizers.Text.Number
         private readonly BaseNumberParser numberParser;
 
         public BaseNumberRangeExtractor(BaseNumberExtractor numberExtractor, BaseNumberExtractor ordinalExtractor, BaseNumberParser numberParser,
-                                        NumberOptions options = NumberOptions.None)
+                                        INumberOptionsConfiguration config)
         {
             this.numberExtractor = numberExtractor;
             this.ordinalExtractor = ordinalExtractor;
             this.numberParser = numberParser;
-            Options = options;
+            Config = config;
         }
 
         internal abstract System.Collections.Immutable.ImmutableDictionary<Regex, string> Regexes { get; }
 
         internal abstract Regex AmbiguousFractionConnectorsRegex { get; }
 
-        protected virtual NumberOptions Options { get; } = NumberOptions.None;
+        protected virtual INumberOptionsConfiguration Config { get; }
 
         protected virtual string ExtractType { get; } = string.Empty;
 
@@ -95,7 +95,7 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             // In ExperimentalMode, cases like "from 3 to 5" and "between 10 and 15" are set to closed at both start and end
-            if ((Options & NumberOptions.ExperimentalMode) != 0)
+            if ((Config.Options & NumberOptions.ExperimentalMode) != 0)
             {
                 foreach (var result in results)
                 {
@@ -257,7 +257,7 @@ namespace Microsoft.Recognizers.Text.Number
         {
             var removeFractionWithInConnector = false;
 
-            if ((Options & NumberOptions.ExperimentalMode) != 0)
+            if ((Config.Options & NumberOptions.ExperimentalMode) != 0)
             {
                 removeFractionWithInConnector = IsFractionWithInConnector(numberStr);
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Parsers/FrenchNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Parsers/FrenchNumberParserConfiguration.cs
@@ -13,15 +13,13 @@ namespace Microsoft.Recognizers.Text.Number.French
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public FrenchNumberParserConfiguration()
-            : this(new CultureInfo(Culture.French))
+        public FrenchNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public FrenchNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
@@ -13,15 +13,13 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public GermanNumberParserConfiguration()
-            : this(new CultureInfo(Culture.German))
+        public GermanNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public GermanNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberRangeExtractor.cs
@@ -11,10 +11,13 @@ namespace Microsoft.Recognizers.Text.Number.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), new BaseNumberParser(new ItalianNumberParserConfiguration()),
-                   options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(NumberExtractor.GetInstance(),
+                   OrdinalExtractor.GetInstance(),
+                   new BaseNumberParser(new ItalianNumberParserConfiguration(config)),
+                   config)
         {
+
             var regexes = new Dictionary<Regex, string>()
             {
                  {

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
@@ -14,21 +14,13 @@ namespace Microsoft.Recognizers.Text.Number.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianNumberParserConfiguration(NumberOptions options)
-            : this()
+        public ItalianNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-            this.Options = options;
-        }
 
-        public ItalianNumberParserConfiguration()
-            : this(new CultureInfo(Culture.Italian))
-        {
-        }
-
-        public ItalianNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberRangeParserConfiguration.cs
@@ -10,19 +10,14 @@ namespace Microsoft.Recognizers.Text.Number.Italian
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public ItalianNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Italian))
+        public ItalianNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public ItalianNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = Italian.NumberExtractor.GetInstance();
             OrdinalExtractor = Italian.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/CardinalExtractor.cs
@@ -1,12 +1,14 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Number.Config;
+
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
     public class CardinalExtractor : BaseNumberExtractor
     {
         // CardinalExtractor = Int + Double
-        public CardinalExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
+        public CardinalExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Text.Number.Config;
 
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
@@ -11,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public IntegerExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
+        public IntegerExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var regexes = new Dictionary<Regex, TypeTag>
             {
@@ -44,7 +45,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
             switch (mode)
             {
-                case JapaneseNumberExtractorMode.Default:
+                case CJKNumberExtractorMode.Default:
                     // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "西九条" from "九"
                     regexes.Add(
@@ -52,7 +53,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
                     break;
 
-                case JapaneseNumberExtractorMode.ExtractAll:
+                case CJKNumberExtractorMode.ExtractAll:
                     // 一百五十五, 负一亿三百二十二, "西九条" from "九"
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
@@ -1,28 +1,14 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
+using Microsoft.Recognizers.Text.Number.Config;
+
 namespace Microsoft.Recognizers.Text.Number.Japanese
 {
-    // These modes can be applied to JapaneseNumberExtractor.
-    // The default more utilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Japanese ideograms.
-    // --> such as "西九条" is a place name in Japanese, should not be extracted.
-    // ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
-    public enum JapaneseNumberExtractorMode
-    {
-        /// <summary>
-        /// Number extraction with an allow list that filters what numbers to extract.
-        /// </summary>
-        Default,
-
-        /// <summary>
-        /// Extract all number-related terms aggressively.
-        /// </summary>
-        ExtractAll,
-    }
 
     public class NumberExtractor : BaseNumberExtractor
     {
-        public NumberExtractor(JapaneseNumberExtractorMode mode = JapaneseNumberExtractorMode.Default)
+        public NumberExtractor(CJKNumberExtractorMode mode = CJKNumberExtractorMode.Default)
         {
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
@@ -10,9 +10,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(new NumberExtractor(), new OrdinalExtractor(), new BaseCJKNumberParser(new JapaneseNumberParserConfiguration()), options: options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(new NumberExtractor(),
+                   new OrdinalExtractor(),
+                   new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(config)),
+                   config)
         {
+
             var regexes = new Dictionary<Regex, string>
             {
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
@@ -13,57 +13,55 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public JapaneseNumberParserConfiguration()
-            : this(new CultureInfo(Culture.Japanese))
+        public JapaneseNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public JapaneseNumberParserConfiguration(CultureInfo ci)
-        {
-            LangMarker = NumbersDefinitions.LangMarker;
-            CultureInfo = ci;
-            IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
-            IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
+            this.Config = config;
+            this.LangMarker = NumbersDefinitions.LangMarker;
+            this.CultureInfo = new CultureInfo(config.Culture);
 
-            DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
-            FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
-            NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
-            HalfADozenText = NumbersDefinitions.HalfADozenText;
-            WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
-            ZeroChar = NumbersDefinitions.ZeroChar;
-            PairChar = NumbersDefinitions.PairChar;
+            this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
+            this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 
-            WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
-            WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
-            WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
-            WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
+            this.DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
+            this.FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
+            this.NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
+            this.HalfADozenText = NumbersDefinitions.HalfADozenText;
+            this.WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
+            this.ZeroChar = NumbersDefinitions.ZeroChar;
+            this.PairChar = NumbersDefinitions.PairChar;
 
-            CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
-            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
-            RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
-            ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
-            FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
-            RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
-            UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
-            RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
-            TenChars = NumbersDefinitions.TenChars.ToImmutableList();
+            this.WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
 
-            HalfADozenRegex = null;
+            this.CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
+            this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
+            this.ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
+            this.FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
+            this.RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
+            this.UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
+            this.RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
+            this.TenChars = NumbersDefinitions.TenChars.ToImmutableList();
+
+            this.HalfADozenRegex = null;
 
             // @TODO Change init to follow design in other languages
-            DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
+            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
@@ -9,19 +9,14 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public JapaneseNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Japanese))
+        public JapaneseNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public JapaneseNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = new NumberExtractor();
             OrdinalExtractor = new OrdinalExtractor();
 
-            NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration());
+            NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
@@ -12,58 +12,56 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public KoreanNumberParserConfiguration()
-            : this(new CultureInfo(Culture.Korean))
+        public KoreanNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public KoreanNumberParserConfiguration(CultureInfo ci)
-        {
-            LangMarker = NumbersDefinitions.LangMarker;
-            CultureInfo = ci;
-            IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
-            IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
+            this.Config = config;
+            this.LangMarker = NumbersDefinitions.LangMarker;
+            this.CultureInfo = new CultureInfo(config.Culture);
 
-            DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
-            FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
-            NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
-            HalfADozenText = NumbersDefinitions.HalfADozenText;
-            WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
-            ZeroChar = NumbersDefinitions.ZeroChar;
-            PairChar = NumbersDefinitions.PairChar;
+            this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
+            this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 
-            WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
-            WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
-            WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
-            WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
+            this.DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
+            this.FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
+            this.NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;
+            this.HalfADozenText = NumbersDefinitions.HalfADozenText;
+            this.WordSeparatorToken = NumbersDefinitions.WordSeparatorToken;
+            this.ZeroChar = NumbersDefinitions.ZeroChar;
+            this.PairChar = NumbersDefinitions.PairChar;
 
-            CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
-            RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
-            RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
-            RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
-            ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
-            RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
-            FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
-            UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
-            RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
-            TenChars = NumbersDefinitions.TenChars.ToImmutableList();
+            this.WrittenDecimalSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenGroupSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenIntegerSeparatorTexts = Enumerable.Empty<string>();
+            this.WrittenFractionSeparatorTexts = Enumerable.Empty<string>();
+
+            this.CardinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.OrdinalNumberMap = new Dictionary<string, long>().ToImmutableDictionary();
+            this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
+            this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
+            this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
+            this.ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
+            this.RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
+            this.FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
+            this.UnitMap = NumbersDefinitions.UnitMap.ToImmutableDictionary();
+            this.RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
+            this.TenChars = NumbersDefinitions.TenChars.ToImmutableList();
 
             // @TODO Change init to follow design in other languages
-            HalfADozenRegex = null;
-            DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex, RegexFlags);
-            NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
-            FractionPrepositionRegex = null;
+            this.HalfADozenRegex = null;
+            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex, RegexFlags);
+            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
+            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.FractionPrepositionRegex = null;
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.xml
+++ b/.NET/Microsoft.Recognizers.Text.Number/Microsoft.Recognizers.Text.Number.xml
@@ -4,19 +4,19 @@
         <name>Microsoft.Recognizers.Text.Number</name>
     </assembly>
     <members>
-        <member name="T:Microsoft.Recognizers.Text.Number.Chinese.ChineseNumberExtractorMode">
+        <member name="T:Microsoft.Recognizers.Text.Number.Config.CJKNumberExtractorMode">
             <summary>
-            These modes only apply to ChineseNumberExtractor.
-            The default more utilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese ideograms.
+            These modes only apply to CJK NumberExtractors.
+            The default mode utilizes an allow list to avoid extracting numbers in ambiguous/undesired combinations of Chinese/Japanese ideograms.
             ExtractAll mode is to be used in cases where extraction should be more aggressive (e.g. in Units extraction).
             </summary>
         </member>
-        <member name="F:Microsoft.Recognizers.Text.Number.Chinese.ChineseNumberExtractorMode.Default">
+        <member name="F:Microsoft.Recognizers.Text.Number.Config.CJKNumberExtractorMode.Default">
             <summary>
             Number extraction with an allow list that filters what numbers to extract.
             </summary>
         </member>
-        <member name="F:Microsoft.Recognizers.Text.Number.Chinese.ChineseNumberExtractorMode.ExtractAll">
+        <member name="F:Microsoft.Recognizers.Text.Number.Config.CJKNumberExtractorMode.ExtractAll">
             <summary>
             Extract all number-related terms aggressively.
             </summary>
@@ -51,16 +51,6 @@
             <param name="positionMap">position Map.</param>
             <param name="numExtResults">number extractor result.</param>
             <returns>return according type "builtin.num" or "builtin.num.percentage".</returns>
-        </member>
-        <member name="F:Microsoft.Recognizers.Text.Number.Japanese.JapaneseNumberExtractorMode.Default">
-            <summary>
-            Number extraction with an allow list that filters what numbers to extract.
-            </summary>
-        </member>
-        <member name="F:Microsoft.Recognizers.Text.Number.Japanese.JapaneseNumberExtractorMode.ExtractAll">
-            <summary>
-            Extract all number-related terms aggressively.
-            </summary>
         </member>
         <member name="T:Microsoft.Recognizers.Text.Number.Korean.KoreanNumberExtractorMode">
             <summary>

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -49,10 +49,11 @@ namespace Microsoft.Recognizers.Text.Number
 
                 return parsedNumbers.Select(BuildModelResult).Where(r => r != null).ToList();
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // Nothing to do. Exceptions in parse should not break users of recognizers.
                 // No result.
+                Console.WriteLine(e);
             }
 
             return new List<ModelResult>();

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -49,11 +49,10 @@ namespace Microsoft.Recognizers.Text.Number
 
                 return parsedNumbers.Select(BuildModelResult).Where(r => r != null).ToList();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // Nothing to do. Exceptions in parse should not break users of recognizers.
                 // No result.
-                Console.WriteLine(e);
             }
 
             return new List<ModelResult>();

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Recognizers.Text.Number
             RegisterModel<NumberRangeModel>(
                 Culture.English,
                 options => new NumberRangeModel(
-                    new BaseNumberRangeParser(new EnglishNumberRangeParserConfiguration(new BaseNumberOptionsConfiguration(Culture.English, options))),
+                    new BaseNumberRangeParser(new EnglishNumberRangeParserConfiguration(
+                                                  new BaseNumberOptionsConfiguration(Culture.English, options))),
                     new English.NumberRangeExtractor(new BaseNumberOptionsConfiguration(Culture.English, options))));
 
             RegisterModel<NumberModel>(
@@ -344,7 +345,8 @@ namespace Microsoft.Recognizers.Text.Number
             /* RegisterModel<NumberRangeModel>(
                Culture.Turkish,
                options => new NumberRangeModel(
-                   new BaseNumberRangeParser(new TurkishNumberRangeParserConfiguration()),
+                   new BaseNumberRangeParser(new TurkishNumberRangeParserConfiguration(
+                                                 new BaseNumberOptionsConfiguration(Culture.Turkish, options))),
                    new Turkish.NumberRangeExtractor(options)));*/
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -81,201 +81,233 @@ namespace Microsoft.Recognizers.Text.Number
             RegisterModel<NumberModel>(
                 Culture.English,
                 options => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.English, options))),
                     English.MergedNumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.English,
                 options => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new EnglishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.English, options))),
                     English.OrdinalExtractor.GetInstance(options)));
 
             RegisterModel<PercentModel>(
                 Culture.English,
                 options => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new EnglishNumberParserConfiguration(options)),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new EnglishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.English, options))),
                     new English.PercentageExtractor(options)));
 
             RegisterModel<NumberRangeModel>(
                 Culture.English,
                 options => new NumberRangeModel(
-                    new BaseNumberRangeParser(new EnglishNumberRangeParserConfiguration()),
-                    new English.NumberRangeExtractor(options)));
+                    new BaseNumberRangeParser(new EnglishNumberRangeParserConfiguration(new BaseNumberOptionsConfiguration(Culture.English, options))),
+                    new English.NumberRangeExtractor(new BaseNumberOptionsConfiguration(Culture.English, options))));
 
             RegisterModel<NumberModel>(
                 Culture.Chinese,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Chinese, options))),
                     new Chinese.NumberExtractor()));
 
             RegisterModel<OrdinalModel>(
                 Culture.Chinese,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new ChineseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new ChineseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Chinese, options))),
                     new Chinese.OrdinalExtractor()));
 
             RegisterModel<PercentModel>(
                 Culture.Chinese,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ChineseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ChineseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Chinese, options))),
                     new Chinese.PercentageExtractor()));
 
             RegisterModel<NumberRangeModel>(
                 Culture.Chinese,
                 (options) => new NumberRangeModel(
-                            new BaseNumberRangeParser(new ChineseNumberRangeParserConfiguration()),
-                            new Chinese.NumberRangeExtractor(options)));
+                            new BaseNumberRangeParser(new ChineseNumberRangeParserConfiguration(
+                                                          new BaseNumberOptionsConfiguration(Culture.Chinese, options))),
+                            new Chinese.NumberRangeExtractor(new BaseNumberOptionsConfiguration(Culture.Chinese, options))));
 
             RegisterModel<NumberModel>(
                 Culture.Spanish,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Spanish, options))),
                     Spanish.NumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.Spanish,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new SpanishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new SpanishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Spanish, options))),
                     Spanish.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.Spanish,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new SpanishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new SpanishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Spanish, options))),
                     new Spanish.PercentageExtractor()));
 
             RegisterModel<NumberRangeModel>(
                 Culture.Spanish,
                 (options) => new NumberRangeModel(
-                    new BaseNumberRangeParser(new SpanishNumberRangeParserConfiguration()),
-                    new Spanish.NumberRangeExtractor(options)));
+                    new BaseNumberRangeParser(new SpanishNumberRangeParserConfiguration(
+                                                  new BaseNumberOptionsConfiguration(Culture.Spanish, options))),
+                    new Spanish.NumberRangeExtractor(new BaseNumberOptionsConfiguration(Culture.Spanish, options))));
 
             RegisterModel<NumberModel>(
                 Culture.Portuguese,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Portuguese, options))),
                     Portuguese.NumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.Portuguese,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new PortugueseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new PortugueseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Portuguese, options))),
                     Portuguese.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.Portuguese,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new PortugueseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new PortugueseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Portuguese, options))),
                     new Portuguese.PercentageExtractor()));
 
             RegisterModel<NumberModel>(
                 Culture.French,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.French, options))),
                     French.NumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.French,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new FrenchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new FrenchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.French, options))),
                     French.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.French,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new FrenchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.French, options))),
                     new French.PercentageExtractor()));
 
             RegisterModel<NumberModel>(
                 Culture.German,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.German, options))),
                     German.NumberExtractor.GetInstance(NumberMode.PureNumber)));
 
             RegisterModel<OrdinalModel>(
                 Culture.German,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new GermanNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new GermanNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.German, options))),
                     German.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.German,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new GermanNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new GermanNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.German, options))),
                     new German.PercentageExtractor()));
 
             RegisterModel<NumberModel>(
                Culture.Italian,
                (options) => new NumberModel(
-                   AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ItalianNumberParserConfiguration()),
+                   AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ItalianNumberParserConfiguration(
+                                                             new BaseNumberOptionsConfiguration(Culture.Italian, options))),
                    Italian.NumberExtractor.GetInstance(NumberMode.PureNumber, options)));
 
             RegisterModel<OrdinalModel>(
                 Culture.Italian,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new ItalianNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new ItalianNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Italian, options))),
                     Italian.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.Italian,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ItalianNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new ItalianNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Italian, options))),
                     new Italian.PercentageExtractor()));
 
             RegisterModel<NumberRangeModel>(
                 Culture.Italian,
                 (options) => new NumberRangeModel(
-                    new BaseNumberRangeParser(new ItalianNumberRangeParserConfiguration()),
-                    new Italian.NumberRangeExtractor(options)));
+                    new BaseNumberRangeParser(new ItalianNumberRangeParserConfiguration(
+                                                  new BaseNumberOptionsConfiguration(Culture.Italian, options))),
+                    new Italian.NumberRangeExtractor(new BaseNumberOptionsConfiguration(Culture.Italian, options))));
 
             RegisterModel<NumberModel>(
                 Culture.Japanese,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Japanese, options))),
                     new Japanese.NumberExtractor()));
 
             RegisterModel<OrdinalModel>(
                 Culture.Japanese,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new JapaneseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new JapaneseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Japanese, options))),
                     new Japanese.OrdinalExtractor()));
 
             RegisterModel<PercentModel>(
                 Culture.Japanese,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new JapaneseNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new JapaneseNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Japanese, options))),
                     new Japanese.PercentageExtractor()));
 
             /*
             RegisterModel<NumberRangeModel>(
                 Culture.Japanese,
                 (options) => new NumberRangeModel(
-                    new BaseNumberRangeParser(new JapaneseNumberRangeParserConfiguration()),
+                    new BaseNumberRangeParser(new JapaneseNumberRangeParserConfiguration(
+                                                  new BaseNumberOptionsConfiguration(Culture.Japanese, options))),
                     new Japanese.NumberRangeExtractor(options)));
             */
 
             RegisterModel<NumberModel>(
                 Culture.Korean,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new KoreanNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new KoreanNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Korean, options))),
                     new Korean.NumberExtractor()));
 
             RegisterModel<NumberModel>(
                 Culture.Dutch,
                 (options) => new NumberModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Dutch, options))),
                     Dutch.NumberExtractor.GetInstance(NumberMode.PureNumber)));
 
             RegisterModel<OrdinalModel>(
                 Culture.Dutch,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new DutchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new DutchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Dutch, options))),
                     Dutch.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.Dutch,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new DutchNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new DutchNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Dutch, options))),
                     new Dutch.PercentageExtractor(options)));
 
             // When registering NumberRangeModel, enable TestNumber_Dutch -> NumberRangeModel tests
@@ -290,28 +322,30 @@ namespace Microsoft.Recognizers.Text.Number
             RegisterModel<NumberModel>(
                Culture.Turkish,
                (options) => new NumberModel(
-                   AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new TurkishNumberParserConfiguration()),
+                   AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new TurkishNumberParserConfiguration(
+                                                             new BaseNumberOptionsConfiguration(Culture.Turkish, options))),
                    Turkish.NumberExtractor.GetInstance(NumberMode.PureNumber)));
-
-            /*TO DO Uncomment once the NumberRangeModel test passes*/
-
-            /* RegisterModel<NumberRangeModel>(
-               Culture.Turkish,
-               options => new NumberRangeModel(
-                   new BaseNumberRangeParser(new TurkishNumberRangeParserConfiguration()),
-                   new Turkish.NumberRangeExtractor(options)));*/
 
             RegisterModel<OrdinalModel>(
                 Culture.Turkish,
                 (options) => new OrdinalModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new TurkishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new TurkishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Turkish, options))),
                     Turkish.OrdinalExtractor.GetInstance()));
 
             RegisterModel<PercentModel>(
                 Culture.Turkish,
                 (options) => new PercentModel(
-                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new TurkishNumberParserConfiguration()),
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Percentage, new TurkishNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Turkish, options))),
                     new Turkish.PercentageExtractor(options)));
+
+            // @TODO Uncomment once the NumberRangeModel test passes
+            /* RegisterModel<NumberRangeModel>(
+               Culture.Turkish,
+               options => new NumberRangeModel(
+                   new BaseNumberRangeParser(new TurkishNumberRangeParserConfiguration()),
+                   new Turkish.NumberRangeExtractor(options)));*/
         }
 
         private static List<ModelResult> RecognizeByModel(Func<NumberRecognizer, IModel> getModelFunc, string query, NumberOptions options)

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Recognizers.Text.Number
             // Add "offset" and "relativeTo" for ordinal
             if (!string.IsNullOrEmpty(ret.Type) && ret.Type.Contains(Constants.MODEL_ORDINAL))
             {
-                if ((this.Config.Options & NumberOptions.SuppressExtendedTypes) == 0 && ret.Metadata.IsOrdinalRelative)
+                if ((this.Config.Config.Options & NumberOptions.SuppressExtendedTypes) == 0 && ret.Metadata.IsOrdinalRelative)
                 {
                     var offset = Config.RelativeReferenceOffsetMap[extResult.Text];
                     var relativeTo = Config.RelativeReferenceRelativeToMap[extResult.Text];
@@ -309,7 +309,7 @@ namespace Microsoft.Recognizers.Text.Number
             handle = Config.HalfADozenRegex.Replace(handle, Config.HalfADozenText);
 
             // Handling cases like "last", "next one", "previous one"
-            if ((this.Config.Options & NumberOptions.SuppressExtendedTypes) == 0)
+            if ((this.Config.Config.Options & NumberOptions.SuppressExtendedTypes) == 0)
             {
                 if (extResult.Metadata != null && extResult.Metadata.IsOrdinalRelative)
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/INumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/INumberParserConfiguration.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Recognizers.Text.Number
 
         ImmutableDictionary<string, string> RelativeReferenceRelativeToMap { get; }
 
-        NumberOptions Options { get; }
+        INumberOptionsConfiguration Config { get; }
 
         CultureInfo CultureInfo { get; }
 
@@ -86,7 +86,7 @@ namespace Microsoft.Recognizers.Text.Number
 
         public ImmutableDictionary<string, string> RelativeReferenceRelativeToMap { get; set; }
 
-        public NumberOptions Options { get; set; }
+        public INumberOptionsConfiguration Config { get; set; }
 
         public CultureInfo CultureInfo { get; set; }
 
@@ -166,11 +166,11 @@ namespace Microsoft.Recognizers.Text.Number
             {
                 if (tokenList[i].Contains("-"))
                 {
-                    var splitedTokens = tokenList[i].Split('-');
-                    if (splitedTokens.Length == 2 && OrdinalNumberMap.ContainsKey(splitedTokens[1]))
+                    var splitTokens = tokenList[i].Split('-');
+                    if (splitTokens.Length == 2 && OrdinalNumberMap.ContainsKey(splitTokens[1]))
                     {
-                        fracWords.Add(splitedTokens[0]);
-                        fracWords.Add(splitedTokens[1]);
+                        fracWords.Add(splitTokens[0]);
+                        fracWords.Add(splitTokens[1]);
                     }
                     else
                     {

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
@@ -14,15 +14,13 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public PortugueseNumberParserConfiguration()
-               : this(new CultureInfo(Culture.Portuguese))
+        public PortugueseNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public PortugueseNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
@@ -11,9 +11,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(NumberExtractor.GetInstance(), OrdinalExtractor.GetInstance(), new BaseNumberParser(new SpanishNumberParserConfiguration()), options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(NumberExtractor.GetInstance(),
+                   OrdinalExtractor.GetInstance(),
+                   new BaseNumberParser(new SpanishNumberParserConfiguration(config)),
+                   config)
         {
+
             var regexes = new Dictionary<Regex, string>()
             {
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
@@ -13,15 +13,13 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishNumberParserConfiguration()
-               : this(new CultureInfo(Culture.Spanish))
+        public SpanishNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public SpanishNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
+
             this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
             this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
 
@@ -41,6 +39,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                 NumbersDefinitions.OrdinalNumberMap,
                 NumbersDefinitions.PrefixCardinalMap,
                 NumbersDefinitions.SuffixOrdinalMap);
+
             this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
@@ -9,19 +9,15 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public SpanishNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Spanish))
+        public SpanishNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public SpanishNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = Spanish.NumberExtractor.GetInstance();
             OrdinalExtractor = Spanish.OrdinalExtractor.GetInstance();
 
-            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(config));
 
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public NumberRangeExtractor(NumberOptions options = NumberOptions.None)
-            : base(
-                  NumberExtractor.GetInstance(),
-                  OrdinalExtractor.GetInstance(),
-                  new BaseNumberParser(new TurkishNumberParserConfiguration()),
-                  options)
+        public NumberRangeExtractor(INumberOptionsConfiguration config)
+            : base(NumberExtractor.GetInstance(),
+                   OrdinalExtractor.GetInstance(),
+                   new BaseNumberParser(new TurkishNumberParserConfiguration(config)),
+                   config)
         {
+
             var regexes = new Dictionary<Regex, string>()
             {
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
@@ -10,15 +10,12 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishNumberParserConfiguration()
-            : this(new CultureInfo(Culture.Turkish))
+        public TurkishNumberParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
 
-        public TurkishNumberParserConfiguration(CultureInfo ci)
-        {
+            this.Config = config;
             this.LangMarker = NumbersDefinitions.LangMarker;
-            this.CultureInfo = ci;
+            this.CultureInfo = new CultureInfo(config.Culture);
 
             this.DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
             this.FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
@@ -8,18 +8,13 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        public TurkishNumberRangeParserConfiguration()
-            : this(new CultureInfo(Culture.Turkish))
+        public TurkishNumberRangeParserConfiguration(INumberOptionsConfiguration config)
         {
-        }
-
-        public TurkishNumberRangeParserConfiguration(CultureInfo ci)
-        {
-            CultureInfo = ci;
+            CultureInfo = new CultureInfo(config.Culture);
 
             NumberExtractor = Turkish.NumberExtractor.GetInstance();
             OrdinalExtractor = Turkish.OrdinalExtractor.GetInstance();
-            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration());
+            NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(config));
             MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
             LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
@@ -6,11 +6,13 @@ using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.Chinese;
 using Microsoft.Recognizers.Text.Number.Chinese;
+using Microsoft.Recognizers.Text.Number.Config;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
 {
     public abstract class ChineseNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
@@ -22,7 +24,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
         protected ChineseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
-            this.UnitNumExtractor = new NumberExtractor(ChineseNumberExtractorMode.ExtractAll);
+            this.UnitNumExtractor = new NumberExtractor(CJKNumberExtractorMode.ExtractAll);
             this.BuildPrefix = NumbersWithUnitDefinitions.BuildPrefix;
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Parsers/ChineseNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Parsers/ChineseNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
             : base(ci)
         {
             this.InternalNumberExtractor = new NumberExtractor();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(Culture.Chinese)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DutchNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Parsers/DutchNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
             : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new DutchNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(Culture.Dutch)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Parsers/EnglishNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Parsers/EnglishNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
                : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new EnglishNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/FrenchNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Parsers/FrenchNumberWithUnitParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
             : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new FrenchNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Parsers/GermanNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Parsers/GermanNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new GermanNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Parsers/ItalianNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Parsers/ItalianNumberWithUnitParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
             : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ItalianNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new ItalianNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/AgeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/AgeExtractorConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
+
 using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -2,8 +2,10 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.RegularExpressions;
+
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Text.Number.Config;
 using Microsoft.Recognizers.Text.Number.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
@@ -22,7 +24,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
         protected JapaneseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
-            this.UnitNumExtractor = new NumberExtractor(JapaneseNumberExtractorMode.ExtractAll);
+            this.UnitNumExtractor = new NumberExtractor(CJKNumberExtractorMode.ExtractAll);
             this.BuildPrefix = NumbersWithUnitDefinitions.BuildPrefix;
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/AgeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/AgeParserConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+
 using Microsoft.Recognizers.Definitions.Japanese;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
@@ -6,7 +7,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
     public class AgeParserConfiguration : JapaneseNumberWithUnitParserConfiguration
     {
         public AgeParserConfiguration()
-            : this(new CultureInfo(Culture.Chinese))
+            : this(new CultureInfo(Culture.Japanese))
         {
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/JapaneseNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Parsers/JapaneseNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
             : base(ci)
         {
             this.InternalNumberExtractor = new NumberExtractor();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new JapaneseNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/PortugueseNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Parsers/PortugueseNumberWithUnitParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
                : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new PortugueseNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpanishNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Parsers/SpanishNumberWithUnitParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
                : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new SpanishNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Parsers/TurkishNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Parsers/TurkishNumberWithUnitParserConfiguration.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
                : base(ci)
         {
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
-            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new TurkishNumberParserConfiguration());
+            this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number, new TurkishNumberParserConfiguration(
+                                                                                  new BaseNumberOptionsConfiguration(ci.Name)));
             this.ConnectorToken = string.Empty;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Sequence/SequenceRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/SequenceRecognizer.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Recognizers.Text.Sequence
         public IModel GetPhoneNumberModel(string culture = null, bool fallbackToDefaultCulture = true)
         {
             if (culture != null && (
-                culture.ToLowerInvariant().StartsWith("zh-", StringComparison.InvariantCulture) ||
-                culture.ToLowerInvariant().StartsWith("ja-", StringComparison.InvariantCulture)))
+                culture.ToLowerInvariant().StartsWith("zh-", StringComparison.Ordinal) ||
+                culture.ToLowerInvariant().StartsWith("ja-", StringComparison.Ordinal)))
             {
                 return GetModel<PhoneNumberModel>(Culture.Chinese, fallbackToDefaultCulture);
             }

--- a/.NET/Microsoft.Recognizers.Text/Config/IConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text/Config/IConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Recognizers.Text.Config
+{
+    public interface IConfiguration
+    {
+
+        string Culture { get; }
+
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text/Culture.cs
+++ b/.NET/Microsoft.Recognizers.Text/Culture.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Microsoft.Recognizers.Text
 {
@@ -66,7 +67,8 @@ namespace Microsoft.Recognizers.Text
             {
                 // Handle cases like EnglishOthers with cultureCode "en-*"
                 var fallbackCultureCodes = SupportedCultureCodes
-                    .Where(o => o.EndsWith("*") && cultureCode.StartsWith(o.Split('-').First())).ToList();
+                    .Where(o => o.EndsWith("*", StringComparison.Ordinal) &&
+                                cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
 
                 if (fallbackCultureCodes.Count == 1)
                 {
@@ -76,7 +78,7 @@ namespace Microsoft.Recognizers.Text
                 // If there is no cultureCode like "-*", map only the prefix
                 // For example, "es-mx" will be mapped to "es-es"
                 fallbackCultureCodes = SupportedCultureCodes
-                    .Where(o => cultureCode.StartsWith(o.Split('-').First())).ToList();
+                    .Where(o => cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
 
                 if (fallbackCultureCodes.Any())
                 {

--- a/.NET/Recognizers-Text.ruleset
+++ b/.NET/Recognizers-Text.ruleset
@@ -357,6 +357,7 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1308" Action="None" /> <!-- Disabling ToUpper warning -->
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="Error" />


### PR DESCRIPTION
This PR simplifies/standardizes how configs are used in DateTime and Number (more to be done later) to make it easier to pass configuration around.
I've also removed some unnecessary chains of constructors across Extractor/Parsers.