### PR TITLE
Update nuget dependecy

### DIFF
--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.csproj
@@ -30,7 +30,7 @@
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="NuGet.CommandLine" Version="4.3.0" />
     <PackageReference Include="vswhere" Version="2.2.11" />
   </ItemGroup>

--- a/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
+++ b/.NET/Microsoft.Recognizers.Text/Microsoft.Recognizers.Text.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <dependency id="System.Collections.Immutable" version="1.4.0" />
       <dependency id="System.ValueTuple" version="4.4.0" />
-      <dependency id="Microsoft.Extensions.Caching.Memory" version="2.0.0" />
+      <dependency id="Microsoft.Extensions.Caching.Memory" version="2.2.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
3.* will wait as some consumers can't update yet. But this update will be needed for .NET Core 3+