### PR TITLE
[JavaScript] Add an indentation rule to ESlint

### DIFF
--- a/JavaScript/.eslintrc.js
+++ b/JavaScript/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         'curly': ["error"],           
         "spaced-comment": ["warn", "always"],
         'semi': 'error', 
-        'brace-style': ["error", "stroustrup"],  
+        'brace-style': ["error", "stroustrup"],
+        'indent': ['error', 4]  
     },
 }; 


### PR DESCRIPTION
### Issue
When applying the autofix, the indentation of certain places was incorrect (see PR#N). After some investigation, we found the rule to fix this.

### Changes made
A new rule was added that makes sure the indentation is the right one:
` 'indent': ['error', 4]`

### Testing
**Pre lint:fix**
![imagen](https://user-images.githubusercontent.com/22912283/62540752-ace1db00-b82e-11e9-8c87-5d55cacc8564.png)

**With old rules**
![imagen](https://user-images.githubusercontent.com/22912283/62540777-ba976080-b82e-11e9-8c67-156074a5aeba.png)

**With new rule**
![imagen](https://user-images.githubusercontent.com/22912283/62540792-c1be6e80-b82e-11e9-8311-37f392f62e42.png)
