### PR TITLE
correcting the recognition of the utterances like an jedem Dienstag (#1812)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -166,8 +166,8 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string SuffixAndRegex = @"(?<suffix>\s*und\s+(eine\s+)?(?<suffix_num>halbe|viertel))";
       public const string PeriodicRegex = @"(?<periodic>(all)?täglich(er|en|es|e)?|(all)?monatlich(er|en|es|e)?|(all)?wöchentlich(er|en|es|e)?|(all)?jährlich(er|en|es|e)?)\b";
       public static readonly string EachUnitRegex = $@"(?<each>(jede(s|r|n|m)?|alle)(?<other>\s+andere(n)?)?\s*{DurationUnitRegex})";
-      public const string EachPrefixRegex = @"\b(?<each>(jede(r|n|s)?|alle)\s*$)";
-      public const string SetEachRegex = @"\b(?<each>(jede(r|n|s)?|alle)\s*)";
+      public const string EachPrefixRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*$)";
+      public const string SetEachRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*)";
       public const string SetLastRegex = @"(?<last>nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b";
       public const string EachDayRegex = @"\s*(jeden)\s*tag\s*\b";
       public const string BeforeEachDayRegex = @"(jeden)\s*tag\s*";

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -384,9 +384,9 @@ EachUnitRegex: !nestedRegex
   def: (?<each>(jede(s|r|n|m)?|alle)(?<other>\s+andere(n)?)?\s*{DurationUnitRegex})
   references: [ DurationUnitRegex ]
 EachPrefixRegex: !simpleRegex
-  def: \b(?<each>(jede(r|n|s)?|alle)\s*$)
+  def: \b(?<each>(jede(r|n|s|m)?|alle)\s*$)
 SetEachRegex: !simpleRegex
-  def: \b(?<each>(jede(r|n|s)?|alle)\s*)
+  def: \b(?<each>(jede(r|n|s|m)?|alle)\s*)
 SetLastRegex: !simpleRegex
   def: (?<last>nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b
 EachDayRegex: !simpleRegex


### PR DESCRIPTION
Adding the character m to the regular expression handling jeden Dienstag like the other propositions:
```
EachUnitRegex: !nestedRegex
  def: (?<each>(jede(s|r|n|m)?|alle)(?<other>\s+andere(n)?)?\s*{DurationUnitRegex})
  references: [ DurationUnitRegex ]
EachPrefixRegex: !simpleRegex
  def: \b(?<each>(jede(r|n|s|m)?|alle)\s*$)
SetEachRegex: !simpleRegex
  def: \b(?<each>(jede(r|n|s|m)?|alle)\s*)
```