### PR TITLE
Build/validation changes for VS2019 and in-progress new language support

### DIFF
--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -15,16 +15,29 @@ for /f "usebackq tokens=*" %%i in (`!vswhere! -latest -products * -requires Micr
 )
 
 ECHO.
-SET MsBuildVersion=15.0
-ECHO # Finding MSBuild !MsBuildVersion!
+ECHO # Finding MSBuild
+
+SET MsBuildVersion=Current
+ECHO # Trying !MsBuildVersion! for VS2019
 
 if EXIST "%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" (
-	SET MSBuild="%VSInstallDir%\MSBuild\15.0\Bin\MSBuild.exe" %*
-	ECHO Found MSBuild !MSBuild!
+	SET MSBuild="%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" %*
 ) else (
-	ECHO "msbuild.exe" could not be found at "!VSInstallDir!"
-	EXIT /B
+	ECHO MSBuild !MSBuild! not found!
+	ECHO.
+	
+	SET MsBuildVersion=15.0
+	ECHO # Trying !MsBuildVersion! for VS2017
+
+	if EXIST "%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" (
+		SET MSBuild="%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" %*
+	) else (
+		ECHO "msbuild.exe" could not be found at "!VSInstallDir!"
+		EXIT /B
+	)
 )
+
+ECHO Found MSBuild !MSBuild!
 
 ECHO.
 ECHO # Check for empty and duplicate inputs in Specs

--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -4,6 +4,10 @@ ECHO ==============================.NET BUILD START=============================
 SETLOCAL EnableDelayedExpansion
 
 ECHO.
+ECHO # Setting encoding to UTF-8
+chcp 65001
+
+ECHO.
 ECHO # Building .NET platform
 REM vswhere is an optional component for Visual Studio and also installed with Build Tools. 
 REM vswhere will look for Community, Professional, and Enterprise editions of Visual Studio

--- a/.NET/Build.CI.cmd
+++ b/.NET/Build.CI.cmd
@@ -23,7 +23,7 @@ ECHO # Trying !MsBuildVersion! for VS2019
 if EXIST "%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" (
 	SET MSBuild="%VSInstallDir%\MSBuild\!MsBuildVersion!\Bin\MSBuild.exe" %*
 ) else (
-	ECHO MSBuild !MSBuild! not found!
+	ECHO MSBuild !MsBuildVersion! not found!
 	ECHO.
 	
 	SET MsBuildVersion=15.0

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
@@ -24,66 +24,67 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public const string LangMarker = @"Ara";
       public const bool CompoundNumberLanguage = false;
       public const bool MultiDecimalSeparatorCulture = true;
-      public const string RoundNumberIntegerRegex = @"(ال)?(?:مائة|آلاف|مائتين|مائتان|ثلاثمائة|أربعمائة|خمسمائة|ستمائة|سبعمائة|ثمانمائة|تسعمائة|ألف|ألفين|مليون|مليار|تريليون)";
-      public const string ZeroToNineIntegerRegex = @"(ال)?(?:ثلاثة|سبعة|ثلاث|ثامن|ثمانية|أربعة|أربع|خمسة|صفر|تسعة|واحد|واحدة|اثنين|اثنتين|اثنان|اثنتين|ست|ستة)";
-      public const string TwoToNineIntegerRegex = @"(ال)?(?:ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنتان|اثنين|اثتنين|اثنتان|ست|ستة)";
-      public const string NegativeNumberTermsRegex = @"(?<negTerm>(سالب|ناقص)\s+)";
+      public const string RoundNumberIntegerRegex = @"(?:مائتان|مائة|مائة|مائتين|ثلاثمائه|أربعة مئة|خمسمائة|ستمائة|سبعمائة|ثمان مائة|تسعمائة|تريليون|ترليون|آلاف|تريليونين|تريليونات|مليار|ملياري|مليارات|مليون|مليونان|ملايين|ملايين|ألف|مليونين|ألفين|مئة|ومائتين|الفين|بألفين|مئتان|الآف)";
+      public const string ZeroToNineIntegerRegex = @"(وخمسة|بإثنان|وواحد|واحد|وأربعة|واثنان|اثنان|وثلاثة|ثلاثة|واربعة|أربعة|خمسة|وستة|ستة|وسبعة|سبعة|وثمانية|ثمانية|ثمانٍ|وتسعة|تسع|أحد|اثني|ثلاث|صفر|سبع|ست|اربع|السادس|الثامنة|تسعة|اثنين|واحدُ|وإثنين|وواحدُ|الواحد:?)";
+      public const string TwoToNineIntegerRegex = @"(?:ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنتان|اثنين|اثتنين|اثنتان|ست|ستة)";
+      public const string NegativeNumberTermsRegex = @"(?<negTerm>(سالب|ناقص)(\s+)?)";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*";
       public const string AnIntRegex = @"(واحد|أحد)(?=\s)";
-      public const string TenToNineteenIntegerRegex = @"(ال)?(?:سبعة عشر|ثلاثة عشر|أربعة عشر|ثمانية عشر|تسعة عشر|خمسة عشر|ستة عشر|حادية عشر|ثانية عشر|عشرة)";
-      public const string TensNumberIntegerRegex = @"(ال)?(?:سبعون|سبعين|عشرون|عشرين|ثلاثون|ثلاثين|ثمانون|ثمانين|تسعون|تسعين|أربعون|أربعين|خمسون|خمسين|ستون|ستين)";
-      public static readonly string SeparaIntRegex = $@"(?:(({TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(\s+(و\s+)?|\s*-\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s+{RoundNumberIntegerRegex})*))|(({AnIntRegex}(\s+{RoundNumberIntegerRegex})+))";
-      public static readonly string AllIntRegex = $@"(?:({SeparaIntRegex})((\s+و\s+)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و\s+)?)*{SeparaIntRegex})";
+      public const string TenToNineteenIntegerRegex = @"(?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|ست|ستة|أحد|أربعة|اثني)\s(عشر|عشرة)))";
+      public const string TensNumberIntegerRegex = @"(عشرة|عشرون|ثلاثون|أربعون|خمسون|ستون|سبعون|ثمانون|تسعين|وعشرين|وثلاثين|وأربعين|وخمسين|وستين|وسبعين|وثمانين|وتسعين|وعشرون|ثلاثون|وأربعون|وخمسون|وستون|وسبعون|وثمانون|وتسعون|عشرين|ثلاثين|أربعين|خمسين|ستين|سبعين|ثمانين|تسعون|العشرون:?)";
+      public static readonly string SeparaIntRegex = $@"(?:((({RoundNumberIntegerRegex}\s{RoundNumberIntegerRegex})|{TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(((و)?)\s+(و)?|\s*-\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s+{RoundNumberIntegerRegex})*))|(((\s+{RoundNumberIntegerRegex})+))";
+      public static readonly string AllIntRegex = $@"(?:({SeparaIntRegex})((\s+(و)?)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و)?)*{SeparaIntRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
-      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[\u0621-\u064A]))(?={placeholder})";
-      public static readonly string NumbersWithSuffix = $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
-      public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+\s+{RoundNumberIntegerRegex}(?=\b)";
-      public const string NumbersWithDozenSuffix = @"(?<=\b)(\d+\s+)(دستة|دستات|دست)(?=\b)";
+      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،]\d+[\u0621-\u064A]))(?={placeholder})";
+      public static readonly string NumbersWithSuffix = $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
+      public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}(?=\b)";
+      public const string NumbersWithDozenSuffix = @"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s+(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\b)";
       public static readonly string AllIntRegexWithLocks = $@"((?<=\b){AllIntRegex}(?=\b))";
-      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((نصف\s+)?(دستة))|(({AllIntRegex}\s+)(دستة|دستات|دست)))(?=\b)";
+      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((نصف\s+)(دزينة|دستة|دستات|دست|دزينات|دزينتين))|({AllIntRegex}(و)?\s+((و)?))(دزينة|دستة|دستات|دست|دزينات|دزينتين))(?=\b)";
       public static readonly string RoundNumberOrdinalRegex = $@"(?:((من|على)\s+)({RoundNumberIntegerRegex}))";
-      public const string NumberOrdinalRegex = @"(?:ثلث|ربع|خمس|سدس|سبع|نصف|ثمن|تسع|عشر|أنصاف|أثلاث|أرباع|أخماس|أسداس|أسباع|أثمان|أتساع|أعشر|أعشار|أول|ثاني|ثالث|رابع|خامس|سادس|سابع|ثامن|تاسع|عاشر|الأول|الأولى|الثاني|الثانية|الثالث|الثالثة|الرابع|الرابعة|خامس|خامسة|الخامسة|السادس|السادسة|السابع|السابعة|الثامن|الثامنة|التاسع|التاسعة|المليون|المليار|التريليون|المليارات|المليار|المائة|المائتان|الثلاثمائة|الأربعمائة|الخمسمائة|الستمائة|السبعمائة|التسعمائة|التريليون|المائة|المائتان|الثلاثمائة|الأربعمائة|الخمسمائة|الستمائة|التسعمائة|الحادية عشرة|الثانية عشرة|الثالثة عشرة|الرابعة عشرة|الخامسة عشرة|السادسة عشرة|السابعة عشرة|الثامنة عشرة|التاسعة عشرة|الحادية|الألف)";
-      public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>((قبل|بعد|سبق|سبقت)(\s+))?((ال)?(تالي|سابق|قادم|آخر|أخير|حالي)(ة)?))";
-      public static readonly string BasicOrdinalRegex = $@"({NumberOrdinalRegex}((\s+و\s+)({{AllIntRegex}}))?|{RelativeOrdinalRegex})";
-      public static readonly string SuffixBasicOrdinalRegex = $@"(?:(((({ZeroToNineIntegerRegex}(\s+و\s+){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})*)\s+(و\s+)?)*({TensNumberIntegerRegex}\s+)?{BasicOrdinalRegex}|{BasicOrdinalRegex})";
+      public const string NumberOrdinalRegex = @"(اخماس|ثلثان|واحد جزء من|أجزاء من|المئتيان|مائتي|الحاديه عشر|سابعًا|خامسا|ثانيا|أول|الأول|الثاني|الثالث|الرابع|الخامس|السابع|الثامن|التاسع|الأولى|الثانية|الثالثة|الرابعة|الخامسة|السادسة|السابعة|التاسعة|السادس عشر|السابعة عشرة|السادسة عشرة|الثالثة عشرة|الحادية عشرة|السابع عشر|سادس عشر|الخامس عشر|الحادية عَشْرةَ|الثانيَ عَشَر|الثانيةَ عَشْرةَ|الثالثَ عَشَرَ|الثالثةَ عَشْرةَ|الرابعَ عَشَرَ|الرابعةَ عَشْرةَ|الخامِسَ عَشَرَ|الخامسةَ عَشْرةَ|السادِسَ عَشَرَ|السادسةَ عَشْرةَ|السابعَ عَشَرَ|السابعةَ عَشْرةَ|الثامنَ عَشَرَ|الثامنةَ عَشْرةَ|التاسعَ عَشَرَ|التاسعةَ عَشْرةَ|الحادِيَ عَشَرَ|الحادي عشر|الثاني عشر|الثالث عشر|الرابع عشر|الثامن عشر|التاسع عشر|الثانية عشرة|الرابعة عشرة|الخامسة عشرة|الثامنة عشرة|التاسعة عشرة|العاشر|العاشرة|عشرون|العشرين|الثلاثين|الثلاثون|الرابعة والأربعون|الرابع والأربعون|خمسون|الخمسون|الستين|ستون|والستين|سبعون|السبعون|والسبعون|ثامن عشر|الثامن عشر|الرابع والأربعين|الثامنة والثمانون|الثامن|والثمانين|وثلثان|ثمن|أثمان|التاسع والتسعون|التاسعة والتسعون|اثمان|خمس|أخماس|وثلاثون|ثلثان|الأخماس|اخماس|ثلثان|واحد جزء من|العشرون|التريليون|الواحد والعشرون|الخامسة والعشرون:?)";
+      public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>((السابق|السابقة|الثانية الى|الأخير|قبل|بعد|سبق|سبقت|التالي|الحالي|واحد قبل|الذي|اخر)(\s+))?((تالي|الحالي|السابقة|سابق|قادم|التالي|الأخير|آخر|أخير|حالي|اخر|الاخير|الأولى)(ة)?)|(الاخر|الاول|الأول|اول|الأولى|الأخير|السابق|التالي|أخر))";
+      public static readonly string BasicOrdinalRegex = $@"({NumberOrdinalRegex}|{RelativeOrdinalRegex})";
+      public static readonly string SuffixBasicOrdinalRegex = $@"(?:(((({TensNumberIntegerRegex}(\s+(و)?|\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({RoundNumberIntegerRegex}|المئة(\s+(و)?)))((\s+{RoundNumberIntegerRegex}|المئة)+|({BasicOrdinalRegex})))\s+(و)?)*({TensNumberIntegerRegex}(\s+|\s*))?{BasicOrdinalRegex}|({TensNumberIntegerRegex}))";
       public static readonly string SuffixRoundNumberOrdinalRegex = $@"(?:({AllIntRegex}\s+){RoundNumberOrdinalRegex})";
-      public static readonly string AllOrdinalRegex = $@"(?:{SuffixBasicOrdinalRegex}|(({NumberOrdinalRegex})(\s+و\s+))?{AllIntRegex}|{SuffixRoundNumberOrdinalRegex})";
+      public static readonly string AllOrdinalRegex = $@"(?:{SuffixBasicOrdinalRegex}|{SuffixRoundNumberOrdinalRegex})";
       public const string OrdinalNumericRegex = @"(?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*\s*th)(?=\b)";
       public static readonly string OrdinalRoundNumberRegex = $@"({RoundNumberOrdinalRegex})";
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
-      public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(و\s+)?)?({AllIntRegex}(\s+|\s*-\s*))?((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|أنصاف|أرباع)(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(و\s+)?)?(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|نصف|ربع))|(نصف))(?=\b)";
-      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(على|في|من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
+      public const string FractionNotationWithSpacesRegex = @"(((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
+      public const string FractionNotationRegex = @"(((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public const string ArabicBuiltInFraction = @"(ثلثان|الوزن|ربع|خمس|عشرونات|ثلاثون:?)";
+      public static readonly string FractionNounRegex = $@"(?<=\b){ArabicBuiltInFraction}|{AllIntRegex}\s(و\s|و){ArabicBuiltInFraction}|(({AllIntRegex}\s(و\s|و)?)?({AllIntRegex})(\s+|\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|أرباع|وربع|ارباع|واحد وربع|نصف|ربع|أنصاف|ربعين|أرباع|ارباع))(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}(\s|(\s*-\s*)|و\s+)?)(({AllOrdinalRegex})|({{NumberOrdinalRegex}})|نصف|وربع|ربع|ونصف))|(نصف|))(?=\b)";
+      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(فوق|على|في|جزء|من|جزء من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+على\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";
-      public static readonly string AllFloatRegex = $@"({AllIntRegex}\s+(فاصلة|نقطة)\s+({AllPointRegex}|{{AllOrdinalRegex}}))";
-      public static readonly string DoubleWithMultiplierRegex = $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
-      public const string DoubleExponentialNotationRegex = @"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)e([+-]*[1-9]\d*)(?=\b)";
-      public const string DoubleCaretExponentialNotationRegex = @"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)\^([+-]*[1-9]\d*)(?=\b)";
-      public static readonly Func<string, string> DoubleDecimalPointRegex = (placeholder) => $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
+      public static readonly string AllFloatRegex = $@"{AllIntRegex}(\s+(نقطة|جزء|جزء من)){AllPointRegex}";
+      public static readonly string DoubleWithMultiplierRegex = $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
+      public const string DoubleExponentialNotationRegex = @"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)e([+-]*[\u0660-\u0669]\d*)(?=\b)";
+      public const string DoubleCaretExponentialNotationRegex = @"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)\^([+-]*[\u0660-\u0669]\d*)(?=\b)";
+      public static readonly Func<string, string> DoubleDecimalPointRegex = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
       public static readonly Func<string, string> DoubleWithoutIntegralRegex = (placeholder) => $@"(?<=\s|^)(?<!(\d+))[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
-      public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s+{RoundNumberIntegerRegex}(?=\b)";
+      public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string DoubleAllFloatRegex = $@"((?<=\b){AllFloatRegex}(?=\b))";
       public const string ConnectorRegex = @"(?<spacer>و)";
-      public static readonly string NumberWithSuffixPercentage = $@"(?<!%)({BaseNumbers.NumberReplaceToken})(\s*)(%(?!{BaseNumbers.NumberReplaceToken})|(بالمائة)\b)";
-      public static readonly string FractionNumberWithSuffixPercentage = $@"(({BaseNumbers.FractionNumberReplaceToken})\s+من)";
-      public static readonly string NumberWithPrefixPercentage = $@"(بالمائة)(\s*)({BaseNumbers.NumberReplaceToken})";
+      public static readonly string NumberWithSuffixPercentage = $@"((?<!(٪|%))({BaseNumbers.NumberReplaceToken})(\s*)((٪|%)(?!{BaseNumbers.NumberReplaceToken})|(بالمائة|في المئة|بالمئة)))";
+      public static readonly string FractionNumberWithSuffixPercentage = $@"(({BaseNumbers.FractionNumberReplaceToken})\s+(من|في المئة))";
+      public static readonly string NumberWithPrefixPercentage = $@"(نسبة|بالمائة)(\s*)({BaseNumbers.NumberReplaceToken})";
       public static readonly string NumberWithPrepositionPercentage = $@"({BaseNumbers.NumberReplaceToken})\s*(في|خارج\s+من)\s*({BaseNumbers.NumberReplaceToken})";
       public const string TillRegex = @"(إلى|خلال|--|-|—|——|~|–)";
-      public const string MoreRegex = @"(?:(أكبر|أعظم|أطول)(\s+من)?|(?<!<|=)>)";
+      public const string MoreRegex = @"(?:(فوق|أكبر|أعظم|أطول|يتجاوز)(\s+من)?|(?<!<|=)>)";
       public const string LessRegex = @"(?:(أقل|اقل|اصغر|أصغر)(\s+من)?|تحت|(?<!>|=)<)";
       public const string EqualRegex = @"(يساوي|(?<!<|>)=)";
       public static readonly string MoreOrEqualPrefix = $@"(((ليس|لا)\s+{LessRegex})|(على\s+الأقل))";
       public static readonly string MoreOrEqual = $@"(?:({MoreRegex}\s+(أو|او)?\s+{EqualRegex})|({EqualRegex}\s+(أو|او)?\s+{MoreRegex})|{MoreOrEqualPrefix}(\s+(أو|او)?\s+{EqualRegex})?|({EqualRegex}\s+(أو|او)?\s+)?{MoreOrEqualPrefix}|>\s*=)";
-      public const string MoreOrEqualSuffix = @"((و|أو)\s+(((أكبر|أعظم|أطول)((?!\s+من)|(\s+من(?!(\s*\d+)))))|((أكبر|أطول)(?!\s+من))))";
+      public const string MoreOrEqualSuffix = @"((و|أو)\s+(((أكبر|أعظم|أطول|فوق)((?!\s+من)|(\s+من(?!(\s*\d+)))))|((فوق|أكبر|أطول)(?!\s+من))))";
       public static readonly string LessOrEqualPrefix = $@"((ليس\s+{MoreRegex})|(at\s+most)|(بحد أقصى))";
-      public static readonly string LessOrEqual = $@"(({LessRegex}\s+(أو)?\s+{EqualRegex})|({EqualRegex}\s+(أو)?\s+{LessRegex})|{LessOrEqualPrefix}(\s+(أو)?\s+{EqualRegex})?|({EqualRegex}\s+(أو)?\s+)?{LessOrEqualPrefix}|<\s*=)";
+      public static readonly string LessOrEqual = $@"(({LessRegex}\s+(أو|او)?\s+{EqualRegex}))";
       public const string LessOrEqualSuffix = @"((و|أو)\s+(أقل)((?!\s+من)|(\s+من(?!(\s*\d+)))))";
       public const string NumberSplitMark = @"(?![,.](?!\d+))";
-      public const string MoreRegexNoNumberSucceed = @"((أكبر|أعظم|أطول)((?!\s+من)|\s+(من(?!(\s*\d+))))|(أكبر|أعظم)(?!(\s*\d+)))";
+      public const string MoreRegexNoNumberSucceed = @"((أكبر|أعظم|أطول|فوق)((?!\s+من)|\s+(من(?!(\s*\d+))))|(فوق|أكبر|أعظم)(?!(\s*\d+)))";
       public const string LessRegexNoNumberSucceed = @"((أقل|أصغر)((?!\s+من)|\s+(من(?!(\s*\d+))))|(تحت|أقل|أصغر)(?!(\s*\d+)))";
       public const string EqualRegexNoNumberSucceed = @"(يساوي)";
       public static readonly string OneNumberRangeMoreRegex1 = $@"({MoreOrEqual}|{MoreRegex})\s*(ال)?(?<number1>({NumberSplitMark}.)+)";
@@ -96,11 +97,11 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string TwoNumberRangeRegex1 = $@"بين\s*(ال)?(?<number1>({NumberSplitMark}.)+)\s*و\s*(ال)?(?<number2>({NumberSplitMark}.)+)";
       public static readonly string TwoNumberRangeRegex2 = $@"({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(و|لكن|,)\s*({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2})";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1}|{OneNumberRangeLessRegex2})\s*(و|لكن|,)\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
-      public static readonly string TwoNumberRangeRegex4 = $@"(من\s+)?(?<number1>({NumberSplitMark}(?!\bمن\b).)+)\s*{TillRegex}\s*(ال)?(?<number2>({NumberSplitMark}.)+)";
-      public const string AmbiguousFractionConnectorsRegex = @"(\bمن|في|بين|من|بين\b)";
-      public const char DecimalSeparatorChar = '.';
+      public static readonly string TwoNumberRangeRegex4 = $@"(من\s+)?(?<number1>({NumberSplitMark}(?!\bمن\b).)+)\s*{TillRegex}\s*(ال\s+)?(?<number2>({NumberSplitMark}.)+)";
+      public const string AmbiguousFractionConnectorsRegex = @"(\bمن|بين|من|بين\b)";
+      public const char DecimalSeparatorChar = ',';
       public const string FractionMarkerToken = @"أكثر";
-      public const char NonDecimalSeparatorChar = ',';
+      public const char NonDecimalSeparatorChar = '،';
       public const string HalfADozenText = @"ستة";
       public const string WordSeparatorToken = @"و";
       public static readonly string[] WrittenDecimalSeparatorTexts = { @"نقطة | فاصلة" };
@@ -340,6 +341,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
         };
       public static readonly Dictionary<string, long> RoundNumberMap = new Dictionary<string, long>
         {
+            { @"ترليون", 1000000000000 },
             { @"مائة", 100 },
             { @"ألف", 1000 },
             { @"مليون", 1000000 },
@@ -381,7 +383,9 @@ namespace Microsoft.Recognizers.Definitions.Arabic
         };
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {
+            { @"الاخر", @"0" },
             { @"آخر", @"0" },
+            { @"اخر", @"0" },
             { @"الأخيرة", @"0" },
             { @"الأخير", @"0" },
             { @"سبقت الأخيرة", @"-1" },
@@ -397,27 +401,45 @@ namespace Microsoft.Recognizers.Definitions.Arabic
             { @"السابقة", @"-1" },
             { @"الحالي", @"0" },
             { @"الحالية", @"0" },
-            { @"السابق", @"-1" }
+            { @"قبل الاخير", @"-1" },
+            { @"واحد قبل الاخير", @"-1" },
+            { @"الثانية الى الاخير", @"-1" },
+            { @"السابق", @"-1" },
+            { @"أخر", @"0" },
+            { @"الاخير", @"0" },
+            { @"اول", @"1" },
+            { @"الاول", @"1" },
+            { @"التالية", @"-1" }
         };
       public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
         {
+            { @"اول", @"current" },
+            { @"التالية", @"current" },
+            { @"الاول", @"current" },
+            { @"الاخر", @"end" },
+            { @"الاخير", @"end" },
+            { @"أخر", @"end" },
             { @"آخر", @"end" },
+            { @"اخر", @"end" },
             { @"الأخيرة", @"end" },
             { @"الأخير", @"end" },
-            { @"سبقت الأخيرة", @"end" },
-            { @"سبقت الأخير", @"end" },
-            { @"قبل الأخير", @"end" },
-            { @"قبل الأخيرة", @"end" },
-            { @"القبل الأخير", @"end" },
+            { @"سبقت الأخيرة", @"current" },
+            { @"سبقت الأخير", @"current" },
+            { @"قبل الأخير", @"current" },
+            { @"قبل الأخيرة", @"current" },
+            { @"القبل الأخير", @"current" },
             { @"التالي", @"current" },
             { @"قادم", @"current" },
-            { @"القادمة", @"current" },
-            { @"القادم", @"current" },
             { @"قادمة", @"current" },
-            { @"السابق", @"current" },
+            { @"القادم", @"current" },
+            { @"القادمة", @"current" },
             { @"السابقة", @"current" },
-            { @"الحالية", @"current" },
-            { @"الحالي", @"current" }
+            { @"الحالي", @"end" },
+            { @"الحالية", @"end" },
+            { @"قبل الاخير", @"current" },
+            { @"واحد قبل الاخير", @"current" },
+            { @"الثانية الى الاخير", @"current" },
+            { @"السابق", @"current" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Arabic.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/TestNumber_Arabic.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Recognizers.Text.Number.Tests
     {
         public static TestResources TestResources { get; protected set; }
 
-        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void NumberModel(TestModel testSpec)
@@ -16,12 +15,14 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             TestNumber(testSpec);
         }
 
+        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void OrdinalModel(TestModel testSpec)
         {
             TestNumber(testSpec);
         }
+        */
 
         [NetCoreTestDataSource]
         [TestMethod]
@@ -30,6 +31,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             TestNumber(testSpec);
         }
 
+        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void NumberRangeModel(TestModel testSpec)
@@ -37,5 +39,6 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             TestNumber(testSpec);
         }
         */
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestBase.cs
@@ -360,29 +360,43 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
                     Assert.AreEqual(expected.End, actual.End, GetMessage(testSpec));
                 }
 
-                if (expected.TypeName.Contains(Number.Constants.MODEL_ORDINAL))
+                if (testSpec.IgnoreResolution)
                 {
-                    if (!expected.TypeName.Equals(Number.Constants.MODEL_ORDINAL_RELATIVE))
-                    {
-                        Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value], GetMessage(testSpec));
-                    }
-
-                    Assert.AreEqual(expected.Resolution[ResolutionKey.Offset], actual.Resolution[ResolutionKey.Offset], GetMessage(testSpec));
-                    Assert.AreEqual(expected.Resolution[ResolutionKey.RelativeTo], actual.Resolution[ResolutionKey.RelativeTo], GetMessage(testSpec));
+                    Assert.Inconclusive(GetMessage(testSpec) + ". Resolution not validated.");
                 }
                 else
                 {
-                    Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value], GetMessage(testSpec));
-                }
 
-                foreach (var key in testResolutionKeys ?? Enumerable.Empty<string>())
-                {
-                    if (!actual.Resolution.ContainsKey(key) && !expected.Resolution.ContainsKey(key))
+                    if (expected.TypeName.Contains(Number.Constants.MODEL_ORDINAL))
                     {
-                        continue;
+                        if (!expected.TypeName.Equals(Number.Constants.MODEL_ORDINAL_RELATIVE))
+                        {
+                            Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value],
+                                            GetMessage(testSpec));
+                        }
+
+                        Assert.AreEqual(expected.Resolution[ResolutionKey.Offset], actual.Resolution[ResolutionKey.Offset],
+                                        GetMessage(testSpec));
+
+                        Assert.AreEqual(expected.Resolution[ResolutionKey.RelativeTo], actual.Resolution[ResolutionKey.RelativeTo],
+                                        GetMessage(testSpec));
+                    }
+                    else
+                    {
+                        Assert.AreEqual(expected.Resolution[ResolutionKey.Value], actual.Resolution[ResolutionKey.Value],
+                                        GetMessage(testSpec));
                     }
 
-                    Assert.AreEqual(expected.Resolution[key].ToString(), actual.Resolution[key].ToString(), GetMessage(testSpec));
+                    foreach (var key in testResolutionKeys ?? Enumerable.Empty<string>())
+                    {
+                        if (!actual.Resolution.ContainsKey(key) && !expected.Resolution.ContainsKey(key))
+                        {
+                            continue;
+                        }
+
+                        Assert.AreEqual(expected.Resolution[key].ToString(), actual.Resolution[key].ToString(),
+                                        GetMessage(testSpec));
+                    }
                 }
             }
         }

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/TestModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
     public enum Platform
     {
         /// <summary>
-        /// dotNet flag
+        /// .NET flag
         /// </summary>
         DotNet = 1,
 
@@ -36,15 +36,20 @@ namespace Microsoft.Recognizers.Text.DataDrivenTests
             Context = new Dictionary<string, object>();
             Results = Enumerable.Empty<object>();
             Debug = false;
+            IgnoreResolution = false;
         }
 
         public string TestType { get; set; }
 
         public string Input { get; set; }
 
+        public string Comment { get; set; }
+
         public IDictionary<string, object> Context { get; set; }
 
         public bool Debug { get; set; }
+
+        public bool IgnoreResolution { get; set; }
 
         public Platform NotSupported { get; set; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var referenceTime = refTime;
 
             object value = null;
-            if (er.Type.Equals(ParserName))
+            if (er.Type.Equals(ParserName, StringComparison.Ordinal))
             {
                 var innerResult = MergeDateAndTime(er.Text, referenceTime);
                 if (!innerResult.Success)

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -2,7 +2,8 @@
   {
     "Input": "تجده في الصفحة ال١٩٢",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
+    "IgnoreResolution": true,
+    "Comment" : "IgnoreResolution should only be used momentarily and as support for new pre-approved languages is added.",
     "Results": [
       {
         "Text": "١٩٢",


### PR DESCRIPTION
- Adding new attribute to momentarily disable Resolution validation in tests (currently only in Numbers*);
- Enabling tests for Number and Percentage in Arabic;
- Build script now works with VS 2019.