### PR TITLE
Workaround for copy failure if "/build/package" doesn't exist

### DIFF
--- a/.NET/build/package/README.txt
+++ b/.NET/build/package/README.txt
@@ -1,0 +1,1 @@
+This directory is required in the nuget package building process.


### PR DESCRIPTION
This issue happens in MacOS/Linux (#1809).