### PR TITLE
[.NET] Italian Number support for skipped cases

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Recognizers.Text.Number.Italian
                 }
             }
 
-            /*The following piece of code is needed in Italian to correctly compute some fraction patterns
-             * e.g. 'due milioni duemiladuecento quinti' (=2002200/5) which is otherwise interpreted as
-             * 2000000/2205 (in Italian, isolated ordinals <10 have a different form respect to when
-             * they are concatenated to other numbers, so the following lines try to keep them isolated
-             * by concatenating the two previous numbers) */
+            // The following piece of code is needed in Italian to correctly compute some fraction patterns
+            // e.g. 'due milioni duemiladuecento quinti' (=2002200/5) which is otherwise interpreted as
+            // 2000000/2205 (in Italian, isolated ordinals <10 have a different form respect to when
+            // they are concatenated to other numbers, so the following lines try to keep them isolated
+            // by concatenating the two previous numbers)
             var fracLen = fracWords.Count;
             if (fracLen > 2 && this.OneToNineOrdinalRegex.Match(fracWords[fracLen - 1]).Success)
             {
@@ -86,10 +86,10 @@ namespace Microsoft.Recognizers.Text.Number.Italian
                 }
             }
 
-            /*The following piece of code is needed to compute the fraction pattern number+'e mezzo'
-             * e.g. 'due e mezzo' ('two and a half') where the numerator is omitted in Italian.
-             * It works by inserting the numerator 'un' ('a') in the list fracWords
-             * so that the pattern is correctly processed.*/
+            // The following piece of code is needed to compute the fraction pattern number+'e mezzo'
+            // e.g. 'due e mezzo' ('two and a half') where the numerator is omitted in Italian.
+            // It works by inserting the numerator 'un' ('a') in the list fracWords
+            // so that the pattern is correctly processed.
             fracLen = fracWords.Count;
             if (fracLen > 2)
             {

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
@@ -86,6 +86,19 @@ namespace Microsoft.Recognizers.Text.Number.Italian
                 }
             }
 
+            /*The following piece of code is needed to compute the fraction pattern number+'e mezzo'
+             * e.g. 'due e mezzo' ('two and a half') where the numerator is omitted in Italian.
+             * It works by inserting the numerator 'un' ('a') in the list fracWords
+             * so that the pattern is correctly processed.*/
+            fracLen = fracWords.Count;
+            if (fracLen > 2)
+            {
+                if (fracWords[fracLen - 1] == "mezzo" && fracWords[fracLen - 2] == "e")
+                {
+                    fracWords.Insert(fracLen - 1, "un");
+                }
+            }
+
             return fracWords;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -26,6 +26,16 @@ namespace Microsoft.Recognizers.Text.Number
                                 GetKeyRegex(this.Config.CardinalNumberMap.Keys) + "|" +
                                 GetKeyRegex(this.Config.OrdinalNumberMap.Keys);
 
+            /*For Italian, we invert the order of Cardinal and Ordinal in singleIntFrac in order to correctly extract
+             * ordinals that contain cardinals such as 'tredicesimo' (thirteenth) which starts with 'tre' (three).
+             * With the standard order, the parser fails to return '13' since only the cardinal 'tre' (3) is extracted*/
+            if (config.CultureInfo.Name == "it-IT")
+            {
+                singleIntFrac = $"{this.Config.WordSeparatorToken}| -|" +
+                                    GetKeyRegex(this.Config.OrdinalNumberMap.Keys) + "|" +
+                                    GetKeyRegex(this.Config.CardinalNumberMap.Keys);
+            }
+
             string textNumberPattern;
 
             // Checks for languages that use "compound numbers". I.e. written number parts are not separated by whitespaces or special characters (e.g., dreihundert in German).

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -22,34 +22,7 @@ namespace Microsoft.Recognizers.Text.Number
             this.isMultiDecimalSeparatorCulture = config.IsMultiDecimalSeparatorCulture;
             this.isCompoundNumberLanguage = config.IsCompoundNumberLanguage;
 
-            var singleIntFrac = $"{this.Config.WordSeparatorToken}| -|" +
-                                GetKeyRegex(this.Config.CardinalNumberMap.Keys) + "|" +
-                                GetKeyRegex(this.Config.OrdinalNumberMap.Keys);
-
-            /*For Italian, we invert the order of Cardinal and Ordinal in singleIntFrac in order to correctly extract
-             * ordinals that contain cardinals such as 'tredicesimo' (thirteenth) which starts with 'tre' (three).
-             * With the standard order, the parser fails to return '13' since only the cardinal 'tre' (3) is extracted*/
-            if (config.CultureInfo.Name == "it-IT")
-            {
-                singleIntFrac = $"{this.Config.WordSeparatorToken}| -|" +
-                                    GetKeyRegex(this.Config.OrdinalNumberMap.Keys) + "|" +
-                                    GetKeyRegex(this.Config.CardinalNumberMap.Keys);
-            }
-
-            string textNumberPattern;
-
-            // Checks for languages that use "compound numbers". I.e. written number parts are not separated by whitespaces or special characters (e.g., dreihundert in German).
-            if (isCompoundNumberLanguage)
-            {
-                textNumberPattern = @"(" + singleIntFrac + @")";
-            }
-            else
-            {
-                // Default case, like in English.
-                textNumberPattern = @"(?<=\b)(" + singleIntFrac + @")(?=\b)";
-            }
-
-            TextNumberRegex = new Regex(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
+            TextNumberRegex = BuildTextNumberRegex();
 
             RoundNumberSet = new HashSet<string>();
             foreach (var roundNumber in this.Config.RoundNumberMap.Keys)
@@ -914,6 +887,39 @@ namespace Microsoft.Recognizers.Text.Number
             }
 
             return ret;
+        }
+
+        private Regex BuildTextNumberRegex()
+        {
+            var singleIntFrac = $"{this.Config.WordSeparatorToken}| -|" +
+                                GetKeyRegex(this.Config.CardinalNumberMap.Keys) + "|" +
+                                GetKeyRegex(this.Config.OrdinalNumberMap.Keys);
+
+            // @TODO consider remodeling the creation of this regex
+            // For Italian, we invert the order of Cardinal and Ordinal in singleIntFrac in order to correctly extract
+            // ordinals that contain cardinals such as 'tredicesimo' (thirteenth) which starts with 'tre' (three).
+            // With the standard order, the parser fails to return '13' since only the cardinal 'tre' (3) is extracted
+            if (this.Config.CultureInfo.Name == "it-IT")
+            {
+                singleIntFrac = $"{this.Config.WordSeparatorToken}| -|" +
+                                    GetKeyRegex(this.Config.OrdinalNumberMap.Keys) + "|" +
+                                    GetKeyRegex(this.Config.CardinalNumberMap.Keys);
+            }
+
+            string textNumberPattern;
+
+            // Checks for languages that use "compound numbers". I.e. written number parts are not separated by whitespaces or special characters (e.g., dreihundert in German).
+            if (isCompoundNumberLanguage)
+            {
+                textNumberPattern = @"(" + singleIntFrac + @")";
+            }
+            else
+            {
+                // Default case, like in English.
+                textNumberPattern = @"(?<=\b)(" + singleIntFrac + @")(?=\b)";
+            }
+
+            return new Regex(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
         }
     }
 }

--- a/Specs/Number/Italian/NumberModel.json
+++ b/Specs/Number/Italian/NumberModel.json
@@ -245,10 +245,16 @@
   },
   {
     "Input": " il 4 maggio ",
-    "NotSupported": "dotnet",
-    "Comment": "4 is extracted as number but it is part of a date (May the 4th), same happens in English test for 4 May",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+      {
+        "Text": "4",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4"
+        }
+      }
+    ]
   },
   {
     "Input": "il liquido da 0,25ml",
@@ -1194,8 +1200,6 @@
   },
   {
     "Input": "uno e mezzo",
-    "NotSupported": "dotnet",
-    "Comment": "mezzo in this context means 0.5 but set in dictionary to 2. recognized as 1/2=0.5 instead of 1+0.5=1.5",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {

--- a/Specs/Number/Italian/OrdinalModel.json
+++ b/Specs/Number/Italian/OrdinalModel.json
@@ -106,7 +106,6 @@
   },
   {
     "Input": "undicesimo",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "python,javascript,java",
     "Results": [
       {


### PR DESCRIPTION
Support for skipped cases:
    [uno e mezzo] (one and a half)
    [undicesimo] (eleventh)

The fix for the second pattern required a modification to BaseNumberParser (switching the order of Cardinal and Ordinal maps for Italian)