### PR TITLE
 Fix invalid end date generation when timex resolution crosses year boundary for javascript platform

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -540,5 +540,25 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("2020-01-13", resolution.Values[0].End);
             Assert.IsNull(resolution.Values[0].Value);
         }
+
+        [TestMethod]
+        public void DataTypes_Resolver_MonthRange_December()
+        {
+            var today = new System.DateTime(2020, 3, 25);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-12" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-12", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-12-01", resolution.Values[0].Start);
+            Assert.AreEqual("2020-01-01", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-12", resolution.Values[1].Timex);
+            Assert.AreEqual("daterange", resolution.Values[1].Type);
+            Assert.AreEqual("2020-12-01", resolution.Values[1].Start);
+            Assert.AreEqual("2021-01-01", resolution.Values[1].End);
+            Assert.IsNull(resolution.Values[1].Value);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             return new Tuple<string, string>(
                 TimexValue.DateValue(new TimexProperty { Year = year, Month = month, DayOfMonth = 1 }),
-                TimexValue.DateValue(new TimexProperty { Year = year, Month = month + 1, DayOfMonth = 1 }));
+                TimexValue.DateValue(new TimexProperty { Year = month == 12 ? year + 1 : year, Month = month == 12 ? 1 : month + 1, DayOfMonth = 1 }));
         }
 
         private static Tuple<string, string> YearWeekDateRange(int year, int weekOfYear, bool? isWeekend)

--- a/JavaScript/packages/datatypes-date-time/src/timexResolver.js
+++ b/JavaScript/packages/datatypes-date-time/src/timexResolver.js
@@ -70,7 +70,7 @@ const weekDateRange = function (year, weekOfYear) {
 const monthDateRange = function (year, month) {
     return {
         start: timexValue.dateValue({ year: year, month: month, dayOfMonth: 1 }),
-        end: timexValue.dateValue({ year: year, month: month + 1, dayOfMonth: 1 })
+        end: timexValue.dateValue({ year: month == 12 ? year + 1 : year, month: month == 12 ? 1 : month + 1, dayOfMonth: 1 })
     };
 };
 

--- a/JavaScript/packages/datatypes-date-time/test/timexResolver.spec.js
+++ b/JavaScript/packages/datatypes-date-time/test/timexResolver.spec.js
@@ -179,6 +179,19 @@ describe('No Network', () => {
                     resolution.values[0].should.have.property('start', '2019-04-10');
                     resolution.values[0].should.have.property('end', '2019-05-01');
                 });
+                it('December', () => {
+                    const today = new Date(2020, 3, 27);
+                    const resolution = resolver.resolve(['XXXX-12'], today);
+                    resolution.should.have.property('values').that.is.an('array').of.length(2);
+                    resolution.values[0].should.have.property('timex', 'XXXX-12');
+                    resolution.values[0].should.have.property('type', 'daterange');
+                    resolution.values[0].should.have.property('start', '2019-12-01');
+                    resolution.values[0].should.have.property('end', '2020-01-01');
+                    resolution.values[1].should.have.property('timex', 'XXXX-12');
+                    resolution.values[1].should.have.property('type', 'daterange');
+                    resolution.values[1].should.have.property('start', '2020-12-01');
+                    resolution.values[1].should.have.property('end', '2021-01-01');
+                });
             });
             describe('timerange', () => {
                 it('4am to 8pm', () => {


### PR DESCRIPTION
I fixed invalid end date generation when timex resolution crosses year boundary for javascript platform by revising codes in javascript/packages/datetypes-date-time/src/timexResolver.js and added a test case in /src/test/timexResolver.spec.js.