### PR TITLE
[.NET] English DatePeriod bug #2053 fix

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             MoreThanRegex = DutchDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = DutchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = DutchDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -199,6 +200,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             MoreThanRegex = EnglishDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = EnglishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = EnglishDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -201,6 +202,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -534,6 +534,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             er = er.OrderBy(t => t.Start).ToList();
 
+            // Handle "now"
+            er = MatchNow(text, er);
+
             return MergeMultipleExtractions(text, er);
         }
 
@@ -542,24 +545,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var er = this.config.DatePointExtractor.Extract(text, reference);
 
             // Handle "now"
-            var matches = this.config.NowRegex.Matches(text);
-            if (matches.Count != 0)
-            {
-                foreach (Match match in matches)
-                {
-                    var nowEr = new ExtractResult
-                    {
-                        Start = match.Index,
-                        Length = match.Length,
-                        Text = text.Substring(match.Index, match.Length),
-                    };
-
-                    er.Add(nowEr);
-
-                }
-
-                er = er.OrderBy(o => o.Start).ToList();
-            }
+            er = MatchNow(text, er);
 
             return MergeMultipleExtractions(text, er);
         }
@@ -792,6 +778,31 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return tokens;
+        }
+
+        // Handle cases with "now"
+        private List<ExtractResult> MatchNow(string text, List<ExtractResult> er)
+        {
+            var matches = this.config.NowRegex.Matches(text);
+            if (matches.Count != 0)
+            {
+                foreach (Match match in matches)
+                {
+                    var nowEr = new ExtractResult
+                    {
+                        Start = match.Index,
+                        Length = match.Length,
+                        Text = text.Substring(match.Index, match.Length),
+                    };
+
+                    er.Add(nowEr);
+
+                }
+
+                er = er.OrderBy(o => o.Start).ToList();
+            }
+
+            return er;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             MoreThanRegex = FrenchDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = FrenchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = FrenchDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -193,6 +194,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             MoreThanRegex = GermanDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = GermanDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = GermanDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = GermanDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -183,6 +184,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             MoreThanRegex = HindiDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = HindiDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = HindiDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = HindiDateExtractorConfiguration.SpecialDayRegex;
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -203,6 +204,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             MoreThanRegex = ItalianDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = ItalianDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = ItalianDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -200,6 +201,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -687,9 +687,23 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ret.Success = true;
                 }
 
-                if (dateContext != null)
+                // Expressions like "today", "tomorrow",... should keep their original year
+                if (dateContext != null && !this.config.SpecialDayRegex.IsMatch(er.Text))
                 {
                     ret = dateContext.ProcessDateEntityResolution(ret);
+                }
+            }
+
+            // Handle expressions with "now"
+            if (er == null)
+            {
+                var nowPr = ParseNowAsDate(text, referenceDate);
+                if (nowPr.Value != null)
+                {
+                    ret.Timex = $"({nowPr.TimexStr}";
+                    ret.FutureValue = (DateObject)((DateTimeResolutionResult)nowPr.Value).FutureValue;
+                    ret.PastValue = (DateObject)((DateTimeResolutionResult)nowPr.Value).PastValue;
+                    ret.Success = true;
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex NowRegex { get; }
 
+        Regex SpecialDayRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> CardinalMap { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             MoreThanRegex = PortugueseDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = PortugueseDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = PortugueseDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = PortugueseDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -185,6 +186,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             MoreThanRegex = SpanishDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = SpanishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = SpanishDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -192,6 +193,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             MoreThanRegex = TurkishDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = TurkishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = TurkishDatePeriodExtractorConfiguration.NowRegex;
+            SpecialDayRegex = TurkishDateExtractorConfiguration.SpecialDayRegex;
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -201,6 +202,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex SpecialDayRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -15433,5 +15433,80 @@
         }
       }
     ]
+  },
+  {
+    "Input": "How many clusters docked between Jan 2019 and today",
+    "Context": {
+      "ReferenceDateTime": "2020-04-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "between jan 2019 and today",
+        "Start": 25,
+        "End": 50,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2020-04-26,P481D)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-04-26"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How many clusters docked between Jan 2019 and tomorrow",
+    "Context": {
+      "ReferenceDateTime": "2020-04-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "between jan 2019 and tomorrow",
+        "Start": 25,
+        "End": 53,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2020-04-27,P482D)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-04-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How many clusters docked between Jan 2019 and now",
+    "Context": {
+      "ReferenceDateTime": "2020-04-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "between jan 2019 and now",
+        "Start": 25,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-01-01,2020-04-26,P481D)",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-04-26"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixes bug #2053 
- the fix required small changes to basecode
- added relevant test cases to DateTimeModel

(again, we noticed some failing test cases in Number module (it seems due to missing Arabic culture))