### PR TITLE
Adding the character "m" as an ending for "jede" like the other existing endings (#1812)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -166,9 +166,9 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string SuffixAndRegex = @"(?<suffix>\s*und\s+(eine\s+)?(?<suffix_num>halbe|viertel))";
       public const string PeriodicRegex = @"(?<periodic>(all)?täglich(er|en|es|e)?|(all)?monatlich(er|en|es|e)?|(all)?wöchentlich(er|en|es|e)?|(all)?jährlich(er|en|es|e)?)\b";
       public static readonly string EachUnitRegex = $@"(?<each>(jede(s|r|n|m)?|alle)(?<other>\s+andere(n)?)?\s*{DurationUnitRegex})";
-      public const string EachPrefixRegex = @"\b(?<each>(jede(r|n|s)?|alle)\s*$)";
-      public const string SetEachRegex = @"\b(?<each>(jede(r|n|s)?|alle)\s*)";
-      public const string SetLastRegex = @"(?<last>nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b";
+      public const string EachPrefixRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*$)";
+      public const string SetEachRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*)";
+      public const string SetLastRegex = @"(?<last>nächste(r|n|s|m)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b";
       public const string EachDayRegex = @"\s*(jeden)\s*tag\s*\b";
       public const string BeforeEachDayRegex = @"(jeden)\s*tag\s*";
       public static readonly string DurationFollowedUnit = $@"(^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";


### PR DESCRIPTION
The ticket #1812 can be solved by just considering the ending "m" like the other ones:
@"\b(?<each>(jede(r|n|s|m)?|alle)\s*$)";