### PR TITLE
[JS Py DateTimeV2] Revise extractor for "after" "before"

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -206,9 +206,11 @@ export class BaseMergedExtractor implements IDateTimeExtractor {
     }
 
     private hasTokenIndex(source: string, regex: RegExp): { matched: boolean, index: number } {
+        // This part is different from C# because no Regex RightToLeft option in JS
         let result = { matched: false, index: -1 };
-        let match = RegExpUtility.getMatches(regex, source).pop();
-        if (match) {
+        let matchResult = RegExpUtility.getMatches(regex, source);
+        let match = matchResult[matchResult.length - 1];
+        if (match && !source.substr(match.index + match.length).trim().length) {
             result.matched = true;
             result.index = match.index;
         }

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
@@ -256,9 +256,12 @@ class BaseMergedExtractor(DateTimeExtractor):
         return er
 
     def has_token_index(self, source: str, pattern: Pattern) -> MatchedIndex:
-        match = regex.search(pattern, source)
-        if match:
-            return MatchedIndex(True, match.start())
+        # This part is different from C# because no Regex RightToLeft option in Python
+        match_result = list(regex.finditer(pattern, source))
+        if match_result:
+            match = match_result[-1]
+            if not source[match.end():].strip():
+                return MatchedIndex(True, match.start())
 
         return MatchedIndex(False, -1)
 

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -3473,7 +3473,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "later this week",
@@ -3487,6 +3486,65 @@
               "type": "daterange",
               "start": "2018-05-31",
               "end": "2018-06-04"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "He will come after his parents after 2016 and before 2018, or before 2019",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "after 2016",
+        "Start": 31,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 46,
+        "End": 56,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 62,
+        "End": 72,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
             }
           ]
         }
@@ -3523,7 +3581,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "later this year",
@@ -3548,7 +3605,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "later in the year",
@@ -3573,7 +3629,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "two days after today",
@@ -3669,7 +3724,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-01T00:00:00"
     },
-    "NotSupported": "python",
     "Results": [
       {
         "Text": "5/3/18 @ 17:49:19",
@@ -3780,7 +3834,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "between 3 and 5 on 1/1/2015",
@@ -3842,7 +3895,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "before 2010",
@@ -3885,7 +3937,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "after 2010",

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -3248,7 +3248,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "after 2010",
@@ -3313,6 +3312,65 @@
               "type": "daterange",
               "start": "1998-01-01",
               "end": "1999-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "He will come after his parents after 2016 and before 2018, or before 2019",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "after 2016",
+        "Start": 31,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 46,
+        "End": 56,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 62,
+        "End": 72,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -3668,7 +3668,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "between 3 and 5 on 1/1/2015",
@@ -3688,6 +3687,65 @@
               "type": "datetimerange",
               "start": "2015-01-01 15:00:00",
               "end": "2015-01-01 17:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "He will come after his parents after 2016 and before 2018, or before 2019",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "after 2016",
+        "Start": 31,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 46,
+        "End": 56,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 62,
+        "End": 72,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
             }
           ]
         }
@@ -3730,7 +3788,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "before 2010",
@@ -3773,7 +3830,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "after 2010",

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -2415,7 +2415,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "later than 1/1/2016",
@@ -2441,7 +2440,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "1/1/2016",
@@ -2491,7 +2489,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "before 1/1/2016",
@@ -2543,7 +2540,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "1/1/2016",
@@ -2567,7 +2563,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "earlier than 1/1/2016",
@@ -2619,7 +2614,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "before Feb 2018",
@@ -2645,7 +2639,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "Feb 2018",
@@ -2696,7 +2689,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "later than 2016",
@@ -2722,7 +2714,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "2016",
@@ -2773,7 +2764,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "after 6:30PM today",
@@ -2799,7 +2789,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "6:30PM today",
@@ -2849,7 +2838,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "the day after tomorrow",
@@ -2873,7 +2861,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "before the day after tomorrow",
@@ -2925,7 +2912,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "earlier than 3pm 5/15/2018",
@@ -2951,7 +2937,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "3pm 5/15/2018",
@@ -2975,7 +2960,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "two days after today",
@@ -3047,7 +3031,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "before 2010",
@@ -3090,7 +3073,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "after 2010",
@@ -4358,6 +4340,65 @@
         },
         "Start": 14,
         "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "He will leave after 2016 and before 2018, or before 2019",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "after 2016",
+        "Start": 14,
+        "Length": 10,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 29,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 45,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
+            }
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
- Simulate C# RightToLeft Regex option in JS & Py
- Enable some test.

TODO: It still not support some tests with "since" Mod in JS & Py