### PR TITLE
[TimexExpression] Modify TimexDateHelpers.date_part_equal() to fix Timex.to_natural_language() 

### DIFF
--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
@@ -10,7 +10,7 @@ def get_date_day(date) -> str:
 def convert_date(timex: Timex, date: datetime):
     if timex.year is not None and timex.month is not None and timex.day_of_month is not None:
         timex_date = datetime(timex.year, timex.month, timex.day_of_month)
-        if TimexDateHelpers.date_part_equal(timex_date, date):
+        if TimexDateHelpers.date_part_equal(timex_date.date(), date.date()):
             return 'today'
         tomorrow = TimexDateHelpers.tomorrow(date)
         if TimexDateHelpers.date_part_equal(timex_date, tomorrow):

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/english/english_timex_relative_convert.py
@@ -93,6 +93,8 @@ def convert_date_time_range(timex: Timex, date: datetime):
 def english_convert_timex_to_string_relative(timex: Timex, date: datetime):
     types = timex.types if len(timex.types) is not 0 else TimexInference.infer(timex)
 
+    if Constants.TIMEX_TYPES_PRESENT in types:
+        return 'now'
     if Constants.TIMEX_TYPES_DATETIMERANGE in types:
         return convert_date_time_range(timex, date)
     if Constants.TIMEX_TYPES_DATERANGE in types:

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_date_helpers.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_date_helpers.py
@@ -13,7 +13,7 @@ class TimexDateHelpers:
 
     @staticmethod
     def date_part_equal(date_x, date_y):
-        return date_x == date_y
+        return date_x.date() == date_y.date()
 
     @staticmethod
     def is_date_in_week(date, start_of_week):

--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_date_helpers.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_date_helpers.py
@@ -13,7 +13,7 @@ class TimexDateHelpers:
 
     @staticmethod
     def date_part_equal(date_x, date_y):
-        return date_x.date() == date_y.date()
+        return date_x == date_y
 
     @staticmethod
     def is_date_in_week(date, start_of_week):

--- a/Python/tests/datatypes/test_timex.py
+++ b/Python/tests/datatypes/test_timex.py
@@ -84,5 +84,11 @@ def test_datatypes_timex_fromtime():
     assert Timex.from_time(Time(23, 59, 30)).timex_value() == 'T23:59:30'
 
 
+def test_datatypes_helpers_equal():
+    reference_date = datetime.now()
+    timex_date = Timex.from_date(datetime.now())
+    assert timex_date.to_natural_language(reference_date) == 'today'
+
+
 def roundtrip(timex):
     assert timex == Timex(timex).timex_value()


### PR DESCRIPTION
Issue #1940
### Changes Made
- Ignore time when comparing dates
- Add `now` when recognizing present types
### Testing

In order to test this issue, we created a small script using the repro steps from the original issue.

![imagen](https://user-images.githubusercontent.com/22912283/69458428-13dbbf00-0d4e-11ea-9203-ac7831f4c01f.png)
