### PR TITLE
Adding "datetime"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -1,11 +1,12 @@
-using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
-using System.Text;
 using System.Text.RegularExpressions;
 
-namespace ChitChattr.BotFramework.Recognizers
+namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
-    public static class TimexRegex2
+    public static class TimexRegex
     {
         const string DateTimeCollectionName = "datetime";
         const string DateCollectionName = "date";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -1,49 +1,54 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
+using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
+namespace ChitChattr.BotFramework.Recognizers
 {
-    public static class TimexRegex
+    public static class TimexRegex2
     {
+        const string DateTimeCollectionName = "datetime";
+        const string DateCollectionName = "date";
+        const string TimeCollectionName = "time";
+        const string PeriodCollectionName = "period";
+
         private static IDictionary<string, Regex[]> timexRegex = new Dictionary<string, Regex[]>
         {
             {
-                "date", new Regex[]
+                DateCollectionName, new Regex[]
                 {
                     // date
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)-(?<dayOfMonth>\d\d)$"),
-                    new Regex(@"^XXXX-WXX-(?<dayOfWeek>\d)$"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-(?<dayOfMonth>\d\d)$"),
+                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
+                    new Regex(@"^XXXX-WXX-(?<dayOfWeek>\d)"),
+                    new Regex(@"^XXXX-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
 
                     // daterange
-                    new Regex(@"^(?<year>\d\d\d\d)$"),
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)$"),
-                    new Regex(@"^(?<season>SP|SU|FA|WI)$"),
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<season>SP|SU|FA|WI)$"),
-                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)$"),
-                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)-(?<weekend>WE)$"),
-                    new Regex(@"^XXXX-(?<month>\d\d)$"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-W(?<weekOfMonth>\d\d)$"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d)-(?<dayOfWeek>\d)$"),
+                    new Regex(@"^(?<year>\d\d\d\d)"),
+                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)"),
+                    new Regex(@"^(?<season>SP|SU|FA|WI)"),
+                    new Regex(@"^(?<year>\d\d\d\d)-(?<season>SP|SU|FA|WI)"),
+                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)"),
+                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)-(?<weekend>WE)"),
+                    new Regex(@"^XXXX-(?<month>\d\d)"),
+                    new Regex(@"^XXXX-(?<month>\d\d)-W(?<weekOfMonth>\d\d)"),
+                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d{1,2})"),
+                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d)-(?<dayOfWeek>\d)"),
                 }
             },
             {
-                "time", new Regex[]
+                TimeCollectionName, new Regex[]
                 {
                     // time
-                    new Regex(@"^T(?<hour>\d\d)$"),
-                    new Regex(@"^T(?<hour>\d\d):(?<minute>\d\d)$"),
-                    new Regex(@"^T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)$"),
+                    new Regex(@"T(?<hour>\d\d)$"),
+                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d)$"),
+                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)$"),
 
                     // timerange
                     new Regex(@"^T(?<partOfDay>DT|NI|MO|AF|EV)$"),
                 }
             },
             {
-                "period", new Regex[]
+                PeriodCollectionName, new Regex[]
                 {
                     new Regex(@"^P(?<amount>\d*\.?\d+)(?<dateUnit>Y|M|W|D)$"),
                     new Regex(@"^PT(?<amount>\d*\.?\d+)(?<timeUnit>H|M|S)$"),
@@ -53,15 +58,30 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static bool Extract(string name, string timex, IDictionary<string, string> result)
         {
-            foreach (var entry in timexRegex[name])
+            var lowerName = name.ToLower();
+            var nameGroup = new string[(lowerName == DateTimeCollectionName ? 2 : 1)];
+
+            if (lowerName == DateTimeCollectionName)
             {
-                if (TryExtract(entry, timex, result))
+                nameGroup[0] = DateCollectionName;
+                nameGroup[1] = TimeCollectionName;
+            }
+            else
+                nameGroup[0] = lowerName;
+
+            var anyTrue = false;
+            foreach (var nameItem in nameGroup)
+            {
+                foreach (var entry in timexRegex[nameItem])
                 {
-                    return true;
+                    if (TryExtract(entry, timex, result))
+                    {
+                        anyTrue = true;
+                    }
                 }
             }
 
-            return false;
+            return anyTrue;
         }
 
         private static bool TryExtract(Regex regex, string timex, IDictionary<string, string> result)


### PR DESCRIPTION
This relates to my previous PR (#1926) - this is possibly a better way to resolve it. Here's the context from that PR:

When I send something like the following to a Luis endpoint "every tuesday at 9:15:27", I'm getting back the following DateTimeSpec: XXXX-WXX-2T09:15:27 . This class can't deal with both "date" and "time" together, so it just returns a piece of them - my suggested alternative is to handle all scenarios - keep doing "date" and "time" as is, but if the user (developer) wants both, (s)he can request "datetime" and it will run both searches and return the combined results. Using my suggested fix, the previous Timex returns now:

[0]: {[0, T09:15:27]}
[1]: {[dayOfWeek, 2]}
[2]: {[hour, 09]}
[3]: {[minute, 15]}
[4]: {[second, 27]}

I've added the option for "datetime", and removed the "^" and "$" start and end markers appropriately. This could be changed (removing "^" and "$") to only doing it if "datetime" is specified - perhaps it depends on whether there's a risk not having it in every run?