### PR TITLE
[CN DataTimeV2] Finalize bug fix for “早”, “晚”

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -568,7 +568,12 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string DateTimePeriodAFRegex = @"(下午|午后|傍晚)";
       public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚)";
       public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜)";
-      public const string SingleWordMorningAndEveningRegex = @"^[早晚]$";
+      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
+        {
+            { @"早", @"^早$" },
+            { @"晚", @"^晚$" },
+            { @"^\d{1,2}号", @"^\d{1,2}号" }
+        };
       public static readonly Dictionary<string, int> DurationUnitValueMap = new Dictionary<string, int>
         {
             { @"Y", 31536000 },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -568,6 +568,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string DateTimePeriodAFRegex = @"(下午|午后|傍晚)";
       public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚)";
       public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜)";
+      public const string SingleWordMorningAndEveningRegex = @"^[早晚]$";
       public static readonly Dictionary<string, int> DurationUnitValueMap = new Dictionary<string, int>
         {
             { @"Y", 31536000 },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
         public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
         public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex SingleWordMOAndEVRegex = new Regex(DateTimeDefinitions.SingleWordMorningAndEveningRegex, RegexFlags);
         public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
@@ -105,6 +106,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 // for cases like "12号"
                 if (Regex.IsMatch(extractResult.Text, negativeCaseRegex))
+                {
+                    continue;
+                }
+
+                // for cases like "早稻田" and "晚安"
+                if (SingleWordMOAndEVRegex.IsMatch(extractResult.Text))
                 {
                     continue;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     continue;
                 }
 
-                // for cases like "早稻田" and "晚安"
+                // for cases like "早" in "早稻田" and "晚" in "晚安"
                 if (SingleWordMOAndEVRegex.IsMatch(extractResult.Text))
                 {
                     continue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             AddTo(ret, SetExtractor.Extract(text, referenceTime));
             AddTo(ret, HolidayExtractor.Extract(text, referenceTime));
 
-            CheckDenyList(ref ret, text);
-
-            ret = FilterAmbiguity(ret, text);
+            ret = CheckDenyList(ret, text);
 
             AddMod(ret, text);
 
@@ -90,7 +88,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         // add some negative case
-        private static void CheckDenyList(ref List<ExtractResult> extractResults, string text)
+        private List<ExtractResult> CheckDenyList(List<ExtractResult> extractResults, string text)
         {
             var ret = new List<ExtractResult>();
 
@@ -111,7 +109,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Add(extractResult);
             }
 
-            extractResults = ret;
+            ret = FilterAmbiguity(ret, text);
+
+            return ret;
         }
 
         private List<ExtractResult> FilterAmbiguity(List<ExtractResult> extractResults, string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             AddTo(ret, SetExtractor.Extract(text, referenceTime));
             AddTo(ret, HolidayExtractor.Extract(text, referenceTime));
 
-            CheckBlackList(ref ret, text);
+            CheckDenyList(ref ret, text);
 
             ret = FilterAmbiguity(ret, text);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         // add some negative case
-        private static void CheckBlackList(ref List<ExtractResult> extractResults, string text)
+        private static void CheckDenyList(ref List<ExtractResult> extractResults, string text)
         {
             var ret = new List<ExtractResult>();
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
@@ -872,7 +872,11 @@ public class ChineseDateTime {
 
     public static final String DateTimePeriodNIRegex = "(半夜|夜间|深夜)";
 
-    public static final String SingleWordMorningAndEveningRegex = "^[早晚]$";
+    public static final ImmutableMap<String, String> AmbiguityFiltersDict = ImmutableMap.<String, String>builder()
+        .put("早", "^早$")
+        .put("晚", "^晚$")
+        .put("^\\d{1,2}号", "^\\d{1,2}号")
+        .build();
 
     public static final ImmutableMap<String, Integer> DurationUnitValueMap = ImmutableMap.<String, Integer>builder()
         .put("Y", 31536000)

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
@@ -872,6 +872,8 @@ public class ChineseDateTime {
 
     public static final String DateTimePeriodNIRegex = "(半夜|夜间|深夜)";
 
+    public static final String SingleWordMorningAndEveningRegex = "^[早晚]$";
+
     public static final ImmutableMap<String, Integer> DurationUnitValueMap = ImmutableMap.<String, Integer>builder()
         .put("Y", 31536000)
         .put("Mon", 2592000)

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
@@ -61,13 +61,11 @@ class ChineseMergedExtractorConfiguration implements IMergedExtractorConfigurati
 
 export class ChineseMergedExtractor extends BaseMergedExtractor {
     private readonly dayOfMonthRegex: RegExp;
-    private readonly SingleWordMOAndEVRegex: RegExp;
 
     constructor(options: DateTimeOptions, dmyDateFormat: boolean = false) {
         let config = new ChineseMergedExtractorConfiguration(dmyDateFormat);
         super(config, options);
         this.dayOfMonthRegex = RegExpUtility.getSafeRegExp(`^\\d{1,2}号`, 'gi');
-        this.SingleWordMOAndEVRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.SingleWordMorningAndEveningRegex);
     }
 
     extract(source: string, refDate: Date): ExtractResult[] {
@@ -146,10 +144,6 @@ export class ChineseMergedExtractor extends BaseMergedExtractor {
             }
 
             if (RegExpUtility.isMatch(this.dayOfMonthRegex, value.text)) {
-                return false;
-            }
-
-            if (RegExpUtility.isMatch(this.SingleWordMOAndEVRegex, value.text)) {
                 return false;
             }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
@@ -61,11 +61,13 @@ class ChineseMergedExtractorConfiguration implements IMergedExtractorConfigurati
 
 export class ChineseMergedExtractor extends BaseMergedExtractor {
     private readonly dayOfMonthRegex: RegExp;
+    private readonly SingleWordMOAndEVRegex: RegExp;
 
     constructor(options: DateTimeOptions, dmyDateFormat: boolean = false) {
         let config = new ChineseMergedExtractorConfiguration(dmyDateFormat);
         super(config, options);
         this.dayOfMonthRegex = RegExpUtility.getSafeRegExp(`^\\d{1,2}号`, 'gi');
+        this.SingleWordMOAndEVRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.SingleWordMorningAndEveningRegex);
     }
 
     extract(source: string, refDate: Date): ExtractResult[] {
@@ -144,6 +146,10 @@ export class ChineseMergedExtractor extends BaseMergedExtractor {
             }
 
             if (RegExpUtility.isMatch(this.dayOfMonthRegex, value.text)) {
+                return false;
+            }
+
+            if (RegExpUtility.isMatch(this.SingleWordMOAndEVRegex, value.text)) {
                 return false;
             }
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -166,7 +166,7 @@ export namespace ChineseDateTime {
     export const DateTimePeriodAFRegex = `(下午|午后|傍晚)`;
     export const DateTimePeriodEVRegex = `(晚上|夜里|夜晚|晚)`;
     export const DateTimePeriodNIRegex = `(半夜|夜间|深夜)`;
-    export const SingleWordMorningAndEveningRegex = `^[早晚]$`;
+    export const AmbiguityFiltersDict: ReadonlyMap<string, string> = new Map<string, string>([["早", "^早$"],["晚", "^晚$"],["^\\d{1,2}号", "^\\d{1,2}号"]]);
     export const DurationUnitValueMap: ReadonlyMap<string, number> = new Map<string, number>([["Y", 31536000],["Mon", 2592000],["W", 604800],["D", 86400],["H", 3600],["M", 60],["S", 1]]);
     export const HolidayNoFixedTimex: ReadonlyMap<string, string> = new Map<string, string>([["父亲节", "-06-WXX-6-3"],["母亲节", "-05-WXX-7-2"],["感恩节", "-11-WXX-4-4"]]);
     export const MergedBeforeRegex = `(前|之前)$`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -166,6 +166,7 @@ export namespace ChineseDateTime {
     export const DateTimePeriodAFRegex = `(下午|午后|傍晚)`;
     export const DateTimePeriodEVRegex = `(晚上|夜里|夜晚|晚)`;
     export const DateTimePeriodNIRegex = `(半夜|夜间|深夜)`;
+    export const SingleWordMorningAndEveningRegex = `^[早晚]$`;
     export const DurationUnitValueMap: ReadonlyMap<string, number> = new Map<string, number>([["Y", 31536000],["Mon", 2592000],["W", 604800],["D", 86400],["H", 3600],["M", 60],["S", 1]]);
     export const HolidayNoFixedTimex: ReadonlyMap<string, string> = new Map<string, string>([["父亲节", "-06-WXX-6-3"],["母亲节", "-05-WXX-7-2"],["感恩节", "-11-WXX-4-4"]]);
     export const MergedBeforeRegex = `(前|之前)$`;

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -770,6 +770,8 @@ DateTimePeriodEVRegex: !simpleRegex
   def: (晚上|夜里|夜晚|晚)
 DateTimePeriodNIRegex: !simpleRegex
   def: (半夜|夜间|深夜)
+SingleWordMorningAndEveningRegex: !simpleRegex
+  def: ^[早晚]$
 DurationUnitValueMap: !dictionary
   types: [string, int]
   entries:

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -770,8 +770,13 @@ DateTimePeriodEVRegex: !simpleRegex
   def: (晚上|夜里|夜晚|晚)
 DateTimePeriodNIRegex: !simpleRegex
   def: (半夜|夜间|深夜)
-SingleWordMorningAndEveningRegex: !simpleRegex
-  def: ^[早晚]$
+# For cases like "12号", singleWord "早" and "晚"
+AmbiguityFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '早': '^早$'
+    '晚': '^晚$'
+    '^\d{1,2}号': '^\d{1,2}号'
 DurationUnitValueMap: !dictionary
   types: [string, int]
   entries:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
@@ -521,7 +521,9 @@ class ChineseDateTime:
     DateTimePeriodAFRegex = f'(下午|午后|傍晚)'
     DateTimePeriodEVRegex = f'(晚上|夜里|夜晚|晚)'
     DateTimePeriodNIRegex = f'(半夜|夜间|深夜)'
-    SingleWordMorningAndEveningRegex = f'^[早晚]$'
+    AmbiguityFiltersDict = dict([("早", "^早$"),
+                                 ("晚", "^晚$"),
+                                 ("^\\d{1,2}号", "^\\d{1,2}号")])
     DurationUnitValueMap = dict([("Y", 31536000),
                                  ("Mon", 2592000),
                                  ("W", 604800),

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
@@ -521,6 +521,7 @@ class ChineseDateTime:
     DateTimePeriodAFRegex = f'(下午|午后|傍晚)'
     DateTimePeriodEVRegex = f'(晚上|夜里|夜晚|晚)'
     DateTimePeriodNIRegex = f'(半夜|夜间|深夜)'
+    SingleWordMorningAndEveningRegex = f'^[早晚]$'
     DurationUnitValueMap = dict([("Y", 31536000),
                                  ("Mon", 2592000),
                                  ("W", 604800),

--- a/Specs/DateTime/Chinese/DateTimePeriodParser.json
+++ b/Specs/DateTime/Chinese/DateTimePeriodParser.json
@@ -473,5 +473,83 @@
         "Length": 5
       }
     ]
+  },
+  {
+    "Input": "我将于八月七号早到达早稻田大学",
+    "Context": {
+      "ReferenceDateTime": "2019-08-19T16:12:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "八月七号早",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-08-07TMO",
+          "FutureResolution": {
+            "startDateTime": "2020-08-07 08:00:00",
+            "endDateTime": "2020-08-07 12:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-08-07 08:00:00",
+            "endDateTime": "2019-08-07 12:00:00"
+          }
+        },
+        "Start": 3,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "明天早上我不打算吃早饭",
+    "Context": {
+      "ReferenceDateTime": "2019-08-19T16:12:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "明天早上",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2019-08-20TMO",
+          "FutureResolution": {
+            "startDateTime": "2019-08-20 08:00:00",
+            "endDateTime": "2019-08-20 12:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-08-20 08:00:00",
+            "endDateTime": "2019-08-20 12:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "晚礼服会在八月七号晚送到您家里",
+    "Context": {
+      "ReferenceDateTime": "2019-08-19T16:12:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "八月七号晚",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-08-07TEV",
+          "FutureResolution": {
+            "startDateTime": "2020-08-07 16:00:00",
+            "endDateTime": "2020-08-07 20:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-08-07 16:00:00",
+            "endDateTime": "2019-08-07 20:00:00"
+          }
+        },
+        "Start": 5,
+        "Length": 5
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Chinese/DateTimePeriodParser.json
+++ b/Specs/DateTime/Chinese/DateTimePeriodParser.json
@@ -505,7 +505,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "java, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "明天早上",

--- a/Specs/DateTime/Chinese/DateTimePeriodParser.json
+++ b/Specs/DateTime/Chinese/DateTimePeriodParser.json
@@ -479,7 +479,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "java, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "八月七号早",
@@ -531,7 +531,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "java, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "八月七号晚",

--- a/Specs/DateTime/Chinese/TimeParser.json
+++ b/Specs/DateTime/Chinese/TimeParser.json
@@ -274,5 +274,53 @@
         "Length": 3
       }
     ]
+  },
+  {
+    "Input": "早稻田大学代表在早八点到达",
+    "Context": {
+      "ReferenceDateTime": "2019-08-19T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "早八点",
+        "Type": "time",
+        "Value": {
+          "Timex": "T08",
+          "FutureResolution": {
+            "time": "08:00:00"
+          },
+          "PastResolution": {
+            "time": "08:00:00"
+          }
+        },
+        "Start": 8,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "他习惯在晚上八点吃晚饭",
+    "Context": {
+      "ReferenceDateTime": "2019-08-19T00:00:00"
+    },
+    "NotSupported": "java, python",
+    "Results": [
+      {
+        "Text": "晚上八点",
+        "Type": "time",
+        "Value": {
+          "Timex": "T20",
+          "FutureResolution": {
+            "time": "20:00:00"
+          },
+          "PastResolution": {
+            "time": "20:00:00"
+          }
+        },
+        "Start": 4,
+        "Length": 4
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Chinese/AgeModel.json
+++ b/Specs/NumberWithUnit/Chinese/AgeModel.json
@@ -119,5 +119,35 @@
         "End": 8
       }
     ]
+  },
+  {
+    "Input": "十二周岁",
+    "Results": [
+      {
+        "Text": "十二周岁",
+        "TypeName": "age",
+        "Resolution": {
+          "value": "12",
+          "unit": "Year"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "他已经有十二周大了",
+    "Results": [
+      {
+        "Text": "十二周大",
+        "TypeName": "age",
+        "Resolution": {
+          "value": "12",
+          "unit": "Week"
+        },
+        "Start": 4,
+        "End": 7
+      }
+    ]
   }
 ]


### PR DESCRIPTION
To fix the wrong extractions of "早" in "早稻田" and "晚" in "晚礼服".
Now the single word "早" and “晚” won't be recognized as an entity.