### PR TITLE
[EN DateTime] Make Q1/Q2 result generalized (.NET)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1873,13 +1873,15 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
                 }
+
+                ret.Timex = $"({DateTimeFormatUtil.LuisDate(-1, beginDate.Month, 1)},{DateTimeFormatUtil.LuisDate(-1, endDate.Month, 1)},P3M)";
             }
             else
             {
                 ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginDate, endDate);
+                ret.Timex = $"({DateTimeFormatUtil.LuisDate(beginDate)},{DateTimeFormatUtil.LuisDate(endDate)},P3M)";
             }
 
-            ret.Timex = $"({DateTimeFormatUtil.LuisDate(beginDate)},{DateTimeFormatUtil.LuisDate(endDate)},P3M)";
             ret.Success = true;
 
             return ret;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
@@ -1449,12 +1449,14 @@ public class BaseDatePeriodParser implements IDateTimeParser {
                 ret.setFutureValue(new Pair<>(beginDate, endDate));
                 ret.setPastValue(new Pair<>(beginDate, endDate));
             }
+
+            ret.setTimex(String.format("(%s,%s,P3M)", DateTimeFormatUtil.luisDate(-1, beginDate.getMonthValue(), 1), DateTimeFormatUtil.luisDate(-1, endDate.getMonthValue(), 1)));
         } else {
             ret.setFutureValue(new Pair<>(beginDate, endDate));
             ret.setPastValue(new Pair<>(beginDate, endDate));
+            ret.setTimex(String.format("(%s,%s,P3M)", DateTimeFormatUtil.luisDate(beginDate), DateTimeFormatUtil.luisDate(endDate)));
         }
 
-        ret.setTimex(String.format("(%s,%s,P3M)", DateTimeFormatUtil.luisDate(beginDate), DateTimeFormatUtil.luisDate(endDate)));
         ret.setSuccess(true);
 
         return ret;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -1207,13 +1207,15 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 result.futureValue = [beginDate, endDate];
                 result.pastValue = [beginDate, endDate];
             }
+
+            result.timex = `(${DateTimeFormatUtil.luisDate(-1, beginDate.getMonth(), 1)},${DateTimeFormatUtil.luisDate(-1, endDate.getMonth(), 1)},P3M)`;
         }
         else {
             result.futureValue = [beginDate, endDate];
             result.pastValue = [beginDate, endDate];
+            result.timex = `(${DateTimeFormatUtil.luisDateFromDate(beginDate)},${DateTimeFormatUtil.luisDateFromDate(endDate)},P3M)`;
         }
 
-        result.timex = `(${DateTimeFormatUtil.luisDateFromDate(beginDate)},${DateTimeFormatUtil.luisDateFromDate(endDate)},P3M)`;
         result.success = true;
         return result;
     }

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -2271,12 +2271,15 @@ class BaseDatePeriodParser(DateTimeParser):
             else:
                 result.future_value = [begin_date, end_date]
                 result.past_value = [begin_date, end_date]
+
+            result.timex = f'({DateTimeFormatUtil.luis_date(-1, begin_date.month, 1)},' \
+                f'{DateTimeFormatUtil.luis_date(-1, end_date.month, 1)},P3M)'
         else:
             result.future_value = [begin_date, end_date]
             result.past_value = [begin_date, end_date]
+            result.timex = f'({DateTimeFormatUtil.luis_date_from_datetime(begin_date)},' \
+                f'{DateTimeFormatUtil.luis_date_from_datetime(end_date)},P3M)'
 
-        result.timex = f'({DateTimeFormatUtil.luis_date_from_datetime(begin_date)},' \
-            f'{DateTimeFormatUtil.luis_date_from_datetime(end_date)},P3M)'
         result.success = True
         return result
 

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -1779,7 +1779,7 @@
         "Text": "Q3",
         "Type": "daterange",
         "Value": {
-          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "Timex": "(XXXX-07-01,XXXX-10-01,P3M)",
           "FutureResolution": {
             "startDate": "2017-07-01",
             "endDate": "2017-10-01"
@@ -1804,7 +1804,7 @@
         "Text": "Q2",
         "Type": "daterange",
         "Value": {
-          "Timex": "(2016-04-01,2016-07-01,P3M)",
+          "Timex": "(XXXX-04-01,XXXX-07-01,P3M)",
           "FutureResolution": {
             "startDate": "2017-04-01",
             "endDate": "2017-07-01"

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14771,5 +14771,77 @@
         }
       }
     ]
+  },
+  {
+    "Input": "How about 2019 q1",
+    "Context": {
+      "ReferenceDateTime": "2019-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019 q1",
+        "Start": 10,
+        "End": 16,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2019-04-01,P3M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-04-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How about 2019-Q1",
+    "Context": {
+      "ReferenceDateTime": "2019-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019-q1",
+        "Start": 10,
+        "End": 16,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2019-04-01,P3M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-04-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How about q3 2019",
+    "Context": {
+      "ReferenceDateTime": "2019-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "q3 2019",
+        "Start": 10,
+        "End": 16,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-07-01,2019-10-01,P3M)",
+              "type": "daterange",
+              "start": "2019-07-01",
+              "end": "2019-10-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14843,5 +14843,69 @@
         }
       }
     ]
+  },
+  {
+    "Input": "q1-2019",
+    "Context": {
+      "ReferenceDateTime": "2019-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "q1-2019",
+        "Start": 0,
+        "End": 6,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2019-01-01,P0M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2019 q3 and 2020 q1",
+    "Context": {
+      "ReferenceDateTime": "2019-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019 q3",
+        "Start": 0,
+        "End": 6,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-07-01,2019-10-01,P3M)",
+              "type": "daterange",
+              "start": "2019-07-01",
+              "end": "2019-10-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2020 q1",
+        "Start": 12,
+        "End": 18,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2020-04-01,P3M)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2020-04-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14725,6 +14725,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "q1",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14723,7 +14723,7 @@
   {
     "Input": "q1 and q2 could be any year",
     "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
+      "ReferenceDateTime": "2019-11-07T00:00:00"
     },
     "Results": [
       {

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14719,5 +14719,57 @@
         }
       }
     ]
+  },
+  {
+    "Input": "q1 and q2 could be any year",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "q1",
+        "Start": 0,
+        "End": 1,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-01-01,XXXX-04-01,P3M)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2019-04-01"
+            },
+            {
+              "timex": "(XXXX-01-01,XXXX-04-01,P3M)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2020-04-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "q2",
+        "Start": 7,
+        "End": 8,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-01,XXXX-07-01,P3M)",
+              "type": "daterange",
+              "start": "2019-04-01",
+              "end": "2019-07-01"
+            },
+            {
+              "timex": "(XXXX-04-01,XXXX-07-01,P3M)",
+              "type": "daterange",
+              "start": "2020-04-01",
+              "end": "2020-07-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14802,6 +14802,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
+    "NotSupported": "python, javascript",
     "Results": [
       {
         "Text": "2019-q1",
@@ -14850,6 +14851,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
+    "NotSupported": "python, javascript",
     "Results": [
       {
         "Text": "q1-2019",

--- a/Specs/DateTime/Turkish/DatePeriodParser.json
+++ b/Specs/DateTime/Turkish/DatePeriodParser.json
@@ -1518,7 +1518,7 @@
         "Text": "üçüncü çeyrek",
         "Type": "daterange",
         "Value": {
-          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "Timex": "(XXXX-07-01,XXXX-10-01,P3M)",
           "FutureResolution": {
             "startDate": "2017-07-01",
             "endDate": "2017-10-01"
@@ -1544,7 +1544,7 @@
         "Text": "ikinci çeyrek",
         "Type": "daterange",
         "Value": {
-          "Timex": "(2016-04-01,2016-07-01,P3M)",
+          "Timex": "(XXXX-04-01,XXXX-07-01,P3M)",
           "FutureResolution": {
             "startDate": "2017-04-01",
             "endDate": "2017-07-01"


### PR DESCRIPTION
This fixes #1984 (.NET only)
- Make quarter Timex result generalized when no year contains.
- Add tests