### PR TITLE
Utils to change result indexing in .NET & bump of vulnerable js dependency

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Recognizers.Text.Number
                     }
                 }
 
-                return parsedNumbers.Select(BuildModelResult).Where(r => r != null).ToList();
+                var modelResults = parsedNumbers.Select(BuildModelResult).Where(r => r != null).ToList();
+
+                return modelResults;
             }
             catch (Exception)
             {

--- a/.NET/Microsoft.Recognizers.Text/Utilities/ResultsProcessor.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/ResultsProcessor.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Microsoft.Recognizers.Text.Utilities
+{
+    public static class ResultsProcessor
+    {
+
+        public static void UpdateUnicodeOffsets(string query, ref List<ModelResult> results)
+        {
+
+            var origin = query;
+
+            // Save UTF-16 code unit index to Unicode Text Element index
+            //
+            // Example : "nai\u0308ve X" will generate a lookup array of [0,1,2,-1,3,4,5,6].
+            //           When we try to find the word "X", we know the UTF-16 offset of "X" is 7,
+            //           and the lookup[7] is 6, so the text element index of "X" is 6.
+            var textElementIndex = new int[origin.Length];
+            for (int i = 0; i < textElementIndex.Length; i++)
+            {
+                textElementIndex[i] = -1;
+            }
+
+            var enumerator = StringInfo.GetTextElementEnumerator(origin);
+            int index = 0;
+            while (enumerator.MoveNext())
+            {
+                textElementIndex[enumerator.ElementIndex] = index;
+                index++;
+            }
+
+            foreach (var result in results)
+            {
+                var utf16Offset = result.Start;
+                var utf16End = result.End;
+
+                result.Start = textElementIndex[utf16Offset];
+                result.End = result.Start + new StringInfo(result.Text).LengthInTextElements - 1;
+            }
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -3730,6 +3730,12 @@
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
 			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"optional": true
+		},
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
@@ -6334,9 +6340,9 @@
 			"integrity": "sha1-Y56dwb8GWJLGQ94x2qJ89YsQaOI="
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
+			"integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -10368,21 +10374,15 @@
 			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
 		},
 		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+			"integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"optional": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -71,7 +71,7 @@
 		"eslint-plugin-only-warn": "^1.0.1",
 		"eslint-utils": "^1.4.2",
 		"express": "^4.16.1",
-		"handlebars": "^4.1.2",
+		"handlebars": "^4.3.0",
 		"js-yaml": "^3.13.1",
 		"lerna": "^2.11.0",
 		"lodash": "^4.17.14",


### PR DESCRIPTION
- Adding class to Text library to process model results and allow indexing by text elements and not only at the character level;

- Bump handlebars version in js due to security alert.