### PR TITLE
[CN DateTimeV2] Speed up the Datetime component.

### DIFF
--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
@@ -102,120 +102,141 @@ class NumberWithUnitExtractor(Extractor):
         if not self._pre_check_str(source):
             return list()
 
+        # To judge whether the input has words in prefix_list or suffix_list
+        flag_prefix = self._find_keyword(source, self.config.prefix_list)
+        flag_suffix = self._find_keyword(source, self.config.suffix_list)
+
         mapping_prefix: Dict[float, PrefixUnitResult] = dict()
         matched: List[bool] = [False] * len(source)
-        numbers: List[ExtractResult] = self.config.unit_num_extractor.extract(
-            source)
         result: List[ExtractResult] = list()
         source_len = len(source)
+        if flag_prefix is True or flag_suffix is True :
+            numbers: List[ExtractResult] = self.config.unit_num_extractor.extract(
+                source)
 
-        # Special case for cases where number multipliers clash with unit
-        ambiguous_multiplier_regex = self.config.ambiguous_unit_number_multiplier_regex
-        if ambiguous_multiplier_regex is not None:
+            # Special case for cases where number multipliers clash with unit
+            ambiguous_multiplier_regex = self.config.ambiguous_unit_number_multiplier_regex
+            if ambiguous_multiplier_regex is not None:
 
-            for num in numbers:
-                match = list(filter(lambda x: x.group(), regex.finditer(
-                    ambiguous_multiplier_regex, num.text)))
-                if match and len(match) == 1:
-                    new_length = num.length - \
-                        (match[0].span()[1] - match[0].span()[0])
-                    num.text = num.text[0:new_length]
-                    num.length = new_length
+                for num in numbers:
+                    match = list(filter(lambda x: x.group(), regex.finditer(
+                        ambiguous_multiplier_regex, num.text)))
+                    if match and len(match) == 1:
+                        new_length = num.length - \
+                            (match[0].span()[1] - match[0].span()[0])
+                        num.text = num.text[0:new_length]
+                        num.length = new_length
 
-        # Mix prefix and numbers, make up a prefix-number combination
-        if self.max_prefix_match_len != 0:
+            # Mix prefix and numbers, make up a prefix-number combination
+            if self.max_prefix_match_len != 0:
+                for num in numbers:
+                    if num.start is None or num.length is None:
+                        continue
+                    max_find_prefix = min(self.max_prefix_match_len, num.start)
+                    if max_find_prefix == 0:
+                        continue
+
+                    left: str = source[num.start - max_find_prefix:num.start]
+                    last_index = len(left)
+                    best_match: Match = None
+                    for pattern in self.prefix_regex:
+                        collection = list(filter(lambda x: len(
+                            x.group()), regex.finditer(pattern, left)))
+                        for match in collection:
+                            if left[match.start():last_index].strip() == match.group():
+                                if best_match is None or best_match.start() >= match.start():
+                                    best_match = match
+                    if best_match:
+                        mapping_prefix[num.start] = PrefixUnitResult(
+                            offset=last_index - best_match.start(),
+                            unit=left[best_match.start():last_index]
+                        )
             for num in numbers:
                 if num.start is None or num.length is None:
                     continue
-                max_find_prefix = min(self.max_prefix_match_len, num.start)
-                if max_find_prefix == 0:
-                    continue
+                start = num.start
+                length = num.length
+                max_find_len = source_len - start - length
 
-                left: str = source[num.start - max_find_prefix:num.start]
-                last_index = len(left)
-                best_match: Match = None
-                for pattern in self.prefix_regex:
-                    collection = list(filter(lambda x: len(
-                        x.group()), regex.finditer(pattern, left)))
-                    for match in collection:
-                        if left[match.start():last_index].strip() == match.group():
-                            if best_match is None or best_match.start() >= match.start():
-                                best_match = match
-                if best_match:
-                    mapping_prefix[num.start] = PrefixUnitResult(
-                        offset=last_index - best_match.start(),
-                        unit=left[best_match.start():last_index]
-                    )
-        for num in numbers:
-            if num.start is None or num.length is None:
-                continue
-            start = num.start
-            length = num.length
-            max_find_len = source_len - start - length
+                prefix_unit: PrefixUnitResult = mapping_prefix.get(start, None)
 
-            prefix_unit: PrefixUnitResult = mapping_prefix.get(start, None)
+                if max_find_len > 0:
+                    right = source[start + length:start + length + max_find_len]
+                    unit_match_list = map(lambda x: list(
+                        regex.finditer(x, right)), self.suffix_regex)
+                    unit_match = chain.from_iterable(unit_match_list)
+                    unit_match = list(filter(lambda x: x.group(), unit_match))
 
-            if max_find_len > 0:
-                right = source[start + length:start + length + max_find_len]
-                unit_match_list = map(lambda x: list(
-                    regex.finditer(x, right)), self.suffix_regex)
-                unit_match = chain.from_iterable(unit_match_list)
-                unit_match = list(filter(lambda x: x.group(), unit_match))
+                    max_len = 0
+                    for match in unit_match:
+                        if match.group():
+                            end_pos = match.start() + len(match.group())
+                            if match.start() >= 0:
+                                middle: str = right[:min(
+                                    match.start(), len(right))]
+                                if max_len < end_pos and (not middle.strip() or middle.strip() == self.config.connector_token):
+                                    max_len = end_pos
+                    if max_len != 0:
+                        for i in range(length + max_len):
+                            matched[i + start] = True
+                        ex_result = ExtractResult()
+                        ex_result.start = start
+                        ex_result.length = length + max_len
+                        ex_result.text = source[start:start + length + max_len]
+                        ex_result.type = self.config.extract_type
 
-                max_len = 0
-                for match in unit_match:
-                    if match.group():
-                        end_pos = match.start() + len(match.group())
-                        if match.start() >= 0:
-                            middle: str = right[:min(
-                                match.start(), len(right))]
-                            if max_len < end_pos and (not middle.strip() or middle.strip() == self.config.connector_token):
-                                max_len = end_pos
-                if max_len != 0:
-                    for i in range(length + max_len):
-                        matched[i + start] = True
+                        if prefix_unit:
+                            ex_result.start -= prefix_unit.offset
+                            ex_result.length += prefix_unit.offset
+                            ex_result.text = prefix_unit.unit + ex_result.text
+
+                        num.start = start - ex_result.start
+                        ex_result.data = num
+
+                        is_not_unit = False
+                        if ex_result.type == Constants.SYS_UNIT_DIMENSION:
+                            non_unit_match = self.config.non_unit_regex.finditer(
+                                source)
+                            for match in non_unit_match:
+                                if ex_result.start >= match.start() and ex_result.end <= match.end():
+                                    is_not_unit = True
+
+                        if is_not_unit:
+                            continue
+
+                        result.append(ex_result)
+                        continue
+                if prefix_unit:
                     ex_result = ExtractResult()
-                    ex_result.start = start
-                    ex_result.length = length + max_len
-                    ex_result.text = source[start:start + length + max_len]
+                    ex_result.start = num.start - prefix_unit.offset
+                    ex_result.length = num.length + prefix_unit.offset
+                    ex_result.text = prefix_unit.unit + num.text
                     ex_result.type = self.config.extract_type
-
-                    if prefix_unit:
-                        ex_result.start -= prefix_unit.offset
-                        ex_result.length += prefix_unit.offset
-                        ex_result.text = prefix_unit.unit + ex_result.text
 
                     num.start = start - ex_result.start
                     ex_result.data = num
-
-                    is_not_unit = False
-                    if ex_result.type == Constants.SYS_UNIT_DIMENSION:
-                        non_unit_match = self.config.non_unit_regex.finditer(
-                            source)
-                        for match in non_unit_match:
-                            if ex_result.start >= match.start() and ex_result.end <= match.end():
-                                is_not_unit = True
-
-                    if is_not_unit:
-                        continue
-
                     result.append(ex_result)
-                    continue
-            if prefix_unit:
-                ex_result = ExtractResult()
-                ex_result.start = num.start - prefix_unit.offset
-                ex_result.length = num.length + prefix_unit.offset
-                ex_result.text = prefix_unit.unit + num.text
-                ex_result.type = self.config.extract_type
-
-                num.start = start - ex_result.start
-                ex_result.data = num
-                result.append(ex_result)
 
         if self.separate_regex:
             result = self._extract_separate_units(source, result)
 
         return result
+
+    def _find_keyword(self, source: str, keyword_list: dict) -> bool:
+        keyword_match_result = False
+
+        if keyword_list:
+            for keyword_str in keyword_list.values():
+                keywords = keyword_str.split("|")
+                for keyword in keywords:
+                    if keyword in source:
+                        keyword_match_result = True
+                        break
+
+                if keyword_match_result is True:
+                    break
+
+        return keyword_match_result
 
     def validate_unit(self, source: str) -> bool:
         return not source.startswith('-')

--- a/Specs/NumberWithUnit/Chinese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Chinese/CurrencyModel.json
@@ -292,7 +292,7 @@
   },
   {
     "Input": "这个手机壳花费你五美元和花费我三块",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "五美元",


### PR DESCRIPTION
This PR fix #1783.
Now the sentence "一二三四五六七二二三四五六七三二三四五六七" would only cost 4 seconds while it would cost more than 45 secs in the past.

The _number_with_unit extractor_ makes the DateTime component slow down. Because of only number_with_unit extractor use EXTRACT_ALL mode, and it will match the whole sentence at a very very low speed. Now we will check the sentence to make sure whether it has units then the _number_with_unit extractor_ would be called, same as the C# code.