### PR TITLE
[Python] Port the changes on BaseDatePeriodExtractor

### DIFF
--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/dateperiod_extractor_config.py
@@ -11,6 +11,10 @@ from .date_extractor import ChineseDateExtractor
 
 class ChineseDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
     @property
+    def previous_prefix_regex(self) -> Pattern:
+        return self._previous_prefix_regex
+
+    @property
     def check_both_before_after(self) -> Pattern:
         return self._check_both_before_after
 
@@ -181,7 +185,9 @@ class ChineseDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             ChineseDateTime.NowRegex)
         self._month_num_regex = RegExpUtility.get_safe_reg_exp(
             ChineseDateTime.MonthNumRegex)
+
         # TODO When the implementation for these properties is added, change the None values to their respective Regexps
+        self._previous_prefix_regex = None
         self._check_both_before_after = None
         self._century_suffix_regex = None
         self._year_period_regex = None

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/dateperiod_extractor_config.py
@@ -18,6 +18,10 @@ from .common_configs import EnglishOrdinalExtractor, EnglishCardinalExtractor
 
 class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
     @property
+    def previous_prefix_regex(self) -> Pattern:
+        return self._previous_prefix_regex
+
+    @property
     def check_both_before_after(self) -> Pattern:
         return self._check_both_before_after
 
@@ -256,6 +260,9 @@ class EnglishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             EnglishDateTime.CenturySuffixRegex
         )
         self._ordinal_extractor = EnglishOrdinalExtractor()
+        self._previous_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.PreviousPrefixRegex
+        )
         # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._cardinal_extractor = EnglishCardinalExtractor()
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/dateperiod_extractor_config.py
@@ -13,10 +13,14 @@ from ..base_dateperiod import DatePeriodExtractorConfiguration, MatchedIndex
 from .duration_extractor_config import FrenchDurationExtractorConfiguration
 from .date_extractor_config import FrenchDateExtractorConfiguration
 from recognizers_text.extractor import Extractor
-from recognizers_number import FrenchOrdinalExtractor, BaseNumberExtractor
+from recognizers_number import FrenchOrdinalExtractor, BaseNumberExtractor, FrenchCardinalExtractor
 
 
 class FrenchDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
+    @property
+    def previous_prefix_regex(self) -> Pattern:
+        return self._previous_prefix_regex
+
     @property
     def check_both_before_after(self) -> Pattern:
         return self._check_both_before_after
@@ -243,9 +247,12 @@ class FrenchDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
             FrenchDateTime.CenturySuffixRegex
         )
         self._ordinal_extractor = FrenchOrdinalExtractor()
+        self._previous_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.PreviousPrefixRegex
+        )
+        self._cardinal_extractor = FrenchCardinalExtractor()
         # TODO When the implementation for these properties is added, change the None values to their respective Regexps
         self._time_unit_regex = None
-        self._cardinal_extractor = None
 
     def get_from_token_index(self, source: str) -> MatchedIndex:
         match = self.from_regex.search(source)

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_extractor_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/dateperiod_extractor_config.py
@@ -19,6 +19,10 @@ from .date_extractor_config import SpanishDateExtractorConfiguration
 class SpanishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
 
     @property
+    def previous_prefix_regex(self) -> Pattern:
+        return self._previous_prefix_regex
+
+    @property
     def check_both_before_after(self) -> Pattern:
         return self._check_both_before_after
 
@@ -254,6 +258,9 @@ class SpanishDatePeriodExtractorConfiguration(DatePeriodExtractorConfiguration):
         self._ordinal_extractor = SpanishOrdinalExtractor()
         self._decade_with_century_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.DecadeWithCenturyRegex)
+        self._previous_prefix_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.PreviousPrefixRegex
+        )
 
     def get_from_token_index(self, source: str) -> MatchedIndex:
         match = self.from_regex.search(source)


### PR DESCRIPTION
### Description
This PR ports the changes made on PR #1884 PR #1936 for .NET to Python.
### Changes Made
**BaseDatePeriodExtractor**

- `match_duration` (logic changes) [#1884] + [#1936]
- `__get_token_for_regex_matching` (new parameter and logic changes) [#1884]
- `merge_multiple_extractions` (logic changes) [#1884]
- `single_time_point_with_patterns` (logic changes) [#1884] + [#1936]
- `__extract_within_next_prefix` (new method) [#1884]
- `_match_within_next_affix_regex` (parameter changes) [#1936]

**DatePeriodExtractorConfig (and subclasses)**

- `property previous_prefix_regex` (new property)
