### PR TITLE
[.NET] Turkish Date support to skipped cases

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public static readonly string TillRegex = $@"(?<till>\b(tot|totdat|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|tot en met|t/m|tot|tot aan)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.English
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public static readonly string TillRegex = $@"(?<till>\b(to|(un)?till?|thru|through)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(and|through|to)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string RelativeRegex = @"\b(?<order>following|next|(up)?coming|this|last|past|previous|current|the)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.French
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>au|et|(jusqu')?[aà]|avant|--|-|—|——)";
       public const string RangeConnectorRegex = @"(?<and>de la|au|[aà]|et(\s*la)?|--|-|—|——)";
       public const string RelativeRegex = @"(?<order>prochaine?|de|du|ce(tte)?|l[ae]|derni[eè]re|pr[eé]c[eé]dente|au\s+cours+(de|du\s*))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.German
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>zu|bis\s*zum|zum|bis|bis\s*hin(\s*zum)?|--|-|—|——)";
       public const string RangeConnectorRegex = @"(?<and>und|--|-|—|——)";
       public const string RelativeRegex = @"(?<order>nächst(er|en|es|e)|kommend(er|en|es|e)|dies(er|em|en|es|e)|letzt(er|en|es|e)|vergangen(er|en|es|e)|vorherig(er|en|es|e)|vorig(er|en|es|e)|dies(er|en|es|e)|jetzig(er|en|es|e)|heutig(er|en|es|e)|aktuell(er|en|es|e)|gestrig(er|en|es|e)|morgig(er|en|es|e)|de[rmsn]|am)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>\b(fino\s+a(l(l[aoe'])?|gli|i)?|a(l(l[aoe'])?|gli|i)?|e\s+(il?|l[aoe']|gli))\b|--|-|—|——|~)";
       public const string RestrictedTillRegex = @"(?<till>\b(fino\s+a(l(l[aoe'])?|gli|i)?)\b|--|-|—|——|~)";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(e(\s+l[aoe']|gli|i)?|a(l(l[aoe'])?|gli|i)?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>ate|as|às|até|ateh|a|ao|--|-|—|——)(\s+(o|[aà](s)?))?";
       public const string AndRegex = @"(?<and>e|e\s*o|--|-|—|——)";
       public const string DayRegex = @"(?<day>01|02|03|04|05|06|07|08|09|1|10|11|12|13|14|15|16|17|18|19|2|20|21|22|23|24|25|26|27|28|29|3|30|31|4|5|6|7|8|9)(?=\b|t)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?";
       public const string AndRegex = @"(?<and>y|y\s*el|--|-|—|——)";
       public const string DayRegex = @"(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(?=\b|t)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
 
     public static class DateTimeDefinitions
     {
+      public const bool CheckBothBeforeAfter = true;
       public const string TillRegex = @"(?<till>\b(kadar|dek|değin)\b)";
       public const string RangeConnectorRegex = @"(?<and>\b(ile|ila)\b|(-|—|——|–))";
       public const string RelativeRegex = @"\b(?<order>ertesi|(bir\s+)?sonraki|gelecek|bu|geçen|son|aynı|(bir\s+)?önceki|evvelki|önümüzdeki)\b";
@@ -105,7 +106,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string WeekOfRegex = @"(haftası)";
       public const string MonthOfRegex = @"(ayı)";
       public static readonly string DateYearRegex = $@"(?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})";
-      public static readonly string YearSuffix = $@"(,?\s*({DateYearRegex}|{FullTextYearRegex}))";
+      public static readonly string YearSuffix = $@"(,?\s*({DateYearRegex}|{FullTextYearRegex})(\s+yılı)?)";
       public const string OnRegex = @"^[\*]";
       public const string RelaxedOnRegex = @"(?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=(nde|nda))\b";
       public const string PrefixWeekDayRegex = @"(\s*[-—–])";
@@ -250,12 +251,12 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public static readonly string AfterRegex = $@"((\b((sonra|sonrasında|daha sonra))(?!\s+veya aynı))|(?<!\w|<)((?<include>>=)|>))";
       public const string SinceRegex = @"((\b(((den|dan)\s+)?beri|sonra veya aynı|((den|dan|ile)\s+)?(başlayarak|başlayan)|erkenden|herhangi bir zamanda)\b\s*)|(?<!\w|<)(>=))";
       public const string AroundRegex = @"(\b(takriben|yaklaşık)\s*|\s*(civarında|civarı|dolaylarında)\b)";
-      public const string AgoRegex = @"\b(önce|evvel)\b";
-      public const string LaterRegex = @"\b(sonra|içinde|(?<day>yarından|bugünden)\s+(itibaren|sonra)|şu andan itibaren)\b";
-      public const string InConnectorRegex = @"^[\*]";
+      public const string AgoRegex = @"\b((?<day>bugünden|gün|dünden|dün)\s+)?(önce|evvel)\b";
+      public const string LaterRegex = @"\b(sonra|(?<day>yarından|yarın|bugünden|gün)\s+(itibaren|sonra)|şu andan itibaren)";
+      public const string InConnectorRegex = @"\b(içinde)\b";
       public const string SinceNumSuffixRegex = @"\b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b";
       public static readonly string SinceYearSuffixRegex = $@"({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)";
-      public static readonly string WithinNextPrefixRegex = $@"\b((?<next>{NextPrefixRegex})?\s+?\d+\s+(hafta|ay|yıl)\s+(içinde))\b";
+      public static readonly string WithinNextPrefixRegex = $@"\b((?<next>{NextPrefixRegex})?(\s+)?(\d+\s+(hafta|ay|yıl)\s+)?içinde)\b";
       public const string MorningStartEndRegex = @"(^sabah$)";
       public const string AfternoonStartEndRegex = @"(^öğle$)";
       public const string EveningStartEndRegex = @"(^akşam$)";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -235,6 +235,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Utilities/DutchDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Utilities/DutchDatetimeUtilityConfiguration.cs
@@ -67,5 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -236,6 +236,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -142,6 +142,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnglishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnglishDatetimeUtilityConfiguration.cs
@@ -67,5 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -72,50 +72,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                     continue;
                 }
 
-                var match = Config.InConnectorRegex.MatchEnd(beforeStr, trim: true);
+                bool inPrefix = true;
+                ret.AddRange(ExtractInConnector(text, beforeStr, afterStr, duration, inPrefix, out bool success));
 
-                if (match.Success)
+                // Check also afterStr
+                if (!success && Config.CheckBothBeforeAfter)
                 {
-                    var startToken = match.Index;
-                    var rangeUnitMatch = Config.RangeUnitRegex.Match(text.Substring(duration.Start, duration.Length));
-
-                    if (rangeUnitMatch.Success)
-                    {
-                        var sinceYearMatch = Config.SinceYearSuffixRegex.Match(afterStr);
-
-                        if (sinceYearMatch.Success)
-                        {
-                            ret.Add(new Token(startToken, duration.End + sinceYearMatch.Length));
-                        }
-                        else
-                        {
-                            ret.Add(new Token(startToken, duration.End));
-                        }
-                    }
-                }
-                else if (Config.CheckBothBeforeAfter)
-                {
-                    // Check also afterStr
-                    match = Config.InConnectorRegex.MatchBegin(afterStr, trim: true);
-                    if (match.Success)
-                    {
-                        var endToken = duration.Start + duration.Length + match.Index + match.Length;
-                        var rangeUnitMatch = Config.RangeUnitRegex.Match(text.Substring(duration.Start, duration.Length));
-
-                        if (rangeUnitMatch.Success)
-                        {
-                            var sinceYearMatch = Config.SinceYearSuffixRegex.Match(beforeStr);
-
-                            if (sinceYearMatch.Success)
-                            {
-                                ret.Add(new Token(sinceYearMatch.Index, endToken - sinceYearMatch.Index));
-                            }
-                            else
-                            {
-                                ret.Add(new Token(duration.Start, endToken - duration.Start));
-                            }
-                        }
-                    }
+                    inPrefix = false;
+                    ret.AddRange(ExtractInConnector(text, afterStr, beforeStr, duration, inPrefix, out success));
                 }
             }
 
@@ -473,30 +437,14 @@ namespace Microsoft.Recognizers.Text.DateTime
             // Check whether there's a year
             var suffix = text.Substring(endIndex);
             var prefix = text.Substring(0, startIndex);
-            var matchYear = this.Config.YearSuffix.Match(suffix);
-            if (matchYear.Success && matchYear.Index == 0)
+            bool inSuffix = true;
+            endIndex += GetYearIndex(suffix, inSuffix, ref year, out bool success);
+
+            // Check also in prefix
+            if (!success && Config.CheckBothBeforeAfter)
             {
-                year = GetYearFromText(matchYear);
-
-                if (year >= Constants.MinYearNum && year <= Constants.MaxYearNum)
-                {
-                    endIndex += matchYear.Length;
-                }
-            }
-            else if (Config.CheckBothBeforeAfter)
-            {
-                // Check also in prefix
-                matchYear = this.Config.YearSuffix.Match(prefix);
-                if (matchYear.Success && matchYear.Index + matchYear.Length == prefix.TrimEnd().Length)
-                {
-                    year = GetYearFromText(matchYear);
-
-                    if (year >= Constants.MinYearNum && year <= Constants.MaxYearNum)
-                    {
-                        startIndex -= matchYear.Length + (prefix.Length - prefix.TrimEnd().Length);
-                    }
-                }
-
+                inSuffix = false;
+                startIndex -= GetYearIndex(prefix, inSuffix, ref year, out success);
             }
 
             var date = DateObject.MinValue.SafeCreateFromValue(year, month, day);
@@ -587,6 +535,57 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             StripInequalityPrefix(er, Config.MoreThanRegex);
             StripInequalityPrefix(er, Config.LessThanRegex);
+        }
+
+        // Used in ExtractRelativeDurationDateWithInPrefix to extract the connector "in" in cases like "In 3 days/weeks/months/years"
+        private List<Token> ExtractInConnector(string text, string firstStr, string secondStr, Token duration, bool inPrefix, out bool success)
+        {
+            List<Token> ret = new List<Token>();
+            var match = inPrefix ? Config.InConnectorRegex.MatchEnd(firstStr, trim: true) : Config.InConnectorRegex.MatchBegin(firstStr, trim: true);
+            success = match.Success;
+
+            if (match.Success)
+            {
+                var rangeUnitMatch = Config.RangeUnitRegex.Match(text.Substring(duration.Start, duration.Length));
+
+                if (rangeUnitMatch.Success)
+                {
+                    var sinceYearMatch = Config.SinceYearSuffixRegex.Match(secondStr);
+
+                    if (sinceYearMatch.Success)
+                    {
+                        var start = inPrefix ? match.Index : sinceYearMatch.Index;
+                        var end = inPrefix ? duration.End + sinceYearMatch.Length : duration.End + match.Index + match.Length;
+                        ret.Add(new Token(start, end));
+                    }
+                    else
+                    {
+                        var start = inPrefix ? match.Index : duration.Start;
+                        var end = inPrefix ? duration.End : duration.End + match.Index + match.Length;
+                        ret.Add(new Token(start, end));
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        private int GetYearIndex(string affix, bool inSuffix, ref int year, out bool success)
+        {
+            int index = 0;
+            var matchYear = this.Config.YearSuffix.Match(affix);
+            success = inSuffix ? matchYear.Success && matchYear.Index == 0 : matchYear.Success && matchYear.Index + matchYear.Length == affix.TrimEnd().Length;
+            if (success)
+            {
+                year = GetYearFromText(matchYear);
+
+                if (year >= Constants.MinYearNum && year <= Constants.MaxYearNum)
+                {
+                    index = inSuffix ? matchYear.Length : matchYear.Length + (affix.Length - affix.TrimEnd().Length);
+                }
+            }
+
+            return index;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IEnumerable<Regex> ImplicitDateList { get; }
 
+        bool CheckBothBeforeAfter { get; }
+
         Regex OfMonth { get; }
 
         Regex MonthEnd { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -204,6 +204,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -141,6 +141,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public static int GetSwiftDay(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Utilities/FrenchDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Utilities/FrenchDatetimeUtilityConfiguration.cs
@@ -68,5 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -201,6 +201,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -137,6 +137,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
@@ -67,5 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -202,6 +202,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Utilities/ItalianDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Utilities/ItalianDatetimeUtilityConfiguration.cs
@@ -68,5 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -591,6 +591,20 @@ namespace Microsoft.Recognizers.Text.DateTime
                         ambiguous = false;
                     }
                 }
+                else if (this.config.CheckBothBeforeAfter)
+                {
+                    // Check also in prefix
+                    var prefix = trimmedText.Substring(0, er[0].Start ?? 0);
+                    matchYear = this.config.YearSuffix.Match(prefix);
+                    if (matchYear.Success)
+                    {
+                        year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(matchYear);
+                        if (year != Constants.InvalidYear)
+                        {
+                            ambiguous = false;
+                        }
+                    }
+                }
             }
 
             // Handling relative month

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -582,28 +582,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                 day = num;
 
                 var suffix = trimmedText.Substring(er[0].Start + er[0].Length ?? 0);
-                var matchYear = this.config.YearSuffix.Match(suffix);
-                if (matchYear.Success)
+                GetYearInAffix(suffix, ref year, ref ambiguous, out bool success);
+
+                // Check also in prefix
+                if (!success && this.config.CheckBothBeforeAfter)
                 {
-                    year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(matchYear);
-                    if (year != Constants.InvalidYear)
-                    {
-                        ambiguous = false;
-                    }
-                }
-                else if (this.config.CheckBothBeforeAfter)
-                {
-                    // Check also in prefix
                     var prefix = trimmedText.Substring(0, er[0].Start ?? 0);
-                    matchYear = this.config.YearSuffix.Match(prefix);
-                    if (matchYear.Success)
-                    {
-                        year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(matchYear);
-                        if (year != Constants.InvalidYear)
-                        {
-                            ambiguous = false;
-                        }
-                    }
+                    GetYearInAffix(prefix, ref year, ref ambiguous, out success);
                 }
             }
 
@@ -933,6 +918,20 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return swift;
+        }
+
+        private void GetYearInAffix(string affix, ref int year, ref bool ambiguous, out bool success)
+        {
+            var matchYear = this.config.YearSuffix.Match(affix);
+            success = matchYear.Success;
+            if (success)
+            {
+                year = ((BaseDateExtractor)this.config.DateExtractor).GetYearFromText(matchYear);
+                if (year != Constants.InvalidYear)
+                {
+                    ambiguous = false;
+                }
+            }
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -89,6 +89,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool CheckBothBeforeAfter { get; }
+
         IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         int GetSwiftMonthOrYear(string text);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -195,6 +195,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -145,6 +145,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
@@ -68,5 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -192,6 +192,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -144,6 +144,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
@@ -67,5 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -242,6 +242,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         IImmutableDictionary<string, int> IDateExtractorConfiguration.MonthOfYear => MonthOfYear;
 
+        bool IDateExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         Regex IDateExtractorConfiguration.OfMonth => OfMonth;
 
         Regex IDateExtractorConfiguration.MonthEnd => MonthEnd;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -142,6 +142,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         public IImmutableList<string> MinusTwoDayTerms { get; }
 
+        bool IDateParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         public int GetSwiftMonthOrYear(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Utilities/TurkishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Utilities/TurkishDatetimeUtilityConfiguration.cs
@@ -67,5 +67,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish.Utilities
         Regex IDateTimeUtilityConfiguration.DateUnitRegex => DateUnitRegex;
 
         Regex IDateTimeUtilityConfiguration.CommonDatePrefixRegex => CommonDatePrefixRegex;
+
+        bool IDateTimeUtilityConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
@@ -29,6 +29,19 @@ namespace Microsoft.Recognizers.Text.DateTime
         public static List<Token> ExtractorDurationWithBeforeAndAfter(string text, ExtractResult er, List<Token> ret,
                                                                       IDateTimeUtilityConfiguration utilityConfiguration)
         {
+            if (utilityConfiguration.CheckBothBeforeAfter)
+            {
+                return ExtractorDurationWithBeforeAndAfterInBeforeAndAfterString(text, er, ret, utilityConfiguration);
+            }
+            else
+            {
+                return ExtractorDurationWithBeforeAndAfterDefault(text, er, ret, utilityConfiguration);
+            }
+        }
+
+        public static List<Token> ExtractorDurationWithBeforeAndAfterDefault(string text, ExtractResult er, List<Token> ret,
+                                                                      IDateTimeUtilityConfiguration utilityConfiguration)
+        {
             var pos = (int)er.Start + (int)er.Length;
 
             if (pos <= text.Length)
@@ -85,6 +98,146 @@ namespace Microsoft.Recognizers.Text.DateTime
             return ret;
         }
 
+        // Same as previous method, but it checks both afterString and beforeString for regex matches
+        public static List<Token> ExtractorDurationWithBeforeAndAfterInBeforeAndAfterString(string text, ExtractResult er, List<Token> ret,
+                                                                      IDateTimeUtilityConfiguration utilityConfiguration)
+        {
+            var pos = (int)er.Start + (int)er.Length;
+
+            if (pos <= text.Length)
+            {
+                var afterString = text.Substring(pos);
+                var beforeString = text.Substring(0, (int)er.Start);
+                var isTimeDuration = utilityConfiguration.TimeUnitRegex.Match(er.Text).Success;
+
+                if (MatchingUtil.GetAgoLaterIndex(afterString, utilityConfiguration.AgoRegex, out var index))
+                {
+                    // We don't support cases like "5 minutes from today" for now
+                    // Cases like "5 minutes ago" or "5 minutes from now" are supported
+                    // Cases like "2 days before today" or "2 weeks from today" are also supported
+                    var isDayMatchInAfterString = utilityConfiguration.AgoRegex.Match(afterString).Groups["day"].Success;
+
+                    if (!(isTimeDuration && isDayMatchInAfterString))
+                    {
+                        ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + index));
+                    }
+
+                    if (!isDayMatchInAfterString)
+                    {
+                        // check if regex match is split between beforeString and afterString
+                        string beforeAfterStr = beforeString + afterString.Substring(0, index);
+                        if (MatchingUtil.GetAgoLaterIndexInBeforeString(beforeAfterStr, utilityConfiguration.AgoRegex, out var indexStart))
+                        {
+                            isDayMatchInAfterString = utilityConfiguration.AgoRegex.Match(beforeAfterStr).Groups["day"].Success;
+
+                            if (isDayMatchInAfterString && !(isTimeDuration && isDayMatchInAfterString))
+                            {
+                                ret.Add(new Token(indexStart, (er.Start + er.Length ?? 0) + index));
+                            }
+                        }
+                    }
+                }
+                else if (MatchingUtil.GetAgoLaterIndexInBeforeString(beforeString, utilityConfiguration.AgoRegex, out index))
+                {
+                    // Check also beforeString
+                    // We don't support cases like "5 minutes from today" for now
+                    // Cases like "5 minutes ago" or "5 minutes from now" are supported
+                    // Cases like "2 days before today" or "2 weeks from today" are also supported
+                    var isDayMatchInBeforeString = utilityConfiguration.AgoRegex.Match(beforeString).Groups["day"].Success;
+                    if (!(isTimeDuration && isDayMatchInBeforeString))
+                    {
+                        ret.Add(new Token(index, (er.Start + er.Length ?? 0) + index));
+                    }
+                }
+                else if (MatchingUtil.GetAgoLaterIndex(afterString, utilityConfiguration.LaterRegex, out index) ||
+                         MatchingUtil.GetAgoLaterIndexInBeforeString(beforeString, utilityConfiguration.LaterRegex, out index))
+                {
+                    Token tokAfter = null, tokBefore = null;
+                    if (MatchingUtil.GetAgoLaterIndex(afterString, utilityConfiguration.LaterRegex, out index))
+                    {
+                        var isDayMatchInAfterString = utilityConfiguration.LaterRegex.Match(afterString).Groups["day"].Success;
+
+                        if (!(isTimeDuration && isDayMatchInAfterString))
+                        {
+                            tokAfter = new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + index);
+                        }
+                    }
+
+                    // Check also beforeString
+                    if (MatchingUtil.GetAgoLaterIndexInBeforeString(beforeString, utilityConfiguration.LaterRegex, out index))
+                    {
+                        var isDayMatchInBeforeString = utilityConfiguration.LaterRegex.Match(beforeString).Groups["day"].Success;
+                        if (!(isTimeDuration && isDayMatchInBeforeString))
+                        {
+                            tokBefore = new Token(index, er.Start + er.Length ?? 0);
+                        }
+                    }
+
+                    if (tokAfter != null && tokBefore != null && tokBefore.Start + tokBefore.Length > tokAfter.Start)
+                    {
+                        // merge overlapping tokens
+                        ret.Add(new Token(tokBefore.Start, tokAfter.Start + tokAfter.Length - tokBefore.Start));
+                    }
+                    else if (tokAfter != null)
+                    {
+                        ret.Add(tokAfter);
+                    }
+                    else if (tokBefore != null)
+                    {
+                        ret.Add(tokBefore);
+                    }
+                }
+                else if (MatchingUtil.GetTermIndex(beforeString, utilityConfiguration.InConnectorRegex, out index))
+                {
+                    // For range unit like "week, month, year", it should output dateRange or datetimeRange
+                    if (!utilityConfiguration.RangeUnitRegex.IsMatch(er.Text))
+                    {
+                        if (er.Start != null && er.Length != null && (int)er.Start >= index)
+                        {
+                            ret.Add(new Token((int)er.Start - index, (int)er.Start + (int)er.Length));
+                        }
+                    }
+                }
+                else if (MatchingUtil.GetAgoLaterIndex(afterString, utilityConfiguration.InConnectorRegex, out index))
+                {
+                    // Check also afterString
+                    // For range unit like "week, month, year", it should output dateRange or datetimeRange
+                    if (!utilityConfiguration.RangeUnitRegex.IsMatch(er.Text))
+                    {
+                        if (er.Start != null && er.Length != null)
+                        {
+                            ret.Add(new Token((int)er.Start, (int)er.Start + (int)er.Length + index));
+                        }
+                    }
+                }
+                else if (MatchingUtil.GetTermIndex(beforeString, utilityConfiguration.WithinNextPrefixRegex, out index))
+                {
+                    // For range unit like "week, month, year, day, second, minute, hour", it should output dateRange or datetimeRange
+                    if (!utilityConfiguration.DateUnitRegex.IsMatch(er.Text) && !utilityConfiguration.TimeUnitRegex.IsMatch(er.Text))
+                    {
+                        if (er.Start != null && er.Length != null && (int)er.Start >= index)
+                        {
+                            ret.Add(new Token((int)er.Start - index, (int)er.Start + (int)er.Length));
+                        }
+                    }
+                }
+                else if (MatchingUtil.GetAgoLaterIndex(afterString, utilityConfiguration.WithinNextPrefixRegex, out index))
+                {
+                    // Check also afterString
+                    // For range unit like "week, month, year, day, second, minute, hour", it should output dateRange or datetimeRange
+                    if (!utilityConfiguration.DateUnitRegex.IsMatch(er.Text) && !utilityConfiguration.TimeUnitRegex.IsMatch(er.Text))
+                    {
+                        if (er.Start != null && er.Length != null)
+                        {
+                            ret.Add(new Token((int)er.Start, (int)er.Start + (int)er.Length + index));
+                        }
+                    }
+                }
+            }
+
+            return ret;
+        }
+
         public static DateTimeResolutionResult ParseDurationWithAgoAndLater(
             string text,
             DateObject referenceTime,
@@ -117,7 +270,14 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     if (pr.Value != null)
                     {
-                        return GetAgoLaterResult(pr, afterStr, beforeStr, referenceTime, numberParser, utilityConfiguration, mode, swiftDay);
+                        if (utilityConfiguration.CheckBothBeforeAfter)
+                        {
+                            return GetAgoLaterResultInBeforeAndAfterString(pr, afterStr, beforeStr, referenceTime, numberParser, utilityConfiguration, mode, swiftDay);
+                        }
+                        else
+                        {
+                            return GetAgoLaterResult(pr, afterStr, beforeStr, referenceTime, numberParser, utilityConfiguration, mode, swiftDay);
+                        }
                     }
                 }
             }
@@ -176,6 +336,151 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 var yearMatch = utilityConfiguration.SinceYearSuffixRegex.Match(afterStr);
+                if (yearMatch.Success)
+                {
+                    var yearString = yearMatch.Groups[Constants.YearGroupName].Value;
+                    var yearEr = new ExtractResult { Text = yearString };
+                    var year = Convert.ToInt32((double)(numberParser.Parse(yearEr).Value ?? 0));
+                    referenceTime = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
+                }
+
+                resultDateTime = DurationParsingUtil.ShiftDateTime(timex, referenceTime.AddDays(swift), true);
+
+                ((DateTimeResolutionResult)durationParseResult.Value).Mod = Constants.AFTER_MOD;
+            }
+
+            if (resultDateTime != referenceTime)
+            {
+                if (mode.Equals(AgoLaterMode.Date))
+                {
+                    ret.Timex = $"{DateTimeFormatUtil.LuisDate(resultDateTime)}";
+                }
+                else if (mode.Equals(AgoLaterMode.DateTime))
+                {
+                    ret.Timex = $"{DateTimeFormatUtil.LuisDateTime(resultDateTime)}";
+                }
+
+                ret.FutureValue = ret.PastValue = resultDateTime;
+                ret.SubDateTimeEntities = new List<object> { durationParseResult };
+                ret.Success = true;
+            }
+
+            return ret;
+        }
+
+        // Same as previous method, but it checks both afterStr and beforeStr for regex matches
+        private static DateTimeResolutionResult GetAgoLaterResultInBeforeAndAfterString(
+            DateTimeParseResult durationParseResult,
+            string afterStr,
+            string beforeStr,
+            DateObject referenceTime,
+            IParser numberParser,
+            IDateTimeUtilityConfiguration utilityConfiguration,
+            AgoLaterMode mode,
+            SwiftDayDelegate swiftDay)
+        {
+            var ret = new DateTimeResolutionResult();
+            var resultDateTime = referenceTime;
+            var timex = durationParseResult.TimexStr;
+
+            if (((DateTimeResolutionResult)durationParseResult.Value).Mod == Constants.MORE_THAN_MOD)
+            {
+                ret.Mod = Constants.MORE_THAN_MOD;
+            }
+            else if (((DateTimeResolutionResult)durationParseResult.Value).Mod == Constants.LESS_THAN_MOD)
+            {
+                ret.Mod = Constants.LESS_THAN_MOD;
+            }
+
+            if (MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.AgoRegex))
+            {
+                var match = utilityConfiguration.AgoRegex.Match(afterStr);
+                var swift = 0;
+
+                // Handle cases like "3 days before yesterday"
+                if (match.Success && !string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    swift = swiftDay(match.Groups["day"].Value);
+                }
+                else if (match.Success && !MatchingUtil.ContainsAgoLaterIndexInBeforeString(beforeStr, utilityConfiguration.AgoRegex))
+                {
+                    match = utilityConfiguration.AgoRegex.Match(beforeStr + " " + afterStr);
+                    if (match.Success && !string.IsNullOrEmpty(match.Groups["day"].Value))
+                    {
+                        swift = swiftDay(match.Groups["day"].Value);
+                    }
+                }
+
+                resultDateTime = DurationParsingUtil.ShiftDateTime(timex, referenceTime.AddDays(swift), false);
+
+                ((DateTimeResolutionResult)durationParseResult.Value).Mod = Constants.BEFORE_MOD;
+            }
+            else if (MatchingUtil.ContainsAgoLaterIndexInBeforeString(beforeStr, utilityConfiguration.AgoRegex))
+            {
+                var match = utilityConfiguration.AgoRegex.Match(beforeStr);
+                var swift = 0;
+
+                // Handle cases like "3 days before yesterday"
+                if (match.Success && !string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    swift = swiftDay(match.Groups["day"].Value);
+                }
+
+                resultDateTime = DurationParsingUtil.ShiftDateTime(timex, referenceTime.AddDays(swift), false);
+
+                ((DateTimeResolutionResult)durationParseResult.Value).Mod = Constants.BEFORE_MOD;
+            }
+            else if (MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.LaterRegex) ||
+                     MatchingUtil.ContainsTermIndex(beforeStr, utilityConfiguration.InConnectorRegex) ||
+                     MatchingUtil.ContainsAgoLaterIndexInBeforeString(beforeStr, utilityConfiguration.LaterRegex))
+            {
+                var match = utilityConfiguration.LaterRegex.Match(afterStr);
+                var swift = 0;
+
+                if (MatchingUtil.ContainsAgoLaterIndexInBeforeString(beforeStr, utilityConfiguration.LaterRegex) && string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    match = utilityConfiguration.LaterRegex.Match(beforeStr);
+                }
+
+                // Handle cases like "3 days after tomorrow"
+                if (match.Success && !string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    swift = swiftDay(match.Groups["day"].Value);
+                }
+
+                var yearMatch = utilityConfiguration.SinceYearSuffixRegex.Match(afterStr);
+                if (yearMatch.Success)
+                {
+                    var yearString = yearMatch.Groups[Constants.YearGroupName].Value;
+                    var yearEr = new ExtractResult { Text = yearString };
+                    var year = Convert.ToInt32((double)(numberParser.Parse(yearEr).Value ?? 0));
+                    referenceTime = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
+                }
+
+                resultDateTime = DurationParsingUtil.ShiftDateTime(timex, referenceTime.AddDays(swift), true);
+
+                ((DateTimeResolutionResult)durationParseResult.Value).Mod = Constants.AFTER_MOD;
+            }
+            else if (MatchingUtil.ContainsAgoLaterIndexInBeforeString(beforeStr, utilityConfiguration.LaterRegex) ||
+                     MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.InConnectorRegex) ||
+                     MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.LaterRegex))
+            {
+                // Check also beforeStr
+                var match = utilityConfiguration.LaterRegex.Match(beforeStr);
+                var swift = 0;
+
+                if (MatchingUtil.ContainsAgoLaterIndex(afterStr, utilityConfiguration.LaterRegex) && string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    match = utilityConfiguration.LaterRegex.Match(beforeStr);
+                }
+
+                // Handle cases like "3 days after tomorrow"
+                if (match.Success && !string.IsNullOrEmpty(match.Groups["day"].Value))
+                {
+                    swift = swiftDay(match.Groups["day"].Value);
+                }
+
+                var yearMatch = utilityConfiguration.SinceYearSuffixRegex.Match(beforeStr);
                 if (yearMatch.Success)
                 {
                     var yearString = yearMatch.Groups[Constants.YearGroupName].Value;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/IDateTimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/IDateTimeUtilityConfiguration.cs
@@ -27,5 +27,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         Regex AmPmDescRegex { get; }
 
         Regex CommonDatePrefixRegex { get; }
+
+        bool CheckBothBeforeAfter { get; }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MatchingUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MatchingUtil.cs
@@ -23,6 +23,20 @@ namespace Microsoft.Recognizers.Text.DateTime
             return false;
         }
 
+        public static bool GetAgoLaterIndexInBeforeString(string text, Regex regex, out int index)
+        {
+            index = -1;
+            var match = regex.MatchEnd(text, trim: true);
+
+            if (match.Success)
+            {
+                index = match.Index;
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool GetTermIndex(string text, Regex regex, out int index)
         {
             index = -1;
@@ -39,6 +53,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         public static bool ContainsAgoLaterIndex(string text, Regex regex)
         {
             return GetAgoLaterIndex(text, regex, out var index);
+        }
+
+        public static bool ContainsAgoLaterIndexInBeforeString(string text, Regex regex)
+        {
+            return GetAgoLaterIndexInBeforeString(text, regex, out var index);
         }
 
         public static bool ContainsTermIndex(string text, Regex regex)

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
   def: (?<till>\b(tot|totdat|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
   def: (?<till>\b(to|(un)?till?|thru|through)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !simpleRegex
   def: (?<till>au|et|(jusqu')?[aà]|avant|--|-|—|——)
 RangeConnectorRegex : !simpleRegex

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !simpleRegex
   def: (?<till>zu|bis\s*zum|zum|bis|bis\s*hin(\s*zum)?|--|-|—|——)
 RangeConnectorRegex : !simpleRegex

--- a/Patterns/Italian/Italian-DateTime.yaml
+++ b/Patterns/Italian/Italian-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !simpleRegex
   def: (?<till>\b(fino\s+a(l(l[aoe'])?|gli|i)?|a(l(l[aoe'])?|gli|i)?|e\s+(il?|l[aoe']|gli))\b|--|-|—|——|~)
 RestrictedTillRegex: !simpleRegex

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !simpleRegex
   def: (?<till>ate|as|às|até|ateh|a|ao|--|-|—|——)(\s+(o|[aà](s)?))?
 AndRegex: !simpleRegex

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool false
 TillRegex: !simpleRegex
   def: (?<till>hasta|al|a|--|-|—|——)(\s+(el|la(s)?))?
 AndRegex: !simpleRegex

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -1,4 +1,5 @@
 ---
+CheckBothBeforeAfter: !bool true
 TillRegex: !simpleRegex
   def: (?<till>\b(kadar|dek|değin)\b)
 RangeConnectorRegex : !simpleRegex
@@ -208,7 +209,7 @@ DateYearRegex: !nestedRegex
   def: (?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, TwoDigitYearRegex ]
 YearSuffix: !nestedRegex
-  def: (,?\s*({DateYearRegex}|{FullTextYearRegex}))
+  def: (,?\s*({DateYearRegex}|{FullTextYearRegex})(\s+yılı)?)
   references: [ DateYearRegex, FullTextYearRegex ]
 OnRegex: !simpleRegex
   def: ^[\*]
@@ -570,18 +571,18 @@ SinceRegex: !simpleRegex
 AroundRegex: !simpleRegex
   def: (\b(takriben|yaklaşık)\s*|\s*(civarında|civarı|dolaylarında)\b)
 AgoRegex: !simpleRegex
-  def: \b(önce|evvel)\b
+  def: \b((?<day>bugünden|gün|dünden|dün)\s+)?(önce|evvel)\b
 LaterRegex: !simpleRegex
-  def: \b(sonra|içinde|(?<day>yarından|bugünden)\s+(itibaren|sonra)|şu andan itibaren)\b
+  def: \b(sonra|(?<day>yarından|yarın|bugünden|gün)\s+(itibaren|sonra)|şu andan itibaren)
 InConnectorRegex: !simpleRegex
-  def: ^[\*]
+  def: \b(içinde)\b
 SinceNumSuffixRegex: !simpleRegex
   def: \b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b
 SinceYearSuffixRegex: !nestedRegex
   def: ({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)
   references: [ YearSuffix, SinceNumSuffixRegex ]
 WithinNextPrefixRegex: !nestedRegex
-  def: \b((?<next>{NextPrefixRegex})?\s+?\d+\s+(hafta|ay|yıl)\s+(içinde))\b
+  def: \b((?<next>{NextPrefixRegex})?(\s+)?(\d+\s+(hafta|ay|yıl)\s+)?içinde)\b
   references: [ NextPrefixRegex ]
 MorningStartEndRegex: !simpleRegex
   def: (^sabah$)

--- a/Specs/DateTime/Turkish/DateExtractor.json
+++ b/Specs/DateTime/Turkish/DateExtractor.json
@@ -573,13 +573,12 @@
   {
     "Input": "iki bin yılı Eylül'ün onunda",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "iki bin yılı Eylül'ün onunda",
+        "Text": "iki bin yılı Eylül'ün onu",
         "Type": "date",
         "Start": 0,
-        "Length": 28
+        "Length": 25
       }
     ]
   },
@@ -622,7 +621,6 @@
   {
     "Input": "Yarından itibaren üç hafta sonra uygun musun?",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "Yarından itibaren üç hafta sonra",

--- a/Specs/DateTime/Turkish/DateParser.json
+++ b/Specs/DateTime/Turkish/DateParser.json
@@ -1733,10 +1733,9 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "iki bin yılı Eylül'ün onunda",
+        "Text": "iki bin yılı Eylül'ün onu",
         "Type": "date",
         "Value": {
           "Timex": "2000-09-10",
@@ -1748,7 +1747,7 @@
           }
         },
         "Start": 0,
-        "Length": 28
+        "Length": 25
       }
     ]
   },
@@ -2118,7 +2117,6 @@
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "Yarından itibaren üç hafta sonra",
@@ -2133,7 +2131,7 @@
           }
         },
         "Start": 0,
-        "Length": 26
+        "Length": 32
       }
     ]
   },
@@ -2143,7 +2141,6 @@
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "Dünden iki gün önce",


### PR DESCRIPTION
Added boolean attribute to yaml files to determine if both before and after strings should be checked for match extension and modified methods in AgoLaterUtils to work according to this attribute.
With this modification, all Date test cases (and others in DatePeriod) pass.