### PR TITLE
[FR|EN Currency] fix wrong recognize "$2000 in 3 year" as "$2000 in 3"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/BaseUnits.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/BaseUnits.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Recognizers.Definitions
       public const string SecondRegex = @"(?<sec>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";
       public static readonly string PmNonUnitRegex = $@"({HourRegex}\s*:\s*{MinuteRegex}(\s*:\s*{SecondRegex})?\s*pm)";
       public const string AmbiguousTimeTerm = @"pm";
-      public const string AmbiguousUnitNumberMultiplierRegex = @"(\s[Kk])";
+      public const string AmbiguousUnitNumbersRegex = @"(\s[Kk])";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -559,7 +559,7 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"Ngwee", @"NGWEE" }
         };
       public const string CompoundUnitConnectorRegex = @"(?<spacer>and)";
-      public const string AmbiguousFractionRegex = @"\s+(over|in|out\s+of)";
+      public const string AmbiguousUnitsRegex = @"\s+(over|in|out\s+of)";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -559,6 +559,7 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"Ngwee", @"NGWEE" }
         };
       public const string CompoundUnitConnectorRegex = @"(?<spacer>and)";
+      public const string AmbiguousFractionRegex = @"\s+(over|in|out\s+of)";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersWithUnitDefinitions.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"Mark Finlandais", @"marks finlandais|mark finlandais|fim|mark" }
         };
       public const string CompoundUnitConnectorRegex = @"(?<spacer>[^.])";
-      public const string AmbiguousFractionRegex = @"\s+sur";
+      public const string AmbiguousUnitsRegex = @"\s+sur";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersWithUnitDefinitions.cs
@@ -272,6 +272,7 @@ namespace Microsoft.Recognizers.Definitions.French
             { @"Mark Finlandais", @"marks finlandais|mark finlandais|fim|mark" }
         };
       public const string CompoundUnitConnectorRegex = @"(?<spacer>[^.])";
+      public const string AmbiguousFractionRegex = @"\s+sur";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public abstract string ExtractType { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/TemperatureExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Chinese))
@@ -36,6 +36,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/TemperatureExtractorConfiguration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Dutch))
@@ -39,6 +39,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         private static readonly Regex CompoundUnitConnRegex =
             new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
+        private static readonly Regex AmbiguousFractionRegex =
+            new Regex(NumbersWithUnitDefinitions.AmbiguousFractionRegex, RegexFlags);
+
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
 
@@ -49,7 +52,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousFractionRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         private static readonly Regex CompoundUnitConnRegex =
             new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
-        private static readonly Regex AmbiguousFractionRegex =
-            new Regex(NumbersWithUnitDefinitions.AmbiguousFractionRegex, RegexFlags);
+        private static readonly Regex AmbiguousUnitsRegex =
+            new Regex(NumbersWithUnitDefinitions.AmbiguousUnitsRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousFractionRegex;
+        public virtual Regex AmbiguousUnitNumbersRegex => AmbiguousUnitsRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/TemperatureExtractorConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.English))
@@ -38,6 +38,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/INumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/INumberWithUnitExtractorConfiguration.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         Regex NonUnitRegex { get; }
 
-        Regex AmbiguousUnitNumberMultiplierRegex { get; }
+        Regex AmbiguousUnitNumbersRegex { get; }
 
         Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
     }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
                 // Special case for cases where number multipliers clash with unit
                 // Or ambiguous fraction like "$2000 over 3 year" should be only recognized "$2000"
-                var ambiguousMultiplierRegex = this.config.AmbiguousUnitNumberMultiplierRegex;
-                if (ambiguousMultiplierRegex != null)
+                var ambiguousUnitNumbersRegex = this.config.AmbiguousUnitNumbersRegex;
+                if (ambiguousUnitNumbersRegex != null)
                 {
                     foreach (var number in numbers)
                     {
-                        var match = ambiguousMultiplierRegex.Matches(number.Text);
+                        var match = ambiguousUnitNumbersRegex.Matches(number.Text);
                         if (match.Count == 1)
                         {
                             var newLength = match[0].Index;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                 var numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
 
                 // Special case for cases where number multipliers clash with unit
+                // Or ambiguous fraction like "$2000 over 3 year" should be only recognized "$2000"
                 var ambiguousMultiplierRegex = this.config.AmbiguousUnitNumberMultiplierRegex;
                 if (ambiguousMultiplierRegex != null)
                 {
@@ -81,9 +82,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                         var match = ambiguousMultiplierRegex.Matches(number.Text);
                         if (match.Count == 1)
                         {
-                            var newLength = number.Text.Length - match[0].Length;
+                            var newLength = match[0].Index;
                             number.Text = number.Text.Substring(0, newLength);
                             number.Length = newLength;
+                            number.Data = Number.Constants.INTEGER_PREFIX + Number.Constants.NUMBER_SUFFIX;
                         }
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         private static readonly Regex CompoundUnitConnRegex =
             new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
-        private static readonly Regex AmbiguousFractionRegex =
-            new Regex(NumbersWithUnitDefinitions.AmbiguousFractionRegex, RegexFlags);
+        private static readonly Regex AmbiguousUnitsRegex =
+            new Regex(NumbersWithUnitDefinitions.AmbiguousUnitsRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
@@ -50,7 +50,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousFractionRegex;
+        public virtual Regex AmbiguousUnitNumbersRegex => AmbiguousUnitsRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         private static readonly Regex CompoundUnitConnRegex =
             new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
+        private static readonly Regex AmbiguousFractionRegex =
+            new Regex(NumbersWithUnitDefinitions.AmbiguousFractionRegex, RegexFlags);
+
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
 
@@ -47,7 +50,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousFractionRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.French))
@@ -35,6 +35,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.German))
@@ -38,6 +38,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Italian))
@@ -35,6 +35,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public IExtractor IntegerExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.Portuguese))
@@ -35,6 +35,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Spanish))
@@ -35,6 +35,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TemperatureExtractorConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
+            new Regex(BaseUnits.AmbiguousUnitNumbersRegex, RegexOptions.None);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.Turkish))
@@ -36,6 +36,6 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
 
         public override string ExtractType => Constants.SYS_UNIT_TEMPERATURE;
 
-        public override Regex AmbiguousUnitNumberMultiplierRegex => AmbiguousUnitMultiplierRegex;
+        public override Regex AmbiguousUnitNumbersRegex => AmbiguousUnitMultiplierRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
 
         public Regex NonUnitRegex => NonUnitsRegex;
 
-        public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+        public virtual Regex AmbiguousUnitNumbersRegex => null;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -637,6 +637,8 @@ FractionalUnitNameToCodeMap: !dictionary
     Ngwee: NGWEE
 CompoundUnitConnectorRegex: !simpleRegex
     def: (?<spacer>and)
+AmbiguousFractionRegex: !simpleRegex
+    def: \s+(over|in|out\s+of)
 CurrencyPrefixList: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/French/French-NumbersWithUnit.yaml
+++ b/Patterns/French/French-NumbersWithUnit.yaml
@@ -351,6 +351,8 @@ CurrencySuffixList: !dictionary
     Mark Finlandais: marks finlandais|mark finlandais|fim|mark
 CompoundUnitConnectorRegex: !simpleRegex
     def: (?<spacer>[^.])
+AmbiguousFractionRegex: !simpleRegex
+    def: \s+sur
 CurrencyPrefixList: !dictionary
   types: [ string, string ]
   entries:

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -13902,5 +13902,52 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I want to loan $10000 over 3 years",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "3 years",
+        "Start": 27,
+        "End": 33,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3Y",
+              "type": "duration",
+              "value": "94608000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I want to loan $10000 in 3 years",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "in 3 years",
+        "Start": 22,
+        "End": 31,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2022-08-12",
+              "type": "date",
+              "value": "2022-08-12"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -11894,5 +11894,52 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I want to loan $10000 over 3 years",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "3 years",
+        "Start": 27,
+        "End": 33,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3Y",
+              "type": "duration",
+              "value": "94608000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I want to loan $10000 in 3 years",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "in 3 years",
+        "Start": 22,
+        "End": 31,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2022-08-12",
+              "type": "date",
+              "value": "2022-08-12"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -1758,5 +1758,29 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Je veux un crédit de EUR 1000 sur 3 ans",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "NotSupported": "javascript, python,java",
+    "Results": [
+      {
+        "Text": "3 ans",
+        "Start": 34,
+        "End": 38,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3Y",
+              "type": "duration",
+              "value": "94608000"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -1771,5 +1771,37 @@
         "End": 16
       }
     ]
+  },
+  {
+    "Input": "I want to loan $10000 over 3 years",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "$10000",
+        "Start": 15,
+        "End": 20,
+        "TypeName": "currency",
+        "Resolution": {
+          "unit": "Dollar",
+          "value": "10000"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I want to earn $10000 in 3 years",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "$10000",
+        "Start": 15,
+        "End": 20,
+        "TypeName": "currency",
+        "Resolution": {
+          "unit": "Dollar",
+          "value": "10000"
+        }
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/French/CurrencyModel.json
+++ b/Specs/NumberWithUnit/French/CurrencyModel.json
@@ -1533,5 +1533,37 @@
     "Input": "pour cent",
     "NotSupported": "javascript,python,java",
     "Results": []
+  },
+  {
+    "Input": "Je veux un crédit de EUR 1000 sur 3 ans",
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eur 1000",
+        "Start": 21,
+        "End": 28,
+        "TypeName": "currency",
+        "Resolution": {
+          "unit": "Euro",
+          "value": "1000"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je veux un crédit de 1000 EUR sur 3 ans",
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1000 eur",
+        "Start": 21,
+        "End": 28,
+        "TypeName": "currency",
+        "Resolution": {
+          "unit": "Euro",
+          "value": "1000"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This fixes #1699 
In french, "Je veux un crédit de EUR 1000 sur 3 ans"  is wrong recognized "EUR 1000 sur"
Now, just fixed in .NET 