### PR TITLE
[CN DateTimeV2 JS] Add support for relative cases like "5天前"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var tokens = new List<Token>();
             tokens.AddRange(BasicRegexMatch(text));
             tokens.AddRange(ImplicitDate(text));
-            tokens.AddRange(DurationWithBeforeAndAfter(text, referenceTime));
+            tokens.AddRange(DurationWithAgoAndLater(text, referenceTime));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
         }
@@ -162,7 +162,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         // process case like "三天前" "两个月前"
-        private static List<Token> DurationWithBeforeAndAfter(string text, DateObject referenceTime)
+        private static List<Token> DurationWithAgoAndLater(string text, DateObject referenceTime)
         {
             var ret = new List<Token>();
             var durationEr = DurationExtractor.Extract(text, referenceTime);
@@ -184,7 +184,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                     if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value)) || (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
                     {
-                        var metadata = new Metadata() { IsDurationWithBeforeAndAfter = true };
+                        var metadata = new Metadata() { IsDurationWithAgoAndLater = true };
                         ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
@@ -156,13 +156,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             tokens.AddRange(MergeDateAndTime(text, referenceTime));
             tokens.AddRange(BasicRegexMatch(text));
             tokens.AddRange(TimeOfToday(text, referenceTime));
-            tokens.AddRange(DurationWithBeforeAndAfter(text, referenceTime));
+            tokens.AddRange(DurationWithAgoAndLater(text, referenceTime));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
         }
 
         // Process case like "5分钟前" "二小时后"
-        private List<Token> DurationWithBeforeAndAfter(string text, DateObject referenceTime)
+        private List<Token> DurationWithAgoAndLater(string text, DateObject referenceTime)
         {
             var ret = new List<Token>();
             var durationEr = DurationExtractor.Extract(text, referenceTime);
@@ -177,7 +177,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                     if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value)) || (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
                     {
-                        var metadata = new Metadata() { IsDurationWithBeforeAndAfter = true };
+                        var metadata = new Metadata() { IsDurationWithAgoAndLater = true };
                         ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             if (!innerResult.Success)
             {
-                innerResult = ParserDurationWithBeforeAndAfter(text, reference);
+                innerResult = ParserDurationWithAgoAndLater(text, reference);
             }
 
             if (innerResult.Success)
@@ -620,7 +620,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         // Handle cases like "三天前"
-        private DateTimeResolutionResult ParserDurationWithBeforeAndAfter(string text, DateObject referenceDate)
+        private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
             var durationRes = durationExtractor.Extract(text, referenceDate);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
                 if (!innerResult.Success)
                 {
-                    innerResult = ParserDurationWithBeforeAndAfter(er.Text, referenceTime);
+                    innerResult = ParserDurationWithAgoAndLater(er.Text, referenceTime);
                 }
 
                 if (innerResult.Success)
@@ -311,7 +311,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         }
 
         // handle cases like "5分钟前", "1小时以后"
-        private DateTimeResolutionResult ParserDurationWithBeforeAndAfter(string text, DateObject referenceDate)
+        private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
             var durationRes = durationExtractor.Extract(text, referenceDate);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var tokens = new List<Token>();
             tokens.AddRange(BasicRegexMatch(text));
             tokens.AddRange(ImplicitDate(text));
-            tokens.AddRange(DurationWithBeforeAndAfter(text, referenceTime));
+            tokens.AddRange(DurationWithAgoAndLater(text, referenceTime));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
         }
@@ -179,7 +179,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         }
 
         // Process case like "三天前" "两个月前"
-        private List<Token> DurationWithBeforeAndAfter(string text, DateObject referenceTime)
+        private List<Token> DurationWithAgoAndLater(string text, DateObject referenceTime)
         {
             var ret = new List<Token>();
             var durationEr = DurationExtractor.Extract(text, referenceTime);
@@ -202,7 +202,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value)) ||
                         (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
                     {
-                        var metadata = new Metadata() { IsDurationWithBeforeAndAfter = true };
+                        var metadata = new Metadata() { IsDurationWithAgoAndLater = true };
                         ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
@@ -155,13 +155,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             tokens.AddRange(MergeDateAndTime(text, referenceTime));
             tokens.AddRange(BasicRegexMatch(text));
             tokens.AddRange(TimeOfToday(text, referenceTime));
-            tokens.AddRange(DurationWithBeforeAndAfter(text, referenceTime));
+            tokens.AddRange(DurationWithAgoAndLater(text, referenceTime));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
         }
 
         // Process case like "5分钟前" "二小时后"
-        private List<Token> DurationWithBeforeAndAfter(string text, DateObject referenceTime)
+        private List<Token> DurationWithAgoAndLater(string text, DateObject referenceTime)
         {
             var ret = new List<Token>();
             var durationEr = DurationExtractor.Extract(text, referenceTime);
@@ -177,7 +177,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     if ((beforeMatch.Success && suffix.StartsWith(beforeMatch.Value)) ||
                         (afterMatch.Success && suffix.StartsWith(afterMatch.Value)))
                     {
-                        var metadata = new Metadata() { IsDurationWithBeforeAndAfter = true };
+                        var metadata = new Metadata() { IsDurationWithAgoAndLater = true };
                         ret.Add(new Token(er.Start ?? 0, (er.Start + er.Length ?? 0) + 1, metadata));
                     }
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             if (!innerResult.Success)
             {
-                innerResult = ParserDurationWithBeforeAndAfter(text, reference);
+                innerResult = ParserDurationWithAgoAndLater(text, reference);
             }
 
             if (innerResult.Success)
@@ -558,7 +558,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         }
 
         // handle cases like "三天前"
-        private DateTimeResolutionResult ParserDurationWithBeforeAndAfter(string text, DateObject referenceDate)
+        private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
             var durationRes = durationExtractor.Extract(text, referenceDate);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
                 if (!innerResult.Success)
                 {
-                    innerResult = ParserDurationWithBeforeAndAfter(er.Text, referenceTime);
+                    innerResult = ParserDurationWithAgoAndLater(er.Text, referenceTime);
                 }
 
                 if (innerResult.Success)
@@ -309,7 +309,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         }
 
         // handle cases like "5分钟前", "1小时以后"
-        private DateTimeResolutionResult ParserDurationWithBeforeAndAfter(string text, DateObject referenceDate)
+        private DateTimeResolutionResult ParserDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
             var ret = new DateTimeResolutionResult();
             var durationRes = durationExtractor.Extract(text, referenceDate);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -135,14 +135,14 @@ namespace Microsoft.Recognizers.Text.DateTime
             var sinceMatchSuffix = config.SinceSuffixRegex.MatchEnd(er.Text, trim: true);
             var equalMatch = config.EqualRegex.MatchBegin(er.Text, trim: true);
 
-            if (beforeMatch.Success && !IsDurationWithBeforeAndAfter(er))
+            if (beforeMatch.Success && !IsDurationWithAgoAndLater(er))
             {
                 hasBefore = true;
                 er.Length -= beforeMatch.Length;
                 er.Text = er.Text.Substring(0, er.Length ?? 0);
                 modStr = beforeMatch.Value;
             }
-            else if (afterMatch.Success && !IsDurationWithBeforeAndAfter(er))
+            else if (afterMatch.Success && !IsDurationWithAgoAndLater(er))
             {
                 hasAfter = true;
                 er.Length -= afterMatch.Length;
@@ -562,9 +562,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             return res;
         }
 
-        private bool IsDurationWithBeforeAndAfter(ExtractResult er)
+        private bool IsDurationWithAgoAndLater(ExtractResult er)
         {
-            return er.Metadata != null && er.Metadata.IsDurationWithBeforeAndAfter;
+            return er.Metadata != null && er.Metadata.IsDurationWithAgoAndLater;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Extractors/Metadata.cs
+++ b/.NET/Microsoft.Recognizers.Text/Extractors/Metadata.cs
@@ -8,7 +8,7 @@
 
         // For cases like "2015年以前" (usually regards as "before 2015" in English), "5天以前" (usually regards as "5 days ago" in English) in Chinese, we need to decide whether this is a "Date with Mode" or "Duration with Before and After". We use this flag to avoid duplicate judgment both in the Extraction step and Parse step.
         // Currently, this flag is only used in Chinese DateTime as other languages don't have this ambiguity cases.
-        public bool IsDurationWithBeforeAndAfter { get; set; } = false;
+        public bool IsDurationWithAgoAndLater { get; set; } = false;
 
         // For Holiday cases as they are special cases of Date
         public bool IsHoliday { get; set; } = false;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
@@ -521,7 +521,7 @@ export class BaseDateTimeParser implements IDateTimeParser {
     }
 
     // handle like "two hours ago"
-    private parserDurationWithAgoAndLater(text: string, referenceTime: Date): DateTimeResolutionResult {
+    protected parserDurationWithAgoAndLater(text: string, referenceTime: Date): DateTimeResolutionResult {
         return AgoLaterUtil.parseDurationWithAgoAndLater(
             text,
             referenceTime,

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDateTime.ts
@@ -189,7 +189,7 @@ export class BaseDateTimeExtractor implements IDateTimeExtractor {
         return tokens;
     }
 
-    private durationWithBeforeAndAfter(source: string, refDate: Date): Token[] {
+    protected durationWithBeforeAndAfter(source: string, refDate: Date): Token[] {
         let tokens: Token[] = new Array<Token>();
         this.config.durationExtractor.extract(source, refDate).forEach(er => {
             let matches = RegExpUtility.getMatches(this.config.unitRegex, er.text);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -526,6 +526,7 @@ export class ChineseDateParser extends BaseDateParser {
         return result;
     }
 
+    // convert Chinese Number to Integer
     private convertChineseToNumber(source: string): number {
         let num = -1;
         let er = this.config.integerExtractor.extract(source);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -527,7 +527,7 @@ export class ChineseDateParser extends BaseDateParser {
     }
 
     // convert Chinese Number to Integer
-    private convertChineseToNumber(source: string): number {
+    private parseChineseWrittenNumberToValue(source: string): number {
         let num = -1;
         let er = this.config.integerExtractor.extract(source);
         if (er && er[0].type === NumberConstants.SYS_NUM_INTEGER) {
@@ -609,7 +609,7 @@ export class ChineseDateParser extends BaseDateParser {
                 let srcUnit = match.groups('unit').value;
 
                 let numberStr = source.substring(durationRes[0].start, match.index - durationRes[0].start);
-                let number =  this.convertChineseToNumber(numberStr);
+                let number =  this.parseChineseWrittenNumberToValue(numberStr);
 
                 if (this.config.unitMap.has(srcUnit)) {
                     let unitStr = this.config.unitMap.get(srcUnit);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -81,12 +81,12 @@ export class ChineseDateExtractor extends BaseDateExtractor {
         let tokens: Token[] = new Array<Token>()
             .concat(super.basicRegexMatch(source))
             .concat(super.implicitDate(source))
-            .concat(this.durationWithBeforeAndAfter(source, referenceDate));
+            .concat(this.durationWithAgoAndLater(source, referenceDate));
         let result = Token.mergeAllTokens(tokens, source, this.extractorName);
         return result;
     }
 
-    protected durationWithBeforeAndAfter(source: string, refDate: Date): Token[] {
+    protected durationWithAgoAndLater(source: string, refDate: Date): Token[] {
         let ret = [];
         let durationEr = this.durationExtractor.extract(source, refDate);
         durationEr.forEach(er => {
@@ -99,7 +99,7 @@ export class ChineseDateExtractor extends BaseDateExtractor {
 
                     if (beforeMatch && suffix.startsWith(beforeMatch.value) || afterMatch && suffix.startsWith(afterMatch.value)) {
                         let metadata = new MetaData();
-                        metadata.IsDurationWithBeforeAndAfter = true;
+                        metadata.IsDurationWithAgoAndLater = true;
                         ret.push(new Token(er.start, pos + 1, metadata));
                     }
                 }
@@ -241,7 +241,7 @@ export class ChineseDateParser extends BaseDateParser {
             }
             if (!innerResult.success) {
                 // TODO create test
-                innerResult = this.parserDurationWithBeforeAndAfter(source, referenceDate);
+                innerResult = this.parserDurationWithAgoAndLater(source, referenceDate);
             }
             if (innerResult.success) {
                 innerResult.futureResolution = {};
@@ -598,7 +598,7 @@ export class ChineseDateParser extends BaseDateParser {
     }
     
     // Handle cases like "三天前"
-    private parserDurationWithBeforeAndAfter(source: string, referenceDate: Date): DateTimeResolutionResult {
+    protected parserDurationWithAgoAndLater(source: string, referenceDate: Date): DateTimeResolutionResult {
         let result = new DateTimeResolutionResult();
         let durationRes = this.durationExtractor.extract(source, referenceDate);
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
@@ -70,7 +70,7 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
             .concat(this.mergeDateAndTime(source, referenceDate))
             .concat(this.basicRegexMatch(source))
             .concat(this.timeOfToday(source, referenceDate))
-            .concat(this.durationWithBeforeAndAfter(source, referenceDate));
+            .concat(this.durationWithAgoAndLater(source, referenceDate));
         let result = Token.mergeAllTokens(tokens, source, this.extractorName);
         return result;
     }
@@ -140,7 +140,7 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
     }
 
     // Process case like "5分钟前" "二小时后"
-    protected durationWithBeforeAndAfter(source: string, refDate: Date): Token[] {
+    protected durationWithAgoAndLater(source: string, refDate: Date): Token[] {
         let ret = [];
         let durationEr = this.durationExtractor.extract(source, refDate);
         durationEr.forEach(er => {
@@ -152,7 +152,7 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
 
                 if (beforeMatch && suffix.startsWith(beforeMatch.value) || afterMatch && suffix.startsWith(afterMatch.value)) {
                     let metadata = new MetaData();
-                    metadata.IsDurationWithBeforeAndAfter = true;
+                    metadata.IsDurationWithAgoAndLater = true;
                     ret.push(new Token(er.start, pos + 1, metadata));
                 }
             }
@@ -266,7 +266,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
                 innerResult = this.parseTimeOfToday(er.text, referenceTime);
             }
             if (!innerResult.success) {
-                innerResult = this.parserDurationWithBeforeAndAfter(er.text, referenceTime);
+                innerResult = this.parserDurationWithAgoAndLater(er.text, referenceTime);
             }
             if (innerResult.success) {
                 innerResult.futureResolution = {};
@@ -390,7 +390,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
     }
 
     // Handle cases like "5分钟前", "1小时以后"
-    private parserDurationWithBeforeAndAfter(source: string, referenceDate: Date): DateTimeResolutionResult {
+    protected parserDurationWithAgoAndLater(source: string, referenceDate: Date): DateTimeResolutionResult {
         let result = new DateTimeResolutionResult();
         let durationRes = this.durationExtractor.extract(source, referenceDate);
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
@@ -401,7 +401,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
                 let srcUnit = match.groups('unit').value;
 
                 let numberStr = source.substring(durationRes[0].start, match.index - durationRes[0].start);
-                let number =  this.convertChineseToNumber(numberStr);
+                let number =  this.parseChineseWrittenNumberToValue(numberStr);
 
                 if (this.config.unitMap.has(srcUnit)) {
                     let unitStr = this.config.unitMap.get(srcUnit);
@@ -460,7 +460,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
     }
 
     // convert Chinese Number to Integer
-    private convertChineseToNumber(source: string): number {
+    private parseChineseWrittenNumberToValue(source: string): number {
         let num = -1;
         let er = this.integerExtractor.extract(source);
         if (er && er[0].type === NumberConstants.SYS_NUM_INTEGER) {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
@@ -1,6 +1,7 @@
-import { IExtractor, ExtractResult, RegExpUtility, StringUtility } from "@microsoft/recognizers-text";
-import { BaseNumberParser, BaseNumberExtractor } from "@microsoft/recognizers-text-number";
-import { Constants, TimeTypeConstants } from "../constants";
+import { IExtractor, ExtractResult, RegExpUtility, StringUtility, MetaData } from "@microsoft/recognizers-text";
+import { AgnosticNumberParserFactory, BaseNumberParser, BaseNumberExtractor, ChineseIntegerExtractor, AgnosticNumberParserType, ChineseNumberParserConfiguration } from "@microsoft/recognizers-text-number";
+import { Constants as NumberConstants  } from "@microsoft/recognizers-text-number";
+import { Constants , TimeTypeConstants } from "../constants";
 import { IDateTimeExtractor, IDateTimeExtractorConfiguration, BaseDateTimeExtractor, IDateTimeParserConfiguration, BaseDateTimeParser } from "../baseDateTime";
 import { BaseDurationExtractor, BaseDurationParser } from "../baseDuration";
 import { BaseDateExtractor, BaseDateParser } from "../baseDate";
@@ -49,8 +50,15 @@ class ChineseDateTimeExtractorConfiguration implements IDateTimeExtractorConfigu
 }
 
 export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
+    static beforeRegex: RegExp = RegExpUtility.getSafeRegExp(ChineseDateTime.BeforeRegex);
+    static afterRegex: RegExp = RegExpUtility.getSafeRegExp(ChineseDateTime.AfterRegex);
+    private readonly dateTimePeriodUnitRegex: RegExp;
+    private readonly durationExtractor: ChineseDurationExtractor;
+
     constructor(dmyDateFormat: boolean) {
         super(new ChineseDateTimeExtractorConfiguration(dmyDateFormat));
+        this.durationExtractor = new ChineseDurationExtractor();
+        this.dateTimePeriodUnitRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.DateTimePeriodUnitRegex);
     }
 
     extract(source: string, refDate: Date): ExtractResult[] {
@@ -62,7 +70,8 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
         let tokens: Token[] = new Array<Token>()
             .concat(this.mergeDateAndTime(source, referenceDate))
             .concat(this.basicRegexMatch(source))
-            .concat(this.timeOfToday(source, referenceDate));
+            .concat(this.timeOfToday(source, referenceDate))
+            .concat(this.durationWithBeforeAndAfter(source, referenceDate));
         let result = Token.mergeAllTokens(tokens, source, this.extractorName);
         return result;
     }
@@ -130,6 +139,27 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
         });
         return tokens;
     }
+
+    // Process case like "5分钟前" "二小时后"
+    protected durationWithBeforeAndAfter(source: string, refDate: Date): Token[] {
+        let ret = [];
+        let durationEr = this.durationExtractor.extract(source, refDate);
+        durationEr.forEach(er => {
+            let pos = er.start + er.length;
+            if (pos < source.length) {
+                let suffix = source.substr(pos, 1);
+                let beforeMatch = RegExpUtility.getMatches(ChineseDateExtractor.beforeRegex, suffix).pop();
+                let afterMatch = RegExpUtility.getMatches(ChineseDateExtractor.afterRegex, suffix).pop();
+
+                if (beforeMatch && suffix.startsWith(beforeMatch.value) || afterMatch && suffix.startsWith(afterMatch.value)) {
+                    let metadata = new MetaData();
+                    metadata.IsDurationWithBeforeAndAfter = true;
+                    ret.push(new Token(er.start, pos + 1, metadata));
+                }
+            }
+        });
+        return ret;
+    }
 }
 
 class ChineseDateTimeParserConfiguration implements IDateTimeParserConfiguration {
@@ -165,6 +195,9 @@ class ChineseDateTimeParserConfiguration implements IDateTimeParserConfiguration
         this.amTimeRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.DateTimeSimpleAmRegex);
         this.specificTimeOfDayRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.TimeOfTodayRegex);
         this.nowRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.NowRegex);
+        this.numberParser = AgnosticNumberParserFactory.getParser(AgnosticNumberParserType.Number, new ChineseNumberParserConfiguration());
+        this.unitRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.DateUnitRegex);
+        this.unitMap = ChineseDateTime.ParserConfigurationUnitMap;
     }
 
     haveAmbiguousToken(text: string, matchedText: string): boolean {
@@ -209,9 +242,13 @@ class ChineseDateTimeParserConfiguration implements IDateTimeParserConfiguration
 }
 
 export class ChineseDateTimeParser extends BaseDateTimeParser {
+    private readonly durationExtractor: ChineseDurationExtractor;
+    private readonly integerExtractor: BaseNumberExtractor
     constructor(dmyDateFormat: boolean) {
         let config = new ChineseDateTimeParserConfiguration(dmyDateFormat);
         super(config);
+        this.durationExtractor = new ChineseDurationExtractor();
+        this.integerExtractor = new ChineseIntegerExtractor();
     }
 
     parse(er: ExtractResult, refTime?: Date): DateTimeParseResult {
@@ -228,6 +265,9 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
             }
             if (!innerResult.success) {
                 innerResult = this.parseTimeOfToday(er.text, referenceTime);
+            }
+            if (!innerResult.success) {
+                innerResult = this.parserDurationWithBeforeAndAfter(er.text, referenceTime);
             }
             if (innerResult.success) {
                 innerResult.futureResolution = {};
@@ -348,5 +388,85 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
         }
 
         return ret;
+    }
+
+    // Handle cases like "5分钟前", "1小时以后"
+    private parserDurationWithBeforeAndAfter(source: string, referenceDate: Date): DateTimeResolutionResult {
+        let result = new DateTimeResolutionResult();
+        let durationRes = this.durationExtractor.extract(source, referenceDate);
+
+        if (durationRes) {
+            let match = RegExpUtility.getMatches(ChineseDateExtractor.dateTimePeriodUnitRegex, source).pop();
+            if (match) {
+                let suffix = source.substring(durationRes[0].start + durationRes[0].length);
+                let srcUnit = match.groups('unit').value;
+
+                let numberStr = source.substring(durationRes[0].start, match.index - durationRes[0].start);
+                let number =  this.convertChineseToNumber(numberStr);
+
+                if (this.config.unitMap.has(srcUnit)) {
+                    let unitStr = this.config.unitMap.get(srcUnit);
+
+                    let beforeMatch = RegExpUtility.getMatches(ChineseDateExtractor.beforeRegex, suffix).pop();
+                    if (beforeMatch && suffix.startsWith(beforeMatch.value)) {
+                        let date : Date;
+                        switch (unitStr) {
+                            case Constants.TimexHour:
+                                date = DateUtils.addHours(referenceDate, -number);
+                                break;
+                            case Constants.TimexMinute:
+                                date = DateUtils.addMinutes(referenceDate, -number);
+                                break;
+                            case Constants.TimexSecond:
+                                date = DateUtils.addSeconds(referenceDate, -number);
+                                break;
+                            default:
+                                return result;
+                        }
+
+                        result.timex = DateTimeFormatUtil.luisDateFromDate(date);
+                        result.futureValue = result.pastValue = date;
+                        result.success = true;
+                        return result;
+                    }
+
+                    let afterMatch = RegExpUtility.getMatches(ChineseDateExtractor.afterRegex, suffix).pop();
+                    if (afterMatch && suffix.startsWith(afterMatch.value)) {
+                        let date: Date;
+                        switch (unitStr) {
+                            case Constants.TimexHour:
+                                date = DateUtils.addHours(referenceDate, number);
+                                break;
+                            case Constants.TimexMinute:
+                                date = DateUtils.addMinutes(referenceDate, number);
+                                break;
+                            case Constants.TimexSecond:
+                                date = DateUtils.addSeconds(referenceDate, number);
+                                break;
+                            default:
+                                return result;
+                        }
+
+                        result.timex = DateTimeFormatUtil.luisDateFromDate(date);
+                        result.futureValue = result.pastValue = date;
+                        result.success = true;
+                        return result;
+                    }
+                }
+
+            }
+        }
+
+        return result;
+    }
+
+    private convertChineseToNumber(source: string): number {
+        let num = -1;
+        let er = this.integerExtractor.extract(source);
+        if (er && er[0].type === NumberConstants.SYS_NUM_INTEGER) {
+            num = Number.parseInt(this.config.numberParser.parse(er[0]).value);
+        }
+
+        return num;
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
@@ -52,13 +52,12 @@ class ChineseDateTimeExtractorConfiguration implements IDateTimeExtractorConfigu
 export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
     static beforeRegex: RegExp = RegExpUtility.getSafeRegExp(ChineseDateTime.BeforeRegex);
     static afterRegex: RegExp = RegExpUtility.getSafeRegExp(ChineseDateTime.AfterRegex);
-    private readonly dateTimePeriodUnitRegex: RegExp;
+    static dateTimePeriodUnitRegex: RegExp = RegExpUtility.getSafeRegExp(ChineseDateTime.DateTimePeriodUnitRegex);
     private readonly durationExtractor: ChineseDurationExtractor;
 
     constructor(dmyDateFormat: boolean) {
         super(new ChineseDateTimeExtractorConfiguration(dmyDateFormat));
         this.durationExtractor = new ChineseDurationExtractor();
-        this.dateTimePeriodUnitRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.DateTimePeriodUnitRegex);
     }
 
     extract(source: string, refDate: Date): ExtractResult[] {
@@ -148,8 +147,8 @@ export class ChineseDateTimeExtractor extends BaseDateTimeExtractor {
             let pos = er.start + er.length;
             if (pos < source.length) {
                 let suffix = source.substr(pos, 1);
-                let beforeMatch = RegExpUtility.getMatches(ChineseDateExtractor.beforeRegex, suffix).pop();
-                let afterMatch = RegExpUtility.getMatches(ChineseDateExtractor.afterRegex, suffix).pop();
+                let beforeMatch = RegExpUtility.getMatches(ChineseDateTimeExtractor.beforeRegex, suffix).pop();
+                let afterMatch = RegExpUtility.getMatches(ChineseDateTimeExtractor.afterRegex, suffix).pop();
 
                 if (beforeMatch && suffix.startsWith(beforeMatch.value) || afterMatch && suffix.startsWith(afterMatch.value)) {
                     let metadata = new MetaData();
@@ -396,7 +395,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
         let durationRes = this.durationExtractor.extract(source, referenceDate);
 
         if (durationRes) {
-            let match = RegExpUtility.getMatches(ChineseDateExtractor.dateTimePeriodUnitRegex, source).pop();
+            let match = RegExpUtility.getMatches(ChineseDateTimeExtractor.dateTimePeriodUnitRegex, source).pop();
             if (match) {
                 let suffix = source.substring(durationRes[0].start + durationRes[0].length);
                 let srcUnit = match.groups('unit').value;
@@ -407,7 +406,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
                 if (this.config.unitMap.has(srcUnit)) {
                     let unitStr = this.config.unitMap.get(srcUnit);
 
-                    let beforeMatch = RegExpUtility.getMatches(ChineseDateExtractor.beforeRegex, suffix).pop();
+                    let beforeMatch = RegExpUtility.getMatches(ChineseDateTimeExtractor.beforeRegex, suffix).pop();
                     if (beforeMatch && suffix.startsWith(beforeMatch.value)) {
                         let date : Date;
                         switch (unitStr) {
@@ -460,6 +459,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
         return result;
     }
 
+    // convert Chinese Number to Integer
     private convertChineseToNumber(source: string): number {
         let num = -1;
         let er = this.integerExtractor.extract(source);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimePeriodConfiguration.ts
@@ -372,7 +372,7 @@ export class ChineseDateTimePeriodParser extends BaseDateTimePeriodParser {
     private readonly TMIRegex: RegExp;
     private readonly TAFRegex: RegExp;
     private readonly TEVRegex: RegExp;
-    private readonly TNIRegex; RegExp;
+    private readonly TNIRegex: RegExp;
     private readonly unitRegex: RegExp;
     private readonly timeOfDayRegex: RegExp;
     private readonly cardinalExtractor: IExtractor;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
@@ -275,14 +275,14 @@ export class ChineseFullMergedParser extends BaseMergedParser {
         let modStr = "";
         let beforeMatch = RegExpUtility.getMatches(this.config.beforeRegex, er.text).pop();
         let afterMatch = RegExpUtility.getMatches(this.config.afterRegex, er.text).pop();
-        if (beforeMatch && !this.isDurationWithBeforeAndAfter(er)) {
+        if (beforeMatch && !this.isDurationWithAgoAndLater(er)) {
             hasBefore = true;
             er.start += beforeMatch.length;
             er.length -= beforeMatch.length;
             er.text = er.text.substring(beforeMatch.length);
             modStr = beforeMatch.value;
         }
-        else if (afterMatch && !this.isDurationWithBeforeAndAfter(er)) {
+        else if (afterMatch && !this.isDurationWithAgoAndLater(er)) {
             hasAfter = true;
             er.start += afterMatch.length;
             er.length -= afterMatch.length;
@@ -453,7 +453,7 @@ export class ChineseFullMergedParser extends BaseMergedParser {
         return type;
     }
 
-    protected isDurationWithBeforeAndAfter(er: ExtractResult): boolean {
-        return er.metaData && er.metaData.IsDurationWithBeforeAndAfter;
+    protected isDurationWithAgoAndLater(er: ExtractResult): boolean {
+        return er.metaData && er.metaData.IsDurationWithAgoAndLater;
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/mergedConfiguration.ts
@@ -275,14 +275,14 @@ export class ChineseFullMergedParser extends BaseMergedParser {
         let modStr = "";
         let beforeMatch = RegExpUtility.getMatches(this.config.beforeRegex, er.text).pop();
         let afterMatch = RegExpUtility.getMatches(this.config.afterRegex, er.text).pop();
-        if (beforeMatch) {
+        if (beforeMatch && !this.isDurationWithBeforeAndAfter(er)) {
             hasBefore = true;
             er.start += beforeMatch.length;
             er.length -= beforeMatch.length;
             er.text = er.text.substring(beforeMatch.length);
             modStr = beforeMatch.value;
         }
-        else if (afterMatch) {
+        else if (afterMatch && !this.isDurationWithBeforeAndAfter(er)) {
             hasAfter = true;
             er.start += afterMatch.length;
             er.length -= afterMatch.length;
@@ -451,5 +451,9 @@ export class ChineseFullMergedParser extends BaseMergedParser {
             }
         }
         return type;
+    }
+
+    protected isDurationWithBeforeAndAfter(er: ExtractResult): boolean {
+        return er.metaData && er.metaData.IsDurationWithBeforeAndAfter;
     }
 }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/constants.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/constants.ts
@@ -1,6 +1,4 @@
 import { BaseDateTime } from "../resources/baseDateTime";
-import { EnglishDateTime } from "../resources/englishDateTime";
-import { ChineseDateTime } from "../resources/chineseDateTime";
 
 export class Constants {
     static readonly SYS_DATETIME_DATE: string = "date";
@@ -65,6 +63,27 @@ export class Constants {
     static readonly LESS_THAN_MOD: string = 'less';
 
     static readonly REF_UNDEF_MOD: string = 'ref_undef';
+
+    // Timex
+    static readonly TimexYear: string = "Y";
+    static readonly TimexMonth: string = "M";
+    static readonly TimexMonthFull: string = "MON";
+    static readonly TimexWeek: string = "W";
+    static readonly TimexDay: string = "D";
+    static readonly TimexBusinessDay: string = "BD";
+    static readonly TimexWeekend: string = "WE";
+    static readonly TimexHour: string = "H";
+    static readonly TimexMinute: string = "M";
+    static readonly TimexSecond: string = "S";
+    static readonly TimexFuzzy: string = 'X';
+    static readonly TimexFuzzyYear: string = "XXXX";
+    static readonly TimexFuzzyMonth: string = "XX";
+    static readonly TimexFuzzyWeek: string = "WXX";
+    static readonly TimexFuzzyDay: string = "XX";
+    static readonly DateTimexConnector: string = "-";
+    static readonly TimeTimexConnector: string = ":";
+    static readonly GeneralPeriodPrefix: string = "P";
+    static readonly TimeTimexPrefix: string = "T";
 
     // Timex of TimeOfDay
     static readonly EarlyMorning: string = "TDA";

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -1,17 +1,19 @@
-import { IExtractor, ExtractResult, QueryProcessor } from "@microsoft/recognizers-text";
+import { IExtractor, ExtractResult, QueryProcessor, MetaData } from "@microsoft/recognizers-text";
 import { RegExpUtility } from "@microsoft/recognizers-text";
 import { IDateTimeParser, DateTimeParseResult } from "../dateTime/parsers";
 import { Constants, TimeTypeConstants } from "../dateTime/constants";
 import { IDateTimeExtractor } from "./baseDateTime";
 
 export class Token {
-    constructor(start: number, end: number) {
+    constructor(start: number, end: number, metaData: MetaData = null) {
         this.start = start;
         this.end = end;
+        this.metaData = metaData;
     }
 
     start: number;
     end: number;
+    metaData: MetaData;
 
     get length(): number {
         return this.end - this.start;
@@ -49,7 +51,8 @@ export class Token {
                 start: token.start,
                 length: token.length,
                 text: source.substr(token.start, token.length),
-                type: extractorName
+                type: extractorName,
+                metaData: token.metaData
             });
         });
         return ret;

--- a/JavaScript/packages/recognizers-text/src/metaData.ts
+++ b/JavaScript/packages/recognizers-text/src/metaData.ts
@@ -17,12 +17,12 @@ export class MetaData {
         this.hasMod = hasMod;
     }
 
-    private isDurationWithBeforeAndAfter: boolean = false;
+    private isDurationWithAgoAndLater: boolean = false;
 
-    get IsDurationWithBeforeAndAfter(): boolean {
-        return this.isDurationWithBeforeAndAfter;
+    get IsDurationWithAgoAndLater(): boolean {
+        return this.isDurationWithAgoAndLater;
     }
-    set IsDurationWithBeforeAndAfter(isDurationWithBeforeAndAfter: boolean) {
-        this.isDurationWithBeforeAndAfter = isDurationWithBeforeAndAfter;
+    set IsDurationWithAgoAndLater(isDurationWithAgoAndLater: boolean) {
+        this.isDurationWithAgoAndLater = isDurationWithAgoAndLater;
     }
 }

--- a/JavaScript/packages/recognizers-text/src/metaData.ts
+++ b/JavaScript/packages/recognizers-text/src/metaData.ts
@@ -16,4 +16,13 @@ export class MetaData {
     set HasMod(hasMod: boolean) {
         this.hasMod = hasMod;
     }
+
+    private isDurationWithBeforeAndAfter: boolean = false;
+
+    get IsDurationWithBeforeAndAfter(): boolean {
+        return this.isDurationWithBeforeAndAfter;
+    }
+    set IsDurationWithBeforeAndAfter(isDurationWithBeforeAndAfter: boolean) {
+        this.isDurationWithBeforeAndAfter = isDurationWithBeforeAndAfter;
+    }
 }

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -2113,7 +2113,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "10分钟之前",
@@ -3829,7 +3829,7 @@
           "values": [
             {
               "timex": "2018-08-25",
-              "type": "datetime",
+              "type": "date",
               "value": "2018-08-25"
             }
           ]

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -2074,7 +2074,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:13:33"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "2分钟前",
@@ -2113,7 +2113,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "10分钟之前",
@@ -2137,7 +2137,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "2小时后",
@@ -2161,7 +2161,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "5年前",
@@ -3807,6 +3807,30 @@
               "type": "datetimerange",
               "start": "2020-07-25 08:00:00",
               "end": "2020-07-25 12:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "他5天前就回来了",
+    "Context": {
+      "ReferenceDateTime": "2018-08-30T14:16:03"
+    },
+    "NotSupported": "python, java",
+    "Results": [
+      {
+        "Text": "5天前",
+        "Start": 1,
+        "End": 3,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-08-25",
+              "type": "datetime",
+              "value": "2018-08-25"
             }
           ]
         }


### PR DESCRIPTION
Fixes #1885 in JavaScript. Add support case for "5天前", ”5小时后“ in JS.