### PR TITLE
[AR Numbers] IgnoreResolution added to re-enabled test specs

### DIFF
--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -1,9 +1,9 @@
 [
   {
     "Input": "تجده في الصفحة ال١٩٢",
-    "NotSupportedByDesign": "javascript, java, python",
     "IgnoreResolution": true,
     "Comment" : "IgnoreResolution should only be used momentarily and as support for new pre-approved languages is added.",
+    "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
         "Text": "١٩٢",
@@ -73,31 +73,27 @@
   {
     "Input": "أريد ١٨٠ميلي لتر من الماء",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "شارع ٢٩ك.ل.م.",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "التاريخ ٤من المايو",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "يوجد في الكأس ,٢٥مل من السائل ",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "وزنه ٠,٠٨",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٠,٠٨",
@@ -113,8 +109,8 @@
   },
   {
     "Input": "وزنه ٠,٢٣٤٥٦",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٠,٢٣٤٥٦",
@@ -130,8 +126,8 @@
   },
   {
     "Input": "مقاسه ٤,٨ .",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٤,٨",
@@ -147,8 +143,8 @@
   },
   {
     "Input": "يوجد ستة عشر تفاحاً.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ستة عشر",
@@ -164,8 +160,8 @@
   },
   {
     "Input": "هي قرأت ثلثان من الكتاب",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلثان",
@@ -181,8 +177,8 @@
   },
   {
     "Input": "مائة وستة عشر صفحة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة وستة عشر",
@@ -198,8 +194,8 @@
   },
   {
     "Input": "مائة وستة صفحات.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة وستة",
@@ -215,8 +211,8 @@
   },
   {
     "Input": "النتيجة الصحيحة هي  مائة وواحدُ وستون",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة وواحدُ وستون",
@@ -232,8 +228,8 @@
   },
   {
     "Input": "واحد من تريليون صفحات تكون مقطوعة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد من تريليون",
@@ -249,8 +245,8 @@
   },
   {
     "Input": "الشمس واحد من مئة تريليونات نجم",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد من مئة تريليونات",
@@ -266,8 +262,8 @@
   },
   {
     "Input": "مائة آلاف دولار",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائة آلاف",
@@ -283,8 +279,8 @@
   },
   {
     "Input": "نصف دزينة من التفاح",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نصف دزينة",
@@ -300,8 +296,8 @@
   },
   {
     "Input": "أريد ٣ دزينات من التفاحة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٣ دزينات",
@@ -334,8 +330,8 @@
   },
   {
     "Input": "أشتريت ثلاث دزينات من التفاحة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث دزينات",
@@ -351,8 +347,8 @@
   },
   {
     "Input": "ثلاث مائة ودزينتين",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث مائة ودزينتين",
@@ -368,8 +364,8 @@
   },
   {
     "Input": "عدد السكان في الهند ١،٢٣٤،٥٦٧",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١،٢٣٤،٥٦٧",
@@ -385,8 +381,8 @@
   },
   {
     "Input": "النتيجة الصحيحة ٩,٢٣٢١٣١٢ ",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٩,٢٣٢١٣١٢",
@@ -402,8 +398,8 @@
   },
   {
     "Input": "-٩,٢٣٢١٣١٢",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-٩,٢٣٢١٣١٢",
@@ -419,8 +415,8 @@
   },
   {
     "Input": "-١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١",
@@ -436,8 +432,8 @@
   },
   {
     "Input": "-١ ٤/٥",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١ ٤/٥",
@@ -453,8 +449,8 @@
   },
   {
     "Input": "لديها ثلاثة اقلام",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاثة",
@@ -470,8 +466,8 @@
   },
   {
     "Input": "رقم الهاتف ١٢٣٤٥٦٧٨٩١٠١٢٣١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٢٣٤٥٦٧٨٩١٠١٢٣١",
@@ -487,8 +483,8 @@
   },
   {
     "Input": "-١٢٣٤٥٦٧٨٩١٠١٢٣١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١٢٣٤٥٦٧٨٩١٠١٢٣١",
@@ -521,8 +517,8 @@
   },
   {
     "Input": "١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١",
@@ -538,8 +534,8 @@
   },
   {
     "Input": "عدد سكان ١ ترليون",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ ترليون",
@@ -555,8 +551,8 @@
   },
   {
     "Input": "في الحديقة ثلاثة اشجار",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاثة",
@@ -572,8 +568,8 @@
   },
   {
     "Input": "في السماء أكثر من واحد ترليون نجمة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد ترليون",
@@ -589,8 +585,8 @@
   },
   {
     "Input": "عدد سكان المنطقة واحد وعشرون تريليون",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد وعشرون تريليون",
@@ -606,8 +602,8 @@
   },
   {
     "Input": "عدد سكان المنطقة واحد وعشرون تريليون وثلاث مائة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد وعشرون تريليون وثلاث مائة",
@@ -640,8 +636,8 @@
   },
   {
     "Input": "تحتوي السلة على اثنين وخمسون فاكهة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "اثنين وخمسون",
@@ -657,8 +653,8 @@
   },
   {
     "Input": "يوجد في الغابة  ثلاث مائة وواحد وثلاثون  أشجار",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث مائة وواحد وثلاثون",
@@ -674,8 +670,8 @@
   },
   {
     "Input": "شريت فستان بألفين ومائتين درهم.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "بألفين ومائتين",
@@ -691,8 +687,8 @@
   },
   {
     "Input": "١e١٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١e١٠",
@@ -708,8 +704,8 @@
   },
   {
     "Input": "١,١^٢٣",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١,١^٢٣",
@@ -725,8 +721,8 @@
   },
   {
     "Input": "البيت قيمته ٣٢٢ ألف ريال",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٣٢٢ ألف",
@@ -742,8 +738,8 @@
   },
   {
     "Input": "سبعين كيلو متر.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سبعين",
@@ -759,8 +755,8 @@
   },
   {
     "Input": "٣/٤ الكأس",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٣/٤",
@@ -776,8 +772,8 @@
   },
   {
     "Input": "المتبقي من الفطيرة خمسة اثمان",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمسة اثمان",
@@ -793,8 +789,8 @@
   },
   {
     "Input": "شربت نصف العصير",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نصف",
@@ -810,8 +806,8 @@
   },
   {
     "Input": "كتبت ثلاث ارباع الصفحة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث ارباع",
@@ -827,8 +823,8 @@
   },
   {
     "Input": "اكتملت عشرون وثلاثة اخماس سجلات",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "عشرون وثلاثة اخماس",
@@ -844,8 +840,8 @@
   },
   {
     "Input": "قراءت ثلاث وعشرون خمس من الكتاب",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث وعشرون خمس",
@@ -861,8 +857,8 @@
   },
   {
     "Input": "تمضي ثلاث وعشرون وثلاثة اخماس يومها في النوم",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث وعشرون وثلاثة اخماس",
@@ -878,8 +874,8 @@
   },
   {
     "Input": "مليون وألفين ومائتين وثلاثة أخماس الأكواب",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مليون وألفين ومائتين وثلاثة أخماس",
@@ -895,8 +891,8 @@
   },
   {
     "Input": "كان لديها واحد ونصف ريال",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد ونصف",
@@ -912,8 +908,8 @@
   },
   {
     "Input": "نام احمد الى ساعة واحد وربع",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد وربع",
@@ -929,8 +925,8 @@
   },
   {
     "Input": "اشرب في اليوم خمسة وربع كأس من الماء",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمسة وربع",
@@ -946,8 +942,8 @@
   },
   {
     "Input": "الشجرتان بينها مسافة مئة وثلاثة ارباع متر",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مئة وثلاثة ارباع",
@@ -963,8 +959,8 @@
   },
   {
     "Input": "كان الناتج واحد جزء من مئة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد جزء من مئة",
@@ -980,8 +976,8 @@
   },
   {
     "Input": "١,١^+٢٣",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١,١^+٢٣",
@@ -997,8 +993,8 @@
   },
   {
     "Input": "٢,٥^-١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢,٥^-١",
@@ -1014,8 +1010,8 @@
   },
   {
     "Input": "-١٢٧,٣٢e١٣",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١٢٧,٣٢e١٣",
@@ -1031,8 +1027,8 @@
   },
   {
     "Input": "١٢,٣٢e+١٤",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٢,٣٢e+١٤",
@@ -1048,8 +1044,8 @@
   },
   {
     "Input": "-١٢e-١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١٢e-١",
@@ -1065,8 +1061,8 @@
   },
   {
     "Input": "كان ثمن حجرة الالماس اثني عشر مليار ريال.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "اثني عشر مليار",
@@ -1082,8 +1078,8 @@
   },
   {
     "Input": "اكلت خمس الفطيرة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمس",
@@ -1116,8 +1112,8 @@
   },
   {
     "Input": "مضت خمس الساعة في التنظيف.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمس",
@@ -1133,8 +1129,8 @@
   },
   {
     "Input": "اريد ثلاثة اخماس العمل منفوذ في الوقت المحدد.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاثة اخماس",
@@ -1150,8 +1146,8 @@
   },
   {
     "Input": "ذاكرت لمدة عشرون اخماس ساعة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "عشرون اخماس",
@@ -1167,8 +1163,8 @@
   },
   {
     "Input": "انتهيت من ثلاث وخمس اعمال اليوم",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث وخمس",
@@ -1184,8 +1180,8 @@
   },
   {
     "Input": "تملك واحد وعشرون اخماس الفندق",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد وعشرون اخماس",
@@ -1201,8 +1197,8 @@
   },
   {
     "Input": "ثلاثة واحد وعشرونات",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاثة واحد وعشرونات",
@@ -1286,8 +1282,8 @@
   },
   {
     "Input": "١ على واحد وعشرون شخص مصاب",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ على واحد وعشرون",
@@ -1303,8 +1299,8 @@
   },
   {
     "Input": "١ على مئة وواحد وعشرون الورقة تم توقيعه",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ على مئة وواحد وعشرون",
@@ -1320,8 +1316,8 @@
   },
   {
     "Input": "الجواب الصحيح ١ جزء من ثلاثة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ جزء من ثلاثة",
@@ -1337,8 +1333,8 @@
   },
   {
     "Input": "١ على ٣ من اكياس الارز",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ على ٣",
@@ -1354,8 +1350,8 @@
   },
   {
     "Input": "واحد على ٣ حقائب مكتملة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد على ٣",
@@ -1371,8 +1367,8 @@
   },
   {
     "Input": "واحد على ٢٠ جواز سفر مختومة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد على ٢٠",
@@ -1388,8 +1384,8 @@
   },
   {
     "Input": "واحد على عشرين ملف مختومة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد على عشرين",
@@ -1405,8 +1401,8 @@
   },
   {
     "Input": "واحد على مائة تخطيطات تمت",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد على مائة",
@@ -1440,13 +1436,12 @@
   {
     "Input": "حجزت رحلتي في درجة الأولى",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "درجة الحرارة سالب واحد",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سالب واحد",
@@ -1462,8 +1457,8 @@
   },
   {
     "Input": "سالب واحد على ٢٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سالب واحد على ٢٠",
@@ -1479,8 +1474,8 @@
   },
   {
     "Input": "ربع كيلو غرام من العدس",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ربع",
@@ -1513,8 +1508,8 @@
   },
   {
     "Input": "النتيجة هي خمسة أثمان",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمسة أثمان",
@@ -1530,8 +1525,8 @@
   },
   {
     "Input": "واحد من ثلاثة طالبات",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد من ثلاثة",
@@ -1547,8 +1542,8 @@
   },
   {
     "Input": "واحد من واحد وعشرون شخص مريض",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "واحد من واحد وعشرون",
@@ -1564,8 +1559,8 @@
   },
   {
     "Input": "خمسة أثمان الكأس",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "خمسة أثمان",
@@ -1581,8 +1576,8 @@
   },
   {
     "Input": "صفر هو٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "صفر",
@@ -1608,8 +1603,8 @@
   },
   {
     "Input": "هل يوجد وقت في يوم ٥/١٧/٢٠١٨؟",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٥",
@@ -1646,13 +1641,12 @@
   {
     "Input": "١مليون ليست رقم.",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "رقم لوحة السيارة ثلاث مئة وواحد.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاث مئة وواحد",
@@ -1669,13 +1663,11 @@
   {
     "Input": "الذي ذكرتها كان باطلا.",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "الدي ذكرتها كانت غير صحيحة.",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -1687,13 +1679,12 @@
   {
     "Input": "هذاك جيد حقا.",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "في بعض البلدان تستطيع ان تكتب ٥.٠٠ او ٥,٠٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٥.٠٠",
@@ -1719,8 +1710,8 @@
   },
   {
     "Input": "ستة وعشرون شخص توفي في حادث في تيكمان.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ستة وعشرون",
@@ -1736,8 +1727,8 @@
   },
   {
     "Input": "اكثر من نصف الناس قدموا الى هنا.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نصف",
@@ -1753,8 +1744,8 @@
   },
   {
     "Input": "أريد أن اربح ١٠٠٠٠ دولار في ٣ سنوات.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠٠٠",
@@ -1780,8 +1771,8 @@
   },
   {
     "Input": "أريد أن ٢٠٠٠ دولار خلال ٣ سنوات.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢٠٠٠",
@@ -1807,8 +1798,8 @@
   },
   {
     "Input": "الكسر الصحيح ٢٠٠٠ على ٣",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢٠٠٠ على ٣",
@@ -1824,8 +1815,8 @@
   },
   {
     "Input": "$٢٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢٠",
@@ -1841,8 +1832,8 @@
   },
   {
     "Input": "الإجابة سالب واحد.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سالب واحد",
@@ -1858,8 +1849,8 @@
   },
   {
     "Input": "-٤/٥",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-٤/٥",
@@ -1875,8 +1866,8 @@
   },
   {
     "Input": "السعر المجموع مائتين وإثنين ألف",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائتين وإثنين ألف",
@@ -1892,8 +1883,8 @@
   },
   {
     "Input": "السعر مائتان وثلاثة جزء من مائة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مائتان وثلاثة جزء من مائة",
@@ -1926,8 +1917,8 @@
   },
   {
     "Input": "مئة وثلاثون أخماس العقد تم كتابته.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مئة وثلاثون أخماس",
@@ -1943,8 +1934,8 @@
   },
   {
     "Input": "-٢,٥^-١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-٢,٥^-١",
@@ -1960,8 +1951,8 @@
   },
   {
     "Input": "درجة الحرارة سالب ٥",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سالب ٥",
@@ -1977,8 +1968,8 @@
   },
   {
     "Input": "١ ٢٣٤ ٥٦٧",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١ ٢٣٤ ٥٦٧",
@@ -1994,8 +1985,8 @@
   },
   {
     "Input": "المسافة بين البيتين مئتان وواحد وسبعون جزء من مئة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مئتان وواحد وسبعون جزء من مئة",

--- a/Specs/Number/Arabic/NumberRangeModel.json
+++ b/Specs/Number/Arabic/NumberRangeModel.json
@@ -2,7 +2,6 @@
   {
     "Input": "1995-01",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -23,8 +22,8 @@
   },
   {
     "Input": "الرقم بين ٢٠ و٣٠.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "بين ٢٠ و٣٠",
@@ -39,8 +38,8 @@
   },
   {
     "Input": "الرقم المحدود بين العاشر وخمسة عشر",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "بين العاشر وخمسة عشر",
@@ -55,8 +54,8 @@
   },
   {
     "Input": "النتيجة بين سالب عشرة وخمسة عشر",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "بين سالب عشرة وخمسة عشر",
@@ -135,8 +134,8 @@
   },
   {
     "Input": "٢٠~١٠٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢٠~١٠٠",
@@ -263,8 +262,8 @@
   },
   {
     "Input": "عمرها فوق الثلاثين",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "فوق الثلاثين",
@@ -407,8 +406,8 @@
   },
   {
     "Input": "طوله تحت ١٧٠.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "تحت ١٧٠",
@@ -423,8 +422,8 @@
   },
   {
     "Input": "ادنى ١٧٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ادنى ١٧٠",
@@ -439,8 +438,8 @@
   },
   {
     "Input": "المبلغ المطلوب أقل من ألف",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "أقل من ألف",
@@ -455,8 +454,8 @@
   },
   {
     "Input": "الجواب يساوي مائة وسبعين",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يساوي مائة وسبعين",
@@ -471,8 +470,8 @@
   },
   {
     "Input": "س>١٠ و ص<٢٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": ">١٠",
@@ -522,13 +521,12 @@
   {
     "Input": "النتيجة النهائي ربع.",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "الرقم يساوي ٢٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يساوي ٢٠",
@@ -543,8 +541,8 @@
   },
   {
     "Input": "يساوي ٢٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يساوي ٢٠",
@@ -560,13 +558,11 @@
   {
     "Input": "رقمي +١ ٢٢٢ ٢٢٢٢/٢٢٢٢",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "رقمي +١ ٢٢٢ ٢٢٢٢ ٢٢٢٢",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -863,8 +859,8 @@
   },
   {
     "Input": "مجال الرقم ١٠٠٠ - ٥٠٠٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠٠ - ٥٠٠٠",
@@ -943,8 +939,8 @@
   },
   {
     "Input": "هل لا تزال الحالة نفسها عندما تكون >٣٠؟",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": ">٣٠",
@@ -975,8 +971,8 @@
   },
   {
     "Input": "هل لا تزال الحالة نفسها عندما تكون <-٣٠؟",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "<-٣٠",
@@ -1008,25 +1004,22 @@
   {
     "Input": "النتيجة هو <>٣٠",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "كان إجابة السؤال =>٣٠",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "الرقم الصحيح هو =<٣٠.",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "يساوي ٢٠٠٠٠ في  ١٩٩٨",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يساوي ٢٠٠٠٠ في  ١٩٩٨",
@@ -1089,8 +1082,8 @@
   },
   {
     "Input": "عدد المرضى يتجاوز ٣٠٠٠",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يتجاوز ٣٠٠٠",
@@ -1162,8 +1155,8 @@
   },
   {
     "Input": "سرعة السيارة يتجاوز ١٥٠ كيلو متر/بالساعة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "يتجاوز ١٥٠",

--- a/Specs/Number/Arabic/OrdinalModel.json
+++ b/Specs/Number/Arabic/OrdinalModel.json
@@ -1,8 +1,8 @@
 [
   {
     "Input": "احذف اخر جملة في الملاحظة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "اخر",
@@ -19,8 +19,8 @@
   },
   {
     "Input": "هل تعني \"التالي\" او \"الاخر\"؟",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التالي",
@@ -48,8 +48,8 @@
   },
   {
     "Input": "أريني الذي قبل الاخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "قبل الاخير",
@@ -66,8 +66,8 @@
   },
   {
     "Input": "اريني الذي قبل الاخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "قبل الاخير",
@@ -102,8 +102,8 @@
   },
   {
     "Input": "أريني الثانية الى الاخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الثانية الى الاخير",
@@ -120,8 +120,8 @@
   },
   {
     "Input": "احذف اخر جملة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "اخر",
@@ -138,8 +138,8 @@
   },
   {
     "Input": "أريني السابق.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "السابق",
@@ -156,8 +156,8 @@
   },
   {
     "Input": "أريني التالي.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التالي",
@@ -174,8 +174,8 @@
   },
   {
     "Input": "أريد الكتابين الأخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأخير",
@@ -192,8 +192,8 @@
   },
   {
     "Input": "أريد الكتاب الأخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأخير",
@@ -210,8 +210,8 @@
   },
   {
     "Input": "أريد ثلاث كتب التالي.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التالي",
@@ -228,8 +228,8 @@
   },
   {
     "Input": "أنظر الى الصفحة التالي.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التالي",
@@ -246,8 +246,8 @@
   },
   {
     "Input": "أريد البسكويت الاخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الاخير",
@@ -264,8 +264,8 @@
   },
   {
     "Input": "أريد الذي قبل الاخير.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "قبل الاخير",
@@ -282,8 +282,8 @@
   },
   {
     "Input": "انتقل الى الصفحة السابقة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "السابقة",
@@ -300,8 +300,8 @@
   },
   {
     "Input": "البيت الحادي عشر",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الحادي عشر",
@@ -318,8 +318,8 @@
   },
   {
     "Input": "السيارة الواحد والعشرون",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الواحد والعشرون",
@@ -336,8 +336,8 @@
   },
   {
     "Input": "الكتاب الثلاثون غير جيد.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الثلاثون",
@@ -354,8 +354,8 @@
   },
   {
     "Input": "السؤال الثاني صعب.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الثاني",
@@ -372,8 +372,8 @@
   },
   {
     "Input": "هي في الصف الحادي عشر.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الحادي عشر",
@@ -390,8 +390,8 @@
   },
   {
     "Input": "دخلت البيت العشرون.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "العشرون",
@@ -408,8 +408,8 @@
   },
   {
     "Input": "هذه المرة الخامسة والعشرون.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الخامسة والعشرون",
@@ -426,8 +426,8 @@
   },
   {
     "Input": "السؤال الواحد والعشرون غير محلولة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الواحد والعشرون",
@@ -444,8 +444,8 @@
   },
   {
     "Input": "وجدت الكتاب المئة والخامسة والعشرون.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "المئة والخامسة والعشرون",
@@ -462,8 +462,8 @@
   },
   {
     "Input": "حدث في العام المئة والخامسة والعشرون.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "المئة والخامسة والعشرون",
@@ -480,8 +480,8 @@
   },
   {
     "Input": "لم أجد الكتاب التريليون.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التريليون",
@@ -516,8 +516,8 @@
   },
   {
     "Input": "في عام المئتيان من بعد الهجرة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "المئتيان",
@@ -534,8 +534,8 @@
   },
   {
     "Input": "احجز مقعد ففي الدرجة الأولى الى سياتل.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأولى",
@@ -552,8 +552,8 @@
   },
   {
     "Input": "اعجبني الأول كتابين.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأول",
@@ -570,8 +570,8 @@
   },
   {
     "Input": "اعجبني الأول.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأول",
@@ -588,8 +588,8 @@
   },
   {
     "Input": "اتحدث الكلمة الأولى",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الأولى",
@@ -606,8 +606,8 @@
   },
   {
     "Input": "أريد الكتب الثلاثة التالي",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "التالي",
@@ -624,8 +624,8 @@
   },
   {
     "Input": "هي انتهت قراءة الكتاب الثاني",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الثاني",
@@ -678,8 +678,8 @@
   },
   {
     "Input": "الصفحة الحالي",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الحالي",
@@ -696,8 +696,8 @@
   },
   {
     "Input": "انظر الى الصفحة الحالي.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "الحالي",

--- a/Specs/Number/Arabic/PercentModel.json
+++ b/Specs/Number/Arabic/PercentModel.json
@@ -1,8 +1,8 @@
 [
   {
     "Input": "هي الوحيدة الذي حصلت على ١٠٠٪.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠٪",
@@ -17,8 +17,8 @@
   },
   {
     "Input": "اصبح شاحن الجوال ١٠٠٪؜.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠٪",
@@ -33,8 +33,8 @@
   },
   {
     "Input": "الاحتمال هو ١٠٠ في المئة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠ في المئة",
@@ -49,8 +49,8 @@
   },
   {
     "Input": "تم تنزيل الملف ١٠٠ بالمئة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠٠ بالمئة",
@@ -65,8 +65,8 @@
   },
   {
     "Input": "الإجابة هو ٢٤٠ في المئة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "٢٤٠ في المئة",
@@ -81,8 +81,8 @@
   },
   {
     "Input": "احتمال وقوع حادث عشرين في المئة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "عشرين في المئة",
@@ -97,8 +97,8 @@
   },
   {
     "Input": "ثلاثين بالمئة ليس الإجابة الصحيحة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثلاثين بالمئة",
@@ -113,8 +113,8 @@
   },
   {
     "Input": "كان نتيجته مئة بالمئة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "مئة بالمئة",
@@ -129,8 +129,8 @@
   },
   {
     "Input": "ما هو نسبة ١٠ من العدد ؟",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نسبة ١٠",
@@ -145,8 +145,8 @@
   },
   {
     "Input": "نسبة اثنين وعشرين كفاية لكل شخص.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نسبة اثنين وعشرين",
@@ -161,8 +161,8 @@
   },
   {
     "Input": "كان يطلب نسبة ٢١٠.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "نسبة ٢١٠",
@@ -177,8 +177,8 @@
   },
   {
     "Input": "احتمال نزول المطر ١٠ بالمائة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١٠ بالمائة",
@@ -193,8 +193,8 @@
   },
   {
     "Input": "ارية فقط سالب خمسة بالمئة.",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "سالب خمسة بالمئة",
@@ -401,12 +401,12 @@
   },
   {
     "Input": "يمكنك الذهاب إلى http://proquest.umi.com/pqdweb?RQT=305&SQ=issn%280024%2D9114%29%20and%20%28ti%28Using%203D%20CAD%20to%20design%20a%20dog%29%20or%20startpage%28158%29%29%20and%20volume%2872%29%20and%20issue%289%29%20and%20pdn%28%3E01%2F01%2F2000%20AND%20%3C12%2F31%2F2000%29&clientId=17859 لمزيد من التفاصيل.",
-    "NotSupported": "javascript, dotnet",
+    "NotSupported": "javascript",
     "Results": []
   },
   {
     "Input": "يمكنك الذهاب إلى https://www.test.com/search?q=30%25%2020%",
-    "NotSupported": "javascript, dotnet",
+    "NotSupported": "javascript",
     "Results": []
   }
 ]


### PR DESCRIPTION
IgnoreResolution property is added to all the test cases that has been validated and where extractor is working fine.

- In Arabic we have the following
- Full pass: **18** (all these are negative test cases across all models which doesn't have a resolution)
- Extract pass: **163**
- Disabled: **88** ( Tests which are failing)
- Not-Supported By Arabic Language: **29**