### PR TITLE
[.NET] Dutch DateTime Date support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TillRegex = $@"(?<till>\b(tot|totdat|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|tot en met|t/m|tot|tot aan)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";
-      public const string RelativeRegex = @"(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)";
+      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de)\b";
       public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
       public const string UpcomingPrefixRegex = @"((aankomende?|komende?|aanstaande))";
       public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b";
@@ -38,18 +38,19 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string CenturySuffixRegex = @"(^eeuw|^centennium)\b";
       public const string ReferencePrefixRegex = @"(dezelfde|hetzelfde|dat|die|overeenkomstige)\b";
       public const string FutureSuffixRegex = @"\b(in\s+de\s+)?(toekomst|vanaf)\b";
-      public const string DayRegex = @"(de\s*)?(?<day>(3[0-1]|[1-2]\d|0?[1-9])(ste|e|de)?)(?=\b|t)";
-      public static readonly string WrittenDayRegex = $@"\b(?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}en)?twintig)|(((één|een)en)?dertig))\b";
-      public const string ImplicitDayRegex = @"(de\s*)?(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))\b";
-      public const string MonthNumRegex = @"(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)?\.?\b";
+      public static readonly string DayRegex = $@"(de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)";
+      public static readonly string WrittenDayRegex = $@"(?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}(en|ën))?twintig)|(((één|een)(en|ën))?dertig))";
+      public static readonly string WrittenCardinalDayRegex = $@"(?<=((de\s+)|\b))(?<day>(éérste|eerste|tweede|derde|vierde|vijfde|zesde|zevende|achtste|negende|tiende|{WrittenElevenToNineteenRegex}de|({WrittenOneToNineRegex}(en|ën))?twintigste|((één|een)(en|ën))?dertigste))";
+      public const string ImplicitDayRegex = @"(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))";
+      public const string MonthNumRegex = @"\b(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b";
       public const string WrittenOneToNineRegex = @"(één|een|twee|drie|vier|vijf|zes|zeven|acht|negen)";
       public const string WrittenElevenToNineteenRegex = @"(elf|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien)";
       public const string WrittenTensRegex = @"(tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)";
       public static readonly string WrittenNumRegex = $@"({WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
-      public static readonly string WrittenCenturyFullYearRegex = $@"((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s+honderd)?)";
+      public static readonly string WrittenCenturyFullYearRegex = $@"((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)";
       public const string WrittenCenturyOrdinalYearRegex = @"((ee|éé)nentwintig|tweeëntwintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig)";
-      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s+honderd)?(\s+en)?)\b";
-      public static readonly string LastTwoYearNumRegex = $@"(zero\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
+      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b";
+      public static readonly string LastTwoYearNumRegex = $@"((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
       public const string OclockRegex = @"(?<oclock>uur)";
       public const string SpecialDescRegex = @"(p\b)";
@@ -57,14 +58,14 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
       public static readonly string AmPmDescRegex = $@"({BaseDateTime.BaseAmPmDescRegex})";
       public static readonly string DescRegex = $@"((({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
-      public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
+      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
-      public const string WeekDayRegex = @"\b(?<weekday>maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag|ma|ma\.|di|di\.|wo|wo\.|woe|woe\.|do|do\.|vr|vr\.|vrij|za|za\.|zat|zat\.|zo|zo\.)(en)?\b";
-      public const string SingleWeekDayRegex = @"\b(?<weekday>maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag|ma|ma\.|di|di\.|wo|wo\.|woe|woe\.|do|do\.|vr|vr\.|vrij|za|za\.|zat|zat\.|zo|zo\.)(en)?\b";
-      public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?de\s+)?{RelativeRegex}\s+maand)\b";
+      public const string WeekDayRegex = @"\b(?<weekday>(((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?)\b|(ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b]))";
+      public const string SingleWeekDayRegex = @"\b(?<weekday>((((maan|dins|woens|donder|vrij|zater|zon)(dag(en)?))\b)|((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)))";
+      public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
-      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(werk)?dag(en)?)\b";
+      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b";
       public const string DateTokenPrefix = @"op ";
       public const string TimeTokenPrefix = @"om ";
       public const string TokenBeforeDate = @"op ";
@@ -98,26 +99,26 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
       public const string WeekOfRegex = @"(de\s+)?(week)(\s+van)(\s+de|het)?";
       public const string MonthOfRegex = @"(maand)(\s*)(van)";
-      public const string MonthRegex = @"(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|december|jan\.?|feb\.?|mar\.?|apr\.?|mei|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?)";
+      public const string MonthRegex = @"\b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))";
       public static readonly string DateYearRegex = $@"(?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})";
-      public static readonly string YearSuffix = $@"(,?\s*({DateYearRegex}|{FullTextYearRegex}))";
-      public static readonly string OnRegex = $@"(?<=\bop\s+)({DayRegex}(en)?)\b";
-      public const string RelaxedOnRegex = @"(?<=\b(op\s+(de\s+|een\s+)?)(10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(e|ste|de)?)\b";
+      public static readonly string YearSuffix = $@"((,|\s*van)?\s*({DateYearRegex}|{FullTextYearRegex}))";
+      public static readonly string OnRegex = $@"(?<=\bop\s+)({DayRegex})\b";
+      public const string RelaxedOnRegex = @"\b(?<=op\s+)(?:de\s+)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:(ste|de|e))?\b";
       public const string PrefixWeekDayRegex = @"(\s*((,?\s*op)|[-—–]))";
       public static readonly string ThisRegex = $@"\b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
       public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
-      public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}((van\s+)?(de\s+)?volgende)\s*week)\b";
-      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|((de\s+)?({RelativeRegex})\s+dag)|gisteren|morgen|vandaag)\b";
-      public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dagen?\s+(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
+      public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b";
+      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|morgen|vandaag)\b";
+      public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
       public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+))?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)s\b";
-      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
+      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(vanaf\s+nu|later))\b";
       public static readonly string SpecialDate = $@"(?=\b(op\s+)(de\s+)?){DayRegex}\b";
       public const string DatePreposition = @"\b(op)";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*,\s*){DateYearRegex}";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";
-      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?({DayRegex}|{WrittenDayRegex})(\.)?(\s+|\s*,\s*|\s*-\s*){MonthRegex}(\.)?((\s+|\s*,\s*|\s+in\s+){DateYearRegex})?\b";
+      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*)?(de\s+)?)?({DayRegex}(\s*dag|\.)?)((\s+|\s*[,-]\s*|\s+van\s+)?{MonthRegex})((\.)?(\s+|\s*,\s*|\s+in\s+)?{DateYearRegex})?\b";
       public static readonly string DateExtractor4 = $@"\b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}(\.)?\s*[/\\\-]\s*{DateYearRegex}";
       public static readonly string DateExtractor5 = $@"\b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}";
       public static readonly string DateExtractor6 = $@"(?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\-\.]{DayRegex}(?![%])\b";
@@ -127,8 +128,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string DateExtractor9L = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}((\s+|\s*,\s*|\s+in\s+){DateYearRegex})(?![%])\b";
       public static readonly string DateExtractor9S = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}(?![%])\b";
       public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}";
-      public static readonly string OfMonth = $@"^\s*(van|in)\s*{MonthRegex}";
-      public static readonly string MonthEnd = $@"{MonthRegex}\s*(de)?\s*$";
+      public static readonly string OfMonth = $@"(^\s*((van|in)\s+)?)({MonthRegex})";
+      public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
       public static readonly string WeekDayEnd = $@"(deze\s+)?{WeekDayRegex}\s*,?\s*$";
       public const string WeekDayStart = @"^[\.]";
       public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maanden|maand|weken|week)\b";
@@ -227,13 +228,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string AgoRegex = @"\b(geleden|voor\s+(?<day>gisteren|vandaag))\b";
       public const string LaterRegex = @"\b(later|vanaf nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b";
       public const string InConnectorRegex = @"\b(in|over)\b";
-      public const string SinceYearSuffixRegex = @"(^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})";
+      public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(in(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b";
       public static readonly string MorningStartEndRegex = $@"(^(('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex}))|((('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(('s|des)\s+middags|in de (na)?middag|{PmDescRegex}))|((('s|des)\s+middags|in de (na)?middag|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(avond|('s|des)?\s+avonds))|((avond|('s|des)?\s+avonds)$)";
       public const string NightStartEndRegex = @"(^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)";
-      public const string InexactNumberRegex = @"\b(een aantal|meerdere|enkele|verscheidene|)\b";
+      public const string InexactNumberRegex = @"\b(een aantal|meerdere|enkele|verscheidene|(een\s+)?paar)\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+({DurationUnitRegex})";
       public static readonly string RelativeTimeUnitRegex = $@"((({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({TimeUnitRegex}))|((de|het|mijn))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string RelativeDurationUnitRegex = $@"(((?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
@@ -244,8 +245,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string SingleAmbiguousTermsRegex = @"^(de\s+)?(dag|week|maand|jaar)$";
       public const string UnspecificDatePeriodRegex = @"^(week|weekend|maand|jaar)$";
       public const string PrepositionSuffixRegex = @"\b(op|in|om|rond(om)?|van|tot)$";
-      public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-z]+\s)?[A-Za-z\d]+)";
-      public static readonly string ForTheRegex = $@"\b((((?<=for\s+)de\s+{FlexibleDayRegex})|((?<=om\s+)(de\s+)?{FlexibleDayRegex}(?<=(st|nd|rd|th))))(?<end>\s*(,|\.|!|\?|$)))";
+      public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))";
+      public static readonly string ForTheRegex = $@"\b((((?<=voor\s+)de\s+{FlexibleDayRegex})|((?<=op\s+)de\s+{FlexibleDayRegex}(?<=(ste|de|e))))(?<end>(\s+(tussen|binnen|terug|tegen|aan|uit|mee|bij|vol|uit|aan|op|in|na|af)\s*)?(\s+(ge\w\w\w+|\w\w\w+en)\s*)?(,|\.|!|\?|$)))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+(?!(de)){DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
@@ -311,6 +312,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"week", 604800 },
             { @"dagen", 86400 },
             { @"dag", 86400 },
+            { @"werkdagen", 86400 },
+            { @"werkdag", 86400 },
             { @"uren", 3600 },
             { @"uur", 3600 },
             { @"u", 3600 },
@@ -368,10 +371,19 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"vrijdag", 5 },
             { @"zaterdag", 6 },
             { @"zondag", 0 },
+            { @"maandagen", 1 },
+            { @"dinsdagen", 2 },
+            { @"woensdagen", 3 },
+            { @"donderdagen", 4 },
+            { @"vrijdagen", 5 },
+            { @"zaterdagen", 6 },
+            { @"zondagen", 0 },
             { @"ma", 1 },
             { @"ma.", 1 },
             { @"dins", 2 },
+            { @"dins.", 2 },
             { @"woens", 3 },
+            { @"woens.", 3 },
             { @"di", 2 },
             { @"di.", 2 },
             { @"wo", 3 },
@@ -391,7 +403,26 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"zo", 0 },
             { @"zo.", 0 },
             { @"zon", 0 },
-            { @"zon.", 0 }
+            { @"zon.", 0 },
+            { @"monday", 1 },
+            { @"tuesday", 2 },
+            { @"wednesday", 3 },
+            { @"thursday", 4 },
+            { @"friday", 5 },
+            { @"saturday", 6 },
+            { @"sunday", 0 },
+            { @"mon", 1 },
+            { @"tue", 2 },
+            { @"tues", 2 },
+            { @"wed", 3 },
+            { @"wedn", 3 },
+            { @"weds", 3 },
+            { @"thu", 4 },
+            { @"thur", 4 },
+            { @"thurs", 4 },
+            { @"fri", 5 },
+            { @"sat", 6 },
+            { @"sun", 0 }
         };
       public static readonly Dictionary<string, int> MonthOfYear = new Dictionary<string, int>
         {
@@ -654,17 +685,18 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"allsaintsday", new string[] { @"allerheiligen" } },
             { @"allsoulsday", new string[] { @"allerzielen" } },
             { @"christmaseve", new string[] { @"kerstavond" } },
-            { @"columbus", new string[] { @"columbusday", @"columbusdag" } },
+            { @"columbus", new string[] { @"columbusdag", @"columbusday" } },
             { @"thanksgiving", new string[] { @"thanksgivingday", @"thanksgiving", @"dankzeggingsdag" } },
             { @"martinlutherking", new string[] { @"martinlutherkingday", @"martinlutherkingjrday", @"martinlutherkingdag", @"mlkdag" } },
             { @"washingtonsbirthday", new string[] { @"washingtonsbirthday", @"washingtonbirthday" } },
             { @"yuandan", new string[] { @"yuandan" } },
+            { @"memorial", new string[] { @"memorialday" } },
             { @"youthday", new string[] { @"jongerendag" } },
-            { @"childrenday", new string[] { @"childrenday", @"childday", @"kinderendag" } },
+            { @"childrenday", new string[] { @"kinderendag" } },
             { @"stgeorgeday", new string[] { @"sintjoris" } },
             { @"mayday", new string[] { @"dagvandearbeid" } },
-            { @"stpatrickday", new string[] { @"stpatrickday", @"stpatricksday" } },
             { @"usindependenceday", new string[] { @"amerikaanseonafhankelijkheidsdag", @"usonafhankelijkheidsdag" } },
+            { @"stpatrickday", new string[] { @"stpatrickday" } },
             { @"groundhougday", new string[] { @"groundhougday", @"bosmarmottendag" } },
             { @"inaugurationday", new string[] { @"inaugurationday", @"inauguratiedag" } },
             { @"arborday", new string[] { @"boomfeestdag" } }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumberDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumberDefinitions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string TenToNineteenIntegerRegex = @"(zeventien|dertien|veertien|achttien|negentien|vijftien|zestien|elf|twaalf|tien)";
       public const string TensNumberIntegerRegex = @"(zeventig|twintig|dertig|tachtig|negentig|veertig|vijftig|zestig)";
       public static readonly string SeparaIntRegex = $@"((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}(\s*{RoundNumberIntegerRegex})+))";
-      public static readonly string AllIntRegex = $@"(((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*(en\s*)?)*{SeparaIntRegex})";
+      public static readonly string AllIntRegex = $@"(((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*((en|ën)\s*)?)*{SeparaIntRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
       public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!(\,\d+[a-zA-Z]))(?={placeholder})";
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((een\s+)?half\s+dozijn)|({AllIntRegex}\s+dozijn(en)?))(?=\b)";
       public const string RoundNumberOrdinalRegex = @"(honderdste|duizendste|miljoenste|miljardste|biljoenste)";
       public const string BasicOrdinalRegex = @"(nulde|eerste|tweede|derde|vierde|vijfd(e|en)|zesde|zevende|achtst(e|en)|negende|tiend(e|en)|elfde|twaalfde|dertiende|veertiende|vijftiende|zestiende|zeventiende|achttiende|negentiende|twintigste|dertigste|veertigste|vijftigste|zestigste|zeventigste|tachtigste|negentigste)";
-      public static readonly string SuffixBasicOrdinalRegex = $@"(((({ZeroToNineIntegerRegex}{RoundNumberIntegerRegex})|({RoundNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex}))?(\s*en)?\s*{BasicOrdinalRegex})";
+      public static readonly string SuffixBasicOrdinalRegex = $@"(((({ZeroToNineIntegerRegex}{RoundNumberIntegerRegex})|({RoundNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})\s*)?((en|ën)\s*)?{BasicOrdinalRegex})";
       public static readonly string SuffixRoundNumberOrdinalRegex = $@"(({AllIntRegex}\s*){RoundNumberOrdinalRegex})";
       public static readonly string AllOrdinalRegex = $@"({SuffixBasicOrdinalRegex}|{SuffixRoundNumberOrdinalRegex})";
       public const string OrdinalSuffixRegex = @"(?<=\b)((\d*(1e|2e|3e|4e|5e|6e|7e|8e|9e|0e))|(1ste|2de|3de|4de|5de|6de|7de|8ste|9de|0de)|([0-9]*1[0-9]de)|([0-9]*[2-9][0-9]ste)|([0-9]*[0](1ste|2de|3de|4de|5de|6de|7de|8ste|9de|0de)))(?=\b)";
@@ -102,7 +102,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string WordSeparatorToken = @"en";
       public static readonly string[] WrittenDecimalSeparatorTexts = { @"komma" };
       public static readonly string[] WrittenGroupSeparatorTexts = { @"punt" };
-      public static readonly string[] WrittenIntegerSeparatorTexts = { @"en" };
+      public static readonly string[] WrittenIntegerSeparatorTexts = { @"en", @"ën" };
       public static readonly string[] WrittenFractionSeparatorTexts = { @"uit", @"van de", @"op de", @"en" };
       public const string HalfADozenRegex = @"(een\s+)?half\s+dozijn";
       public const string GrossRegex = @"(een\s+)?gros";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
@@ -180,7 +180,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     var numVal = int.Parse(pr.Value.ToString(), CultureInfo.InvariantCulture);
                     ret.Timex = TimexUtility.GenerateDurationTimex(numVal, Constants.TimexBusinessDay, false);
-                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[1]];
+
+                    // The line below was containing this.config.UnitValueMap[srcUnit.Split()[1]]
+                    // it was updated to accommodate single word "business day" expressions.
+                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[srcUnit.Split().Length - 1]];
                     ret.Success = true;
 
                     return ret;
@@ -288,7 +291,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 else if (match.Groups[Constants.BusinessDayGroupName].Success)
                 {
                     ret.Timex = TimexUtility.GenerateDurationTimex(numVal, Constants.TimexBusinessDay, false);
-                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[1]];
+
+                    // The line below was containing this.config.UnitValueMap[srcUnit.Split()[1]]
+                    // it was updated to accommodate single word "business day" expressions.
+                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[srcUnit.Split().Length - 1]];
                     ret.Success = true;
                 }
             }
@@ -325,7 +331,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 else if (match.Groups[Constants.BusinessDayGroupName].Success)
                 {
                     ret.Timex = TimexUtility.GenerateDurationTimex(numVal, Constants.TimexBusinessDay, false);
-                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[1]];
+
+                    // The line below was containing this.config.UnitValueMap[srcUnit.Split()[1]]
+                    // it was updated to accommodate single word "business day" expressions.
+                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[srcUnit.Split().Length - 1]];
                     ret.Success = true;
                 }
             }

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -11,7 +11,7 @@ RangeConnectorRegex: !nestedRegex
 ArticleRegex: !simpleRegex
   def: \b(de|het|een)\b
 RelativeRegex: !simpleRegex
-  def: (?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)
+  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de)\b
 StrictRelativeRegex: !simpleRegex
   def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b
 UpcomingPrefixRegex: !simpleRegex
@@ -36,16 +36,20 @@ ReferencePrefixRegex: !simpleRegex
   def: (dezelfde|hetzelfde|dat|die|overeenkomstige)\b
 FutureSuffixRegex: !simpleRegex
   def: \b(in\s+de\s+)?(toekomst|vanaf)\b
-DayRegex: !simpleRegex
-  def: (de\s*)?(?<day>(3[0-1]|[1-2]\d|0?[1-9])(ste|e|de)?)(?=\b|t)
+DayRegex: !nestedRegex
+  def: (de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)
+  references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex ]
 # 1-31 written
 WrittenDayRegex: !nestedRegex
-  def: \b(?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}en)?twintig)|(((één|een)en)?dertig))\b
-  references: [WrittenOneToNineRegex, WrittenElevenToNineteenRegex]
+  def: (?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}(en|ën))?twintig)|(((één|een)(en|ën))?dertig))
+  references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex ]
+WrittenCardinalDayRegex: !nestedRegex
+  def: (?<=((de\s+)|\b))(?<day>(éérste|eerste|tweede|derde|vierde|vijfde|zesde|zevende|achtste|negende|tiende|{WrittenElevenToNineteenRegex}de|({WrittenOneToNineRegex}(en|ën))?twintigste|((één|een)(en|ën))?dertigste))
+  references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex ]
 ImplicitDayRegex: !simpleRegex
-  def: (de\s*)?(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))\b
+  def: (?<day>(3[0-1]|[0-2]?\d)(ste|e|de))
 MonthNumRegex: !simpleRegex
-  def: (?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)?\.?\b
+  def: \b(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b
 WrittenOneToNineRegex: !simpleRegex
   def: (één|een|twee|drie|vier|vijf|zes|zeven|acht|negen)
 WrittenElevenToNineteenRegex: !simpleRegex
@@ -56,15 +60,15 @@ WrittenNumRegex: !nestedRegex
   def: ({WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
 WrittenCenturyFullYearRegex: !nestedRegex
-  def: ((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s+honderd)?)
+  def: ((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)
   references: [ WrittenOneToNineRegex]
 WrittenCenturyOrdinalYearRegex: !simpleRegex
   def: ((ee|éé)nentwintig|tweeëntwintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig)
 CenturyRegex: !nestedRegex
-  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s+honderd)?(\s+en)?)\b
+  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b
   references: [WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex ]
 LastTwoYearNumRegex: !nestedRegex
-  def: (zero\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)
+  def: ((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
 FullTextYearRegex: !nestedRegex
   def: \b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b
@@ -87,18 +91,19 @@ DescRegex: !nestedRegex
   def: ((({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})
   references: [ OclockRegex, AmDescRegex, PmDescRegex, AmPmDescRegex, SpecialDescRegex ]
 # Exclude cases that include the "Am/Pm" suffix
+# Exclude when preceded by "$" symbol
 TwoDigitYearRegex: !nestedRegex
-  def: \b(?<![$])(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
+  def: \b(?<!\$)(?<year>([0-27-9]\d))(?!(\s*((\:)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
   references: [ AmDescRegex, PmDescRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
 WeekDayRegex: !simpleRegex
-  def: \b(?<weekday>maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag|ma|ma\.|di|di\.|wo|wo\.|woe|woe\.|do|do\.|vr|vr\.|vrij|za|za\.|zat|zat\.|zo|zo\.)(en)?\b
+  def: \b(?<weekday>(((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?)\b|(ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b]))
 SingleWeekDayRegex: !simpleRegex
-  def: \b(?<weekday>maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag|ma|ma\.|di|di\.|wo|wo\.|woe|woe\.|do|do\.|vr|vr\.|vrij|za|za\.|zat|zat\.|zo|zo\.)(en)?\b
+  def: \b(?<weekday>((((maan|dins|woens|donder|vrij|zater|zon)(dag(en)?))\b)|((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)))
 RelativeMonthRegex: !nestedRegex
-  def: (?<relmonth>((van\s+)?de\s+)?{RelativeRegex}\s+maand)\b
+  def: (?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b
   references: [RelativeRegex]
 WrittenMonthRegex: !simpleRegex
   def: (((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))
@@ -106,7 +111,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(werk)?dag(en)?)\b
+  def: (?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b
 DateTokenPrefix: 'op '
 TimeTokenPrefix: 'om '
 TokenBeforeDate: 'op '
@@ -189,20 +194,21 @@ WeekOfRegex: !simpleRegex
 MonthOfRegex: !simpleRegex
   def: (maand)(\s*)(van)
 MonthRegex: !simpleRegex
-  def: (?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|december|jan\.?|feb\.?|mar\.?|apr\.?|mei|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?)
+  def: \b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))
 # This is a look-behind assertion. Some cases should extract two digits as year like 11/25/16, where 16 means 2016.
 # The assertion determines if not connected with am/pm or hour separator (:), which should be a time.
 DateYearRegex: !nestedRegex
   def: (?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, TwoDigitYearRegex ]
 YearSuffix: !nestedRegex
-  def: (,?\s*({DateYearRegex}|{FullTextYearRegex}))
+  def: ((,|\s*van)?\s*({DateYearRegex}|{FullTextYearRegex}))
   references: [ DateYearRegex, FullTextYearRegex ]
 OnRegex: !nestedRegex
-  def: (?<=\bop\s+)({DayRegex}(en)?)\b
+  def: (?<=\bop\s+)({DayRegex})\b
   references: [ DayRegex ]
+# Ordinals are incomplete
 RelaxedOnRegex: !simpleRegex
-  def: (?<=\b(op\s+(de\s+|een\s+)?)(10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(e|ste|de)?)\b
+  def: \b(?<=op\s+)(?:de\s+)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:(ste|de|e))?\b
 PrefixWeekDayRegex: !simpleRegex
   def: (\s*((,?\s*op)|[-—–]))
 ThisRegex: !nestedRegex
@@ -212,13 +218,13 @@ LastDateRegex: !nestedRegex
   def: \b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b
   references: [ PreviousPrefixRegex, WeekDayRegex ]
 NextDateRegex: !nestedRegex
-  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}((van\s+)?(de\s+)?volgende)\s*week)\b
+  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b
   references: [ NextPrefixRegex, WeekDayRegex ]
 SpecialDayRegex: !nestedRegex
-  def: \b(eergisteren|overmorgen|((de\s+)?({RelativeRegex})\s+dag)|gisteren|morgen|vandaag)\b
+  def: \b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|morgen|vandaag)\b
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
-  def: \b((?<number>{WrittenNumRegex})\s+dagen?\s+(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
+  def: \b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
   references: [ WrittenNumRegex ]
 RelativeDayRegex: !nestedRegex
   def: \b(((de\s+)?{RelativeRegex}\s+dag))\b
@@ -226,7 +232,7 @@ RelativeDayRegex: !nestedRegex
 SetWeekDayRegex: !simpleRegex
   def: \b(?<prefix>op\s+({ArticleRegex}\s+))?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)s\b
 WeekDayOfMonthRegex: !nestedRegex
-  def: (?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}\s+{MonthSuffixRegex})
+  def: (?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))
   references: [ WeekDayRegex, MonthSuffixRegex ]
 RelativeWeekDayRegex: !nestedRegex
   def: \b({WrittenNumRegex}\s+{WeekDayRegex}\s+(vanaf\s+nu|later))\b
@@ -239,12 +245,16 @@ DatePreposition: !simpleRegex
 DateExtractorYearTermRegex: !nestedRegex
   def: (\s+|\s*,\s*){DateYearRegex}
   references: [ DateYearRegex ]
+# Maandag, Mei 2
 DateExtractor1: !nestedRegex
   def: \b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?
   references: [ WeekDayRegex, MonthRegex, DayRegex, DateExtractorYearTermRegex ]
+# Maandag 2 Mei
+# TODO: add ... van 2019?
 DateExtractor3: !nestedRegex
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?({DayRegex}|{WrittenDayRegex})(\.)?(\s+|\s*,\s*|\s*-\s*){MonthRegex}(\.)?((\s+|\s*,\s*|\s+in\s+){DateYearRegex})?\b
-  references: [ WeekDayRegex, DayRegex, MonthRegex, DateYearRegex, WrittenDayRegex ]
+  def: \b({WeekDayRegex}(\s+|\s*,\s*)?(de\s+)?)?({DayRegex}(\s*dag|\.)?)((\s+|\s*[,-]\s*|\s+van\s+)?{MonthRegex})((\.)?(\s+|\s*,\s*|\s+in\s+)?{DateYearRegex})?\b
+  references: [ WeekDayRegex, DayRegex, MonthRegex, DateYearRegex ]
+# 05/02/2019
 DateExtractor4: !nestedRegex
   def: \b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}(\.)?\s*[/\\\-]\s*{DateYearRegex}
   references: [ MonthNumRegex, DayRegex, DateYearRegex ]
@@ -277,10 +287,10 @@ DateExtractorA: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}
   references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex, DayRegex, WeekDayRegex ]
 OfMonth: !nestedRegex
-  def: ^\s*(van|in)\s*{MonthRegex}
+  def: (^\s*((van|in)\s+)?)({MonthRegex})
   references: [ MonthRegex ]
 MonthEnd: !nestedRegex
-  def: '{MonthRegex}\s*(de)?\s*$'
+  def: '{MonthRegex}(\s+de\s*)?$'
   references: [ MonthRegex ]
 WeekDayEnd: !nestedRegex
   def: '(deze\s+)?{WeekDayRegex}\s*,?\s*$'
@@ -527,8 +537,9 @@ LaterRegex: !simpleRegex
   def: \b(later|vanaf nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b
 InConnectorRegex: !simpleRegex
   def: \b(in|over)\b
-SinceYearSuffixRegex: !simpleRegex
+SinceYearSuffixRegex: !nestedRegex
   def: (^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})
+  references: [ SinceRegex, YearSuffix ]
 WithinNextPrefixRegex: !nestedRegex
   def: \b(in(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
@@ -544,7 +555,7 @@ EveningStartEndRegex: !simpleRegex
 NightStartEndRegex: !simpleRegex
   def: (^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)
 InexactNumberRegex: !simpleRegex
-  def: \b(een aantal|meerdere|enkele|verscheidene|)\b
+  def: \b(een aantal|meerdere|enkele|verscheidene|(een\s+)?paar)\b
 InexactNumberUnitRegex: !nestedRegex
   def: ({InexactNumberRegex})\s+({DurationUnitRegex})
   references: [InexactNumberRegex, DurationUnitRegex]
@@ -571,10 +582,10 @@ UnspecificDatePeriodRegex: !simpleRegex
 PrepositionSuffixRegex: !simpleRegex
   def: \b(op|in|om|rond(om)?|van|tot)$
 FlexibleDayRegex: !simpleRegex
-  def: (?<DayOfMonth>([A-Za-z]+\s)?[A-Za-z\d]+)
+  def: (?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))
 ForTheRegex: !nestedRegex
-  def: \b((((?<=for\s+)de\s+{FlexibleDayRegex})|((?<=om\s+)(de\s+)?{FlexibleDayRegex}(?<=(st|nd|rd|th))))(?<end>\s*(,|\.|!|\?|$)))
-  references: [FlexibleDayRegex]
+  def: \b((((?<=voor\s+)de\s+{FlexibleDayRegex})|((?<=op\s+)de\s+{FlexibleDayRegex}(?<=(ste|de|e))))(?<end>(\s+(tussen|binnen|terug|tegen|aan|uit|mee|bij|vol|uit|aan|op|in|na|af)\s*)?(\s+(ge\w\w\w+|\w\w\w+en)\s*)?(,|\.|!|\?|$)))
+  references: [ FlexibleDayRegex ]
 WeekDayAndDayOfMonthRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b
   references: [WeekDayRegex, FlexibleDayRegex]
@@ -680,6 +691,8 @@ UnitValueMap: !dictionary
     week: 604800
     dagen: 86400
     dag: 86400
+    werkdagen: 86400
+    werkdag: 86400
     uren: 3600
     uur: 3600
     u: 3600
@@ -738,10 +751,19 @@ DayOfWeek: !dictionary
     vrijdag: 5
     zaterdag: 6
     zondag: 0
+    maandagen: 1
+    dinsdagen: 2
+    woensdagen: 3
+    donderdagen: 4
+    vrijdagen: 5
+    zaterdagen: 6
+    zondagen: 0
     ma: 1
     ma.: 1
     dins: 2
+    dins.: 2
     woens: 3
+    woens.: 3
     di: 2
     di.: 2
     wo: 3
@@ -762,6 +784,25 @@ DayOfWeek: !dictionary
     zo.: 0
     zon: 0
     zon.: 0
+    monday: 1
+    tuesday: 2
+    wednesday: 3
+    thursday: 4
+    friday: 5
+    saturday: 6
+    sunday: 0
+    mon: 1
+    tue: 2
+    tues: 2
+    wed: 3
+    wedn: 3
+    weds: 3
+    thu: 4
+    thur: 4
+    thurs: 4
+    fri: 5
+    sat: 6
+    sun: 0
 MonthOfYear: !dictionary
   types: [ string, int ]
   entries:
@@ -1023,21 +1064,22 @@ HolidayNames: !dictionary
     bastilleday: [ fransenationalefeestdag, bestormingvandebastille ]
     halloweenday: [ halloween, allerheiligenavond ]
     allhallowday: [ allerheiligen ]
-    allsaintsday: [ allerheiligen ]
+    allsaintsday: [ allerheiligen ] # Duplicate of allhallowday?
     allsoulsday: [ allerzielen ]
     christmaseve: [ kerstavond ]
     # Holidays not celebrated extensively in the Netherlands
-    columbus: [ columbusday, columbusdag ]
+    columbus: [ columbusdag, columbusday ] # TODO or remove?
     thanksgiving: [ thanksgivingday, thanksgiving, dankzeggingsdag ]
-    martinlutherking: [ martinlutherkingday, martinlutherkingjrday, martinlutherkingdag, mlkdag ]
-    washingtonsbirthday: [ washingtonsbirthday, washingtonbirthday ]
-    yuandan: [ yuandan ]
-    youthday: [ jongerendag ]
-    childrenday: [ childrenday, childday, kinderendag ]
+    martinlutherking: [ martinlutherkingday, martinlutherkingjrday, martinlutherkingdag, mlkdag ] # TODO or remove?
+    washingtonsbirthday: [ washingtonsbirthday, washingtonbirthday ] # TODO or remove?
+    yuandan: [ yuandan ] # TODO or remove?
+    memorial: [ memorialday ] # US only, no Dutch variant
+    youthday: [ jongerendag ] # TODO or remove?
+    childrenday: [ kinderendag ] # TODO or remove?
     stgeorgeday: [ sintjoris ]
     mayday: [ dagvandearbeid ]
-    stpatrickday: [ stpatrickday, stpatricksday ] 
     usindependenceday: [ amerikaanseonafhankelijkheidsdag, usonafhankelijkheidsdag ]
+    stpatrickday: [ stpatrickday ] # TODO or remove?
     groundhougday: [ groundhougday, bosmarmottendag ]
     inaugurationday: [ inaugurationday, inauguratiedag ]
     arborday: [ boomfeestdag ]

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -25,7 +25,7 @@ SeparaIntRegex: !nestedRegex
   def: ((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|{RoundNumberIntegerRegex}|(({AnIntRegex}(\s*{RoundNumberIntegerRegex})+))
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex, AnIntRegex ]
 AllIntRegex: !nestedRegex
-  def: (((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*(en\s*)?)*{SeparaIntRegex})
+  def: (((({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(en|ën){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|({ZeroToNineIntegerRegex}|{AnIntRegex}))?(\s*{RoundNumberIntegerRegex}))\s*((en|ën)\s*)?)*{SeparaIntRegex})
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, SeparaIntRegex ]
 PlaceHolderPureNumber: !simpleRegex
   def: \b
@@ -54,7 +54,7 @@ RoundNumberOrdinalRegex: !simpleRegex
 BasicOrdinalRegex: !simpleRegex
   def: (nulde|eerste|tweede|derde|vierde|vijfd(e|en)|zesde|zevende|achtst(e|en)|negende|tiend(e|en)|elfde|twaalfde|dertiende|veertiende|vijftiende|zestiende|zeventiende|achttiende|negentiende|twintigste|dertigste|veertigste|vijftigste|zestigste|zeventigste|tachtigste|negentigste)
 SuffixBasicOrdinalRegex: !nestedRegex
-  def: (((({ZeroToNineIntegerRegex}{RoundNumberIntegerRegex})|({RoundNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex}))?(\s*en)?\s*{BasicOrdinalRegex})
+  def: (((({ZeroToNineIntegerRegex}{RoundNumberIntegerRegex})|({RoundNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})\s*)?((en|ën)\s*)?{BasicOrdinalRegex})
   references: [ TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, BasicOrdinalRegex ]
 SuffixRoundNumberOrdinalRegex: !nestedRegex
   def: (({AllIntRegex}\s*){RoundNumberOrdinalRegex})
@@ -160,7 +160,7 @@ MoreRegexNoNumberSucceed: !simpleRegex
 LessRegexNoNumberSucceed: !simpleRegex
   def: ((minder|lager|kleiner)((?!\s+dan)|\s+(dan(?!(\s*\d+))))|(beneden|onder)(?!(\s*\d+)))
 EqualRegexNoNumberSucceed: !simpleRegex
-  def: (gelijk?((?!\s+(aan|tot))|(\s+(aan|tot)(?!(\s*\d+))))) 
+  def: (gelijk?((?!\s+(aan|tot))|(\s+(aan|tot)(?!(\s*\d+)))))
 OneNumberRangeMoreRegex1: !nestedRegex
   def: ({MoreOrEqual}|{MoreRegex})\s*(de\s+)?(?<number1>((?!((\.(?!\d+))|(,(?!\d+)))).)+)
   references: [ MoreOrEqual, MoreRegex ]
@@ -169,7 +169,7 @@ OneNumberRangeMoreRegex2: !nestedRegex
   references: [ MoreOrEqualSuffix ]
 OneNumberRangeMoreSeparateRegex: !nestedRegex
   def: ({EqualRegex}\s+(?<number1>({NumberSplitMark}.)+)(\s+of\s+){MoreRegexNoNumberSucceed})|({MoreRegex}\s+(?<number1>({NumberSplitMark}.)+)(\s+of\s+){EqualRegexNoNumberSucceed})
-  references: [ EqualRegex, MoreRegex, EqualRegexNoNumberSucceed, MoreRegexNoNumberSucceed, NumberSplitMark ]  
+  references: [ EqualRegex, MoreRegex, EqualRegexNoNumberSucceed, MoreRegexNoNumberSucceed, NumberSplitMark ]
 OneNumberRangeLessRegex1: !nestedRegex
   def: ({LessOrEqual}|{LessRegex})\s*(de\s+)?(?<number2>((?!((\.(?!\d+))|(,(?!\d+)))).)+)
   references: [ LessOrEqual, LessRegex ]
@@ -178,7 +178,7 @@ OneNumberRangeLessRegex2: !nestedRegex
   references: [ LessOrEqualSuffix ]
 OneNumberRangeLessSeparateRegex: !nestedRegex
   def: ({EqualRegex}\s+(?<number1>({NumberSplitMark}.)+)(\s+of\s+){LessRegexNoNumberSucceed})|({LessRegex}\s+(?<number1>({NumberSplitMark}.)+)(\s+of\s+){EqualRegexNoNumberSucceed})
-  references: [ EqualRegex, LessRegex, EqualRegexNoNumberSucceed, LessRegexNoNumberSucceed, NumberSplitMark ]  
+  references: [ EqualRegex, LessRegex, EqualRegexNoNumberSucceed, LessRegexNoNumberSucceed, NumberSplitMark ]
 OneNumberRangeEqualRegex: !nestedRegex
   def: '{EqualRegex}\s*(the\s+)?(?<number1>((?!((\.(?!\d+))|(,(?!\d+)))).)+)'
   references: [ EqualRegex ]
@@ -194,7 +194,7 @@ TwoNumberRangeRegex3: !nestedRegex
 TwoNumberRangeRegex4: !nestedRegex
   def: (van\s+)?(?<number1>((?!((\.(?!\d+))|(,(?!\d+))|\van\b)).)+)\s*{TillRegex}\s*(de\s+)?(?<number2>((?!((\.(?!\d+))|(,(?!\d+)))).)+)
   references: [ TillRegex ]
-AmbiguousFractionConnectorsRegex: !simpleRegex 
+AmbiguousFractionConnectorsRegex: !simpleRegex
   def: ^[.]  # TODO: modify regex according to the counterpart in English
 # "in" is ambiguous for cases like "more than 30000 in 2009", other connector "out of", "over" is not ambiguous in English
 #Parser
@@ -205,7 +205,7 @@ HalfADozenText: zes
 WordSeparatorToken: en
 WrittenDecimalSeparatorTexts: [komma]
 WrittenGroupSeparatorTexts: [punt]
-WrittenIntegerSeparatorTexts: [en]
+WrittenIntegerSeparatorTexts: [en, ën]
 WrittenFractionSeparatorTexts: [uit, van de, op de, en]
 HalfADozenRegex: !simpleRegex
   def: (een\s+)?half\s+dozijn

--- a/Specs/DateTime/Dutch/DateExtractor.json
+++ b/Specs/DateTime/Dutch/DateExtractor.json
@@ -40,10 +40,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 jan",
+        "Text": "1 jan.",
         "Type": "date",
         "Start": 15,
-        "Length": 5
+        "Length": 6
       }
     ]
   },
@@ -241,7 +241,6 @@
   },
   {
     "Input": "Ik ga terug op 28 november",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -254,7 +253,6 @@
   },
   {
     "Input": "Ik ga terug op wo. 22 jan",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -579,7 +577,6 @@
   },
   {
     "Input": "Ik speel honkbal op elf mei",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -592,7 +589,6 @@
   },
   {
     "Input": "Ik ga terug op vier mei",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -617,7 +613,6 @@
   },
   {
     "Input": "Ik ga de eerste van januari terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -630,7 +625,6 @@
   },
   {
     "Input": "Ik ga eenentwintig mei terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -643,7 +637,6 @@
   },
   {
     "Input": "Ik kom eenentwintig mei terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -655,21 +648,19 @@
     ]
   },
   {
-    "Input": "Ik ga de tweede dag van augustus terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga de tweede aug terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tweede dag van augustus",
+        "Text": "tweede aug",
         "Type": "date",
         "Start": 9,
-        "Length": 23
+        "Length": 10
       }
     ]
   },
   {
     "Input": "Ik ga twintig juni terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -717,80 +708,74 @@
     ]
   },
   {
-    "Input": "Ik ging terug voor de 27ste",
-    "NotSupported": "dotnet",
+    "Input": "Ik ging terug op de 27ste",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 27ste",
+        "Text": "de 27ste",
         "Type": "date",
-        "Start": 14,
-        "Length": 13
+        "Start": 17,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Ik ging terug voor de 27e",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 27e",
+        "Text": "de 27e",
         "Type": "date",
-        "Start": 14,
-        "Length": 11
+        "Start": 19,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "Ik ging terug voor de 21ste",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 21ste",
+        "Text": "de 21ste",
         "Type": "date",
-        "Start": 14,
-        "Length": 13
+        "Start": 19,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Ik ging terug voor de 22e",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 22e",
+        "Text": "de 22e",
         "Type": "date",
-        "Start": 14,
-        "Length": 11
+        "Start": 19,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "Ik ging voor de tweede terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de tweede",
+        "Text": "de tweede",
         "Type": "date",
-        "Start": 8,
-        "Length": 14
+        "Start": 13,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "Ik ging terug voor de eenendertigste",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de eenendertigste",
+        "Text": "de eenendertigste",
         "Type": "date",
-        "Start": 14,
-        "Length": 22
+        "Start": 19,
+        "Length": 17
       }
     ]
   },
@@ -832,7 +817,6 @@
   },
   {
     "Input": "Ik kwam terug op de tweede!",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -845,7 +829,6 @@
   },
   {
     "Input": "Kwam je terug op de tweeëntwintigste?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -881,7 +864,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -972,7 +954,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -988,7 +969,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1004,7 +984,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1020,7 +999,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1033,7 +1011,6 @@
   },
   {
     "Input": "Ik ga de tweede zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1046,7 +1023,6 @@
   },
   {
     "Input": "Ik ga de eerste zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1059,7 +1035,6 @@
   },
   {
     "Input": "Ik ga de derde dinsdag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1072,7 +1047,6 @@
   },
   {
     "Input": "Ik ga de vijfde zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1085,40 +1059,37 @@
   },
   {
     "Input": "Ik ga de zesde zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "zesde zondag",
+        "Text": "zondag",
         "Type": "date",
-        "Start": 9,
-        "Length": 12
+        "Start": 15,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "Ik ga de tiende maandag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tiende maandag",
+        "Text": "maandag",
         "Type": "date",
-        "Start": 9,
-        "Length": 14
+        "Start": 16,
+        "Length": 7
       }
     ]
   },
   {
-    "Input": "Ik ga volgende maand de 20ste terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga 20ste van de volgende maand terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende maand de 20ste",
+        "Text": "20ste van de volgende maand",
         "Type": "date",
         "Start": 6,
-        "Length": 23
+        "Length": 27
       }
     ]
   },
@@ -1136,7 +1107,6 @@
   },
   {
     "Input": "Cortana kan een Skype call organiseren op vrijdag deze week of donderdag volgende week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1154,15 +1124,20 @@
     ]
   },
   {
-    "Input": "Cortana kan een Skype call organiseren voor vrijdag of zondag deze week",
-    "NotSupported": "dotnet",
+    "Input": "Cortana kan een Skype call organiseren voor vrijdag van deze week of deze week op zondag",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vrijdag of zondag deze week",
+        "Text": "vrijdag van deze week",
         "Type": "date",
         "Start": 44,
-        "Length": 27
+        "Length": 21
+      },
+	  {
+        "Text": "deze week op zondag",
+        "Type": "date",
+        "Start": 69,
+        "Length": 19
       }
     ]
   },
@@ -1252,7 +1227,6 @@
   },
   {
     "Input": "maandag, tweeëntwintig jan. 2018",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1265,7 +1239,6 @@
   },
   {
     "Input": "op zondag eenentwintig januari tweeduizend en achttien",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1278,7 +1251,6 @@
   },
   {
     "Input": "op eenentwintig september negentien achtenzeventig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1290,21 +1262,19 @@
     ]
   },
   {
-    "Input": "op 20 september negentienhonderd een één",
-    "NotSupported": "dotnet",
+    "Input": "op 20 september negentienhonderd en één",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20 september negentienhonderd een één",
+        "Text": "20 september negentienhonderd en één",
         "Type": "date",
         "Start": 3,
-        "Length": 37
+        "Length": 36
       }
     ]
   },
   {
     "Input": "op de tiende van september tweeduizend",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1317,7 +1287,6 @@
   },
   {
     "Input": "Ben je vrij op 13-5-2015?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1419,7 +1388,6 @@
   },
   {
     "Input": "Ik ga 12 januari van 2016 terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1467,15 +1435,14 @@
     ]
   },
   {
-    "Input": "Ik ga 21-04-'16 terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga 21/04/16 terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21-04-'16",
+        "Text": "21/04/16",
         "Type": "date",
         "Start": 6,
-        "Length": 9
+        "Length": 8
       }
     ]
   },
@@ -1625,7 +1592,6 @@
   },
   {
     "Input": "Ik ga woens, 22 jan terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1686,20 +1652,18 @@
   },
   {
     "Input": "Ik ga op vrijdag volgende week terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vrijdag volgende week",
+        "Text": "op vrijdag volgende week",
         "Type": "date",
-        "Start": 9,
-        "Length": 21
+        "Start": 6,
+        "Length": 24
       }
     ]
   },
   {
     "Input": "Ik ga op dins. terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1712,7 +1676,6 @@
   },
   {
     "Input": "Ik ga op dins. terug, goed nieuws.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1725,7 +1688,6 @@
   },
   {
     "Input": "Ik ga op dins terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1858,7 +1820,6 @@
   },
   {
     "Input": "Ik ga de dag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1907,27 +1868,25 @@
   },
   {
     "Input": "een basketbal op de elfde mei",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de elfde mei",
+        "Text": "elfde mei",
         "Type": "date",
-        "Start": 17,
-        "Length": 12
+        "Start": 20,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "Ik ga de vierde van mei terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de vierde van mei",
+        "Text": "vierde van mei",
         "Type": "date",
-        "Start": 6,
-        "Length": 17
+        "Start": 9,
+        "Length": 14
       }
     ]
   },
@@ -1936,16 +1895,15 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4e van maart",
+        "Text": "de 4e van maart",
         "Type": "date",
-        "Start": 9,
-        "Length": 12
+        "Start": 6,
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik ga eerste van jan terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1958,7 +1916,6 @@
   },
   {
     "Input": "Ik ga eenentwintigste mei terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1974,16 +1931,15 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " tweede van aug",
+        "Text": "tweede van aug",
         "Type": "date",
-        "Start": 5,
-        "Length": 15
+        "Start": 6,
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik ga tweeëntwintigste van juni terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2032,7 +1988,6 @@
   },
   {
     "Input": "Ik ging voor de 27e terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2045,7 +2000,6 @@
   },
   {
     "Input": "Ik ging voor de 27e terug.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2058,7 +2012,6 @@
   },
   {
     "Input": "Ik ging voor de 27e terug!",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2071,7 +2024,6 @@
   },
   {
     "Input": "Ik ging voor de 21e terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2084,7 +2036,6 @@
   },
   {
     "Input": "Ik ging voor de 22e terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2097,7 +2048,6 @@
   },
   {
     "Input": "Ik ging voor de tweeëntwintigste terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2110,7 +2060,6 @@
   },
   {
     "Input": "Ik ging voor de eenendertigste terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2146,41 +2095,38 @@
     ]
   },
   {
-    "Input": "Ik ging de 22e terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ging op de 22e terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de 22e",
         "Type": "date",
-        "Start": 8,
+        "Start": 11,
         "Length": 6
       }
     ]
   },
   {
-    "Input": "Ik ging de tweede terug!",
-    "NotSupported": "dotnet",
+    "Input": "Ik ging op de tweede terug!",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de tweede",
         "Type": "date",
-        "Start": 8,
+        "Start": 11,
         "Length": 9
       }
     ]
   },
   {
-    "Input": "Ik ging tweeëntwintigste terug?",
-    "NotSupported": "dotnet",
+    "Input": "Ik ging op de tweeëntwintigste terug?",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tweeëntwintigste",
+        "Text": "de tweeëntwintigste",
         "Type": "date",
-        "Start": 8,
-        "Length": 16
+        "Start": 11,
+        "Length": 19
       }
     ]
   },
@@ -2204,7 +2150,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2280,7 +2225,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2296,7 +2240,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2309,7 +2252,6 @@
   },
   {
     "Input": "Ik ga tweede zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2321,21 +2263,19 @@
     ]
   },
   {
-    "Input": "Ik ga eerst zondag terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga eerste zondag terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eerst zondag",
+        "Text": "eerste zondag",
         "Type": "date",
         "Start": 6,
-        "Length": 12
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik ga derde dinsdag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2348,7 +2288,6 @@
   },
   {
     "Input": "Ik ga vijfde zondag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2385,7 +2324,6 @@
   },
   {
     "Input": "Ik ga 20e van volgende maand terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2397,14 +2335,13 @@
     ]
   },
   {
-    "Input": "Ik g 31e van deze maand terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga 31e van deze maand terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "31e van deze maand",
         "Type": "date",
-        "Start": 5,
+        "Start": 6,
         "Length": 18
       }
     ]
@@ -2423,27 +2360,25 @@
   },
   {
     "Input": "We hadden een meeting 1 maand, 21 dagen geleden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 maand, 21 dagen",
+        "Text": "1 maand, 21 dagen geleden",
         "Type": "date",
         "Start": 22,
-        "Length": 17
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik vertrok hier 2 jaar, 1 maand, 21 dagen geleden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 jaar, 1 maand, 21 dagen",
+        "Text": "2 jaar, 1 maand, 21 dagen geleden",
         "Type": "date",
         "Start": 16,
-        "Length": 25
+        "Length": 33
       }
     ]
   },
@@ -2461,14 +2396,13 @@
   },
   {
     "Input": "Ik vertrok hier 1 maand, 2 jaar en 21 dagen geleden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 maand, 2 jaar en 21 dagen",
+        "Text": "1 maand, 2 jaar en 21 dagen geleden",
         "Type": "date",
         "Start": 16,
-        "Length": 27
+        "Length": 35
       }
     ]
   },
@@ -2498,7 +2432,6 @@
   },
   {
     "Input": "maandag, tweeëntwintig jan, 2018",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2511,7 +2444,6 @@
   },
   {
     "Input": "op zondag eenentwintig jan tweeduizend achttien",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2523,21 +2455,19 @@
     ]
   },
   {
-    "Input": "op september de eenentwintigste negentienachtenzeventig",
-    "NotSupported": "dotnet",
+    "Input": "op september de eenentwintigste negentien achtenzeventig",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "september de eenentwintigste negentienachtenzeventig",
+        "Text": "september de eenentwintigste negentien achtenzeventig",
         "Type": "date",
         "Start": 3,
-        "Length": 52
+        "Length": 53
       }
     ]
   },
   {
     "Input": "op 10 september, negentien nul een",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2550,7 +2480,6 @@
   },
   {
     "Input": "op de tiende van september, tweeduizend",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2654,7 +2583,6 @@
   {
     "Input": "het nominale bedrag van haar 6 1/4% converteerbaren",
     "Comment": "1/4 shouldn't recognized as date here",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   }

--- a/Specs/DateTime/Dutch/DateParser.json
+++ b/Specs/DateTime/Dutch/DateParser.json
@@ -31,7 +31,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 okt",
+        "Text": "2 okt.",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-10-02",
@@ -43,7 +43,7 @@
           }
         },
         "Start": 15,
-        "Length": 5
+        "Length": 6
       }
     ]
   },
@@ -76,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -464,7 +463,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1e van januari",
+        "Text": "de 1e van januari",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-01-01",
@@ -475,8 +474,8 @@
             "date": "2016-01-01"
           }
         },
-        "Start": 10,
-        "Length": 14
+        "Start": 7,
+        "Length": 17
       }
     ]
   },
@@ -509,7 +508,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -558,7 +556,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -579,15 +576,14 @@
     ]
   },
   {
-    "Input": "Ik ga de tweede dag van Augustus terug.",
+    "Input": "Ik ga de tweede van Augustus terug.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tweede dag van Augustus",
+        "Text": "tweede van Augustus",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-08-02",
@@ -599,7 +595,7 @@
           }
         },
         "Start": 9,
-        "Length": 23
+        "Length": 19
       }
     ]
   },
@@ -608,7 +604,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1065,7 +1060,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1234,11 +1228,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "paar maanden geleden",
+        "Text": "een paar maanden geleden",
         "Type": "date",
         "Value": {
           "Timex": "2016-08-07",
@@ -1249,8 +1242,8 @@
             "date": "2016-08-07"
           }
         },
-        "Start": 15,
-        "Length": 20
+        "Start": 11,
+        "Length": 24
       }
     ]
   },
@@ -1259,7 +1252,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1284,11 +1276,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de 27ste",
+        "Text": "de 27ste",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-27",
@@ -1296,11 +1287,11 @@
             "date": "2016-11-27"
           },
           "PastResolution": {
-            "date": "2016-11-27"
+            "date": "2016-10-27"
           }
         },
-        "Start": 4,
-        "Length": 11
+        "Start": 7,
+        "Length": 8
       }
     ]
   },
@@ -1309,7 +1300,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1321,7 +1311,7 @@
             "date": "2016-11-27"
           },
           "PastResolution": {
-            "date": "2016-11-27"
+            "date": "2016-10-27"
           }
         },
         "Start": 7,
@@ -1334,7 +1324,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1346,7 +1335,7 @@
             "date": "2016-11-21"
           },
           "PastResolution": {
-            "date": "2016-11-21"
+            "date": "2016-10-21"
           }
         },
         "Start": 7,
@@ -1359,11 +1348,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de 22ste",
+        "Text": "de 22ste",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -1371,11 +1359,11 @@
             "date": "2016-11-22"
           },
           "PastResolution": {
-            "date": "2016-11-22"
+            "date": "2016-10-22"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 16,
+        "Length": 8
       }
     ]
   },
@@ -1384,23 +1372,22 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de tweede",
+        "Text": "de tweede",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-02",
           "FutureResolution": {
-            "date": "2016-11-02"
+            "date": "2016-12-02"
           },
           "PastResolution": {
             "date": "2016-11-02"
           }
         },
-        "Start": 4,
-        "Length": 12
+        "Start": 7,
+        "Length": 9
       }
     ]
   },
@@ -1409,11 +1396,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de tweeëntwintigste",
+        "Text": "de tweeëntwintigste",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -1421,11 +1407,11 @@
             "date": "2016-11-22"
           },
           "PastResolution": {
-            "date": "2016-11-22"
+            "date": "2016-10-22"
           }
         },
-        "Start": 13,
-        "Length": 22
+        "Start": 16,
+        "Length": 19
       }
     ]
   },
@@ -1434,11 +1420,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de dertigste",
+        "Text": "de dertigste",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-30",
@@ -1446,11 +1431,11 @@
             "date": "2016-11-30"
           },
           "PastResolution": {
-            "date": "2016-11-30"
+            "date": "2016-10-30"
           }
         },
-        "Start": 4,
-        "Length": 15
+        "Start": 7,
+        "Length": 12
       }
     ]
   },
@@ -1459,7 +1444,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8080661+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1484,7 +1468,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8110663+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1557,7 +1540,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8140457+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1582,7 +1564,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8150456+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1631,7 +1612,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8200463+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1656,7 +1636,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8200463+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1705,7 +1684,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T17:25:49.8225493+08:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1730,7 +1708,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1755,11 +1732,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "31ste van deze maand",
+        "Text": "de 31ste van deze maand",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-31",
@@ -1770,8 +1746,8 @@
             "date": "0001-01-01"
           }
         },
-        "Start": 9,
-        "Length": 20
+        "Start": 6,
+        "Length": 23
       }
     ]
   },
@@ -1876,7 +1852,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1969,15 +1944,14 @@
     ]
   },
   {
-    "Input": "Ik ben 2 jaar en 21 dagen geleden hier vertrokken.",
+    "Input": "Ik ben 2 jaar, 1 maand en 21 dagen geleden hier vertrokken.",
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 jaar en 21 dagen geleden",
+        "Text": "2 jaar, 1 maand en 21 dagen geleden",
         "Type": "date",
         "Value": {
           "Timex": "2015-10-02",
@@ -1989,7 +1963,7 @@
           }
         },
         "Start": 7,
-        "Length": 26
+        "Length": 35
       }
     ]
   },
@@ -2018,15 +1992,14 @@
     ]
   },
   {
-    "Input": "We hebben volgende maand op de 20ste een vergadering",
+    "Input": "We hebben op de 20ste van volgende maand een vergadering",
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende maand op de 20ste",
+        "Text": "de 20ste van volgende maand",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-20",
@@ -2037,8 +2010,8 @@
             "date": "2018-01-20"
           }
         },
-        "Start": 10,
-        "Length": 26
+        "Start": 13,
+        "Length": 27
       }
     ]
   },
@@ -2067,15 +2040,14 @@
     ]
   },
   {
-    "Input": "Maandag eenentwintig jan. 2018",
+    "Input": "Maandag tweeëntwintig jan. 2018",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "Maandag eenentwintig jan. 2018",
+        "Text": "Maandag tweeëntwintig jan. 2018",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-22",
@@ -2087,7 +2059,7 @@
           }
         },
         "Start": 0,
-        "Length": 30
+        "Length": 31
       }
     ]
   },
@@ -2096,11 +2068,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op zondag eenentwintig januari tweeduizend achttien",
+        "Text": "zondag eenentwintig januari tweeduizend achttien",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-21",
@@ -2111,33 +2082,32 @@
             "date": "2018-01-21"
           }
         },
-        "Start": 0,
-        "Length": 51
+        "Start": 3,
+        "Length": 48
       }
     ]
   },
   {
-    "Input": "op eenentwintig September negentien zeven en tachtig",
+    "Input": "op eenentwintig September negentien zevenentachtig",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op eenentwintig September negentien zeven en tachtig",
+        "Text": "eenentwintig September negentien zevenentachtig",
         "Type": "date",
         "Value": {
-          "Timex": "1978-09-21",
+          "Timex": "1987-09-21",
           "FutureResolution": {
-            "date": "1978-09-21"
+            "date": "1987-09-21"
           },
           "PastResolution": {
-            "date": "1978-09-21"
+            "date": "1987-09-21"
           }
         },
-        "Start": 0,
-        "Length": 52
+        "Start": 3,
+        "Length": 47
       }
     ]
   },
@@ -2146,11 +2116,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op 10 september, negentien en een",
+        "Text": "10 september, negentien en een",
         "Type": "date",
         "Value": {
           "Timex": "1901-09-10",
@@ -2161,8 +2130,8 @@
             "date": "1901-09-10"
           }
         },
-        "Start": 0,
-        "Length": 33
+        "Start": 3,
+        "Length": 30
       }
     ]
   },
@@ -2171,11 +2140,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de tiende van september, tweeduizend",
+        "Text": "tiende van september, tweeduizend",
         "Type": "date",
         "Value": {
           "Timex": "2000-09-10",
@@ -2186,8 +2154,8 @@
             "date": "2000-09-10"
           }
         },
-        "Start": 0,
-        "Length": 36
+        "Start": 3,
+        "Length": 33
       }
     ]
   },
@@ -2336,15 +2304,14 @@
     ]
   },
   {
-    "Input": "Ik ga terug over 4 dagen gerekend vanaf gisteren.",
+    "Input": "Ik ga terug vier dagen gerekend vanaf gisteren.",
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4 dagen gerekend vanaf gisteren",
+        "Text": "vier dagen gerekend vanaf gisteren",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-23",
@@ -2355,8 +2322,8 @@
             "date": "2018-04-23"
           }
         },
-        "Start": 17,
-        "Length": 31
+        "Start": 12,
+        "Length": 34
       }
     ]
   },
@@ -2365,7 +2332,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2626,11 +2592,10 @@
     ]
   },
   {
-    "Input": "Ik ga 15 terug",
+    "Input": "Ik ga op 15 terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2645,7 +2610,7 @@
             "date": "2016-10-15"
           }
         },
-        "Start": 6,
+        "Start": 9,
         "Length": 2
       }
     ]
@@ -2658,7 +2623,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 okt",
+        "Text": "2 okt.",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-10-02",
@@ -2670,7 +2635,7 @@
           }
         },
         "Start": 6,
-        "Length": 5
+        "Length": 6
       }
     ]
   },
@@ -2819,15 +2784,14 @@
     ]
   },
   {
-    "Input": "Ik ga 21-04-'16 terug",
+    "Input": "Ik ga 21/04/16 terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21-04-'16",
+        "Text": "21/04/16",
         "Type": "date",
         "Value": {
           "Timex": "2016-04-21",
@@ -2839,7 +2803,7 @@
           }
         },
         "Start": 6,
-        "Length": 9
+        "Length": 8
       }
     ]
   },
@@ -3064,11 +3028,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "woens, 22e van jan ",
+        "Text": "woens, 22e van jan",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-01-22",
@@ -3080,7 +3043,7 @@
           }
         },
         "Start": 6,
-        "Length": 19
+        "Length": 18
       }
     ]
   },
@@ -3089,11 +3052,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de eerste van jan",
+        "Text": "eerste van jan",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-01-01",
@@ -3104,8 +3066,8 @@
             "date": "2016-01-01"
           }
         },
-        "Start": 6,
-        "Length": 17
+        "Start": 9,
+        "Length": 14
       }
     ]
   },
@@ -3114,11 +3076,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de eenentwintigste van mei",
+        "Text": "eenentwintigste van mei",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-05-21",
@@ -3129,8 +3090,8 @@
             "date": "2016-05-21"
           }
         },
-        "Start": 6,
-        "Length": 26
+        "Start": 9,
+        "Length": 23
       }
     ]
   },
@@ -3139,11 +3100,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de tweede van aug",
+        "Text": "tweede van aug",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-08-02",
@@ -3154,8 +3114,8 @@
             "date": "2016-08-02"
           }
         },
-        "Start": 6,
-        "Length": 17
+        "Start": 9,
+        "Length": 14
       }
     ]
   },
@@ -3164,11 +3124,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de tweeëntwintigste van juni ",
+        "Text": "tweeëntwintigste van juni",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-06-22",
@@ -3179,8 +3138,8 @@
             "date": "2016-06-22"
           }
         },
-        "Start": 6,
-        "Length": 29
+        "Start": 9,
+        "Length": 25
       }
     ]
   },
@@ -3621,7 +3580,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3742,7 +3700,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3767,7 +3724,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3888,7 +3844,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3913,11 +3868,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 21e",
+        "Text": "de 21e",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-21",
@@ -3928,8 +3882,8 @@
             "date": "2016-10-21"
           }
         },
-        "Start": 8,
-        "Length": 11
+        "Start": 13,
+        "Length": 6
       }
     ]
   },
@@ -3938,7 +3892,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3963,7 +3916,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3988,7 +3940,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4109,7 +4060,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4134,7 +4084,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4159,7 +4108,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4184,7 +4132,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4209,7 +4156,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4230,11 +4176,10 @@
     ]
   },
   {
-    "Input": "Ik ga derde dinsdagterug",
+    "Input": "Ik ga derde dinsdag terug",
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4259,7 +4204,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4284,7 +4228,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4309,7 +4252,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4430,7 +4372,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4455,7 +4396,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4552,7 +4492,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4601,7 +4540,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4626,7 +4564,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4647,15 +4584,14 @@
     ]
   },
   {
-    "Input": "op eenentwintig september negentienachtenzeventig",
+    "Input": "op eenentwintig september negentien achtenzeventig",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eenentwintig september negentienachtenzeventig",
+        "Text": "eenentwintig september negentien achtenzeventig",
         "Type": "date",
         "Value": {
           "Timex": "1978-09-21",
@@ -4667,7 +4603,7 @@
           }
         },
         "Start": 3,
-        "Length": 46
+        "Length": 47
       }
     ]
   },
@@ -4676,7 +4612,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4845,7 +4780,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5086,7 +5020,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T08:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {


### PR DESCRIPTION
All test cases passes.

Notes:
Some test cases were updated due to ambiguous translations or when the corresponding English test case made use of some particular arrangement of words.
BaseDurationParser has been modified to take into account the case when "business day" is just one word ("werkdag" in Dutch). 