### PR TITLE
[.NET] Turkish DateTime Date support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -23,25 +23,22 @@ namespace Microsoft.Recognizers.Definitions.Turkish
     {
       public const string TillRegex = @"(?<till>\b(kadar|dek|değin)\b)";
       public const string RangeConnectorRegex = @"(?<and>\b(ile|ila)\b|(-|—|——|–))";
-      public const string RelativeRegex = @"\b(?<order>ertesi|bir sonraki|gelecek|bu|geçen|bir önceki|evvelki|önümüzdeki)\b";
-      public const string StrictRelativeRegex = @"\b(?<order>ertesi|bir sonraki|gelecek|bu|geçen|bir önceki|evvelki|önümüzdeki)\b";
+      public const string RelativeRegex = @"\b(?<order>ertesi|(bir\s+)?sonraki|gelecek|bu|geçen|son|aynı|(bir\s+)?önceki|evvelki|önümüzdeki)\b";
+      public const string StrictRelativeRegex = @"\b(?<order>ertesi|(bir\s+)?sonraki|gelecek|bu|geçen|son|aynı|(bir\s+)?önceki|evvelki|önümüzdeki)\b";
       public const string UpcomingPrefixRegex = @"((bu\s+)?(yaklaşan))";
-      public const string NextPrefixRegex = @"\b(bir sonraki|gelecek|önümüzdeki)\b";
+      public const string NextPrefixRegex = @"\b(bir sonraki|gelecek|önümüzdeki|ertesi)\b";
       public const string AfterNextSuffixRegex = @"\b(after\s+(the\s+)?next)\b";
-      public const string PastPrefixRegex = @"(geçen)\b";
-      public const string PreviousPrefixRegex = @"(geçen|bir önceki|evvelki)\b";
+      public const string PastPrefixRegex = @"(son)\b";
+      public static readonly string PreviousPrefixRegex = $@"(geçen|bir önceki|önceki|evvelki|{PastPrefixRegex})\b";
       public const string ThisPrefixRegex = @"(bu|şimdiki)\b";
       public const string RangePrefixRegex = @"(arasında)";
       public const string CenturySuffixRegex = @"(^yüzyıl)\b";
       public const string ReferencePrefixRegex = @"(o|şu|aynı)\b";
       public const string FutureSuffixRegex = @"\b(ileride|gelecekte)\b";
-      public const string DayRegex = @"(?<day>(10|20|30|(1|2|3)1|(1|2)2|(1|2)3|(1|2)4|(1|2)5|(1|2)6|(1|2)7|(1|2)8|(1|2)9|1|2|3|4|5|6|7|8|9))";
-      public const string WrittenDayRegex = @"(((on|yirmi)\s)?(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz)|on|yirmi|otuz bir|otuz)";
-      public const string ImplicitDayRegex = @"(?<day>(10'uncu|20'nci|30'uncu|(1|2|3)1'inci|(1|2)2'nci|(1|2)3'üncü|(1|2)4'üncü|(1|2)5'inci|(1|2)6'ncı|(1|2)7'nci|(1|2)8'inci|(1|2)9'uncu))";
-      public const string DaySuffixRegex = @"(?<day>(1|5|8|11|15|18|21|25|28|31)'i|(2|7|12|17|20|22|27)'si|(3|4|13|14|23|24)'ü|(6|16|26)'sı|(9|10|19|29|30)'u)";
+      public const string DayRegex = @"(?<day>(10|20|30|31|(1|2)[1-9]|0?[1-9])('i|'si|'sı|'ü|'u)?)";
+      public const string ImplicitDayRegex = @"(?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=\b)";
       public const string DayFromSuffixRegex = @"(?<day>(1|5|8|11|15|18|21|25|28|31)'inden|(2|7|12|17|20|22|27)'sinden|(3|4|13|14|23|24)'ünden|(6|16|26)'sından|(9|10|19|29|30)'undan)";
       public const string DayToSuffixRegex = @"(?<day>(1|5|8|11|15|18|21|25|28|31)'ine|(2|7|12|17|20|22|27)'sine|(3|4|13|14|23|24)'üne|(6|16|26)'sına|(9|10|19|29|30)'una)";
-      public const string WrittenDayAtSuffixRegex = @"(((on|yirmi)\s)?(biri(nde)?|ikisi(nde)?|üçü(nde)?|dördü(nde)?|beşi(nde)?|altısı(nda)?|yedisi(nde)?|sekizi(nde)?|dokuzu(nda)?)|onu(nda)?|yirmisi(nde)?|otuzu(nda)?|otuz biri(nde)?)";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public const string WrittenOneToNineRegex = @"(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz)";
       public const string WrittenElevenToNineteenRegex = @"(on\s(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz))";
@@ -51,7 +48,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string WrittenCenturyOrdinalYearRegex = $@"((on|yirmi|otuz|kırk|elli|altmış|yetmiş|seksen|doksan)\s{WrittenOneToNineRegex}|{WrittenOneToNineRegex})";
       public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex})\b";
       public static readonly string LastTwoYearNumRegex = $@"(sıfır\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
-      public static readonly string FullTextYearRegex = $@"\b(({WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+{WrittenCenturyOrdinalYearRegex}|{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}|(iki\s+)?bin)\b";
+      public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+(?<lasttwoyearnum>{WrittenCenturyOrdinalYearRegex})|(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|(iki\s+)?bin)|(?<lasttwoyearnum>{WrittenCenturyOrdinalYearRegex}))";
       public static readonly string FullTextAtYearRegex = $@"\b((({WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+)?(((on|yirmi|otuz|kırk|elli|altmış|yetmiş|seksen|doksan)\s+)?(birde|ikide|üçte|dörtte|beşte|altıda|yedide|sekizde|dokuzda)|onda|yirmide|otuzda|kırkta|ellide|altmışta|yetmişte|seksende|doksanda)|{WrittenCenturyFullYearRegex}de|(iki\s)?binde)\b";
       public const string OclockRegex = @"(?<oclock>saat)";
       public const string SpecialDescRegex = @"((?<ipm>)p\b)";
@@ -61,15 +58,16 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string DescRegex = $@"((({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
       public const string TwoDigitYearRegex = @"\b(?<![$])(?<year>([0-27-9]\d))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
-      public const string WeekDayRegex = @"\b(?<weekday>pazartesi(leri)?|salı(ları)?|çarşamba(ları)?|perşembe(leri)?|cuma(ları)?|cumartesi(leri)?|pazar(ları)?|pzt|sal|çrş|per|cum|cmt|paz)\b";
+      public const string WeekDayRegex = @"\b(?<weekday>pazartesi(leri|si)?|salı(ları|sı)?|çarşamba(ları|sı)?|perşembe(leri|si)?|cuma(ları|sı)?|cumartesi(leri|si)?|pazar(ları|ı)?|pzt|sal|çrş|per|cum|cmt|paz)(\s+günü)?\b";
       public const string SingleWeekDayRegex = @"\b(?<weekday>pazartesi|salı|çarşamba|perşembe|cuma|cumartesi|pazar|pzt|sal|çrş|per|cum|cmt|paz)\b";
-      public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+ay)\b";
+      public const string MonthRegex = @"(?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)";
+      public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+(ayın|ay))\b";
       public const string WrittenMonthRegex = @"(?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)(\s+ayı)?";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((?<!\d+)((ocak|şubat|mart|mayıs|ağustos|aralık)(ta)|(nisan|haziran|temmuz|kasım)(da)|(eylül|ekim)(de))|{WrittenMonthRegex}(\sayında)|{RelativeRegex}\sayda))";
       public const string ProperMonthSuffixRegex = @"(?<msuf>(ocak|şubat|mart|mayıs|ağustos|aralık)('ta)|(nisan|haziran|temmuz|kasım)('da)|(eylül|ekim)('de))";
-      public static readonly string MonthPossessiveSuffixRegex = $@"(?<msuf>((ocak|şubat|mart|nisan|mayıs|haziran|kasım|aralık)('ın)|(temmuz|ağustos)('un)|eylül'ün|ekim'in|{MonthRegex}(\sayının)|{RelativeRegex}\sayın))";
+      public static readonly string MonthPossessiveSuffixRegex = $@"((?<month>(ocak|şubat|mart|nisan|mayıs|haziran|kasım|aralık)('ın)|(temmuz|ağustos)('un)|eylül'ün|ekim'in)|{MonthRegex}(\s+ayının)|{RelativeMonthRegex})";
       public const string MonthToSuffixRegex = @"(?<msuf>((ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|kasım|aralık)'a|(eylül|ekim)'e))";
-      public const string DateUnitRegex = @"(?<unit>yıl|ay|hafta|gün)\b";
+      public const string DateUnitRegex = @"(?<unit>yıl|ay|hafta|(?<business>iş\s+)günü|gün)\b";
       public const string DateTokenPrefix = @"on ";
       public const string TimeTokenPrefix = @"at ";
       public const string TokenBeforeDate = @"on ";
@@ -79,7 +77,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string MonthFrontBetweenRegex = $@"\b({WrittenMonthRegex}\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?(\s+{RangePrefixRegex})?\b";
       public static readonly string BetweenRegex = $@"\b({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})(\s+{WrittenMonthRegex})((\s+|\s*,\s*){YearRegex})?(\s+{RangePrefixRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\s|,?){YearRegex})|({RelativeRegex}\s(yıl|sene)|seneye)\s{WrittenMonthRegex}(\s+ayı)?)\b";
-      public static readonly string OneWordPeriodRegex = $@"\b(({RelativeRegex}\s+)?{WrittenMonthRegex}\s+ayı|(ay|ayın|sene)|({NextPrefixRegex}\s+)?{WrittenMonthRegex}\s+ayı)\b";
+      public static readonly string OneWordPeriodRegex = $@"\b(({RelativeRegex}\s+)?{WrittenMonthRegex}\s+ayı|({NextPrefixRegex}\s+)?{WrittenMonthRegex}\s+ayı)\b";
       public static readonly string MonthNumWithYear = $@"\b({MonthNumRegex}(\s*)[/\-\.](\s*){BaseDateTime.FourDigitYearRegex})\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>({MonthPossessiveSuffixRegex}|({BaseDateTime.FourDigitYearRegex}\s+yılı\s+|{RelativeRegex}\s+yılın\s+)?{WrittenMonthRegex}\s+ayının)\s+(?<cardinal>ilk|birinci|1(.|'inci)|ikinci|2(.|'inci)|üçüncü|3(.|'inci)|dördüncü|4(.|'inci)|beşinci|5(.|'inci)|son)\s+haftası)\b";
       public static readonly string WeekOfYearRegex = $@"\b(?<woy>({YearRegex}\s+yılının|{RelativeRegex}\s+yılın)\s+((?<cardinal>((on|yirmi|otuz|kırk|elli)\s+)?(birinci|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu|onuncu|yirminci|otuzuncu|kırkıncı|ellinci)|elli birinci|elli ikinci|(1|2|3|4|5)?1(.|'inci)|(1|2|3|4|5)?2(.|'inci)|(1|2|3|4)?3(.|'üncü)|(1|2|3|4)?4(.|'üncü)|(1|2|3|4)?5(.|'inci)|(1|2|3|4)?6(.|'ıncı)|(1|2|3|4)?7(.|'nci)|(1|2|3|4)?8(.|'inci)|(1|2|3|4)?9(.|'uncu))|son)\s+haftası)\b";
@@ -106,40 +104,39 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string WhichWeekRegex = @"\b((?<cardinal>((on|yirmi|otuz|kırk|elli)\s)?(birinci|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu|onuncu|yirminci|otuzuncu|kırkıncı|ellinci)|elli birinci|elli ikinci|(1|2|3|4|5)?1(.|'inci)|(1|2|3|4|5)?2(.|'inci)|(1|2|3|4)?3(.|'üncü)|(1|2|3|4)?4(.|'üncü)|(1|2|3|4)?5(.|'inci)|(1|2|3|4)?6(.|'ıncı)|(1|2|3|4)?7(.|'nci)|(1|2|3|4)?8(.|'inci)|(1|2|3|4)?9(.|'uncu))|son)\s+hafta\b";
       public const string WeekOfRegex = @"(haftası)";
       public const string MonthOfRegex = @"(ayı)";
-      public const string MonthRegex = @"(?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)";
-      public const string AmbiguousMonthP0Regex = @"^[\*]";
+      public const string AmbiguousMonthP0Regex = @"\b(bir\s+ara)\b";
       public static readonly string DateYearRegex = $@"(?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})";
       public static readonly string YearSuffix = $@"(,?\s*({DateYearRegex}|{FullTextYearRegex}))";
-      public const string OnRegex = @"(?<day>(1|5|8|11|15|18|21|25|28|31)'inde|(2|7|12|17|20|22|27)'sinde|(3|4|13|14|23|24)'ünde|(6|16|26)'sında|(9|10|19|29|30)'unda)\b";
-      public const string RelaxedOnRegex = @"(?<day>(11|15|18|21|25|28|31)'inde|(12|17|20|22|27)'sinde|(13|14|23|24)'ünde|(16|26)'sında|(10|19|29|30)'unda)\b";
+      public const string OnRegex = @"^[\*]";
+      public const string RelaxedOnRegex = @"(?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=(nde|nda))\b";
       public const string PrefixWeekDayRegex = @"(\s*[-—–])";
-      public static readonly string ThisRegex = $@"\b(bu(\s+hafta)?\s+{WeekDayRegex}(\s+günü)?)\b";
-      public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s+hafta)?\s+{WeekDayRegex}(\s+günü)?)\b";
-      public static readonly string NextDateRegex = $@"\b(({NextPrefixRegex}(\s+hafta)?|haftaya)\s+{WeekDayRegex}(\s+günü)?)\b";
-      public static readonly string SpecialDayRegex = $@"\b((dünden önceki|yarından sonraki)\s+gün|(önceki|sonraki)\s+gün|{RelativeRegex}\s+gün|dün|yarın|bugün)\b";
-      public static readonly string SpecialDayWithNumRegex = $@"\b((?<day>dünden|yarından|bugünden)\s+(?<number>{WrittenNumRegex})\s+gün\s+sonra)\b";
+      public static readonly string ThisRegex = $@"\b(bu(\s+hafta)?\s+{WeekDayRegex})\b";
+      public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s+hafta)?\s+{WeekDayRegex})\b";
+      public static readonly string NextDateRegex = $@"\b(({NextPrefixRegex}(\s+hafta)?|haftaya)\s+{WeekDayRegex})\b";
+      public static readonly string SpecialDayRegex = $@"\b((dünden önceki|yarından sonraki)\s+gün|(önceki|sonraki)\s+gün|{RelativeRegex}\s+gün|(benim\s+)?günüm|dün(den)?|yarın(dan)?|bugün)\b";
+      public static readonly string SpecialDayWithNumRegex = $@"\b((?<day>dünden|yarından|bugünden|şu andan)\s+(itibaren\s+)?(?<number>{WrittenNumRegex})\s+gün\s+(sonra|içinde))\b";
       public static readonly string RelativeDayRegex = $@"\b({RelativeRegex}\s+gün)\b";
       public const string SetWeekDayRegex = @"\b(?<weekday>sabahları|öğlenleri|akşamları|geceleri|pazartesileri|salıları|çarşambaları|perşembeleri|cumaları|cumartesileri|pazarları)\b";
-      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>({MonthPossessiveSuffixRegex}|{WrittenMonthRegex}\s+ayının|{RelativeRegex}\s+ayın)\s+(?<cardinal>birinci|1'inci|1.|ilk|ikinci|2'nci|2.|üçüncü|3'üncü|3.|dördüncü|4'üncü|4.|beşinci|5'inci|5.|son)\s+{WeekDayRegex}(\s+günü)?)";
-      public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(sonra))\b";
+      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>({MonthPossessiveSuffixRegex}|{WrittenMonthRegex}\s+ayının|{RelativeRegex}\s+ayın)\s+(?<cardinal>birinci|1'inci|1.|ilk|ikinci|2'nci|2.|üçüncü|3'üncü|3.|dördüncü|4'üncü|4.|beşinci|5'inci|5.|son)\s+{WeekDayRegex})";
+      public static readonly string RelativeWeekDayRegex = $@"\b((şu\s+andan\s+itibaren\s+)?{WrittenNumRegex}\s+{WeekDayRegex}\s+(sonra))\b";
       public static readonly string SpecialDate = $@"\b{DayRegex}\s+günü\b";
       public const string DatePreposition = @"^[\*]";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*,\s*){DateYearRegex}";
-      public static readonly string DateExtractor1 = $@"\b(({DayRegex}|{WrittenDayRegex})\s+{MonthRegex}(\s+{FullTextAtYearRegex})|(({DayRegex}|{WrittenDayRegex})\s+{MonthRegex}(\s+({DateYearRegex}|{YearRegex}))?)((\s*\(\s*{SingleWeekDayRegex}\s*\))|\s*,?\s+{SingleWeekDayRegex}(\s+günü)?)?)";
-      public static readonly string DateExtractor3 = $@"\b(({RelativeRegex}\s+ayın\s+)?({WrittenDayAtSuffixRegex}|{OnRegex}|{DaySuffixRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b";
+      public static readonly string DateExtractor1 = $@"\b(({DayRegex}\s+{MonthRegex}(\s+{DateYearRegex})?)((\s*\(\s*{SingleWeekDayRegex}\s*\))|\s*,?\s+{SingleWeekDayRegex}(\s+günü)?)?)";
+      public static readonly string DateExtractor3 = $@"\b(({RelativeRegex}\s+ayın\s+)?({OnRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b";
       public static readonly string DateExtractor4 = $@"\b(({RelativeRegex}\s+)?({SingleWeekDayRegex}\s+(günü\s+)?)?(\({DayRegex}\s+{MonthRegex}(\s+{DateYearRegex})?\)|(\s*,\s*)?{DayRegex}\s+{MonthToSuffixRegex}))\b";
       public static readonly string DateExtractor5 = $@"\b({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})((\s*\(\s*{SingleWeekDayRegex}\s*\))|\s*,?\s+{SingleWeekDayRegex}(\s+günü)?)?";
       public static readonly string DateExtractor6 = $@"({RelativeRegex}\s+)?({SingleWeekDayRegex}\s+)?(\({DayRegex}\s*[/\\.]\s*{MonthNumRegex}\s*[/\\.]\s*{DateYearRegex}\))\b";
-      public static readonly string DateExtractor7 = $@"\b(({DayRegex}|{WrittenDayRegex})\s+{ProperMonthSuffixRegex})\b";
-      public static readonly string DateExtractor8 = $@"\b(({YearRegex}\s+yılı\s+)?({MonthPossessiveSuffixRegex})\s+({WrittenDayAtSuffixRegex}|{OnRegex}|{DaySuffixRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b";
-      public static readonly string DateExtractor9 = $@"\b((ayın\s+)?{DaySuffixRegex}\s+{SingleWeekDayRegex}(\s+günü)?)";
+      public static readonly string DateExtractor7 = $@"\b(({DayRegex})\s+{ProperMonthSuffixRegex})\b";
+      public const string DateExtractor8 = @"^[\*]";
+      public static readonly string DateExtractor9 = $@"\b({SingleWeekDayRegex}\s+{OnRegex})\b";
       public const string DateExtractor7L = @"^[\*]";
       public const string DateExtractor7S = @"^[\*]";
       public const string DateExtractor9L = @"^[\*]";
       public const string DateExtractor9S = @"^[\*]";
       public const string DateExtractorA = @"^[\*]";
-      public static readonly string OfMonth = $@"^{MonthRegex}\s*ayının";
-      public static readonly string MonthEnd = $@"{MonthRegex}\s*(ayı)?\s*$";
+      public static readonly string OfMonth = $@"^\s*{MonthRegex}";
+      public static readonly string MonthEnd = $@"{MonthPossessiveSuffixRegex}\s*$";
       public static readonly string WeekDayEnd = $@"(bu\s+)?{WeekDayRegex}\s*,?\s*$";
       public const string RangeUnitRegex = @"\b(?<unit>hafta|ay|yıl)\b";
       public const string HourNumRegex = @"\b(?<hournum>bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|on|on bir|on iki)\b";
@@ -207,11 +204,11 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string SpecificTimeBetweenAnd = $@"(?<time1>({TimeRegex2}|{HourRegex}|{PeriodHourNumRegex}))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|{HourRegex}|{PeriodHourNumRegex}))({RangePrefixRegex}\s+)?";
       public const string SuffixAfterRegex = @"\b((veya|ve)\s+(sonrasında|sonra))\b";
       public const string PrepositionRegex = @"^[\*]";
-      public const string TimeOfDayRegex = @"\b(?<timeOfDay>((sabahın|öğlenin|akşamın|gecenin|günün|mesainin)\s+((erken|geç)\s(saatinde|saatlerinde))))\b";
+      public const string TimeOfDayRegex = @"\b(?<timeOfDay>((sabahın|öğlenin|akşamın|gecenin|günün|mesainin)\s+((erken|geç)\s(saatinde|saatlerinde))|iş\s+saati(nde)?|mesai(de)?))\b";
       public static readonly string SpecificTimeOfDayRegex = $@"\b(({RelativeRegex}\s+{TimeOfDayRegex})\b|\bbu\s(sabah|akşam|gece))\b";
       public static readonly string TimeFollowedUnit = $@"^\s*{TimeUnitRegex}";
       public static readonly string TimeNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){TimeUnitRegex}";
-      public static readonly string[] BusinessHourSplitStrings = { @"mesai" };
+      public static readonly string[] BusinessHourSplitStrings = { @"iş", @"saati", @"saatinde", @"mesai", @"mesaide" };
       public const string NowRegex = @"\b(?<now>(hemen\s+)?şimdi|en kısa\s(sürede|zamanda)|ilk fırsatta|bir an\s(önce|evvel)|hemen|vakit geçirmeden|(mümkün olduğunca|olabildiğince)\sçabuk|son\s(dönemlerde|zamanlarda|günlerde)|geçenlerde|yakınlarda|(bu|şu)\sıralar|yakın zamanda|(bu|şu|son)\sgünlerde|önceden|evvelce|bundan önce|daha önce)\b";
       public const string SuffixRegex = @"\b(sabah|sabahleyin|sabahtan|öğleden sonra|akşam|akşamleyin|gece|geceleyin)\b";
       public const string DateTimeTimeOfDayRegex = @"\b(?<timeOfDay>sabah|öğle|öğlen|akşam|gece)\b";
@@ -234,7 +231,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string EachUnitRegex = $@"(?<each>(her)(bir)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(her)\s*$)";
       public const string SetEachRegex = @"\b(?<each>(her)\s*)";
-      public const string SetLastRegex = @"(?<last>izleyen|sonraki|ertesi|gelecek|bu|geçen|son|önceki|evvelsi|şimdiki)";
+      public const string SetLastRegex = @"(?<last>izleyen|bir sonraki|sonraki|ertesi|gelecek|bu|geçen|son|önceki|evvelsi|şimdiki)";
       public const string EachDayRegex = @"^\s*her\s*gün\b";
       public static readonly string DurationFollowedUnit = $@"(^\s*{DurationUnitRegex}\s+{SuffixAndRegex})|(^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}";
@@ -253,8 +250,8 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string AfterRegex = $@"((\b((sonra|sonrasında|daha sonra))(?!\s+veya aynı))|(?<!\w|<)((?<include>>=)|>))";
       public const string SinceRegex = @"((\b(((den|dan)\s+)?beri|sonra veya aynı|((den|dan|ile)\s+)?(başlayarak|başlayan)|erkenden|herhangi bir zamanda)\b\s*)|(?<!\w|<)(>=))";
       public const string AroundRegex = @"(\b(takriben|yaklaşık)\s*|\s*(civarında|civarı|dolaylarında)\b)";
-      public const string AgoRegex = @"\b(önce|(?<day>dünden|bugünden)\s+(önce|evvel))\b";
-      public const string LaterRegex = @"\b(sonra|(?<day>yarından|bugünden)\s+(itibaren|sonra)|bugünden\s+\d+\s+(gün|hafta|ay|yıl)(\s+sonra)?|yarından\s+itibaren\s+\d+\s+(gün|hafta|ay|yıl)(\s+sonra)?)\b";
+      public const string AgoRegex = @"\b(önce|evvel)\b";
+      public const string LaterRegex = @"\b(sonra|içinde|(?<day>yarından|bugünden)\s+(itibaren|sonra)|şu andan itibaren)\b";
       public const string InConnectorRegex = @"^[\*]";
       public const string SinceNumSuffixRegex = @"\b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b";
       public static readonly string SinceYearSuffixRegex = $@"({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)";
@@ -271,14 +268,16 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string ConnectorRegex = @"^(-|,|@)$";
       public const string FromToRegex = @"^[\*]";
       public static readonly string RelativeAtDateTimeUnitRegex = $@"(({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({AtDateTimeUnitRegex}))";
-      public const string SingleAmbiguousMonthRegex = @"^(the\s+)?(ocak|mayıs|ekim|aralık)$";
+      public const string SingleAmbiguousMonthRegex = @"^(ocak|mayıs|ekim|aralık|tem|ara)$";
       public const string SingleAmbiguousTermsRegex = @"^(gün|hafta|ay|yıl)$";
       public const string UnspecificDatePeriodRegex = @"^(gün|hafta sonu|hafta|ay|yıl)$";
       public const string PrepositionSuffixRegex = @"^[\*]";
-      public const string FlexibleDayRegex = @"(?<DayOfMonth>[A-Za-z\d]+(\s([A-Za-z]+))?)";
-      public static readonly string ForTheRegex = $@"\b(({FlexibleDayRegex})(?=(')))";
-      public static readonly string WeekDayAndDayOfMonthRegex = $@"\b({FlexibleDayRegex}\s{WeekDayRegex})\b";
-      public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+{DayRegex}\b";
+      public const string WrittenDayRegex = @"(?<day>bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|on|on\s+bir|on\s+iki|on\s+üç|on\s+dört|on\s+beş|on\s+altı|on\s+yedi|on\s+sekiz|on\s+dokuz|yirmi|yirmi\s+bir|yirmi\s+iki|yirmi\s+üç|yirmi\s+dört|yirmi\s+beş|yirmi\s+altı|yirmi\s+yedi|yirmi\s+sekiz|yirmi\s+dokuz|otuz|otuz\s+bir)";
+      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>({WrittenDayRegex}|{DayRegex}))";
+      public static readonly string ForTheRegex = $@"\b(?<!{SingleWeekDayRegex}\s+)(?<DayOfMonth>{FlexibleDayRegex}((?=((')(?!(ın|un|in|si|i|nci)\b)))|(?='ü)|'?(i|ü|si)(?=nde)|(?='(ı|u))|'?(ı|u|sı)(?=nda)))";
+      public static readonly string ForTheRegex1 = $@"\b(?<DayOfMonth>({FlexibleDayRegex})((?=('))|(i|ü|si)(?=nde)|(ı|u|sı)(?=nda)|(?=(i|ü|ı|u|si|sı)\b)))";
+      public static readonly string WeekDayAndDayOfMonthRegex = $@"\b({SingleWeekDayRegex}\s+{ForTheRegex1}|(?<DayOfMonth>({FlexibleDayRegex}))\s+{SingleWeekDayRegex})";
+      public static readonly string WeekDayAndDayRegex = $@"\b{SingleWeekDayRegex}\s+({DayRegex}|{FlexibleDayRegex})(?=(nde|nda))";
       public const string RestOfDateRegex = @"\b(((bu\s)?(haftanın|ayın|yılın)|haftamın|ayımın|yılımın)\s+(geri kalanı))\b";
       public const string RestOfDateTimeRegex = @"\b((günün|günümün|bugünün)\s+(geri kalanı))\b";
       public const string MealTimeRegex = @"\b(at\s+)?(?<mealTime>öğle yemeği zamanı|öğle yemeği vakti)\b";
@@ -312,6 +311,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
             { @"yıl", @"Y" },
             { @"yıllar", @"Y" },
             { @"ay", @"MO" },
+            { @"ayın", @"MO" },
             { @"aylar", @"MO" },
             { @"hafta", @"W" },
             { @"haftalar", @"W" },
@@ -335,10 +335,12 @@ namespace Microsoft.Recognizers.Definitions.Turkish
             { @"yıllar", 31536000 },
             { @"ay", 2592000 },
             { @"aylar", 2592000 },
+            { @"ayın", 2592000 },
             { @"hafta", 604800 },
             { @"haftalar", 604800 },
             { @"gün", 86400 },
             { @"günler", 86400 },
+            { @"günü", 86400 },
             { @"saat", 3600 },
             { @"saatler", 3600 },
             { @"sa.", 3600 },
@@ -372,6 +374,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
         };
       public static readonly Dictionary<string, int> CardinalMap = new Dictionary<string, int>
         {
+            { @"ilk", 1 },
             { @"birinci", 1 },
             { @"1''inci", 1 },
             { @"1.", 1 },
@@ -391,34 +394,72 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly Dictionary<string, int> DayOfWeek = new Dictionary<string, int>
         {
             { @"pazartesi", 1 },
+            { @"pazartesisi", 1 },
             { @"salı", 2 },
+            { @"salısı", 2 },
             { @"çarşamba", 3 },
+            { @"çarşambası", 3 },
             { @"perşembe", 4 },
+            { @"perşembesi", 4 },
             { @"cuma", 5 },
+            { @"cuması", 5 },
             { @"cumartesi", 6 },
+            { @"cumartesisi", 6 },
             { @"pazar", 0 },
+            { @"pazarı", 0 },
             { @"pzt", 1 },
             { @"sal", 2 },
             { @"çrş", 3 },
             { @"per", 4 },
             { @"cum", 5 },
             { @"cts", 6 },
-            { @"paz", 0 }
+            { @"paz", 0 },
+            { @"monday", 1 },
+            { @"tuesday", 2 },
+            { @"wednesday", 3 },
+            { @"thursday", 4 },
+            { @"friday", 5 },
+            { @"saturday", 6 },
+            { @"sunday", 0 },
+            { @"mon", 1 },
+            { @"tue", 2 },
+            { @"tues", 2 },
+            { @"wed", 3 },
+            { @"wedn", 3 },
+            { @"weds", 3 },
+            { @"thu", 4 },
+            { @"thur", 4 },
+            { @"thurs", 4 },
+            { @"fri", 5 },
+            { @"sat", 6 },
+            { @"sun", 0 }
         };
       public static readonly Dictionary<string, int> MonthOfYear = new Dictionary<string, int>
         {
             { @"ocak", 1 },
+            { @"ocak'ın", 1 },
             { @"şubat", 2 },
+            { @"şubat'ın", 2 },
             { @"mart", 3 },
+            { @"mart'ın", 3 },
             { @"nisan", 4 },
+            { @"nisan'ın", 4 },
             { @"mayıs", 5 },
+            { @"mayıs'ın", 5 },
             { @"haziran", 6 },
+            { @"haziran'ın", 6 },
             { @"temmuz", 7 },
+            { @"temmuz'un", 7 },
             { @"ağustos", 8 },
+            { @"ağustos'un", 8 },
             { @"eylül", 9 },
+            { @"eylül'ün", 9 },
             { @"ekim", 10 },
+            { @"ekim'in", 10 },
             { @"kasım", 11 },
+            { @"kasım'ın", 11 },
             { @"aralık", 12 },
+            { @"aralık'ın", 12 },
             { @"oca", 1 },
             { @"şub", 2 },
             { @"mar", 3 },
@@ -559,37 +600,46 @@ namespace Microsoft.Recognizers.Definitions.Turkish
         };
       public static readonly Dictionary<string, int> DayOfMonth = new Dictionary<string, int>
         {
-            { @"1", 1 },
-            { @"2", 2 },
-            { @"3", 3 },
-            { @"4", 4 },
-            { @"5", 5 },
-            { @"6", 6 },
-            { @"7", 7 },
-            { @"8", 8 },
-            { @"9", 9 },
-            { @"10", 10 },
-            { @"11", 11 },
-            { @"12", 12 },
-            { @"13", 13 },
-            { @"14", 14 },
-            { @"15", 15 },
-            { @"16", 16 },
-            { @"17", 17 },
-            { @"18", 18 },
-            { @"19", 19 },
-            { @"20", 20 },
-            { @"21", 21 },
-            { @"22", 22 },
-            { @"23", 23 },
-            { @"24", 24 },
-            { @"25", 25 },
-            { @"26", 26 },
-            { @"27", 27 },
-            { @"28", 28 },
-            { @"29", 29 },
-            { @"30", 30 },
-            { @"31", 31 }
+            { @"1'i", 1 },
+            { @"2'si", 2 },
+            { @"3'ü", 3 },
+            { @"4'ü", 4 },
+            { @"5'i", 5 },
+            { @"6'sı", 6 },
+            { @"7'si", 7 },
+            { @"8'i", 8 },
+            { @"9'u", 9 },
+            { @"10'u", 10 },
+            { @"11'i", 11 },
+            { @"12'si", 12 },
+            { @"13'ü", 13 },
+            { @"14'ü", 14 },
+            { @"15'i", 15 },
+            { @"16'sı", 16 },
+            { @"17'si", 17 },
+            { @"18'i", 18 },
+            { @"19'u", 19 },
+            { @"20'si", 20 },
+            { @"21'i", 21 },
+            { @"22'si", 22 },
+            { @"23'ü", 23 },
+            { @"24'ü", 24 },
+            { @"25'i", 25 },
+            { @"26'sı", 26 },
+            { @"27'si", 27 },
+            { @"28'i", 28 },
+            { @"29'u", 29 },
+            { @"30'u", 30 },
+            { @"31'i", 31 },
+            { @"01'i", 1 },
+            { @"02'si", 2 },
+            { @"03'ü", 3 },
+            { @"04'ü", 4 },
+            { @"05'i", 5 },
+            { @"06'sı", 6 },
+            { @"07'si", 7 },
+            { @"08'i", 8 },
+            { @"09'u", 9 }
         };
       public static readonly Dictionary<string, double> DoubleNumbers = new Dictionary<string, double>
         {
@@ -732,15 +782,24 @@ namespace Microsoft.Recognizers.Definitions.Turkish
         };
       public static readonly IList<string> SameDayTerms = new List<string>
         {
-            @"bugün"
+            @"bugün",
+            @"bugünden",
+            @"şu andan",
+            @"aynı gün"
         };
       public static readonly IList<string> PlusOneDayTerms = new List<string>
         {
-            @"yarın"
+            @"yarın",
+            @"yarından",
+            @"ertesi",
+            @"sonraki gün"
         };
       public static readonly IList<string> MinusOneDayTerms = new List<string>
         {
-            @"dün"
+            @"dün",
+            @"dünden",
+            @"önceki gün",
+            @"son gün"
         };
       public static readonly IList<string> PlusTwoDayTerms = new List<string>
         {
@@ -758,11 +817,13 @@ namespace Microsoft.Recognizers.Definitions.Turkish
         };
       public static readonly IList<string> LastCardinalTerms = new List<string>
         {
-            @"geçen"
+            @"geçen",
+            @"son"
         };
       public static readonly IList<string> MonthTerms = new List<string>
         {
-            @"ay"
+            @"ay",
+            @"ayın"
         };
       public static readonly IList<string> MonthToDateTerms = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
@@ -55,8 +55,9 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string NegativeAllIntRegexWithLocks = $@"((?<=\b){NegativeAllIntRegex}(?=\b))";
       public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((yarım\s+)?düzine)|({AllIntRegex}\s+düzine))(?=\b)";
       public const string RoundNumberOrdinalRegex = @"(yüzüncü|bininci|milyonuncu|milyarıncı|trilyonuncu)";
+      public const string NumberOrdinalRegex = @"(birinci|ilk|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu)";
       public const string TensOrdinalRegex = @"(onuncu|yirminci|otuzuncu|kırkıncı|ellinci|altmışıncı|yetmişinci|sekseninci|doksanıncı)";
-      public static readonly string OneToHundredOrdinalRegex = $@"(({TensNumberIntegerRegex}\s)?(birinci|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu)|{TensOrdinalRegex})";
+      public static readonly string OneToHundredOrdinalRegex = $@"(({TensNumberIntegerRegex}\s)?{NumberOrdinalRegex}|{TensOrdinalRegex})";
       public static readonly string HundredsOrdinalRegex = $@"(({TwoToNineIntegerRegex}\s)?(yüzüncü))";
       public static readonly string HundredToThousandOrdinalRegex = $@"({HundredsNumberIntegerRegex}\s{OneToHundredOrdinalRegex}|{HundredsOrdinalRegex})";
       public static readonly string ThousandsOrdinalRegex = $@"(({TwoToNineIntegerRegex}\s)?(bininci))";
@@ -69,11 +70,10 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string AboveTrillionOrdinalRegex = $@"({TrillionsNumberIntegerRegex}\s({OneToHundredOrdinalRegex}|{HundredToThousandOrdinalRegex}|{ThousandToMillionOrdinalRegex}|{MillionToBillionOrdinalRegex}|{BillionToTrillionOrdinalRegex})|{TrillionsOrdinalRegex})";
       public const string RelativeOrdinalRegex = @"((bir\s)?(sonraki|önceki)|sondan birinci|sondan bir önceki|sondan ikinci|(en\s)?son)";
       public static readonly string AllOrdinalRegex = $@"({OneToHundredOrdinalRegex}|{HundredToThousandOrdinalRegex}|{ThousandToMillionOrdinalRegex}|{MillionToBillionOrdinalRegex}|{BillionToTrillionOrdinalRegex}|{AboveTrillionOrdinalRegex})";
-      public const string OrdinalSuffixRegex = @"(?<=\b)((\d*(1(\.|'inci)|2(\.|'nci)|3(\.|'üncü)|4(\.|'üncü)|5(\.|'inci)|6(\.|'ıncı)|7(\.|'inci)|8(\.|'inci)|9(\.|'uncu))))(?=\b)";
-      public const string OrdinalTensSuffixRegex = @"(?<=\b)((\d*(10(\.|'uncu)|20(\.|'nci)|30(\.|'uncu)|40(\.|'ıncı)|50(\.|'inci)|60(\.|'ıncı)|70(\.|'inci)|80(\.|'inci)|90(\.|'ıncı))))(?=\b)";
-      public const string OrdinalRoundSuffixRegex = @"(?<=\b)((\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000(\.?000){2}(\.|'ıncı)|000(\.?000){2}\.?000(\.|'uncu))))(?=\b)";
-      public static readonly string OrdinalNumericRegex = $@"(?<=\b)({OrdinalSuffixRegex}|{OrdinalTensSuffixRegex}|{OrdinalRoundSuffixRegex})(?=\b)";
-      public static readonly string OrdinalTurkishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
+      public const string AllOrdinalSuffix = @"(onu(?=nda)?|yirmisi(?=nde)?|otuzu(?=nda)?|kırkı(?=nda)?|ellisi(?=nde)?|altmışı(?=nda)?|yetmişi(?=nde)?|sekseni(?=nde)?|doksanı(?=nda)?|((on|yirmi|otuz)\s+)?(biri(?=nde)?|ilk|ikisi(?=nde)?|üçü(?=nde)?|dördü(?=nde)?|beşi(?=nde)?|altısı(?=nda)?|yedisi(?=nde)?|sekizi(?=nde)?|dokuzu(?=nda)?))";
+      public const string OrdinalSuffixRegex = @"(?<=\b)(\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000\.?000\.?000(\.|'ıncı)|000\.?000\.?000\.?000(\.|'uncu)|10(\.|'uncu|'u(?=nda)?)|20(\.|'nci|'si(?=nde)?)|30(\.|'uncu|'u(?=nda)?)|40(\.|'ıncı|'ı(?=nda)?)|50(\.|'inci|'si(?=nde)?)|60(\.|'ıncı|'ı(?=nda)?)|70(\.|'inci|'i(?=nde)?)|80(\.|'inci|'i(?=nde)?)|90(\.|'ıncı|'ı(?=nda)?)|1(\.|'inci|'i(?=nde)?)|2(\.|'nci|'si(?=nde)?)|3(\.|'üncü|'ü(?=nde)?)|4(\.|'üncü|'ü(?=nde)?)|5(\.|'inci|'i(?=nde)?)|6(\.|'ıncı|'sı(?=nda)?)|7(\.|'inci|'si(?=nde)?)|8(\.|'inci|'i(?=nde)?)|9(\.|'uncu|'u(?=nda)?)))";
+      public const string OrdinalNumericRegex = @"(?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*('inci|'ıncı|'uncu|'üncü|'nci|'ncı))(?=\b)";
+      public static readonly string OrdinalTurkishRegex = $@"(?<=\b)({AllOrdinalRegex}(?=\b)|{AllOrdinalSuffix})";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s)?(buçuk|çeyrek|yarım))(?=\b)";
@@ -179,36 +179,46 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly Dictionary<string, long> OrdinalNumberMap = new Dictionary<string, long>
         {
             { @"birinci", 1 },
+            { @"biri", 1 },
+            { @"ilk", 1 },
             { @"ikinci", 2 },
+            { @"ikisi", 2 },
             { @"ikincil", 2 },
             { @"yarım", 2 },
             { @"buçuk", 2 },
             { @"üçüncü", 3 },
+            { @"üçü", 3 },
             { @"dördüncü", 4 },
+            { @"dördü", 4 },
             { @"çeyrek", 4 },
             { @"beşinci", 5 },
+            { @"beşi", 5 },
             { @"altıncı", 6 },
+            { @"altısı", 6 },
             { @"yedinci", 7 },
+            { @"yedisi", 7 },
             { @"sekizinci", 8 },
+            { @"sekizi", 8 },
             { @"dokuzuncu", 9 },
+            { @"dokuzu", 9 },
             { @"onuncu", 10 },
-            { @"on birinci", 11 },
-            { @"on ikinci", 12 },
-            { @"on üçüncü", 13 },
-            { @"on dördüncü", 14 },
-            { @"on beşinci", 15 },
-            { @"on altıncı", 16 },
-            { @"on yedinci", 17 },
-            { @"on sekizinci", 18 },
-            { @"on dokuzuncu", 19 },
+            { @"onu", 10 },
             { @"yirminci", 20 },
+            { @"yirmisi", 20 },
             { @"otuzuncu", 30 },
+            { @"otuzu", 30 },
             { @"kırkıncı", 40 },
+            { @"kırkı", 40 },
             { @"ellinci", 50 },
+            { @"ellisi", 50 },
             { @"altmışıncı", 60 },
+            { @"altmışı", 60 },
             { @"yetmişinci", 70 },
+            { @"yetmişi", 70 },
             { @"sekseninci", 80 },
+            { @"sekseni", 80 },
             { @"donsanıncı", 90 },
+            { @"doksanı", 90 },
             { @"yüzüncü", 100 },
             { @"bininci", 1000 },
             { @"milyonuncu", 1000000 },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -331,13 +331,23 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 // Get week day from text directly, compare it with the weekday generated above
                                 // to see whether they refer to the same week day
                                 var extractedWeekDayStr = matchCase.Groups["weekday"].Value;
-                                var matchLength = result.Start + result.Length - matchCase.Index;
+
+                                // calculate matchLength considering that matchCase can preceed or follow result
+                                var matchLength = matchCase.Index < result.Start ? result.Start + result.Length - matchCase.Index : matchCase.Index + matchCase.Length - result.Start;
 
                                 if (!date.Equals(DateObject.MinValue) &&
                                     numWeekDayInt == Config.DayOfWeek[extractedWeekDayStr] &&
                                     matchCase.Length == matchLength)
                                 {
-                                    ret.Add(new Token(matchCase.Index, result.Start + result.Length ?? 0));
+                                    if (matchCase.Index < result.Start)
+                                    {
+                                        ret.Add(new Token(matchCase.Index, result.Start + result.Length ?? 0));
+                                    }
+                                    else
+                                    {
+                                        ret.Add(new Token((int)result.Start, matchCase.Index + matchCase.Length));
+                                    }
+
                                     isFound = true;
                                 }
                             }
@@ -454,6 +464,16 @@ namespace Microsoft.Recognizers.Text.DateTime
             // Check whether there's a weekday
             var prefix = text.Substring(0, startIndex);
             var matchWeekDay = this.Config.WeekDayEnd.Match(prefix);
+
+            // Check for weekday in the suffix
+            if (!matchWeekDay.Success)
+            {
+                suffix = text.Substring(endIndex);
+                var weekDayStart = @"^\s*,?\s*" + this.Config.WeekDayRegex;
+                Regex weekDayStartRegex = new Regex(weekDayStart, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                matchWeekDay = weekDayStartRegex.Match(suffix);
+            }
+
             if (matchWeekDay.Success)
             {
                 // Get weekday from context directly, compare it with the weekday extraction above
@@ -466,7 +486,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     if (!date.Equals(DateObject.MinValue) && weekDay1 == weekDay2)
                     {
-                        startIndex = matchWeekDay.Index;
+                        if (matchWeekDay.Index < startIndex)
+                        {
+                            startIndex = matchWeekDay.Index;
+                        }
+                        else
+                        {
+                            endIndex += matchWeekDay.Length;
+                        }
                     }
                 }
             }

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -4,21 +4,22 @@ TillRegex: !simpleRegex
 RangeConnectorRegex : !simpleRegex
   def: (?<and>\b(ile|ila)\b|(-|—|——|–))
 RelativeRegex: !simpleRegex
-  def: \b(?<order>ertesi|bir sonraki|gelecek|bu|geçen|bir önceki|evvelki|önümüzdeki)\b
+  def: \b(?<order>ertesi|(bir\s+)?sonraki|gelecek|bu|geçen|son|aynı|(bir\s+)?önceki|evvelki|önümüzdeki)\b
 StrictRelativeRegex: !simpleRegex
-  def: \b(?<order>ertesi|bir sonraki|gelecek|bu|geçen|bir önceki|evvelki|önümüzdeki)\b
+  def: \b(?<order>ertesi|(bir\s+)?sonraki|gelecek|bu|geçen|son|aynı|(bir\s+)?önceki|evvelki|önümüzdeki)\b
 UpcomingPrefixRegex: !simpleRegex
   def: ((bu\s+)?(yaklaşan))
 NextPrefixRegex: !simpleRegex
-  def: \b(bir sonraki|gelecek|önümüzdeki)\b
+  def: \b(bir sonraki|gelecek|önümüzdeki|ertesi)\b
 # In Turkish, use of "after the next" requires a noun in between
 # e.g. "after the next week" translates to "gelecek haftadan sonra" ("week" is between "after" and "next")
 AfterNextSuffixRegex: !simpleRegex
   def: \b(after\s+(the\s+)?next)\b
 PastPrefixRegex: !simpleRegex
-  def: (geçen)\b
-PreviousPrefixRegex: !simpleRegex
-  def: (geçen|bir önceki|evvelki)\b
+  def: (son)\b
+PreviousPrefixRegex: !nestedRegex
+  def: (geçen|bir önceki|önceki|evvelki|{PastPrefixRegex})\b
+  references: [ PastPrefixRegex ]
 ThisPrefixRegex: !simpleRegex
   def: (bu|şimdiki)\b
 # Note that RangePrefixRegex is actually used as a suffix in Turkish
@@ -31,19 +32,13 @@ ReferencePrefixRegex: !simpleRegex
 FutureSuffixRegex: !simpleRegex
   def: \b(ileride|gelecekte)\b
 DayRegex: !simpleRegex
-  def: (?<day>(10|20|30|(1|2|3)1|(1|2)2|(1|2)3|(1|2)4|(1|2)5|(1|2)6|(1|2)7|(1|2)8|(1|2)9|1|2|3|4|5|6|7|8|9))
-WrittenDayRegex: !simpleRegex
-  def: (((on|yirmi)\s)?(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz)|on|yirmi|otuz bir|otuz)
+  def: (?<day>(10|20|30|31|(1|2)[1-9]|0?[1-9])('i|'si|'sı|'ü|'u)?)
 ImplicitDayRegex: !simpleRegex
-  def: (?<day>(10'uncu|20'nci|30'uncu|(1|2|3)1'inci|(1|2)2'nci|(1|2)3'üncü|(1|2)4'üncü|(1|2)5'inci|(1|2)6'ncı|(1|2)7'nci|(1|2)8'inci|(1|2)9'uncu))
-DaySuffixRegex: !simpleRegex
-  def: (?<day>(1|5|8|11|15|18|21|25|28|31)'i|(2|7|12|17|20|22|27)'si|(3|4|13|14|23|24)'ü|(6|16|26)'sı|(9|10|19|29|30)'u)
+  def: (?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=\b)
 DayFromSuffixRegex: !simpleRegex
   def: (?<day>(1|5|8|11|15|18|21|25|28|31)'inden|(2|7|12|17|20|22|27)'sinden|(3|4|13|14|23|24)'ünden|(6|16|26)'sından|(9|10|19|29|30)'undan)
 DayToSuffixRegex: !simpleRegex
   def: (?<day>(1|5|8|11|15|18|21|25|28|31)'ine|(2|7|12|17|20|22|27)'sine|(3|4|13|14|23|24)'üne|(6|16|26)'sına|(9|10|19|29|30)'una)
-WrittenDayAtSuffixRegex: !simpleRegex
-  def: (((on|yirmi)\s)?(biri(nde)?|ikisi(nde)?|üçü(nde)?|dördü(nde)?|beşi(nde)?|altısı(nda)?|yedisi(nde)?|sekizi(nde)?|dokuzu(nda)?)|onu(nda)?|yirmisi(nde)?|otuzu(nda)?|otuz biri(nde)?)
 MonthNumRegex: !simpleRegex
   def: (?<month>1[0-2]|(0)?[1-9])\b
 WrittenOneToNineRegex: !simpleRegex
@@ -68,7 +63,7 @@ LastTwoYearNumRegex: !nestedRegex
   def: (sıfır\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
 FullTextYearRegex: !nestedRegex
-  def: \b(({WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+{WrittenCenturyOrdinalYearRegex}|{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}|(iki\s+)?bin)\b
+  def: \b((?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+(?<lasttwoyearnum>{WrittenCenturyOrdinalYearRegex})|(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|(iki\s+)?bin)|(?<lasttwoyearnum>{WrittenCenturyOrdinalYearRegex}))
   references: [ WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex ]
 FullTextAtYearRegex: !nestedRegex
   def: \b((({WrittenCenturyFullYearRegex}|(iki\s+)?bin)\s+)?(((on|yirmi|otuz|kırk|elli|altmış|yetmiş|seksen|doksan)\s+)?(birde|ikide|üçte|dörtte|beşte|altıda|yedide|sekizde|dokuzda)|onda|yirmide|otuzda|kırkta|ellide|altmışta|yetmişte|seksende|doksanda)|{WrittenCenturyFullYearRegex}de|(iki\s)?binde)\b
@@ -97,11 +92,13 @@ YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
 WeekDayRegex: !simpleRegex
-  def: \b(?<weekday>pazartesi(leri)?|salı(ları)?|çarşamba(ları)?|perşembe(leri)?|cuma(ları)?|cumartesi(leri)?|pazar(ları)?|pzt|sal|çrş|per|cum|cmt|paz)\b
+  def: \b(?<weekday>pazartesi(leri|si)?|salı(ları|sı)?|çarşamba(ları|sı)?|perşembe(leri|si)?|cuma(ları|sı)?|cumartesi(leri|si)?|pazar(ları|ı)?|pzt|sal|çrş|per|cum|cmt|paz)(\s+günü)?\b
 SingleWeekDayRegex: !simpleRegex
   def: \b(?<weekday>pazartesi|salı|çarşamba|perşembe|cuma|cumartesi|pazar|pzt|sal|çrş|per|cum|cmt|paz)\b
+MonthRegex: !simpleRegex
+  def: (?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)
 RelativeMonthRegex: !nestedRegex
-  def: (?<relmonth>{RelativeRegex}\s+ay)\b
+  def: (?<relmonth>{RelativeRegex}\s+(ayın|ay))\b
   references: [RelativeRegex]
 WrittenMonthRegex: !simpleRegex
   def: (?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)(\s+ayı)?
@@ -111,12 +108,12 @@ MonthSuffixRegex: !nestedRegex
 ProperMonthSuffixRegex: !simpleRegex
   def: (?<msuf>(ocak|şubat|mart|mayıs|ağustos|aralık)('ta)|(nisan|haziran|temmuz|kasım)('da)|(eylül|ekim)('de))
 MonthPossessiveSuffixRegex: !nestedRegex
-  def: (?<msuf>((ocak|şubat|mart|nisan|mayıs|haziran|kasım|aralık)('ın)|(temmuz|ağustos)('un)|eylül'ün|ekim'in|{MonthRegex}(\sayının)|{RelativeRegex}\sayın))
-  references: [ MonthRegex, RelativeRegex ]
+  def: ((?<month>(ocak|şubat|mart|nisan|mayıs|haziran|kasım|aralık)('ın)|(temmuz|ağustos)('un)|eylül'ün|ekim'in)|{MonthRegex}(\s+ayının)|{RelativeMonthRegex})
+  references: [ MonthRegex, RelativeMonthRegex ]
 MonthToSuffixRegex: !simpleRegex
   def: (?<msuf>((ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|kasım|aralık)'a|(eylül|ekim)'e))
 DateUnitRegex: !simpleRegex
-  def: (?<unit>yıl|ay|hafta|gün)\b
+  def: (?<unit>yıl|ay|hafta|(?<business>iş\s+)günü|gün)\b
 # DateTokenPrefix, TimeTokenPrefix, TokenBeforeDate, TokenBeforeTime are not localized since there is no counterpart
 DateTokenPrefix: 'on '
 TimeTokenPrefix: 'at '
@@ -138,7 +135,7 @@ MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\s|,?){YearRegex})|({RelativeRegex}\s(yıl|sene)|seneye)\s{WrittenMonthRegex}(\s+ayı)?)\b
   references: [ WrittenMonthRegex, YearRegex, RelativeRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b(({RelativeRegex}\s+)?{WrittenMonthRegex}\s+ayı|(ay|ayın|sene)|({NextPrefixRegex}\s+)?{WrittenMonthRegex}\s+ayı)\b
+  def: \b(({RelativeRegex}\s+)?{WrittenMonthRegex}\s+ayı|({NextPrefixRegex}\s+)?{WrittenMonthRegex}\s+ayı)\b
   references: [ RelativeRegex, WrittenMonthRegex, NextPrefixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b({MonthNumRegex}(\s*)[/\-\.](\s*){BaseDateTime.FourDigitYearRegex})\b
@@ -205,11 +202,9 @@ WeekOfRegex: !simpleRegex
   def: (haftası)
 MonthOfRegex: !simpleRegex
   def: (ayı)
-MonthRegex: !simpleRegex
-  def: (?<month>ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık|oca|şub|mar|nis|may|haz|eyl|eki|kas|ara)
 # Cases collected from mined data. Regex to be removed once all platforms move to AmbiguityFiltersDict. 
 AmbiguousMonthP0Regex: !simpleRegex
-  def: ^[\*]
+  def: \b(bir\s+ara)\b
 # This is a look-behind assertion. Some cases should extract two digits as year like 11/25/16, where 16 means 2016. 
 # The assertion determines if not connected with am/pm or hour separator (:), which should be a time.
 DateYearRegex: !nestedRegex
@@ -219,25 +214,25 @@ YearSuffix: !nestedRegex
   def: (,?\s*({DateYearRegex}|{FullTextYearRegex}))
   references: [ DateYearRegex, FullTextYearRegex ]
 OnRegex: !simpleRegex
-  def: (?<day>(1|5|8|11|15|18|21|25|28|31)'inde|(2|7|12|17|20|22|27)'sinde|(3|4|13|14|23|24)'ünde|(6|16|26)'sında|(9|10|19|29|30)'unda)\b
+  def: ^[\*]
 RelaxedOnRegex: !simpleRegex
-  def: (?<day>(11|15|18|21|25|28|31)'inde|(12|17|20|22|27)'sinde|(13|14|23|24)'ünde|(16|26)'sında|(10|19|29|30)'unda)\b
+  def: (?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=(nde|nda))\b
 PrefixWeekDayRegex: !simpleRegex
   def: (\s*[-—–])
 ThisRegex: !nestedRegex
-  def: \b(bu(\s+hafta)?\s+{WeekDayRegex}(\s+günü)?)\b
+  def: \b(bu(\s+hafta)?\s+{WeekDayRegex})\b
   references: [ WeekDayRegex ]
 LastDateRegex: !nestedRegex
-  def: \b({PreviousPrefixRegex}(\s+hafta)?\s+{WeekDayRegex}(\s+günü)?)\b
+  def: \b({PreviousPrefixRegex}(\s+hafta)?\s+{WeekDayRegex})\b
   references: [ PreviousPrefixRegex, WeekDayRegex ]
 NextDateRegex: !nestedRegex
-  def: \b(({NextPrefixRegex}(\s+hafta)?|haftaya)\s+{WeekDayRegex}(\s+günü)?)\b
+  def: \b(({NextPrefixRegex}(\s+hafta)?|haftaya)\s+{WeekDayRegex})\b
   references: [ NextPrefixRegex, WeekDayRegex ]
 SpecialDayRegex: !nestedRegex
-  def: \b((dünden önceki|yarından sonraki)\s+gün|(önceki|sonraki)\s+gün|{RelativeRegex}\s+gün|dün|yarın|bugün)\b
+  def: \b((dünden önceki|yarından sonraki)\s+gün|(önceki|sonraki)\s+gün|{RelativeRegex}\s+gün|(benim\s+)?günüm|dün(den)?|yarın(dan)?|bugün)\b
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
-  def: \b((?<day>dünden|yarından|bugünden)\s+(?<number>{WrittenNumRegex})\s+gün\s+sonra)\b
+  def: \b((?<day>dünden|yarından|bugünden|şu andan)\s+(itibaren\s+)?(?<number>{WrittenNumRegex})\s+gün\s+(sonra|içinde))\b
   references: [ WrittenNumRegex ]
 RelativeDayRegex: !nestedRegex
   def: \b({RelativeRegex}\s+gün)\b
@@ -245,10 +240,10 @@ RelativeDayRegex: !nestedRegex
 SetWeekDayRegex: !simpleRegex
   def: \b(?<weekday>sabahları|öğlenleri|akşamları|geceleri|pazartesileri|salıları|çarşambaları|perşembeleri|cumaları|cumartesileri|pazarları)\b
 WeekDayOfMonthRegex: !nestedRegex
-  def: (?<wom>({MonthPossessiveSuffixRegex}|{WrittenMonthRegex}\s+ayının|{RelativeRegex}\s+ayın)\s+(?<cardinal>birinci|1'inci|1.|ilk|ikinci|2'nci|2.|üçüncü|3'üncü|3.|dördüncü|4'üncü|4.|beşinci|5'inci|5.|son)\s+{WeekDayRegex}(\s+günü)?)
+  def: (?<wom>({MonthPossessiveSuffixRegex}|{WrittenMonthRegex}\s+ayının|{RelativeRegex}\s+ayın)\s+(?<cardinal>birinci|1'inci|1.|ilk|ikinci|2'nci|2.|üçüncü|3'üncü|3.|dördüncü|4'üncü|4.|beşinci|5'inci|5.|son)\s+{WeekDayRegex})
   references: [ MonthPossessiveSuffixRegex, WrittenMonthRegex, WeekDayRegex, RelativeRegex ]
 RelativeWeekDayRegex: !nestedRegex
-  def: \b({WrittenNumRegex}\s+{WeekDayRegex}\s+(sonra))\b
+  def: \b((şu\s+andan\s+itibaren\s+)?{WrittenNumRegex}\s+{WeekDayRegex}\s+(sonra))\b
   references: [ WrittenNumRegex, WeekDayRegex ]
 SpecialDate: !nestedRegex
   def: \b{DayRegex}\s+günü\b
@@ -259,11 +254,11 @@ DateExtractorYearTermRegex: !nestedRegex
   def: (\s+|\s*,\s*){DateYearRegex}
   references: [ DateYearRegex ]
 DateExtractor1: !nestedRegex
-  def: \b(({DayRegex}|{WrittenDayRegex})\s+{MonthRegex}(\s+{FullTextAtYearRegex})|(({DayRegex}|{WrittenDayRegex})\s+{MonthRegex}(\s+({DateYearRegex}|{YearRegex}))?)((\s*\(\s*{SingleWeekDayRegex}\s*\))|\s*,?\s+{SingleWeekDayRegex}(\s+günü)?)?)
-  references: [ SingleWeekDayRegex, DayRegex, WrittenDayRegex, MonthRegex, DateYearRegex, YearRegex, FullTextAtYearRegex ]
+  def: \b(({DayRegex}\s+{MonthRegex}(\s+{DateYearRegex})?)((\s*\(\s*{SingleWeekDayRegex}\s*\))|\s*,?\s+{SingleWeekDayRegex}(\s+günü)?)?)
+  references: [ SingleWeekDayRegex, DayRegex, MonthRegex, DateYearRegex ]
 DateExtractor3: !nestedRegex
-  def: \b(({RelativeRegex}\s+ayın\s+)?({WrittenDayAtSuffixRegex}|{OnRegex}|{DaySuffixRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b
-  references: [ RelativeRegex, WrittenDayAtSuffixRegex, OnRegex, DaySuffixRegex, SingleWeekDayRegex ]
+  def: \b(({RelativeRegex}\s+ayın\s+)?({OnRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b
+  references: [ RelativeRegex, OnRegex, SingleWeekDayRegex ]
 DateExtractor4: !nestedRegex
   def: \b(({RelativeRegex}\s+)?({SingleWeekDayRegex}\s+(günü\s+)?)?(\({DayRegex}\s+{MonthRegex}(\s+{DateYearRegex})?\)|(\s*,\s*)?{DayRegex}\s+{MonthToSuffixRegex}))\b
   references: [ RelativeRegex, DayRegex, SingleWeekDayRegex, MonthRegex, DateYearRegex, MonthToSuffixRegex ]
@@ -274,14 +269,13 @@ DateExtractor6: !nestedRegex
   def: ({RelativeRegex}\s+)?({SingleWeekDayRegex}\s+)?(\({DayRegex}\s*[/\\.]\s*{MonthNumRegex}\s*[/\\.]\s*{DateYearRegex}\))\b
   references: [ RelativeRegex, DayRegex, MonthNumRegex, SingleWeekDayRegex, DateYearRegex ]
 DateExtractor7: !nestedRegex
-  def: \b(({DayRegex}|{WrittenDayRegex})\s+{ProperMonthSuffixRegex})\b
-  references: [ DayRegex, WrittenDayRegex, ProperMonthSuffixRegex ]
-DateExtractor8: !nestedRegex
-  def: \b(({YearRegex}\s+yılı\s+)?({MonthPossessiveSuffixRegex})\s+({WrittenDayAtSuffixRegex}|{OnRegex}|{DaySuffixRegex})(\s*\(\s*{SingleWeekDayRegex}\s*\))?)\b
-  references: [ YearRegex, MonthPossessiveSuffixRegex, WrittenDayAtSuffixRegex, OnRegex, DaySuffixRegex, SingleWeekDayRegex ]
+  def: \b(({DayRegex})\s+{ProperMonthSuffixRegex})\b
+  references: [ DayRegex, ProperMonthSuffixRegex ]
+DateExtractor8: !simpleRegex
+  def: ^[\*]
 DateExtractor9: !nestedRegex
-  def: \b((ayın\s+)?{DaySuffixRegex}\s+{SingleWeekDayRegex}(\s+günü)?)
-  references: [ DaySuffixRegex, SingleWeekDayRegex ]
+  def: \b({SingleWeekDayRegex}\s+{OnRegex})\b
+  references: [ SingleWeekDayRegex, OnRegex ]
 DateExtractor7L: !simpleRegex
   def: ^[\*]
 DateExtractor7S: !simpleRegex
@@ -293,11 +287,11 @@ DateExtractor9S: !simpleRegex
 DateExtractorA: !simpleRegex
   def: ^[\*]
 OfMonth: !nestedRegex
-  def: ^{MonthRegex}\s*ayının
+  def: ^\s*{MonthRegex}
   references: [ MonthRegex ]
 MonthEnd: !nestedRegex
-  def: '{MonthRegex}\s*(ayı)?\s*$'
-  references: [ MonthRegex ]
+  def: '{MonthPossessiveSuffixRegex}\s*$'
+  references: [ MonthPossessiveSuffixRegex ]
 WeekDayEnd: !nestedRegex
   def: '(bu\s+)?{WeekDayRegex}\s*,?\s*$'
   references: [ WeekDayRegex ]
@@ -462,7 +456,7 @@ SuffixAfterRegex: !simpleRegex
 PrepositionRegex: !simpleRegex
   def: ^[\*]
 TimeOfDayRegex: !simpleRegex
-  def: \b(?<timeOfDay>((sabahın|öğlenin|akşamın|gecenin|günün|mesainin)\s+((erken|geç)\s(saatinde|saatlerinde))))\b
+  def: \b(?<timeOfDay>((sabahın|öğlenin|akşamın|gecenin|günün|mesainin)\s+((erken|geç)\s(saatinde|saatlerinde))|iş\s+saati(nde)?|mesai(de)?))\b
 SpecificTimeOfDayRegex: !nestedRegex
   def: \b(({RelativeRegex}\s+{TimeOfDayRegex})\b|\bbu\s(sabah|akşam|gece))\b
   references: [ TimeOfDayRegex, RelativeRegex ]
@@ -472,7 +466,7 @@ TimeFollowedUnit: !nestedRegex
 TimeNumberCombinedWithUnit: !nestedRegex
   def: \b(?<num>\d+(\.\d*)?){TimeUnitRegex}
   references: [ TimeUnitRegex ]
-BusinessHourSplitStrings: ['mesai']
+BusinessHourSplitStrings: ['iş', 'saati', 'saatinde', 'mesai', 'mesaide']
 NowRegex: !simpleRegex
   def: \b(?<now>(hemen\s+)?şimdi|en kısa\s(sürede|zamanda)|ilk fırsatta|bir an\s(önce|evvel)|hemen|vakit geçirmeden|(mümkün olduğunca|olabildiğince)\sçabuk|son\s(dönemlerde|zamanlarda|günlerde)|geçenlerde|yakınlarda|(bu|şu)\sıralar|yakın zamanda|(bu|şu|son)\sgünlerde|önceden|evvelce|bundan önce|daha önce)\b
 SuffixRegex: !simpleRegex
@@ -527,7 +521,7 @@ EachPrefixRegex: !simpleRegex
 SetEachRegex: !simpleRegex
   def: \b(?<each>(her)\s*)
 SetLastRegex: !simpleRegex
-  def: (?<last>izleyen|sonraki|ertesi|gelecek|bu|geçen|son|önceki|evvelsi|şimdiki)
+  def: (?<last>izleyen|bir sonraki|sonraki|ertesi|gelecek|bu|geçen|son|önceki|evvelsi|şimdiki)
 EachDayRegex: !simpleRegex
   def: ^\s*her\s*gün\b
 DurationFollowedUnit: !nestedRegex
@@ -576,9 +570,9 @@ SinceRegex: !simpleRegex
 AroundRegex: !simpleRegex
   def: (\b(takriben|yaklaşık)\s*|\s*(civarında|civarı|dolaylarında)\b)
 AgoRegex: !simpleRegex
-  def: \b(önce|(?<day>dünden|bugünden)\s+(önce|evvel))\b
+  def: \b(önce|evvel)\b
 LaterRegex: !simpleRegex
-  def: \b(sonra|(?<day>yarından|bugünden)\s+(itibaren|sonra)|bugünden\s+\d+\s+(gün|hafta|ay|yıl)(\s+sonra)?|yarından\s+itibaren\s+\d+\s+(gün|hafta|ay|yıl)(\s+sonra)?)\b
+  def: \b(sonra|içinde|(?<day>yarından|bugünden)\s+(itibaren|sonra)|şu andan itibaren)\b
 InConnectorRegex: !simpleRegex
   def: ^[\*]
 SinceNumSuffixRegex: !simpleRegex
@@ -619,7 +613,7 @@ RelativeAtDateTimeUnitRegex: !nestedRegex
   def: (({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({AtDateTimeUnitRegex}))
   references: [NextPrefixRegex, PreviousPrefixRegex, ThisPrefixRegex, AtDateTimeUnitRegex]
 SingleAmbiguousMonthRegex: !simpleRegex
-  def: ^(the\s+)?(ocak|mayıs|ekim|aralık)$
+  def: ^(ocak|mayıs|ekim|aralık|tem|ara)$
 # Filter ambiguous single word datetime extractions in CalendarMode or when adding the modifier
 SingleAmbiguousTermsRegex: !simpleRegex
   def: ^(gün|hafta|ay|yıl)$
@@ -627,17 +621,23 @@ UnspecificDatePeriodRegex: !simpleRegex
   def: ^(gün|hafta sonu|hafta|ay|yıl)$
 PrepositionSuffixRegex: !simpleRegex
   def: ^[\*]
-FlexibleDayRegex: !simpleRegex
-  def: (?<DayOfMonth>[A-Za-z\d]+(\s([A-Za-z]+))?)
+WrittenDayRegex: !simpleRegex
+  def: (?<day>bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|on|on\s+bir|on\s+iki|on\s+üç|on\s+dört|on\s+beş|on\s+altı|on\s+yedi|on\s+sekiz|on\s+dokuz|yirmi|yirmi\s+bir|yirmi\s+iki|yirmi\s+üç|yirmi\s+dört|yirmi\s+beş|yirmi\s+altı|yirmi\s+yedi|yirmi\s+sekiz|yirmi\s+dokuz|otuz|otuz\s+bir)
+FlexibleDayRegex: !nestedRegex
+  def: (?<DayOfMonth>({WrittenDayRegex}|{DayRegex}))
+  references: [WrittenDayRegex, DayRegex ]
 ForTheRegex: !nestedRegex
-  def: \b(({FlexibleDayRegex})(?=(')))
-  references: [FlexibleDayRegex]
+  def: \b(?<!{SingleWeekDayRegex}\s+)(?<DayOfMonth>{FlexibleDayRegex}((?=((')(?!(ın|un|in|si|i|nci)\b)))|(?='ü)|'?(i|ü|si)(?=nde)|(?='(ı|u))|'?(ı|u|sı)(?=nda)))
+  references: [ FlexibleDayRegex, SingleWeekDayRegex ]
+ForTheRegex1: !nestedRegex
+  def: \b(?<DayOfMonth>({FlexibleDayRegex})((?=('))|(i|ü|si)(?=nde)|(ı|u|sı)(?=nda)|(?=(i|ü|ı|u|si|sı)\b)))
+  references: [ FlexibleDayRegex ]
 WeekDayAndDayOfMonthRegex: !nestedRegex
-  def: \b({FlexibleDayRegex}\s{WeekDayRegex})\b
-  references: [WeekDayRegex, FlexibleDayRegex]
+  def: \b({SingleWeekDayRegex}\s+{ForTheRegex1}|(?<DayOfMonth>({FlexibleDayRegex}))\s+{SingleWeekDayRegex})
+  references: [ SingleWeekDayRegex, ForTheRegex1, FlexibleDayRegex ]
 WeekDayAndDayRegex: !nestedRegex
-  def: \b{WeekDayRegex}\s+{DayRegex}\b
-  references: [WeekDayRegex, DayRegex]
+  def: \b{SingleWeekDayRegex}\s+({DayRegex}|{FlexibleDayRegex})(?=(nde|nda))
+  references: [ SingleWeekDayRegex, DayRegex, FlexibleDayRegex ]
 RestOfDateRegex: !simpleRegex
   def: \b(((bu\s)?(haftanın|ayın|yılın)|haftamın|ayımın|yılımın)\s+(geri kalanı))\b
 RestOfDateTimeRegex: !simpleRegex
@@ -713,6 +713,7 @@ UnitMap: !dictionary
     yıl: Y
     yıllar: Y
     ay: MO
+    ayın: MO
     aylar: MO
     hafta: W
     haftalar: W
@@ -736,10 +737,12 @@ UnitValueMap: !dictionary
     yıllar: 31536000
     ay: 2592000
     aylar: 2592000
+    ayın: 2592000
     hafta: 604800
     haftalar: 604800
     gün: 86400
     günler: 86400
+    günü: 86400
     saat: 3600
     saatler: 3600
     sa.: 3600
@@ -773,6 +776,7 @@ SeasonValueMap: !dictionary
 CardinalMap: !dictionary
   types: [ string, int]
   entries:
+    ilk: 1
     birinci: 1
     1''inci: 1
     1.: 1
@@ -792,12 +796,19 @@ DayOfWeek: !dictionary
   types: [ string, int ]
   entries: 
     pazartesi: 1
+    pazartesisi: 1
     salı: 2
+    salısı: 2
     çarşamba: 3
+    çarşambası: 3
     perşembe: 4
+    perşembesi: 4
     cuma: 5
+    cuması: 5
     cumartesi: 6
+    cumartesisi: 6
     pazar: 0
+    pazarı: 0
     pzt: 1
     sal: 2
     çrş: 3
@@ -805,21 +816,52 @@ DayOfWeek: !dictionary
     cum: 5
     cts: 6
     paz: 0
+    monday: 1
+    tuesday: 2
+    wednesday: 3
+    thursday: 4
+    friday: 5
+    saturday: 6
+    sunday: 0
+    mon: 1
+    tue: 2
+    tues: 2
+    wed: 3
+    wedn: 3
+    weds: 3
+    thu: 4
+    thur: 4
+    thurs: 4
+    fri: 5
+    sat: 6
+    sun: 0
 MonthOfYear: !dictionary
   types: [ string, int ]
   entries:
     'ocak': 1
+    'ocak''ın': 1
     'şubat': 2
+    'şubat''ın': 2
     'mart': 3
+    'mart''ın': 3
     'nisan': 4
+    'nisan''ın': 4
     'mayıs': 5
+    'mayıs''ın': 5
     'haziran': 6
+    'haziran''ın': 6
     'temmuz': 7
+    'temmuz''un': 7
     'ağustos': 8
+    'ağustos''un': 8
     'eylül': 9
+    'eylül''ün': 9
     'ekim': 10
+    'ekim''in': 10
     'kasım': 11
+    'kasım''ın': 11
     'aralık': 12
+    'aralık''ın': 12
     'oca': 1
     'şub': 2
     'mar': 3
@@ -960,37 +1002,46 @@ Numbers: !dictionary
 DayOfMonth: !dictionary
   types: [ string, int ]
   entries:
-    '1': 1
-    '2': 2
-    '3': 3
-    '4': 4
-    '5': 5
-    '6': 6
-    '7': 7
-    '8': 8
-    '9': 9
-    '10': 10
-    '11': 11
-    '12': 12
-    '13': 13
-    '14': 14
-    '15': 15
-    '16': 16
-    '17': 17
-    '18': 18
-    '19': 19
-    '20': 20
-    '21': 21
-    '22': 22
-    '23': 23
-    '24': 24
-    '25': 25
-    '26': 26
-    '27': 27
-    '28': 28
-    '29': 29
-    '30': 30
-    '31': 31
+    '1''i': 1
+    '2''si': 2
+    '3''ü': 3
+    '4''ü': 4
+    '5''i': 5
+    '6''sı': 6
+    '7''si': 7
+    '8''i': 8
+    '9''u': 9
+    '10''u': 10
+    '11''i': 11
+    '12''si': 12
+    '13''ü': 13
+    '14''ü': 14
+    '15''i': 15
+    '16''sı': 16
+    '17''si': 17
+    '18''i': 18
+    '19''u': 19
+    '20''si': 20
+    '21''i': 21
+    '22''si': 22
+    '23''ü': 23
+    '24''ü': 24
+    '25''i': 25
+    '26''sı': 26
+    '27''si': 27
+    '28''i': 28
+    '29''u': 29
+    '30''u': 30
+    '31''i': 31
+    '01''i': 1
+    '02''si': 2
+    '03''ü': 3
+    '04''ü': 4
+    '05''i': 5
+    '06''sı': 6
+    '07''si': 7
+    '08''i': 8
+    '09''u': 9
 DoubleNumbers: !dictionary
   types: [ string, double ]
   entries: 
@@ -1137,14 +1188,23 @@ SameDayTerms: !list
   types: [ string ]
   entries: 
     - bugün
+    - bugünden
+    - şu andan
+    - aynı gün
 PlusOneDayTerms: !list
   types: [ string ]
   entries: 
     - yarın
+    - yarından
+    - ertesi
+    - sonraki gün
 MinusOneDayTerms: !list
   types: [ string ]
   entries: 
     - dün
+    - dünden
+    - önceki gün
+    - son gün
 PlusTwoDayTerms: !list
   types: [ string ]
   entries: 
@@ -1164,10 +1224,12 @@ LastCardinalTerms: !list
   types: [ string ]
   entries:
     - geçen
+    - son
 MonthTerms: !list
   types: [ string ]
   entries:
     - ay
+    - ayın
 MonthToDateTerms: !list
   types: [ string ]
   entries:

--- a/Patterns/Turkish/Turkish-Numbers.yaml
+++ b/Patterns/Turkish/Turkish-Numbers.yaml
@@ -86,11 +86,13 @@ AllIntRegexWithDozenSuffixLocks: !nestedRegex
 # Ordinal Regex
 RoundNumberOrdinalRegex: !simpleRegex
   def: (yüzüncü|bininci|milyonuncu|milyarıncı|trilyonuncu)
+NumberOrdinalRegex: !simpleRegex
+  def: (birinci|ilk|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu)
 TensOrdinalRegex: !simpleRegex
   def: (onuncu|yirminci|otuzuncu|kırkıncı|ellinci|altmışıncı|yetmişinci|sekseninci|doksanıncı)
 OneToHundredOrdinalRegex: !nestedRegex
-  def: (({TensNumberIntegerRegex}\s)?(birinci|ikinci|üçüncü|dördüncü|beşinci|altıncı|yedinci|sekizinci|dokuzuncu)|{TensOrdinalRegex})
-  references: [TensNumberIntegerRegex, TensOrdinalRegex]
+  def: (({TensNumberIntegerRegex}\s)?{NumberOrdinalRegex}|{TensOrdinalRegex})
+  references: [TensNumberIntegerRegex, NumberOrdinalRegex, TensOrdinalRegex]
 HundredsOrdinalRegex: !nestedRegex
   def: (({TwoToNineIntegerRegex}\s)?(yüzüncü))
   references: [TwoToNineIntegerRegex]
@@ -126,18 +128,15 @@ RelativeOrdinalRegex: !simpleRegex
 AllOrdinalRegex: !nestedRegex
   def: ({OneToHundredOrdinalRegex}|{HundredToThousandOrdinalRegex}|{ThousandToMillionOrdinalRegex}|{MillionToBillionOrdinalRegex}|{BillionToTrillionOrdinalRegex}|{AboveTrillionOrdinalRegex})
   references: [OneToHundredOrdinalRegex, HundredToThousandOrdinalRegex, ThousandToMillionOrdinalRegex, MillionToBillionOrdinalRegex, BillionToTrillionOrdinalRegex, AboveTrillionOrdinalRegex]
+AllOrdinalSuffix: !simpleRegex
+  def: (onu(?=nda)?|yirmisi(?=nde)?|otuzu(?=nda)?|kırkı(?=nda)?|ellisi(?=nde)?|altmışı(?=nda)?|yetmişi(?=nde)?|sekseni(?=nde)?|doksanı(?=nda)?|((on|yirmi|otuz)\s+)?(biri(?=nde)?|ilk|ikisi(?=nde)?|üçü(?=nde)?|dördü(?=nde)?|beşi(?=nde)?|altısı(?=nda)?|yedisi(?=nde)?|sekizi(?=nde)?|dokuzu(?=nda)?))
 OrdinalSuffixRegex: !simpleRegex
-  def: (?<=\b)((\d*(1(\.|'inci)|2(\.|'nci)|3(\.|'üncü)|4(\.|'üncü)|5(\.|'inci)|6(\.|'ıncı)|7(\.|'inci)|8(\.|'inci)|9(\.|'uncu))))(?=\b)
-OrdinalTensSuffixRegex: !simpleRegex
-  def: (?<=\b)((\d*(10(\.|'uncu)|20(\.|'nci)|30(\.|'uncu)|40(\.|'ıncı)|50(\.|'inci)|60(\.|'ıncı)|70(\.|'inci)|80(\.|'inci)|90(\.|'ıncı))))(?=\b)
-OrdinalRoundSuffixRegex: !simpleRegex
-  def: (?<=\b)((\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000(\.?000){2}(\.|'ıncı)|000(\.?000){2}\.?000(\.|'uncu))))(?=\b)
-OrdinalNumericRegex: !nestedRegex
-  def: (?<=\b)({OrdinalSuffixRegex}|{OrdinalTensSuffixRegex}|{OrdinalRoundSuffixRegex})(?=\b)
-  references: [ OrdinalSuffixRegex, OrdinalTensSuffixRegex, OrdinalRoundSuffixRegex ]
+  def: (?<=\b)(\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000\.?000\.?000(\.|'ıncı)|000\.?000\.?000\.?000(\.|'uncu)|10(\.|'uncu|'u(?=nda)?)|20(\.|'nci|'si(?=nde)?)|30(\.|'uncu|'u(?=nda)?)|40(\.|'ıncı|'ı(?=nda)?)|50(\.|'inci|'si(?=nde)?)|60(\.|'ıncı|'ı(?=nda)?)|70(\.|'inci|'i(?=nde)?)|80(\.|'inci|'i(?=nde)?)|90(\.|'ıncı|'ı(?=nda)?)|1(\.|'inci|'i(?=nde)?)|2(\.|'nci|'si(?=nde)?)|3(\.|'üncü|'ü(?=nde)?)|4(\.|'üncü|'ü(?=nde)?)|5(\.|'inci|'i(?=nde)?)|6(\.|'ıncı|'sı(?=nda)?)|7(\.|'inci|'si(?=nde)?)|8(\.|'inci|'i(?=nde)?)|9(\.|'uncu|'u(?=nda)?)))
+OrdinalNumericRegex: !simpleRegex
+  def: (?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*('inci|'ıncı|'uncu|'üncü|'nci|'ncı))(?=\b)
 OrdinalTurkishRegex: !nestedRegex
-  def: (?<=\b){AllOrdinalRegex}(?=\b)
-  references: [ AllOrdinalRegex ]
+  def: (?<=\b)({AllOrdinalRegex}(?=\b)|{AllOrdinalSuffix})
+  references: [ AllOrdinalRegex, AllOrdinalSuffix ]
 # Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
@@ -322,36 +321,46 @@ OrdinalNumberMap: !dictionary
   types: [ string, long ]
   entries:
     birinci: 1
+    biri: 1
+    ilk: 1
     ikinci: 2
+    ikisi: 2
     ikincil: 2
     yarım: 2
     buçuk: 2
     üçüncü: 3
+    üçü: 3
     dördüncü: 4
+    dördü: 4
     çeyrek: 4
     beşinci: 5
+    beşi: 5
     altıncı: 6
+    altısı: 6
     yedinci: 7
+    yedisi: 7
     sekizinci: 8
+    sekizi: 8
     dokuzuncu: 9
+    dokuzu: 9
     onuncu: 10
-    on birinci: 11
-    on ikinci: 12
-    on üçüncü: 13
-    on dördüncü: 14
-    on beşinci: 15
-    on altıncı: 16
-    on yedinci: 17
-    on sekizinci: 18
-    on dokuzuncu: 19
+    onu: 10
     yirminci: 20
+    yirmisi: 20
     otuzuncu: 30
+    otuzu: 30
     kırkıncı: 40
+    kırkı: 40
     ellinci: 50
+    ellisi: 50
     altmışıncı: 60
+    altmışı: 60
     yetmişinci: 70
+    yetmişi: 70
     sekseninci: 80
+    sekseni: 80
     donsanıncı: 90
+    doksanı: 90
     yüzüncü: 100
     bininci: 1000
     milyonuncu: 1000000

--- a/Specs/DateTime/Turkish/DateExtractor.json
+++ b/Specs/DateTime/Turkish/DateExtractor.json
@@ -292,10 +292,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Mayıs'ın on birinde",
+        "Text": "Mayıs'ın on biri",
         "Type": "date",
         "Start": 0,
-        "Length": 19
+        "Length": 16
       }
     ]
   },
@@ -304,10 +304,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Mayıs'ın dördünde",
+        "Text": "Mayıs'ın dördü",
         "Type": "date",
         "Start": 0,
-        "Length": 17
+        "Length": 14
       }
     ]
   },
@@ -316,10 +316,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Mart'ın 4'ünde",
+        "Text": "Mart'ın 4'ü",
         "Type": "date",
         "Start": 0,
-        "Length": 14
+        "Length": 11
       }
     ]
   },
@@ -340,16 +340,15 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Haziran'ın yirmi ikisinde",
+        "Text": "Haziran'ın yirmi ikisi",
         "Type": "date",
         "Start": 0,
-        "Length": 25
+        "Length": 22
       }
     ]
   },
   {
     "Input": "27'nci kata gideceğim",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -363,14 +362,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27'si Çarşamba günü",
+        "Text": "27'si Çarşamba",
         "Type": "date",
         "Start": 0,
-        "Length": 16
+        "Length": 14
       }
     ]
   },
@@ -403,10 +401,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Gelecek ayın 20'sinde",
+        "Text": "Gelecek ayın 20'si",
         "Type": "date",
         "Start": 0,
-        "Length": 21
+        "Length": 18
       }
     ]
   },
@@ -415,10 +413,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Bu ayın 31'inde",
+        "Text": "Bu ayın 31'i",
         "Type": "date",
         "Start": 0,
-        "Length": 15
+        "Length": 12
       }
     ]
   },
@@ -505,10 +503,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "gelecek ayın 20'sinde",
+        "Text": "gelecek ayın 20'si",
         "Type": "date",
         "Start": 8,
-        "Length": 21
+        "Length": 18
       }
     ]
   },
@@ -553,10 +551,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Yirmi bir Eylül bin dokuz yüz yetmiş sekizde",
+        "Text": "Yirmi bir Eylül bin dokuz yüz yetmiş sekiz",
         "Type": "date",
         "Start": 0,
-        "Length": 44
+        "Length": 42
       }
     ]
   },
@@ -565,16 +563,17 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "10 Eylül bin dokuz yüz birde",
+        "Text": "10 Eylül bin dokuz yüz bir",
         "Type": "date",
         "Start": 0,
-        "Length": 28
+        "Length": 26
       }
     ]
   },
   {
     "Input": "iki bin yılı Eylül'ün onunda",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "iki bin yılı Eylül'ün onunda",
@@ -621,15 +620,15 @@
     ]
   },
   {
-    "Input": "Yarından itibaren üç hafta uygun musun?",
-    "NotSupported": "dotnet",
+    "Input": "Yarından itibaren üç hafta sonra uygun musun?",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "Yarından itibaren üç hafta",
+        "Text": "Yarından itibaren üç hafta sonra",
         "Type": "date",
         "Start": 0,
-        "Length": 26
+        "Length": 32
       }
     ]
   },
@@ -653,7 +652,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {

--- a/Specs/DateTime/Turkish/DateParser.json
+++ b/Specs/DateTime/Turkish/DateParser.json
@@ -1,10 +1,9 @@
 [
   {
-    "Input": "15'te döneceğim",
+    "Input": "15'inde döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -19,7 +18,7 @@
             "date": "2016-10-15"
           }
         },
-        "Start": 16,
+        "Start": 0,
         "Length": 2
       }
     ]
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -44,21 +42,20 @@
             "date": "2016-10-02"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 6
       }
     ]
   },
   {
-    "Input": "12 Ocak, 2016'da döneceğim",
+    "Input": "12 Ocak 2016'da döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12 Ocak, 2016",
+        "Text": "12 Ocak 2016",
         "Type": "date",
         "Value": {
           "Timex": "2016-01-12",
@@ -69,8 +66,8 @@
             "date": "2016-01-12"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -79,11 +76,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12 Ocak 2016 Pazartesi ",
+        "Text": "12 Ocak 2016 Pazartesi",
         "Type": "date",
         "Value": {
           "Timex": "2016-01-12",
@@ -94,8 +90,8 @@
             "date": "2016-01-12"
           }
         },
-        "Start": 13,
-        "Length": 25
+        "Start": 0,
+        "Length": 22
       }
     ]
   },
@@ -104,11 +100,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "",
+        "Text": "22/02/2016",
         "Type": "date",
         "Value": {
           "Timex": "2016-02-22",
@@ -119,17 +114,16 @@
             "date": "2016-02-22"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 10
       }
     ]
   },
   {
-    "Input": "21/04/2016'da dönceğim",
+    "Input": "21/04/2016'da döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +138,7 @@
             "date": "2016-04-21"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 10
       }
     ]
@@ -154,7 +148,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -169,21 +162,20 @@
             "date": "2016-04-21"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 10
       }
     ]
   },
   {
-    "Input": "08/12/2015'de döneceğim",
+    "Input": "12/08/2015'te döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "8/12/2015 12:00:00 AM",
+        "Text": "12/08/2015",
         "Type": "date",
         "Value": {
           "Timex": "2015-08-12",
@@ -194,7 +186,7 @@
             "date": "2015-08-12"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 10
       }
     ]
@@ -204,7 +196,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -219,8 +210,8 @@
             "date": "2016-01-01"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -229,7 +220,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -244,21 +234,20 @@
             "date": "2016-01-22"
           }
         },
-        "Start": 13,
-        "Length": 14
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
   {
-    "Input": "Mayıs yirmi birde döneceğim",
+    "Input": "Yirmi bir Mayıs'ta döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Mayıs yirmi bir",
+        "Text": "Yirmi bir Mayıs",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-05-21",
@@ -269,8 +258,8 @@
             "date": "2016-05-21"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 15
       }
     ]
   },
@@ -279,7 +268,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -294,17 +282,16 @@
             "date": "2016-08-02"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
   {
-    "Input": "Haziran'ın yirmi ikisinde dönceğim",
+    "Input": "Haziran'ın yirmi ikisinde döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -319,8 +306,8 @@
             "date": "2016-06-22"
           }
         },
-        "Start": 13,
-        "Length": 21
+        "Start": 0,
+        "Length": 22
       }
     ]
   },
@@ -329,7 +316,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -344,8 +330,8 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 16,
-        "Length": 6
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -354,7 +340,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -369,7 +354,7 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 5
       }
     ]
@@ -379,7 +364,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -394,8 +378,8 @@
             "date": "2016-11-08"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -404,7 +388,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -419,8 +402,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 9
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -429,7 +412,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -444,8 +426,8 @@
             "date": "2016-11-05"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
@@ -454,7 +436,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -469,8 +450,8 @@
             "date": "2016-11-09"
           }
         },
-        "Start": 13,
-        "Length": 22
+        "Start": 0,
+        "Length": 20
       }
     ]
   },
@@ -479,7 +460,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -494,8 +474,8 @@
             "date": "2016-11-08"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -504,7 +484,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -519,8 +498,8 @@
             "date": "2016-11-11"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -529,7 +508,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -544,8 +522,8 @@
             "date": "2016-11-20"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -554,7 +532,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -569,7 +546,7 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 11
       }
     ]
@@ -579,7 +556,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -594,8 +570,8 @@
             "date": "2016-11-11"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -604,7 +580,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -619,8 +594,8 @@
             "date": "2016-11-20"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 19
       }
     ]
   },
@@ -629,7 +604,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -644,8 +618,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
@@ -654,7 +628,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -669,8 +642,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -679,7 +652,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -694,21 +666,20 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
-    "Input": "gün döneceğim",
+    "Input": "Aynı gün döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "gün",
+        "Text": "Aynı gün",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-07",
@@ -719,8 +690,8 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -729,7 +700,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -744,8 +714,8 @@
             "date": "2016-06-15"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 15
       }
     ]
   },
@@ -754,7 +724,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -769,8 +738,8 @@
             "date": "2016-07-01"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 23
       }
     ]
   },
@@ -779,7 +748,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -794,21 +762,20 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 13,
-        "Length": 30
+        "Start": 0,
+        "Length": 21
       }
     ]
   },
   {
-    "Input": "Gelecek gafta Cuma günü döneceğim",
+    "Input": "Gelecek hafta Cuma günü döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Gelecek gafta Cuma günü",
+        "Text": "Gelecek hafta Cuma günü",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-18",
@@ -819,8 +786,8 @@
             "date": "2016-11-18"
           }
         },
-        "Start": 13,
-        "Length": 19
+        "Start": 0,
+        "Length": 23
       }
     ]
   },
@@ -829,11 +796,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "benim günüm / günüm",
+        "Text": "benim günüm",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-07",
@@ -844,17 +810,16 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 10,
-        "Length": 6
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
-    "Input": "İki hafta içinde döneceğim",
+    "Input": "iki hafta içinde döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -869,8 +834,8 @@
             "date": "2016-11-21"
           }
         },
-        "Start": 13,
-        "Length": 18
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -879,7 +844,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -894,7 +858,7 @@
             "date": "2016-10-07"
           }
         },
-        "Start": 16,
+        "Start": 0,
         "Length": 11
       }
     ]
@@ -904,7 +868,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -919,8 +882,8 @@
             "date": "2016-08-07"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 0,
+        "Length": 14
       }
     ]
   },
@@ -929,7 +892,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -944,8 +906,8 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 0,
+        "Length": 15
       }
     ]
   },
@@ -954,11 +916,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27'si",
+        "Text": "27",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-27",
@@ -969,21 +930,20 @@
             "date": "2016-10-27"
           }
         },
-        "Start": 16,
-        "Length": 6
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
-    "Input": "21'sinde döndüm",
+    "Input": "21'inde döndüm",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21'i",
+        "Text": "21",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-21",
@@ -994,8 +954,8 @@
             "date": "2016-10-21"
           }
         },
-        "Start": 16,
-        "Length": 8
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -1004,11 +964,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22'si",
+        "Text": "22",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -1019,8 +978,8 @@
             "date": "2016-10-22"
           }
         },
-        "Start": 16,
-        "Length": 8
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -1029,11 +988,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "yirmi iki",
+        "Text": "yirmi ikisi",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -1044,8 +1002,8 @@
             "date": "2016-10-22"
           }
         },
-        "Start": 16,
-        "Length": 17
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -1054,11 +1012,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "otuz",
+        "Text": "otuzu",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-30",
@@ -1069,8 +1026,8 @@
             "date": "2016-10-30"
           }
         },
-        "Start": 16,
-        "Length": 10
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -1079,7 +1036,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1094,8 +1050,8 @@
             "date": "2017-09-21"
           }
         },
-        "Start": 12,
-        "Length": 17
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -1104,7 +1060,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1119,8 +1074,8 @@
             "date": "2017-09-22"
           }
         },
-        "Start": 12,
-        "Length": 15
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -1129,7 +1084,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1144,8 +1098,8 @@
             "date": "2017-09-23"
           }
         },
-        "Start": 12,
-        "Length": 17
+        "Start": 0,
+        "Length": 14
       }
     ]
   },
@@ -1154,7 +1108,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1169,8 +1122,8 @@
             "date": "2017-09-15"
           }
         },
-        "Start": 12,
-        "Length": 15
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -1179,7 +1132,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1194,8 +1146,8 @@
             "date": "2017-09-21"
           }
         },
-        "Start": 12,
-        "Length": 25
+        "Start": 0,
+        "Length": 19
       }
     ]
   },
@@ -1204,7 +1156,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1219,8 +1170,8 @@
             "date": "2017-09-22"
           }
         },
-        "Start": 12,
-        "Length": 24
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -1229,7 +1180,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1244,8 +1194,8 @@
             "date": "2017-09-15"
           }
         },
-        "Start": 12,
-        "Length": 18
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1254,7 +1204,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1269,8 +1218,8 @@
             "date": "2017-09-10"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1279,7 +1228,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1294,8 +1242,8 @@
             "date": "2017-09-03"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -1304,7 +1252,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1319,8 +1266,8 @@
             "date": "2017-09-19"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -1329,7 +1276,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1344,8 +1290,8 @@
             "date": "0001-01-01"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -1354,7 +1300,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1369,7 +1314,7 @@
             "date": "2016-12-20"
           }
         },
-        "Start": 12,
+        "Start": 0,
         "Length": 18
       }
     ]
@@ -1379,7 +1324,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1394,8 +1338,8 @@
             "date": "0001-01-01"
           }
         },
-        "Start": 12,
-        "Length": 18
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1404,7 +1348,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1419,8 +1362,8 @@
             "date": "2018-01-12"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1429,7 +1372,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1444,17 +1386,16 @@
             "date": "2015-09-18"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
-    "Input": "İki gün önce döndüm",
+    "Input": "iki gün önce döndüm",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1469,17 +1410,16 @@
             "date": "2016-11-05"
           }
         },
-        "Start": 12,
+        "Start": 0,
         "Length": 12
       }
     ]
   },
   {
-    "Input": "İki yıl önce döndüm",
+    "Input": "iki yıl önce döndüm",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1494,8 +1434,8 @@
             "date": "2014-11-07"
           }
         },
-        "Start": 12,
-        "Length": 13
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1504,7 +1444,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1529,11 +1468,10 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 ay 21 gün önce ",
+        "Text": "1 ay 21 gün önce",
         "Type": "date",
         "Value": {
           "Timex": "2017-10-02",
@@ -1544,8 +1482,8 @@
             "date": "2017-10-02"
           }
         },
-        "Start": 17,
-        "Length": 19
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -1554,7 +1492,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1569,8 +1506,8 @@
             "date": "2015-10-02"
           }
         },
-        "Start": 12,
-        "Length": 27
+        "Start": 0,
+        "Length": 22
       }
     ]
   },
@@ -1579,7 +1516,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1594,8 +1530,8 @@
             "date": "2019-12-14"
           }
         },
-        "Start": 17,
-        "Length": 21
+        "Start": 0,
+        "Length": 18
       }
     ]
   },
@@ -1604,7 +1540,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1619,8 +1554,8 @@
             "date": "2015-10-02"
           }
         },
-        "Start": 12,
-        "Length": 27
+        "Start": 0,
+        "Length": 22
       }
     ]
   },
@@ -1629,11 +1564,10 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 ay, 21 gün önce ",
+        "Text": "1 ay, 21 gün önce",
         "Type": "date",
         "Value": {
           "Timex": "2017-10-02",
@@ -1644,8 +1578,8 @@
             "date": "2017-10-02"
           }
         },
-        "Start": 17,
-        "Length": 20
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
@@ -1654,7 +1588,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1669,8 +1602,8 @@
             "date": "2018-01-20"
           }
         },
-        "Start": 17,
-        "Length": 22
+        "Start": 0,
+        "Length": 18
       }
     ]
   },
@@ -1679,7 +1612,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1694,21 +1626,20 @@
             "date": "1391-12-05"
           }
         },
-        "Start": 17,
-        "Length": 15
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
   {
-    "Input": "yirmi iki Ocak, Pazartesi, 2018",
+    "Input": "yirmi iki Ocak 2018, Pazartesi",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "yirmi iki Ocak, Pazartesi, 2018",
+        "Text": "yirmi iki Ocak 2018, Pazartesi",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-22",
@@ -1720,20 +1651,19 @@
           }
         },
         "Start": 0,
-        "Length": 28
+        "Length": 30
       }
     ]
   },
   {
-    "Input": "Pazar günü, yirmi bir Ocak iki bin on sekiz",
+    "Input": "Yirmi bir Ocak iki bin on sekiz, Pazar günü",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Pazar, yirmi bir Ocak iki bin on sekiz",
+        "Text": "Yirmi bir Ocak iki bin on sekiz, Pazar günü",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-21",
@@ -1744,21 +1674,20 @@
             "date": "2018-01-21"
           }
         },
-        "Start": 3,
-        "Length": 47
+        "Start": 0,
+        "Length": 43
       }
     ]
   },
   {
-    "Input": "yirmi bir Eylül ondokuz yetmiş sekiz",
+    "Input": "yirmi bir Eylül bin dokuz yüz yetmiş sekiz",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "yirmi bir Eylül ondokuz yetmiş sekiz",
+        "Text": "yirmi bir Eylül bin dokuz yüz yetmiş sekiz",
         "Type": "date",
         "Value": {
           "Timex": "1978-09-21",
@@ -1769,21 +1698,20 @@
             "date": "1978-09-21"
           }
         },
-        "Start": 3,
-        "Length": 49
+        "Start": 0,
+        "Length": 42
       }
     ]
   },
   {
-    "Input": "10 Eylül, on dokuz sıfır bir",
+    "Input": "10 Eylül bin dokuz yüz bir",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "10 Eylül, on dokuz sıfır bir",
+        "Text": "10 Eylül bin dokuz yüz bir",
         "Type": "date",
         "Value": {
           "Timex": "1901-09-10",
@@ -1794,21 +1722,21 @@
             "date": "1901-09-10"
           }
         },
-        "Start": 3,
-        "Length": 31
+        "Start": 0,
+        "Length": 26
       }
     ]
   },
   {
-    "Input": "Eylül'ün onunda, iki bin",
+    "Input": "iki bin yılı Eylül'ün onunda",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "Eylül'ün onu, iki bin",
+        "Text": "iki bin yılı Eylül'ün onunda",
         "Type": "date",
         "Value": {
           "Timex": "2000-09-10",
@@ -1819,21 +1747,20 @@
             "date": "2000-09-10"
           }
         },
-        "Start": 7,
-        "Length": 32
+        "Start": 0,
+        "Length": 28
       }
     ]
   },
   {
-    "Input": "Gelecek ayın ilk Cuma'sı seni göreceğim",
+    "Input": "Gelecek ayın ilk Cuması seni göreceğim",
     "Context": {
       "ReferenceDateTime": "2018-03-20T09:58:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Gelecek ayın ilk Cuma'sı ",
+        "Text": "Gelecek ayın ilk Cuması",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-04-WXX-5-#1",
@@ -1844,8 +1771,8 @@
             "date": "2018-04-06"
           }
         },
-        "Start": 13,
-        "Length": 30
+        "Start": 0,
+        "Length": 23
       }
     ]
   },
@@ -1854,11 +1781,10 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "gelecek ayın ikinci pazartesi ",
+        "Text": "gelecek ayın ikinci pazartesi",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-04-WXX-1-#2",
@@ -1869,21 +1795,20 @@
             "date": "2018-04-09"
           }
         },
-        "Start": 12,
-        "Length": 31
+        "Start": 6,
+        "Length": 29
       }
     ]
   },
   {
-    "Input": "Önceki ayın üçüncü Çarşamba'sı döndüm",
+    "Input": "Önceki ayın üçüncü Çarşambası döndüm",
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Önceki ayın üçüncü Çarşamba'sı",
+        "Text": "Önceki ayın üçüncü Çarşambası",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-02-WXX-3-#3",
@@ -1894,8 +1819,8 @@
             "date": "2018-02-21"
           }
         },
-        "Start": 12,
-        "Length": 37
+        "Start": 0,
+        "Length": 29
       }
     ]
   },
@@ -1904,7 +1829,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1919,8 +1843,8 @@
             "date": "2018-03-27"
           }
         },
-        "Start": 19,
-        "Length": 17
+        "Start": 0,
+        "Length": 18
       }
     ]
   },
@@ -1929,7 +1853,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1944,8 +1867,8 @@
             "date": "2018-04-01"
           }
         },
-        "Start": 16,
-        "Length": 22
+        "Start": 0,
+        "Length": 24
       }
     ]
   },
@@ -1954,11 +1877,10 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Yarından itibaren iki gün",
+        "Text": "Yarından itibaren iki gün içinde",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-23",
@@ -1969,8 +1891,8 @@
             "date": "2018-04-23"
           }
         },
-        "Start": 13,
-        "Length": 22
+        "Start": 0,
+        "Length": 32
       }
     ]
   },
@@ -1979,11 +1901,10 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Dünden itibaren dört gün",
+        "Text": "Dünden itibaren dört gün içinde",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-23",
@@ -1994,8 +1915,8 @@
             "date": "2018-04-23"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 31
       }
     ]
   },
@@ -2004,7 +1925,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2019,7 +1939,7 @@
             "date": "2015-05-13"
           }
         },
-        "Start": 16,
+        "Start": 0,
         "Length": 9
       }
     ]
@@ -2029,7 +1949,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2044,21 +1963,20 @@
             "date": "2015-05-13"
           }
         },
-        "Start": 21,
-        "Length": 9
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
-    "Input": "03.07.2017'de döneceğim",
+    "Input": "07.03.2017'de döneceğim",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "03.07.2017",
+        "Text": "07.03.2017",
         "Type": "date",
         "Value": {
           "Timex": "2017-03-07",
@@ -2069,8 +1987,8 @@
             "date": "2017-03-07"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2079,11 +1997,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5/5/1989 12:00:00 AM",
+        "Text": "05/05/1989",
         "Type": "date",
         "Value": {
           "Timex": "1989-05-05",
@@ -2094,8 +2011,8 @@
             "date": "1989-05-05"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2104,11 +2021,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5/5/1971 12:00:00 AM",
+        "Text": "05/05/1971",
         "Type": "date",
         "Value": {
           "Timex": "1971-05-05",
@@ -2119,21 +2035,20 @@
             "date": "1971-05-05"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
-    "Input": "Şu andan itibaren iki Pazar uygun musun?",
+    "Input": "Şu andan itibaren iki Pazar sonra uygun musun?",
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Şu andan itibaren iki Pazar",
+        "Text": "Şu andan itibaren iki Pazar sonra",
         "Type": "date",
         "Value": {
           "Timex": "2018-05-20",
@@ -2144,21 +2059,20 @@
             "date": "2018-05-20"
           }
         },
-        "Start": 18,
-        "Length": 20
+        "Start": 0,
+        "Length": 33
       }
     ]
   },
   {
-    "Input": "İki Pazartesi sonra uygun musun?",
+    "Input": "iki Pazartesi sonra uygun musun?",
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "İki Pazartesi sonra",
+        "Text": "iki Pazartesi sonra",
         "Type": "date",
         "Value": {
           "Timex": "2018-05-21",
@@ -2169,21 +2083,20 @@
             "date": "2018-05-21"
           }
         },
-        "Start": 18,
-        "Length": 16
+        "Start": 0,
+        "Length": 19
       }
     ]
   },
   {
-    "Input": "Bugünden sonra iki gün uygun musun?",
+    "Input": "Bugünden iki gün sonra uygun musun?",
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Bugünden sonra iki gün",
+        "Text": "Bugünden iki gün sonra",
         "Type": "date",
         "Value": {
           "Timex": "2018-06-02",
@@ -2194,21 +2107,21 @@
             "date": "2018-06-02"
           }
         },
-        "Start": 18,
-        "Length": 20
+        "Start": 0,
+        "Length": 22
       }
     ]
   },
   {
-    "Input": "Yarından itibaren üç hafta uygun musun?",
+    "Input": "Yarından itibaren üç hafta sonra uygun musun?",
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "Yarından itibaren üç hafta",
+        "Text": "Yarından itibaren üç hafta sonra",
         "Type": "date",
         "Value": {
           "Timex": "2018-06-22",
@@ -2219,21 +2132,21 @@
             "date": "2018-06-22"
           }
         },
-        "Start": 18,
-        "Length": 25
+        "Start": 0,
+        "Length": 26
       }
     ]
   },
   {
-    "Input": "Dünden önceki iki gün neredeydin?",
+    "Input": "Dünden iki gün önce neredeydin?",
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "Dünden önceki iki gün",
+        "Text": "Dünden iki gün önce",
         "Type": "date",
         "Value": {
           "Timex": "2018-05-28",
@@ -2244,8 +2157,8 @@
             "date": "2018-05-28"
           }
         },
-        "Start": 15,
-        "Length": 25
+        "Start": 0,
+        "Length": 19
       }
     ]
   },
@@ -2254,7 +2167,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2269,17 +2181,16 @@
             "date": "2018-07-26"
           }
         },
-        "Start": 13,
-        "Length": 10
+        "Start": 0,
+        "Length": 14
       }
     ]
   },
   {
-    "Input": "Cortana, lütfen dört iş günü içinde bir ara bir Skype görüşmesi ayarla",
+    "Input": "Cortana, lütfen dört iş günü içinde bir-ara bir Skype görüşmesi ayarla",
     "Context": {
       "ReferenceDateTime": "2018-08-21T08:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2294,8 +2205,8 @@
             "date": "2018-08-27"
           }
         },
-        "Start": 45,
-        "Length": 21
+        "Start": 16,
+        "Length": 19
       }
     ]
   }


### PR DESCRIPTION
DateExtractor : pass: 54 | fail: 2
DateParser: pass: 89 | fail: 3

Failing Cases:
- "dünden iki gün önce neredeydin" (where were you two days before yesterday?)
the structure of the sentence in Turkish is "yesterday two day before where were you?".
It is not supported because the method ExtractorDurationWithBeforeAndAfter only checks for the group "day" after the duration match "two day before".
- "Yarından itibaren üç hafta sonra uygun musun?" (Are you available three weeks from tomorrow?)
Same as above, 'Yarından' (tomorrow) appears before the duration match 'itibaren üç hafta sonra' (after three weeks from)
- "iki bin yılı Eylül'ün onunda" (on the tenth of September, two thousand)
similarly to the previous cases, here the year 'iki bin yılı' (two thousand) comes before the NumberWithMonth match 'eylül'ün onu' (tenth of September) but the method ExtendWithWeekdayAndYear only checks for years after the match. 

Wondering if we should proceed as we did for Italian Set, moving the involved methods (e.g. NumberWithMonth) to a separate class and using composition to be able to modify these functions only for Turkish.