### PR TITLE
TimexRangeResolver now correctly handles a time with date constraints.

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRangeResolve.cs
@@ -592,5 +592,44 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsTrue(r.Contains("2018-06-17T16"));
             Assert.AreEqual(2, r.Count);
         }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_time()
+        {
+            var resolutions = TimexRangeResolver.Evaluate(
+                new[] { "T09" },
+                new[] { "(2020-01-01,2020-01-02,P1D)" });
+            Assert.AreEqual(1, resolutions.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_time_with_daterange_constraint()
+        {
+            var candidates = new[] { "T09" };
+            var constraints = new[] { "P3D" };
+            var resolutions = TimexRangeResolver.Evaluate(candidates, constraints);
+            Assert.AreEqual(1, resolutions.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_time_with_datetimerange_constraint()
+        {
+            var resolutions = TimexRangeResolver.Evaluate(
+                new[] { "T09" },
+                new[] { "(2020-01-01T00:00:00,2020-01-02T00:00:00,PT24H)" });
+
+            Assert.AreEqual(1, resolutions.Count);
+        }
+
+        [TestMethod]
+        public void DataTypes_RangeResolve_datetime_with_daterange_constraint()
+        {
+            var resolutions = TimexRangeResolver.Evaluate(
+                new[] { "2020-01-01T09", "2020-01-02T09" },
+                new[] { "(2020-01-01,2020-01-02,P1D)" });
+            Assert.AreEqual(1, resolutions.Count);
+            Assert.AreEqual(1, resolutions.First().Month);
+        }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
@@ -212,6 +212,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static IEnumerable<string> ResolveDateAgainstConstraint(TimexProperty timex, DateRange constraint)
         {
+
             if (timex.Month != null && timex.DayOfMonth != null)
             {
                 var result = new List<string>();
@@ -240,6 +241,23 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     t.Month = d.Month;
                     t.DayOfMonth = d.Day;
                     result.Add(t.TimexValue);
+                }
+
+                return result;
+            }
+
+            if (timex.Hour != null)
+            {
+                var result = new List<string>();
+                DateTime day = constraint.Start;
+                while (day <= constraint.End)
+                {
+                    var t = timex.Clone();
+                    t.Year = day.Year;
+                    t.Month = day.Month;
+                    t.DayOfMonth = day.Day;
+                    result.AddRange(ResolveDefiniteAgainstConstraint(t, constraint));
+                    day = day.AddDays(1);
                 }
 
                 return result;


### PR DESCRIPTION
For example T09, constrained to today or torrmow ("let's meet at 9").
Previously, when trying to resolve a TIMEX with just an hour (T09), nothing would be resolved when having specific date constraints.
Now datetimes are returned correctly with the time.
(When having non-specific range constraints, the same TIMEX expression (T09) would be returned, this is unchanged).
Unit tests included.
Fixes #1095