### PR TITLE
[EN DateTimeV2] Add support for cases like 2019/sep/21

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string DateExtractor8 = $@"(?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}(?![%])\b";
       public static readonly string DateExtractor9L = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}{DateExtractorYearTermRegex}(?![%])\b";
       public static readonly string DateExtractor9S = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}(?![%])\b";
-      public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}";
+      public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}";
       public static readonly string OfMonth = $@"^\s*of\s*{MonthRegex}";
       public static readonly string MonthEnd = $@"{MonthRegex}\s*(the)?\s*$";
       public static readonly string WeekDayEnd = $@"(this\s+)?{WeekDayRegex}\s*,?\s*$";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -376,9 +376,10 @@ public class EnglishDateTime {
             .replace("{MonthNumRegex}", MonthNumRegex)
             .replace("{WeekDayRegex}", WeekDayRegex);
 
-    public static final String DateExtractorA = "\\b({WeekDayRegex}\\s+)?{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*{MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*{DayRegex}"
+    public static final String DateExtractorA = "\\b({WeekDayRegex}\\s+)?{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*({MonthNumRegex}|{MonthRegex})\\s*[/\\\\\\-\\.]\\s*{DayRegex}"
             .replace("{BaseDateTime.FourDigitYearRegex}", BaseDateTime.FourDigitYearRegex)
             .replace("{MonthNumRegex}", MonthNumRegex)
+            .replace("{MonthRegex}", MonthRegex)
             .replace("{DayRegex}", DayRegex)
             .replace("{WeekDayRegex}", WeekDayRegex);
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/englishDateTime.ts
@@ -114,7 +114,7 @@ export namespace EnglishDateTime {
     export const DateExtractor8 = `(?<=${DatePreposition}\\s+)(${StrictRelativeRegex}\\s+)?(${WeekDayRegex}\\s+)?${DayRegex}[\\\\\\-]${MonthNumRegex}(?![%])\\b`;
     export const DateExtractor9L = `\\b(${WeekDayRegex}\\s+)?${DayRegex}\\s*/\\s*${MonthNumRegex}${DateExtractorYearTermRegex}(?![%])\\b`;
     export const DateExtractor9S = `\\b(${WeekDayRegex}\\s+)?${DayRegex}\\s*/\\s*${MonthNumRegex}(?![%])\\b`;
-    export const DateExtractorA = `\\b(${WeekDayRegex}\\s+)?${BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*${MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*${DayRegex}`;
+    export const DateExtractorA = `\\b(${WeekDayRegex}\\s+)?${BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*(${MonthNumRegex}|${MonthRegex})\\s*[/\\\\\\-\\.]\\s*${DayRegex}`;
     export const OfMonth = `^\\s*of\\s*${MonthRegex}`;
     export const MonthEnd = `${MonthRegex}\\s*(the)?\\s*$`;
     export const WeekDayEnd = `(this\\s+)?${WeekDayRegex}\\s*,?\\s*$`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
@@ -68,7 +68,7 @@ export namespace SpanishDateTime {
     export const FromRegex = `((desde|de)(\\s*la(s)?)?)$`;
     export const ConnectorAndRegex = `(y\\s*(la(s)?)?)$`;
     export const BetweenRegex = `(entre\\s*(la(s)?)?)`;
-    export const WeekDayRegex = `\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|sa|do)\\b`;
+    export const WeekDayRegex = `\\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)\\b`;
     export const OnRegex = `(?<=\\ben\\s+)(${DayRegex}s?)\\b`;
     export const RelaxedOnRegex = `(?<=\\b(en|el|del)\\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)\\b`;
     export const ThisRegex = `\\b((este\\s*)${WeekDayRegex})|(${WeekDayRegex}\\s*((de\\s+)?esta\\s+semana))\\b`;

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -12,7 +12,7 @@ StrictRelativeRegex: !simpleRegex
   def: \b(?<order>following|next|(up)?coming|this|last|past|previous|current)\b
 UpcomingPrefixRegex: !simpleRegex
   def: ((this\s+)?((up)?coming))
-NextPrefixRegex: !nestedRegex
+NextPrefixRegex: !nestedRegex 
   def: \b(following|next|{UpcomingPrefixRegex})\b
   references: [ UpcomingPrefixRegex ]
 # We make "next" and "upcoming" separately as when parsing, some behaviours are different
@@ -275,8 +275,8 @@ DateExtractor9S: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}(?![%])\b
   references: [ DayRegex, MonthNumRegex, WeekDayRegex ]
 DateExtractorA: !nestedRegex
-  def: \b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}
-  references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex, DayRegex, WeekDayRegex ]
+  def: \b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}
+  references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex, MonthRegex, DayRegex, WeekDayRegex ]
 OfMonth: !nestedRegex
   def: ^\s*of\s*{MonthRegex}
   references: [ MonthRegex ]

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/english_date_time.py
@@ -117,7 +117,7 @@ class EnglishDateTime:
     DateExtractor8 = f'(?<={DatePreposition}\\s+)({StrictRelativeRegex}\\s+)?({WeekDayRegex}\\s+)?{DayRegex}[\\\\\\-]{MonthNumRegex}(?![%])\\b'
     DateExtractor9L = f'\\b({WeekDayRegex}\\s+)?{DayRegex}\\s*/\\s*{MonthNumRegex}{DateExtractorYearTermRegex}(?![%])\\b'
     DateExtractor9S = f'\\b({WeekDayRegex}\\s+)?{DayRegex}\\s*/\\s*{MonthNumRegex}(?![%])\\b'
-    DateExtractorA = f'\\b({WeekDayRegex}\\s+)?{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*{MonthNumRegex}\\s*[/\\\\\\-\\.]\\s*{DayRegex}'
+    DateExtractorA = f'\\b({WeekDayRegex}\\s+)?{BaseDateTime.FourDigitYearRegex}\\s*[/\\\\\\-\\.]\\s*({MonthNumRegex}|{MonthRegex})\\s*[/\\\\\\-\\.]\\s*{DayRegex}'
     OfMonth = f'^\\s*of\\s*{MonthRegex}'
     MonthEnd = f'{MonthRegex}\\s*(the)?\\s*$'
     WeekDayEnd = f'(this\\s+)?{WeekDayRegex}\\s*,?\\s*$'

--- a/Specs/DateTime/English/DateExtractor.json
+++ b/Specs/DateTime/English/DateExtractor.json
@@ -1593,5 +1593,27 @@
     "Comment": "Only August 2019 should be extracted as a DateRange, so no output in Date only. Java disabled due to issue in lookbehind.",
     "NotSupported": "dotnet, java, javascript, python",
     "Results": []
+  },
+  {
+    "Input": "i'll go back 2019-sep-1",
+    "Results": [
+      {
+        "Text": "2019-sep-1",
+        "Type": "date",
+        "Start": 13,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "i'll go back 2019/sep/01",
+    "Results": [
+      {
+        "Text": "2019/sep/01",
+        "Type": "date",
+        "Start": 13,
+        "Length": 11
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -2866,5 +2866,51 @@
         "Length": 26
       }
     ]
+  },
+  {
+    "Input": "i'll go back 2019-sep-1.",
+    "Context": {
+      "ReferenceDateTime": "2018-08-21T08:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019-sep-1",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-09-01",
+          "FutureResolution": {
+            "date": "2019-09-01"
+          },
+          "PastResolution": {
+            "date": "2019-09-01"
+          }
+        },
+        "Start": 13,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "i'll go back 2019/sep/01.",
+    "Context": {
+      "ReferenceDateTime": "2018-08-21T08:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019/sep/01",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-09-01",
+          "FutureResolution": {
+            "date": "2019-09-01"
+          },
+          "PastResolution": {
+            "date": "2019-09-01"
+          }
+        },
+        "Start": 13,
+        "Length": 11
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DatePeriodExtractor.json
+++ b/Specs/DateTime/English/DatePeriodExtractor.json
@@ -3816,5 +3816,27 @@
         "Length": 11
       }
     ]
+  },
+  {
+    "Input": "I was not there from 2019/aug/01 to today",
+    "Results": [
+      {
+        "Text": "from 2019/aug/01 to today",
+        "Type": "daterange",
+        "Start": 16,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "I was not there from 2019-aug-1 to today",
+    "Results": [
+      {
+        "Text": "from 2019-aug-1 to today",
+        "Type": "daterange",
+        "Start": 16,
+        "Length": 24
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -5844,5 +5844,55 @@
         "Length": 11
       }
     ]
+  },
+  {
+    "Input": "I was not there from 2019-aug-1 to today",
+    "Context": {
+      "ReferenceDateTime": "2019-10-14T15:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from 2019-aug-1 to today",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "(2019-08-01,2019-10-14,P74D)",
+          "FutureResolution": {
+            "startDate": "2019-08-01",
+            "endDate": "2019-10-14"
+          },
+          "PastResolution": {
+            "startDate": "2019-08-01",
+            "endDate": "2019-10-14"
+          }
+        },
+        "Start": 16,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "I was not there from 2019/aug/01 to today",
+    "Context": {
+      "ReferenceDateTime": "2019-09-30T15:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from 2019/aug/01 to today",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "(2019-08-01,2019-09-30,P60D)",
+          "FutureResolution": {
+            "startDate": "2019-08-01",
+            "endDate": "2019-09-30"
+          },
+          "PastResolution": {
+            "startDate": "2019-08-01",
+            "endDate": "2019-09-30"
+          }
+        },
+        "Start": 16,
+        "Length": 25
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14579,5 +14579,99 @@
         }
       }
     ]
+  },
+  {
+    "Input": "How about 2019/aug/01",
+    "Context": {
+      "ReferenceDateTime": "2019-09-19T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019/aug/01",
+        "Start": 10,
+        "End": 20,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-08-01",
+              "type": "date",
+              "value": "2019-08-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How about 2019-aug-1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-19T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019-aug-1",
+        "Start": 10,
+        "End": 19,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-08-01",
+              "type": "date",
+              "value": "2019-08-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "He has been China from 2019-aug-01 to today.",
+    "Context": {
+      "ReferenceDateTime": "2019-10-14T01:00:00"
+    },
+    "Results": [
+      {
+        "Text": "from 2019-aug-01 to today",
+        "Start": 18,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-08-01,2019-10-14,P74D)",
+              "type": "daterange",
+              "start": "2019-08-01",
+              "end": "2019-10-14"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2019/aug/01 to today",
+    "Context": {
+      "ReferenceDateTime": "2019-10-14T10:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019/aug/01 to today",
+        "Start": 0,
+        "End": 19,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-08-01,2019-10-14,P74D)",
+              "type": "daterange",
+              "start": "2019-08-01",
+              "end": "2019-10-14"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix #1894 
- support Date cases like 2019/sep/21 and 2019-sep-20.
- support DatePeriod cases like 2019/sep/21 to today.