### PR TITLE
Fixing bug with "weekend" flag on Week in year, e.g. "2020-W02-WE"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -479,5 +479,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(resolution.Values[0].Start);
             Assert.IsNull(resolution.Values[0].End);
         }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTime_Weekend()
+        {
+            var today = new System.DateTime(2020, 1, 7);
+            var resolution = TimexResolver.Resolve(new[] { "2020-W02-WE" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("2020-W02-WE", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2020-01-11", resolution.Values[0].Start);
+            Assert.AreEqual("2020-01-13", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -234,11 +234,13 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 TimexValue.DateValue(new TimexProperty { Year = year, Month = month + 1, DayOfMonth = 1 }));
         }
 
-        private static Tuple<string, string> YearWeekDateRange(int year, int weekOfYear)
+        private static Tuple<string, string> YearWeekDateRange(int year, int weekOfYear, bool? isWeekend)
         {
             var dateInWeek = new DateObject(year, 1, 1) + TimeSpan.FromDays((weekOfYear - 1) * 7);
 
-            var start = TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, dateInWeek);
+            var start = (isWeekend == null || isWeekend.Value == false) ?
+                            TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, dateInWeek) :
+                            TimexDateHelpers.DateOfNextDay(DayOfWeek.Saturday, dateInWeek);
             var end = TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, dateInWeek + TimeSpan.FromDays(7));
 
             return new Tuple<string, string>(
@@ -299,7 +301,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
                 if (timex.Year != null && timex.WeekOfYear != null)
                 {
-                    var dateRange = YearWeekDateRange(timex.Year.Value, timex.WeekOfYear.Value);
+                    var dateRange = YearWeekDateRange(timex.Year.Value, timex.WeekOfYear.Value, timex.Weekend);
 
                     return new List<Resolution.Entry>
                     {


### PR DESCRIPTION
This was actually raised in a StackOverflow question - see https://stackoverflow.com/questions/59615953/luis-test-tool-datetime-different-than-locally-resolved-datetime

Basically, the TimexResolver is ignoring if the timex has a "weekend" attached to it, to get the start and end of the period.