### PR TITLE
Fixes Javascript DateTimeRecognizer error - Fixes Issue #1826

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -327,7 +327,7 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         if (!referenceDate) {
             referenceDate = new Date();
         }
-        let resultValue;
+        let resultValue = null;
         if (extractorResult.type === this.parserName) {
             let source = extractorResult.text.trim().toLowerCase();
             let innerResult = this.parseMonthWithYear(source, referenceDate);


### PR DESCRIPTION
`resultValue` should be initialized to `null`.

Fixes Issue #1826