### PR TITLE
[v2] Preparing for NPM packages 1.3.0 

### DIFF
--- a/JavaScript/lerna.json
+++ b/JavaScript/lerna.json
@@ -4,5 +4,5 @@
     "packages/recognizers-*",
     "packages/datatypes-date-time"
   ],
-  "version": "1.2.7"
+  "version": "1.3.0"
 }

--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -606,12 +606,12 @@
 		"@microsoft/recognizers-text-choice": {
 			"version": "file:packages/recognizers-choice",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
+				"@microsoft/recognizers-text": "~1.3.0",
 				"grapheme-splitter": "^1.0.2"
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				}
 			}
@@ -622,22 +622,22 @@
 		"@microsoft/recognizers-text-date-time": {
 			"version": "file:packages/recognizers-date-time",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
-				"@microsoft/recognizers-text-number": "~1.2.7",
-				"@microsoft/recognizers-text-number-with-unit": "~1.2.7",
+				"@microsoft/recognizers-text": "~1.3.0",
+				"@microsoft/recognizers-text-number": "~1.3.0",
+				"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
 				"lodash.isequal": "^4.5.0",
 				"lodash.tonumber": "^4.0.3"
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				},
 				"@microsoft/recognizers-text-number": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
 						"bignumber.js": "^7.2.1",
 						"lodash.escaperegexp": "^4.1.2",
 						"lodash.sortby": "^4.7.0",
@@ -652,11 +652,11 @@
 					}
 				},
 				"@microsoft/recognizers-text-number-with-unit": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
-						"@microsoft/recognizers-text-number": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
+						"@microsoft/recognizers-text-number": "~1.3.0",
 						"lodash.escaperegexp": "^4.1.2",
 						"lodash.last": "^3.0.0",
 						"lodash.max": "^4.0.1"
@@ -675,7 +675,7 @@
 		"@microsoft/recognizers-text-number": {
 			"version": "file:packages/recognizers-number",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
+				"@microsoft/recognizers-text": "~1.3.0",
 				"bignumber.js": "^7.2.1",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.sortby": "^4.7.0",
@@ -683,7 +683,7 @@
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				},
 				"bignumber.js": {
@@ -699,22 +699,22 @@
 		"@microsoft/recognizers-text-number-with-unit": {
 			"version": "file:packages/recognizers-number-with-unit",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
-				"@microsoft/recognizers-text-number": "~1.2.7",
+				"@microsoft/recognizers-text": "~1.3.0",
+				"@microsoft/recognizers-text-number": "~1.3.0",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.last": "^3.0.0",
 				"lodash.max": "^4.0.1"
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				},
 				"@microsoft/recognizers-text-number": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
 						"bignumber.js": "^7.2.1",
 						"lodash.escaperegexp": "^4.1.2",
 						"lodash.sortby": "^4.7.0",
@@ -741,12 +741,12 @@
 		"@microsoft/recognizers-text-sequence": {
 			"version": "file:packages/recognizers-sequence",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
+				"@microsoft/recognizers-text": "~1.3.0",
 				"grapheme-splitter": "^1.0.2"
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				}
 			}
@@ -754,43 +754,43 @@
 		"@microsoft/recognizers-text-suite": {
 			"version": "file:packages/recognizers-text-suite",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.2.7",
-				"@microsoft/recognizers-text-choice": "~1.2.7",
-				"@microsoft/recognizers-text-data-types-timex-expression": "~1.2.7",
-				"@microsoft/recognizers-text-date-time": "~1.2.7",
-				"@microsoft/recognizers-text-number": "~1.2.7",
-				"@microsoft/recognizers-text-number-with-unit": "~1.2.7",
-				"@microsoft/recognizers-text-sequence": "~1.2.7"
+				"@microsoft/recognizers-text": "~1.3.0",
+				"@microsoft/recognizers-text-choice": "~1.3.0",
+				"@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
+				"@microsoft/recognizers-text-date-time": "~1.3.0",
+				"@microsoft/recognizers-text-number": "~1.3.0",
+				"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
+				"@microsoft/recognizers-text-sequence": "~1.3.0"
 			},
 			"dependencies": {
 				"@microsoft/recognizers-text": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true
 				},
 				"@microsoft/recognizers-text-choice": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
 						"grapheme-splitter": "^1.0.2"
 					}
 				},
 				"@microsoft/recognizers-text-date-time": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
-						"@microsoft/recognizers-text-number": "~1.2.7",
-						"@microsoft/recognizers-text-number-with-unit": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
+						"@microsoft/recognizers-text-number": "~1.3.0",
+						"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
 						"lodash.isequal": "^4.5.0",
 						"lodash.tonumber": "^4.0.3"
 					}
 				},
 				"@microsoft/recognizers-text-number": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
 						"bignumber.js": "^7.2.1",
 						"lodash.escaperegexp": "^4.1.2",
 						"lodash.sortby": "^4.7.0",
@@ -805,21 +805,21 @@
 					}
 				},
 				"@microsoft/recognizers-text-number-with-unit": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
-						"@microsoft/recognizers-text-number": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
+						"@microsoft/recognizers-text-number": "~1.3.0",
 						"lodash.escaperegexp": "^4.1.2",
 						"lodash.last": "^3.0.0",
 						"lodash.max": "^4.0.1"
 					}
 				},
 				"@microsoft/recognizers-text-sequence": {
-					"version": "1.2.7",
+					"version": "1.3.0",
 					"bundled": true,
 					"requires": {
-						"@microsoft/recognizers-text": "~1.2.7",
+						"@microsoft/recognizers-text": "~1.3.0",
 						"grapheme-splitter": "^1.0.2"
 					}
 				},

--- a/JavaScript/package-lock.json
+++ b/JavaScript/package-lock.json
@@ -608,12 +608,6 @@
 			"requires": {
 				"@microsoft/recognizers-text": "~1.3.0",
 				"grapheme-splitter": "^1.0.2"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				}
 			}
 		},
 		"@microsoft/recognizers-text-data-types-timex-expression": {
@@ -627,49 +621,6 @@
 				"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
 				"lodash.isequal": "^4.5.0",
 				"lodash.tonumber": "^4.0.3"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"@microsoft/recognizers-text-number": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"bignumber.js": "^7.2.1",
-						"lodash.escaperegexp": "^4.1.2",
-						"lodash.sortby": "^4.7.0",
-						"lodash.trimend": "^4.5.1"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "7.2.1",
-							"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-							"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-						}
-					}
-				},
-				"@microsoft/recognizers-text-number-with-unit": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"@microsoft/recognizers-text-number": "~1.3.0",
-						"lodash.escaperegexp": "^4.1.2",
-						"lodash.last": "^3.0.0",
-						"lodash.max": "^4.0.1"
-					}
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"bundled": true
-				},
-				"xregexp": {
-					"version": "3.2.0",
-					"bundled": true
-				}
 			}
 		},
 		"@microsoft/recognizers-text-number": {
@@ -680,20 +631,6 @@
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.sortby": "^4.7.0",
 				"lodash.trimend": "^4.5.1"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"bignumber.js": {
-					"version": "7.2.1",
-					"bundled": true
-				},
-				"xregexp": {
-					"version": "4.1.1",
-					"bundled": true
-				}
 			}
 		},
 		"@microsoft/recognizers-text-number-with-unit": {
@@ -704,38 +641,6 @@
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.last": "^3.0.0",
 				"lodash.max": "^4.0.1"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"@microsoft/recognizers-text-number": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"bignumber.js": "^7.2.1",
-						"lodash.escaperegexp": "^4.1.2",
-						"lodash.sortby": "^4.7.0",
-						"lodash.trimend": "^4.5.1"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "7.2.1",
-							"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-							"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-						}
-					}
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"bundled": true
-				},
-				"xregexp": {
-					"version": "3.2.0",
-					"bundled": true
-				}
 			}
 		},
 		"@microsoft/recognizers-text-sequence": {
@@ -743,12 +648,6 @@
 			"requires": {
 				"@microsoft/recognizers-text": "~1.3.0",
 				"grapheme-splitter": "^1.0.2"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				}
 			}
 		},
 		"@microsoft/recognizers-text-suite": {
@@ -761,76 +660,6 @@
 				"@microsoft/recognizers-text-number": "~1.3.0",
 				"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
 				"@microsoft/recognizers-text-sequence": "~1.3.0"
-			},
-			"dependencies": {
-				"@microsoft/recognizers-text": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"@microsoft/recognizers-text-choice": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"grapheme-splitter": "^1.0.2"
-					}
-				},
-				"@microsoft/recognizers-text-date-time": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"@microsoft/recognizers-text-number": "~1.3.0",
-						"@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-						"lodash.isequal": "^4.5.0",
-						"lodash.tonumber": "^4.0.3"
-					}
-				},
-				"@microsoft/recognizers-text-number": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"bignumber.js": "^7.2.1",
-						"lodash.escaperegexp": "^4.1.2",
-						"lodash.sortby": "^4.7.0",
-						"lodash.trimend": "^4.5.1"
-					},
-					"dependencies": {
-						"bignumber.js": {
-							"version": "7.2.1",
-							"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-							"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-						}
-					}
-				},
-				"@microsoft/recognizers-text-number-with-unit": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"@microsoft/recognizers-text-number": "~1.3.0",
-						"lodash.escaperegexp": "^4.1.2",
-						"lodash.last": "^3.0.0",
-						"lodash.max": "^4.0.1"
-					}
-				},
-				"@microsoft/recognizers-text-sequence": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"@microsoft/recognizers-text": "~1.3.0",
-						"grapheme-splitter": "^1.0.2"
-					}
-				},
-				"bignumber.js": {
-					"version": "4.1.0",
-					"bundled": true
-				},
-				"xregexp": {
-					"version": "3.2.0",
-					"bundled": true
-				}
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -5874,9 +5703,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
 			"optional": true
 		},
 		"function-bind": {
@@ -6340,9 +6169,9 @@
 			"integrity": "sha1-Y56dwb8GWJLGQ94x2qJ89YsQaOI="
 		},
 		"handlebars": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
-			"integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+			"integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -10374,9 +10203,9 @@
 			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
 		},
 		"uglify-js": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
-			"integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
+			"integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.3",

--- a/JavaScript/package.json
+++ b/JavaScript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recognizers",
-	"version": "1.2.7",
+	"version": "1.3.0",
 	"license": "MIT",
 	"repository": {
 		"type": "git",

--- a/JavaScript/packages/datatypes-date-time/package-lock.json
+++ b/JavaScript/packages/datatypes-date-time/package-lock.json
@@ -57,5 +57,5 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		}
 	},
-	"version": "1.2.7"
+	"version": "1.3.0"
 }

--- a/JavaScript/packages/datatypes-date-time/package.json
+++ b/JavaScript/packages/datatypes-date-time/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/recognizers-text-data-types-timex-expression",
-  "version": "1.2.7",
-  "description": "Support for TIMEX representation of data time",
+  "version": "1.3.0",
+  "description": "Support for TIMEX-based representation of datetime entities",
   "author": "Microsoft",
   "license": "MIT",
   "keywords": [

--- a/JavaScript/packages/recognizers-choice/package-lock.json
+++ b/JavaScript/packages/recognizers-choice/package-lock.json
@@ -8,5 +8,5 @@
 			"integrity": "sha1-Y56dwb8GWJLGQ94x2qJ89YsQaOI="
 		}
 	},
-	"version": "1.2.7"
+	"version": "1.3.0"
 }

--- a/JavaScript/packages/recognizers-choice/package.json
+++ b/JavaScript/packages/recognizers-choice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-choice",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text-choice provides recognition of Boolean (yes/no) answers expressed in multiple languages, as well as base classes to support lists of alternative choices.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.2.7",
+    "@microsoft/recognizers-text": "~1.3.0",
     "grapheme-splitter": "^1.0.2"
   }
 }

--- a/JavaScript/packages/recognizers-date-time/package-lock.json
+++ b/JavaScript/packages/recognizers-date-time/package-lock.json
@@ -13,5 +13,5 @@
 			"integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
 		}
 	},
-	"version": "1.2.7"
+	"version": "1.3.0"
 }

--- a/JavaScript/packages/recognizers-date-time/package.json
+++ b/JavaScript/packages/recognizers-date-time/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-date-time",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text provides robust recognition and resolution of date/time expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -35,8 +35,8 @@
   "dependencies": {
     "lodash.isequal": "^4.5.0",
     "lodash.tonumber": "^4.0.3",
-    "@microsoft/recognizers-text": "~1.2.7",
-    "@microsoft/recognizers-text-number": "~1.2.7",
-    "@microsoft/recognizers-text-number-with-unit": "~1.2.7"
+    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text-number": "~1.3.0",
+    "@microsoft/recognizers-text-number-with-unit": "~1.3.0"
   }
 }

--- a/JavaScript/packages/recognizers-number-with-unit/package-lock.json
+++ b/JavaScript/packages/recognizers-number-with-unit/package-lock.json
@@ -18,5 +18,5 @@
 			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
 		}
 	},
-	"version": "1.2.7"
+	"version": "1.3.0"
 }

--- a/JavaScript/packages/recognizers-number-with-unit/package.json
+++ b/JavaScript/packages/recognizers-number-with-unit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-number-with-unit",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text-number-with-unit provides robust recognition and resolution of numbers with units expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -34,7 +34,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.last": "^3.0.0",
     "lodash.max": "^4.0.1",
-    "@microsoft/recognizers-text": "~1.2.7",
-    "@microsoft/recognizers-text-number": "~1.2.7"
+    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text-number": "~1.3.0"
   }
 }

--- a/JavaScript/packages/recognizers-number/package-lock.json
+++ b/JavaScript/packages/recognizers-number/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/recognizers-text-number",
-	"version": "1.2.7",
+	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/JavaScript/packages/recognizers-number/package.json
+++ b/JavaScript/packages/recognizers-number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-number",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text-number provides robust recognition and resolution of numbers expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.2.7",
+    "@microsoft/recognizers-text": "~1.3.0",
     "bignumber.js": "^7.2.1",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.sortby": "^4.7.0",

--- a/JavaScript/packages/recognizers-sequence/package-lock.json
+++ b/JavaScript/packages/recognizers-sequence/package-lock.json
@@ -8,5 +8,5 @@
       "integrity": "sha1-Y56dwb8GWJLGQ94x2qJ89YsQaOI="
     }
   },
-  "version": "1.2.7"
+  "version": "1.3.0"
 }

--- a/JavaScript/packages/recognizers-sequence/package.json
+++ b/JavaScript/packages/recognizers-sequence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/recognizers-text-sequence",
-  "version": "1.2.7",
-  "description": "recognizers-text-sequence provides robust recognition and resolution of series entities like phone numbers and IP addresses.",
+  "version": "1.3.0",
+  "description": "recognizers-text-sequence provides robust recognition and resolution of series entities like phone numbers, URLs, and e-mail and IP addresses.",
   "author": "Microsoft Corp.",
   "license": "MIT",
   "keywords": [
@@ -32,7 +32,7 @@
     "prepare": "npm run build-resources && npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.2.7",
+    "@microsoft/recognizers-text": "~1.3.0",
     "grapheme-splitter": "^1.0.2"
   }
 }

--- a/JavaScript/packages/recognizers-text-suite/package.json
+++ b/JavaScript/packages/recognizers-text-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text-suite",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text-suite provides robust recognition and resolution of numbers, units, date/time, and more; expressed in multiple languages.",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -32,12 +32,12 @@
     "prepare": "npm run clean-build && tsc && rollup -c"
   },
   "dependencies": {
-    "@microsoft/recognizers-text-data-types-timex-expression": "~1.2.7",
-    "@microsoft/recognizers-text": "~1.2.7",
-    "@microsoft/recognizers-text-number": "~1.2.7",
-    "@microsoft/recognizers-text-number-with-unit": "~1.2.7",
-    "@microsoft/recognizers-text-date-time": "~1.2.7",
-    "@microsoft/recognizers-text-sequence": "~1.2.7",
-    "@microsoft/recognizers-text-choice": "~1.2.7"
+    "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
+    "@microsoft/recognizers-text": "~1.3.0",
+    "@microsoft/recognizers-text-number": "~1.3.0",
+    "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
+    "@microsoft/recognizers-text-date-time": "~1.3.0",
+    "@microsoft/recognizers-text-sequence": "~1.3.0",
+    "@microsoft/recognizers-text-choice": "~1.3.0"
   }
 }

--- a/JavaScript/packages/recognizers-text/package.json
+++ b/JavaScript/packages/recognizers-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/recognizers-text",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "recognizers-text provides base classes for robust recognition and resolution of text entities.",
   "author": "Microsoft Corp.",
   "license": "MIT",


### PR DESCRIPTION
This PR solves the failing build for packages 1.3.0 on #1995 

To solve this, we updated lerna latest version and deleted` package.lock.json file` and ejecuted `build.ci.cmd` file it updated the package.lock.json.