### PR TITLE
fix the bug that model can't processd date period like end/beginning/middle of $Year in English

### DIFF
--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -1,4 +1,4 @@
-ECHO ==============================.NET BUILD START==============================
+ ECHO ==============================.NET BUILD START==============================
 
 @ECHO off
 SETLOCAL EnableDelayedExpansion

--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -1,4 +1,4 @@
- ECHO ==============================.NET BUILD START==============================
+ECHO ==============================.NET BUILD START==============================
 
 @ECHO off
 SETLOCAL EnableDelayedExpansion

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
@@ -246,6 +246,10 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string TwoNumberRangeRegex2 = $@"({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2}|{OneNumberRangeMoreRegex3})\s*(且|(并|並)且?|而且|((的)?同時)|((的)?同时)|[,，])?\s*({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2}|{OneNumberRangeLessRegex3})";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2}|{OneNumberRangeLessRegex3})\s*(且|(并|並)且?|而且|((的)?同時)|((的)?同时)|[,，])?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2}|{OneNumberRangeMoreRegex3})";
       public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!(([,，](?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!(([,，](?!\d+))|。)).)+)";
+      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
+        {
+            { @"十", @"十足" }
+        };
       public const string AmbiguousFractionConnectorsRegex = @"^[.]";
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {
@@ -254,10 +258,6 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
         {
             { @"", @"" }
-        };
-      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
-        {
-            { @"十", @"十足" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string AmbiguousRangeModifierPrefix = @"(from)";
       public static readonly string NumberEndingPattern = $@"^(?:\s+(?<meeting>meeting|appointment|conference|((skype|teams)\s+)?call)\s+to\s+(?<newTime>{PeriodHourNumRegex}|{HourRegex})([\.]?$|(\.,|,|!|\?)))";
       public const string OneOnOneRegex = @"\b(1\s*:\s*1(?!\d))|(one (on )?one|one\s*-\s*one|one\s*:\s*one)\b";
-      public static readonly string LaterEarlyPeriodRegex = $@"\b(({PrefixPeriodRegex})\s*\b\s*(?<suffix>{OneWordPeriodRegex})|({UnspecificEndOfRangeRegex}))\b";
+      public static readonly string LaterEarlyPeriodRegex = $@"\b(({PrefixPeriodRegex})\s*\b\s*(?<suffix>{OneWordPeriodRegex}|(?<FourDigitYear>{BaseDateTime.FourDigitYearRegex}))|({UnspecificEndOfRangeRegex}))\b";
       public static readonly string WeekWithWeekDayRangeRegex = $@"\b((?<week>({NextPrefixRegex}|{PreviousPrefixRegex}|this)\s+week)((\s+between\s+{WeekDayRegex}\s+and\s+{WeekDayRegex})|(\s+from\s+{WeekDayRegex}\s+to\s+{WeekDayRegex})))\b";
       public const string GeneralEndingRegex = @"^\s*((\.,)|\.|,|!|\?)?\s*$";
       public const string MiddlePauseRegex = @"\s*(,)\s*";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1105,6 +1105,43 @@ namespace Microsoft.Recognizers.Text.DateTime
                         ret.Success = true;
                         return ret;
                     }
+                    else if (!string.IsNullOrEmpty(match.Groups["FourDigitYear"].Value))
+                    {
+                        var date = referenceDate.AddYears(swift);
+                        int.TryParse(match.Groups["FourDigitYear"].Value, out year);
+
+                        var beginDate = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);
+                        var endDate = inclusiveEndPeriod ?
+                            DateObject.MinValue.SafeCreateFromValue(year, 12, 31) :
+                            DateObject.MinValue.SafeCreateFromValue(year, 12, 31).AddDays(1);
+
+                        if (earlyPrefix)
+                        {
+                            endDate = inclusiveEndPeriod ?
+                                DateObject.MinValue.SafeCreateFromValue(year, 4, 30) :
+                                DateObject.MinValue.SafeCreateFromValue(year, 4, 30).AddDays(1);
+                        }
+                        else if (midPrefix)
+                        {
+                            beginDate = DateObject.MinValue.SafeCreateFromValue(year, 5, 1);
+                            endDate = inclusiveEndPeriod ?
+                                DateObject.MinValue.SafeCreateFromValue(year, 8, 30) :
+                                DateObject.MinValue.SafeCreateFromValue(year, 8, 30).AddDays(1);
+                        }
+                        else if (latePrefix)
+                        {
+                            beginDate = DateObject.MinValue.SafeCreateFromValue(year, 9, 1);
+                        }
+
+                        ret.Timex = isReferenceDatePeriod ? TimexUtility.GenerateYearTimex() : TimexUtility.GenerateYearTimex(beginDate);
+
+                        ret.FutureValue =
+                            ret.PastValue =
+                                new Tuple<DateObject, DateObject>(beginDate, endDate);
+
+                        ret.Success = true;
+                        return ret;
+                    }
                 }
             }
             else

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -6046,5 +6046,86 @@
         "Length": 9
       }
     ]
+  },
+  {
+    "Input": "This company was established at the end of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-23T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "end of 2000",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2000",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2000-09-01",
+            "endDate": "2001-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-09-01",
+            "endDate": "2001-01-01"
+          }
+        },
+        "Start": 36,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the beginning of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-23T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "beginning of 2000",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2000",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2000-05-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2000-05-01"
+          }
+        },
+        "Start": 36,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the middle of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-23T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "middle of 2000",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2000",
+          "Mod": "mid",
+          "FutureResolution": {
+            "startDate": "2000-05-01",
+            "endDate": "2000-08-31"
+          },
+          "PastResolution": {
+            "startDate": "2000-05-01",
+            "endDate": "2000-08-31"
+          }
+        },
+        "Start": 36,
+        "Length": 14
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -15031,7 +15031,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "NotSupported":"java, javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "lunchtime",
@@ -15056,7 +15056,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "NotSupported":"java, javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "at lunchtime",
@@ -15272,6 +15272,84 @@
               "type": "daterange",
               "start": "2020-06-26",
               "end": "2020-06-28"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the end of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "end of 2000",
+        "Start": 36,
+        "End": 46,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "end",
+              "type": "daterange",
+              "start": "2000-09-01",
+              "end": "2001-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the middle of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "middle of 2000",
+        "Start": 36,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "mid",
+              "type": "daterange",
+              "start": "2000-05-01",
+              "end": "2000-08-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the beginning of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "beginning of 2000",
+        "Start": 36,
+        "End": 52,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "start",
+              "type": "daterange",
+              "start": "2000-01-01",
+              "end": "2000-05-01"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -11553,7 +11553,7 @@
             }
           ]
         }
-      }      
+      }
     ]
   },
   {
@@ -12363,7 +12363,7 @@
   },
   {
     "Input": "I'm at Eastern Daylight Time",
-    "NotSupported":"javascript,python",
+    "NotSupported": "javascript,python",
     "Results": [
       {
         "Text": "eastern daylight time",
@@ -12384,7 +12384,7 @@
   },
   {
     "Input": "I'm at Central Daylight Time",
-    "NotSupported":"javascript,python",
+    "NotSupported": "javascript,python",
     "Results": [
       {
         "Text": "central daylight time",
@@ -12405,7 +12405,7 @@
   },
   {
     "Input": "It's about 1pm ACDT",
-    "NotSupported":"javascript,python",
+    "NotSupported": "javascript,python",
     "Results": [
       {
         "Text": "1pm acdt",
@@ -12505,7 +12505,7 @@
   },
   {
     "Input": "We will have lunch together with Jim",
-    "Comment":"Disable this for now because of new features in .NET",
+    "Comment": "Disable this for now because of new features in .NET",
     "NotSupported": "javascript, python, java",
     "Context": {
       "ReferenceDateTime": "2019-09-12T00:00:00"
@@ -12662,6 +12662,84 @@
               "type": "timezone",
               "value": "UTC-12:00",
               "utcOffsetMins": "-720"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the end of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "end of 2000",
+        "Start": 36,
+        "End": 46,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "end",
+              "type": "daterange",
+              "start": "2000-09-01",
+              "end": "2001-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the middle of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "middle of 2000",
+        "Start": 36,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "mid",
+              "type": "daterange",
+              "start": "2000-05-01",
+              "end": "2000-08-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "This company was established at the beginning of 2000",
+    "Context": {
+      "ReferenceDateTime": "2020-04-24T10:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "beginning of 2000",
+        "Start": 36,
+        "End": 52,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "start",
+              "type": "daterange",
+              "start": "2000-01-01",
+              "end": "2000-05-01"
             }
           ]
         }


### PR DESCRIPTION
I changed the LaterEarlyPeriodRegex in English DateTimeDefinitions to make it able to match end/beginning/middle of $Year. Also, I changed codes in BaseDatePeriodParser to output right results. Finally, I add three test cases in Specs/DateTime/English/DatePeriodParser.json，DateTimeModel.json and DateTimeComplexCalendar.json.