### PR TITLE
Catering for a week-in-month scenario, eg. "XXXX-08-W02"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -456,6 +456,20 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_DateTime_Nov_6_at_11_45_25()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "2019-11-06T11:45:25" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("2019-11-06T11:45:25", resolution.Values[0].Timex);
+            Assert.AreEqual("datetime", resolution.Values[0].Type);
+            Assert.AreEqual("2019-11-06 11:45:25", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTime_Nov_6_at_11_45_25_UTC()
+        {
+            var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
             var resolution = TimexResolver.Resolve(new[] { "2019-11-06T11:45:25Z" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -431,5 +431,25 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(resolution.Values[1].Start);
             Assert.IsNull(resolution.Values[1].End);
         }
+
+        [TestMethod]
+        public void DataTypes_Resolver_Date_SecondWeekInAugust()
+        {
+            var today = new System.DateTime(2019, 11, 06);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-08-W02" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-08-W02", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2018-08-06", resolution.Values[0].Start);
+            Assert.AreEqual("2018-08-13", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-08-W02", resolution.Values[1].Timex);
+            Assert.AreEqual("daterange", resolution.Values[1].Type);
+            Assert.AreEqual("2019-08-05", resolution.Values[1].Start);
+            Assert.AreEqual("2019-08-12", resolution.Values[1].End);
+            Assert.IsNull(resolution.Values[1].Value);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -451,5 +451,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("2019-08-12", resolution.Values[1].End);
             Assert.IsNull(resolution.Values[1].Value);
         }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTime_Nov_6_at_11_45_25()
+        {
+            var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "2019-11-06T11:45:25Z" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("2019-11-06T11:45:25", resolution.Values[0].Timex);
+            Assert.AreEqual("datetime", resolution.Values[0].Type);
+            Assert.AreEqual("2019-11-06 11:45:25", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -173,7 +173,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.Month != null && timex.WeekOfMonth != null)
             {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}";
+                // return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}";
+                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-W{timex.WeekOfMonth?.ToString("D2")}";
             }
 
             if (timex.Month != null)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -173,7 +173,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.Month != null && timex.WeekOfMonth != null)
             {
-                // return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}";
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-W{timex.WeekOfMonth?.ToString("D2")}";
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 TimeCollectionName, new Regex[]
                 {
                     // time
-                    new Regex(@"T(?<hour>\d\d)$"),
-                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d)$"),
-                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)$"),
+                    new Regex(@"T(?<hour>\d\d)Z?$"),
+                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d)Z?$"),
+                    new Regex(@"T(?<hour>\d\d):(?<minute>\d\d):(?<second>\d\d)Z?$"),
 
                     // timerange
                     new Regex(@"^T(?<partOfDay>DT|NI|MO|AF|EV)$"),


### PR DESCRIPTION
I've logged some previous PRs but was using the Regex directly - now I'm using the Resolver directly and seeing how it works - this is a more comprehensive PR, including a new unit Test. This deals with a
"2nd week in August" example scenario properly ("XXXX-08-W02").