### PR TITLE
[Python] Add utilities file with decimal precision decorator (fix issue 2035)

### DIFF
--- a/Python/libraries/recognizers-number/recognizers_number/number/__init__.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/__init__.py
@@ -8,3 +8,4 @@ from .french import *
 from .japanese import *
 from .number_recognizer import *
 from .parser_factory import *
+from .utilities import *

--- a/Python/libraries/recognizers-number/recognizers_number/number/chinese/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/chinese/parsers.py
@@ -13,8 +13,6 @@ from recognizers_number.number.cjk_parsers import CJKNumberParser
 from recognizers_number.number.parsers import BaseNumberParser, NumberParserConfiguration
 from recognizers_number.culture import CultureInfo
 
-getcontext().prec = 15
-
 
 class ChineseNumberParserConfiguration(NumberParserConfiguration):
     @property

--- a/Python/libraries/recognizers-number/recognizers_number/number/japanese/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/japanese/parsers.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Pattern, Optional
 from collections import namedtuple
-from decimal import Decimal, getcontext
+from decimal import Decimal
 import copy
 import regex
 
@@ -12,8 +12,6 @@ from recognizers_number.resources.japanese_numeric import JapaneseNumeric
 from recognizers_number.number.cjk_parsers import CJKNumberParserConfiguration
 from recognizers_number.number.parsers import BaseNumberParser, NumberParserConfiguration
 from recognizers_number.culture import CultureInfo
-
-getcontext().prec = 15
 
 
 class JapaneseNumberParserConfiguration(CJKNumberParserConfiguration):

--- a/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/parsers.py
@@ -7,8 +7,7 @@ from recognizers_text.extractor import ExtractResult
 from recognizers_text.parser import Parser, ParseResult
 from recognizers_number.culture import CultureInfo
 from recognizers_number.number.constants import Constants
-
-getcontext().prec = 15
+from recognizers_number.number.utilities import precision
 
 
 class NumberParserConfiguration(ABC):
@@ -350,6 +349,7 @@ class BaseNumberParser(Parser):
         result.value = int_part_real + Decimal(point_part_real)
         return result
 
+    @precision(prec=15)
     def _power_number_parse(self, ext_result: ExtractResult) -> ParseResult:
         result = ParseResult(ext_result)
 
@@ -534,6 +534,7 @@ class BaseNumberParser(Parser):
 
         return ch == self.config.non_decimal_separator_char and not(distance <= decimal_length and culture_regex.match(culture.code))
 
+    @precision(prec=15)
     def _get_digital_value(self, digits_str: str, power: int) -> Decimal:
         tmp: Decimal = Decimal(0)
         scale: Decimal = Decimal(10)

--- a/Python/libraries/recognizers-number/recognizers_number/number/utilities.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/utilities.py
@@ -1,0 +1,13 @@
+from decimal import localcontext
+
+
+def precision(*args, **kwargs):
+    def decorator(f):
+        def inner_decorator(*a, **kwa):
+            with localcontext() as ctx:
+                ctx.prec = kwargs['prec']
+                return f(*a, **kwa)
+
+        return inner_decorator
+
+    return decorator


### PR DESCRIPTION
## Description
This aims to fix the issue [2035 ](https://github.com/microsoft/Recognizers-Text/issues/2035)**[Python | * Number] Number parser reduces the global precision of decimals** 

## Details
A utilities.py class was created in recognizers-number (matching that of other recognizers) containing a decorator that can be reused to set decimal precision without affecting the global context.
References to `getcontext().prec = 15` were also removed.

### Passing tests
![image](https://user-images.githubusercontent.com/20074735/77657827-95d63180-6f54-11ea-8b02-0e5e1a9729ab.png)