### PR TITLE
[.NET] Turkish Number fixes

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
     public static class NumbersDefinitions
     {
       public const string LangMarker = @"Tr";
-      public const bool CompoundNumberLanguage = false;
+      public const bool CompoundNumberLanguage = true;
       public const bool MultiDecimalSeparatorCulture = true;
       public const string DigitsNumberRegex = @"\d+|\d{1,3}(\.\d{3})";
       public const string RoundNumberIntegerRegex = @"(yüz|bin|milyon|milyar|trilyon)";
@@ -32,22 +32,22 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string NegativeNumberTermsRegex = @"(?<negTerm>(eksi|negatif)\s+)";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*";
       public const string TensNumberIntegerRegex = @"(on|yirmi|otuz|kırk|elli|altmış|yetmiş|seksen|doksan)";
-      public static readonly string HundredsNumberIntegerRegex = $@"({TwoToNineIntegerRegex}\syüz|yüz)";
-      public static readonly string TenToHundredRegex = $@"({TensNumberIntegerRegex}(\s{OneToNineIntegerRegex}))";
-      public static readonly string HundredToThousandRegex = $@"({HundredsNumberIntegerRegex}(\s({OneToNineIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex})))";
-      public static readonly string ThousandsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{TwoToNineIntegerRegex}|{TensNumberIntegerRegex})\sbin|bin)";
-      public static readonly string ThousandToMillionRegex = $@"({ThousandsNumberIntegerRegex}(\s({HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{{TensNumberIntegerRegex}}|{OneToNineIntegerRegex})))";
-      public static readonly string MillionsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\smilyon)";
-      public static readonly string MillionToBillionRegex = $@"({MillionsNumberIntegerRegex}(\s({ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
-      public static readonly string BillionsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\smilyar)";
-      public static readonly string BillionToTrillionRegex = $@"({BillionsNumberIntegerRegex}(\s({MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
-      public static readonly string TrillionsNumberIntegerRegex = $@"(({ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\strilyon)";
-      public static readonly string AboveTrillionRegex = $@"({TrillionsNumberIntegerRegex}(\s({BillionToTrillionRegex}|{BillionsNumberIntegerRegex}|{MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
+      public static readonly string HundredsNumberIntegerRegex = $@"({TwoToNineIntegerRegex}\s*yüz|yüz)";
+      public static readonly string TenToHundredRegex = $@"({TensNumberIntegerRegex}(\s*{OneToNineIntegerRegex}))";
+      public static readonly string HundredToThousandRegex = $@"({HundredsNumberIntegerRegex}(\s*({OneToNineIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex})))";
+      public static readonly string ThousandsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{TwoToNineIntegerRegex}|{TensNumberIntegerRegex})\s*bin|bin)";
+      public static readonly string ThousandToMillionRegex = $@"({ThousandsNumberIntegerRegex}(\s*({HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{{TensNumberIntegerRegex}}|{OneToNineIntegerRegex})))";
+      public static readonly string MillionsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*milyon)";
+      public static readonly string MillionToBillionRegex = $@"({MillionsNumberIntegerRegex}(\s*({ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
+      public static readonly string BillionsNumberIntegerRegex = $@"(({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*milyar)";
+      public static readonly string BillionToTrillionRegex = $@"({BillionsNumberIntegerRegex}(\s*({MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
+      public static readonly string TrillionsNumberIntegerRegex = $@"(({ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*trilyon)";
+      public static readonly string AboveTrillionRegex = $@"({TrillionsNumberIntegerRegex}(\s*({BillionToTrillionRegex}|{BillionsNumberIntegerRegex}|{MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))";
       public static readonly string AllIntRegex = $@"({AboveTrillionRegex}|{BillionToTrillionRegex}|{MillionToBillionRegex}|{ThousandToMillionRegex}|{MillionsNumberIntegerRegex}|{BillionsNumberIntegerRegex}|{TrillionsNumberIntegerRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})";
       public static readonly string NegativeAllIntRegex = $@"(eksi\s)({OneToNineIntegerRegex}|{TenToHundredRegex}|{HundredToThousandRegex}|{ThousandToMillionRegex}|{MillionToBillionRegex}|{BillionToTrillionRegex}|{AboveTrillionRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
-      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!(,\d+[a-zA-Z]))(?={placeholder})";
+      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})";
       public static readonly string NumbersWithSuffix = $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public const string NumbersWithDozenSuffix = @"(((?<!\d+\s*)-\s*)|(?<=\b))\d+\s+düzine(?=\b)";
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string RelativeOrdinalRegex = @"((bir\s)?(sonraki|önceki)|sondan birinci|sondan bir önceki|sondan ikinci|(en\s)?son)";
       public static readonly string AllOrdinalRegex = $@"({OneToHundredOrdinalRegex}|{HundredToThousandOrdinalRegex}|{ThousandToMillionOrdinalRegex}|{MillionToBillionOrdinalRegex}|{BillionToTrillionOrdinalRegex}|{AboveTrillionOrdinalRegex})";
       public const string AllOrdinalSuffix = @"(onu(?=nda)?|yirmisi(?=nde)?|otuzu(?=nda)?|kırkı(?=nda)?|ellisi(?=nde)?|altmışı(?=nda)?|yetmişi(?=nde)?|sekseni(?=nde)?|doksanı(?=nda)?|((on|yirmi|otuz)\s+)?(biri(?=nde)?|ilk|ikisi(?=nde)?|üçü(?=nde)?|dördü(?=nde)?|beşi(?=nde)?|altısı(?=nda)?|yedisi(?=nde)?|sekizi(?=nde)?|dokuzu(?=nda)?))";
-      public const string OrdinalSuffixRegex = @"(?<=\b)(\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000\.?000\.?000(\.|'ıncı)|000\.?000\.?000\.?000(\.|'uncu)|10(\.|'uncu|'u(?=nda)?)|20(\.|'nci|'si(?=nde)?)|30(\.|'uncu|'u(?=nda)?)|40(\.|'ıncı|'ı(?=nda)?)|50(\.|'inci|'si(?=nde)?)|60(\.|'ıncı|'ı(?=nda)?)|70(\.|'inci|'i(?=nde)?)|80(\.|'inci|'i(?=nde)?)|90(\.|'ıncı|'ı(?=nda)?)|1(\.|'inci|'i(?=nde)?)|2(\.|'nci|'si(?=nde)?)|3(\.|'üncü|'ü(?=nde)?)|4(\.|'üncü|'ü(?=nde)?)|5(\.|'inci|'i(?=nde)?)|6(\.|'ıncı|'sı(?=nda)?)|7(\.|'inci|'si(?=nde)?)|8(\.|'inci|'i(?=nde)?)|9(\.|'uncu|'u(?=nda)?)))";
+      public const string OrdinalSuffixRegex = @"(?<=\b)(\d*(00(\.(?!\d+)|'üncü)|000(\.(?!\d+)|'inci)|000\.?000(\.(?!\d+)|'uncu)|000\.?000\.?000(\.(?!\d+)|'ıncı)|000\.?000\.?000\.?000(\.(?!\d+)|'uncu)|10(\.(?!\d+)|'uncu|'u(?=nda)?)|20(\.(?!\d+)|'nci|'si(?=nde)?)|30(\.(?!\d+)|'uncu|'u(?=nda)?)|40(\.(?!\d+)|'ıncı|'ı(?=nda)?)|50(\.(?!\d+)|'inci|'si(?=nde)?)|60(\.(?!\d+)|'ıncı|'ı(?=nda)?)|70(\.(?!\d+)|'inci|'i(?=nde)?)|80(\.(?!\d+)|'inci|'i(?=nde)?)|90(\.(?!\d+)|'ıncı|'ı(?=nda)?)|1(\.(?!\d+)|'inci|'i(?=nde)?)|2(\.(?!\d+)|'nci|'si(?=nde)?)|3(\.(?!\d+)|'üncü|'ü(?=nde)?)|4(\.(?!\d+)|'üncü|'ü(?=nde)?)|5(\.(?!\d+)|'inci|'i(?=nde)?)|6(\.(?!\d+)|'ıncı|'sı(?=nda)?)|7(\.(?!\d+)|'inci|'si(?=nde)?)|8(\.(?!\d+)|'inci|'i(?=nde)?)|9(\.(?!\d+)|'uncu|'u(?=nda)?)))";
       public const string OrdinalNumericRegex = @"(?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*('inci|'ıncı|'uncu|'üncü|'nci|'ncı))(?=\b)";
       public static readonly string OrdinalTurkishRegex = $@"(?<=\b)({AllOrdinalRegex}(?=\b)|{AllOrdinalSuffix})";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             this.LangMarker = NumbersDefinitions.LangMarker;
             this.CultureInfo = new CultureInfo(config.Culture);
 
+            this.IsCompoundNumberLanguage = NumbersDefinitions.CompoundNumberLanguage;
+            this.IsMultiDecimalSeparatorCulture = NumbersDefinitions.MultiDecimalSeparatorCulture;
+
             this.DecimalSeparatorChar = NumbersDefinitions.DecimalSeparatorChar;
             this.FractionMarkerToken = NumbersDefinitions.FractionMarkerToken;
             this.NonDecimalSeparatorChar = NumbersDefinitions.NonDecimalSeparatorChar;

--- a/Patterns/Turkish/Turkish-Numbers.yaml
+++ b/Patterns/Turkish/Turkish-Numbers.yaml
@@ -1,6 +1,6 @@
 ---
 LangMarker: Tr
-CompoundNumberLanguage: !bool false
+CompoundNumberLanguage: !bool true
 MultiDecimalSeparatorCulture: !bool true
 # Integer Regex
 DigitsNumberRegex: !simpleRegex
@@ -21,37 +21,37 @@ NegativeNumberSignRegex: !nestedRegex
 TensNumberIntegerRegex: !simpleRegex   # 10,20,...,90
   def: (on|yirmi|otuz|kırk|elli|altmış|yetmiş|seksen|doksan)
 HundredsNumberIntegerRegex: !nestedRegex   # 100,200,...,900
-  def: ({TwoToNineIntegerRegex}\syüz|yüz)
+  def: ({TwoToNineIntegerRegex}\s*yüz|yüz)
   references: [TwoToNineIntegerRegex]
 TenToHundredRegex: !nestedRegex   # 11,12,...,99 (tens are not included)
-  def: ({TensNumberIntegerRegex}(\s{OneToNineIntegerRegex}))
+  def: ({TensNumberIntegerRegex}(\s*{OneToNineIntegerRegex}))
   references: [TensNumberIntegerRegex, OneToNineIntegerRegex]
 HundredToThousandRegex: !nestedRegex   # 100,101,102,...,999 (hundreds are not included)
-  def: ({HundredsNumberIntegerRegex}(\s({OneToNineIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex})))
+  def: ({HundredsNumberIntegerRegex}(\s*({OneToNineIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex})))
   references: [HundredsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, TensNumberIntegerRegex]
 ThousandsNumberIntegerRegex: !nestedRegex   # 1000,2000,...,999.000
-  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{TwoToNineIntegerRegex}|{TensNumberIntegerRegex})\sbin|bin)
+  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{TwoToNineIntegerRegex}|{TensNumberIntegerRegex})\s*bin|bin)
   references: [TwoToNineIntegerRegex, TensNumberIntegerRegex, TenToHundredRegex, HundredsNumberIntegerRegex, HundredToThousandRegex]
 ThousandToMillionRegex: !nestedRegex   # 1000,1001,1002,...,999.999 (thousands are not included is not included)
-  def: ({ThousandsNumberIntegerRegex}(\s({HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex}|{OneToNineIntegerRegex})))
+  def: ({ThousandsNumberIntegerRegex}(\s*({HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex}|{OneToNineIntegerRegex})))
   references: [ThousandsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, HundredsNumberIntegerRegex]
 MillionsNumberIntegerRegex: !nestedRegex   # 1.000.000,2.000.000,...,999.000.000
-  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\smilyon)
+  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*milyon)
   references: [OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, TensNumberIntegerRegex, HundredsNumberIntegerRegex]
 MillionToBillionRegex: !nestedRegex   # 1.000.000,...,999.999.999 (millions are not included)
-  def: ({MillionsNumberIntegerRegex}(\s({ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
+  def: ({MillionsNumberIntegerRegex}(\s*({ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
   references: [MillionsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, ThousandToMillionRegex, ThousandsNumberIntegerRegex, HundredsNumberIntegerRegex, TensNumberIntegerRegex]
 BillionsNumberIntegerRegex: !nestedRegex   # 1.000.000.000,2.000.000.000,...,999.000.000.000
-  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\smilyar)
+  def: (({HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*milyar)
   references: [OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, TensNumberIntegerRegex, HundredsNumberIntegerRegex]
 BillionToTrillionRegex: !nestedRegex   # 1.000.000.000,...,999.999.999.999 (billions are not included)
-  def: ({BillionsNumberIntegerRegex}(\s({MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
+  def: ({BillionsNumberIntegerRegex}(\s*({MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
   references: [BillionsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, ThousandToMillionRegex, MillionToBillionRegex, MillionsNumberIntegerRegex, HundredsNumberIntegerRegex, ThousandsNumberIntegerRegex, TensNumberIntegerRegex]
 TrillionsNumberIntegerRegex: !nestedRegex   # 1.000.000.000.000,...,999.000.000.000.000 (1.000.000.000.000 is not included)
-  def: (({ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\strilyon)
+  def: (({ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})\s*trilyon)
   references: [ThousandsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, TensNumberIntegerRegex, HundredsNumberIntegerRegex]
 AboveTrillionRegex: !nestedRegex   # Greater than or equal to 1.000.000.000.000
-  def: ({TrillionsNumberIntegerRegex}(\s({BillionToTrillionRegex}|{BillionsNumberIntegerRegex}|{MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
+  def: ({TrillionsNumberIntegerRegex}(\s*({BillionToTrillionRegex}|{BillionsNumberIntegerRegex}|{MillionToBillionRegex}|{MillionsNumberIntegerRegex}|{ThousandToMillionRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{TenToHundredRegex}|{HundredsNumberIntegerRegex}|{OneToNineIntegerRegex}|{TensNumberIntegerRegex})))
   references: [TrillionsNumberIntegerRegex, OneToNineIntegerRegex, TenToHundredRegex, HundredToThousandRegex, ThousandToMillionRegex, MillionToBillionRegex, BillionToTrillionRegex, BillionsNumberIntegerRegex, MillionsNumberIntegerRegex, ThousandsNumberIntegerRegex, HundredsNumberIntegerRegex, TensNumberIntegerRegex]
 AllIntRegex: !nestedRegex
   def: ({AboveTrillionRegex}|{BillionToTrillionRegex}|{MillionToBillionRegex}|{ThousandToMillionRegex}|{MillionsNumberIntegerRegex}|{BillionsNumberIntegerRegex}|{TrillionsNumberIntegerRegex}|{ThousandsNumberIntegerRegex}|{HundredToThousandRegex}|{HundredsNumberIntegerRegex}|{TenToHundredRegex}|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})
@@ -64,7 +64,7 @@ PlaceHolderPureNumber: !simpleRegex
 PlaceHolderDefault: !simpleRegex
   def: \D|\b
 NumbersWithPlaceHolder: !paramsRegex
-  def: (((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!(,\d+[a-zA-Z]))(?={placeholder})
+  def: (((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})
   params: [ placeholder ]
 NumbersWithSuffix: !nestedRegex
   def: (((?<!\d+\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)
@@ -131,7 +131,7 @@ AllOrdinalRegex: !nestedRegex
 AllOrdinalSuffix: !simpleRegex
   def: (onu(?=nda)?|yirmisi(?=nde)?|otuzu(?=nda)?|kırkı(?=nda)?|ellisi(?=nde)?|altmışı(?=nda)?|yetmişi(?=nde)?|sekseni(?=nde)?|doksanı(?=nda)?|((on|yirmi|otuz)\s+)?(biri(?=nde)?|ilk|ikisi(?=nde)?|üçü(?=nde)?|dördü(?=nde)?|beşi(?=nde)?|altısı(?=nda)?|yedisi(?=nde)?|sekizi(?=nde)?|dokuzu(?=nda)?))
 OrdinalSuffixRegex: !simpleRegex
-  def: (?<=\b)(\d*(00(\.|'üncü)|000(\.|'inci)|000\.?000(\.|'uncu)|000\.?000\.?000(\.|'ıncı)|000\.?000\.?000\.?000(\.|'uncu)|10(\.|'uncu|'u(?=nda)?)|20(\.|'nci|'si(?=nde)?)|30(\.|'uncu|'u(?=nda)?)|40(\.|'ıncı|'ı(?=nda)?)|50(\.|'inci|'si(?=nde)?)|60(\.|'ıncı|'ı(?=nda)?)|70(\.|'inci|'i(?=nde)?)|80(\.|'inci|'i(?=nde)?)|90(\.|'ıncı|'ı(?=nda)?)|1(\.|'inci|'i(?=nde)?)|2(\.|'nci|'si(?=nde)?)|3(\.|'üncü|'ü(?=nde)?)|4(\.|'üncü|'ü(?=nde)?)|5(\.|'inci|'i(?=nde)?)|6(\.|'ıncı|'sı(?=nda)?)|7(\.|'inci|'si(?=nde)?)|8(\.|'inci|'i(?=nde)?)|9(\.|'uncu|'u(?=nda)?)))
+  def: (?<=\b)(\d*(00(\.(?!\d+)|'üncü)|000(\.(?!\d+)|'inci)|000\.?000(\.(?!\d+)|'uncu)|000\.?000\.?000(\.(?!\d+)|'ıncı)|000\.?000\.?000\.?000(\.(?!\d+)|'uncu)|10(\.(?!\d+)|'uncu|'u(?=nda)?)|20(\.(?!\d+)|'nci|'si(?=nde)?)|30(\.(?!\d+)|'uncu|'u(?=nda)?)|40(\.(?!\d+)|'ıncı|'ı(?=nda)?)|50(\.(?!\d+)|'inci|'si(?=nde)?)|60(\.(?!\d+)|'ıncı|'ı(?=nda)?)|70(\.(?!\d+)|'inci|'i(?=nde)?)|80(\.(?!\d+)|'inci|'i(?=nde)?)|90(\.(?!\d+)|'ıncı|'ı(?=nda)?)|1(\.(?!\d+)|'inci|'i(?=nde)?)|2(\.(?!\d+)|'nci|'si(?=nde)?)|3(\.(?!\d+)|'üncü|'ü(?=nde)?)|4(\.(?!\d+)|'üncü|'ü(?=nde)?)|5(\.(?!\d+)|'inci|'i(?=nde)?)|6(\.(?!\d+)|'ıncı|'sı(?=nda)?)|7(\.(?!\d+)|'inci|'si(?=nde)?)|8(\.(?!\d+)|'inci|'i(?=nde)?)|9(\.(?!\d+)|'uncu|'u(?=nda)?)))
 OrdinalNumericRegex: !simpleRegex
   def: (?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*('inci|'ıncı|'uncu|'üncü|'nci|'ncı))(?=\b)
 OrdinalTurkishRegex: !nestedRegex

--- a/Specs/Number/Turkish/NumberModel.json
+++ b/Specs/Number/Turkish/NumberModel.json
@@ -2116,5 +2116,25 @@
         }
       }
     ]
+  },
+  {
+    "Input": "onbinaltıyüz",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "onbinaltıyüz",
+        "Start": 0,
+        "End": 11,
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10600"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "10.000tl",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
   }
 ]

--- a/Specs/Number/Turkish/OrdinalModel.json
+++ b/Specs/Number/Turkish/OrdinalModel.json
@@ -298,5 +298,10 @@
         }
       }
     ]
+  },
+  {
+    "Input": "10.000tl",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
   }
 ]


### PR DESCRIPTION
Fixes to cases:
- "10.000tl", originally recognized as currency "10000tl", cardinal "10" and ordinal "10.". Now only recognized as currency.
- Added support for compound numbers (used informally) e.g. "onbinaltıyüz" ("on bin altı yüz" -> 10600)