### PR TITLE
[DE DateTimeV2] Fix wrong result when Date entity  contains "sende"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(um|gegen|in|on))?\s*$";
       public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex})\s*(,\s*)?(am\s+)?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string SimpleTimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+um)?\s*({HourNumRegex}|{BaseDateTime.HourRegex})";
-      public const string SpecificEndOfRegex = @"((das|am|an( dem)?)\s+)?ende(\s+(de[mnsr])?)\s*";
+      public const string SpecificEndOfRegex = @"((das|am|an( dem)?)\s+)?\bende(\s+(de[mnsr])?)\s*";
       public const string UnspecificEndOfRegex = @"^[.]";
       public const string UnspecificEndOfRangeRegex = @"^[.]";
       public const string PeriodTimeOfDayRegex = @"\b(((?<early>(früh( am|er)|am frühen)(\s+|-))|(?<late>(spät( am|er)|am späten)(\s+|-)))?(?<timeOfDay>morgens?|früh|(vor|nach)mittags?|(nachts?|primetime)|abends?))\b";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/EnglishDateTime.java
@@ -681,7 +681,7 @@ public class EnglishDateTime {
     public static final String PeriodicRegex = "\\b(?<periodic>daily|monthly|weekly|biweekly|yearly|annual(ly)?)\\b";
 
     public static final String EachUnitRegex = "(?<each>(each|every|once an?)(?<other>\\s+other)?\\s*({DurationUnitRegex}|{WeekDayRegex}))"
-            .replace("{DurationUnitRegex}", DurationUnitRegex);
+            .replace("{DurationUnitRegex}", DurationUnitRegex)
             .replace("{WeekDayRegex}", WeekDayRegex);
 
     public static final String EachPrefixRegex = "\\b(?<each>(each|(every)|once an?)\\s*$)";

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -358,7 +358,7 @@ SimpleTimeOfTodayBeforeRegex: !nestedRegex
   def: '{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+um)?\s*({HourNumRegex}|{BaseDateTime.HourRegex})'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
-  def: ((das|am|an( dem)?)\s+)?ende(\s+(de[mnsr])?)\s*
+  def: ((das|am|an( dem)?)\s+)?\bende(\s+(de[mnsr])?)\s*
 UnspecificEndOfRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Specs/DateTime/German/DateExtractor.json
+++ b/Specs/DateTime/German/DateExtractor.json
@@ -266,5 +266,17 @@
         "Length": 9
       }
     ]
+  },
+  {
+    "Input": "sende eine geburtstagsabfrage für morgen",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "morgen",
+        "Type": "date",
+        "Start": 34,
+        "Length": 6
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/German/DateParser.json
+++ b/Specs/DateTime/German/DateParser.json
@@ -526,5 +526,29 @@
         "Length": 8
       }
     ]
+  },
+  {
+    "Input": "sende eine geburtstagsabfrage für morgen",
+    "Context": {
+      "ReferenceDateTime": "2019-12-02T00:00:00"
+    },
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "morgen",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-12-03",
+          "FutureResolution": {
+            "date": "2019-12-03"
+          },
+          "PastResolution": {
+            "date": "2019-12-03"
+          }
+        },
+        "Start": 34,
+        "Length": 6
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -1696,7 +1696,7 @@
   {
     "Input": "sende eine geburtstagsabfrage für morgen",
     "Context": {
-      "ReferenceDateTime": "2019-09-19T00:00:00"
+      "ReferenceDateTime": "2019-12-02T00:00:00"
     },
     "Results": [
       {

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -1692,5 +1692,28 @@
         }
       }
     ]
+  },
+  {
+    "Input": "sende eine geburtstagsabfrage für morgen",
+    "Context": {
+      "ReferenceDateTime": "2019-09-19T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "morgen",
+        "Start": 34,
+        "End": 39,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-12-03",
+              "type": "date",
+              "value": "2019-12-03"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This fixes #1946 
- Revise a regex that led to this bug.
- Add test.