### PR TITLE
[.NET] Fix the incorrect extracting of date from number sequence (#2078)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedDateTimeExtractor.cs
@@ -284,6 +284,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
+            // @TODO: Refactor to remove this method and use the general ambiguity filter approach
+            extractResults = extractResults.Where(er => !(text.Substring(0, (int)er.Start).Trim().EndsWith("-") || text.Substring((int)(er.Start + er.Length)).Trim().StartsWith("-")))
+                    .ToList();
+
             return extractResults;
         }
 

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -15583,5 +15583,70 @@
         }
       }
     ]
+  },
+  {
+    "Input": "The ssn is 123-12-1234",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "The COVID-19 was very serious at 02-02-2020 - 03-03-2020",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "02-02-2020 - 03-03-2020",
+        "Start": 33,
+        "End": 55,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-02-02,2020-03-03,P30D)",
+              "type": "daterange",
+              "start": "2020-02-02",
+              "end": "2020-03-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The code of this object is 133-03-03-2020",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "The file's name is sales_report-2002-10-09.xlsx",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "2015-1-32 is a wrong date",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "Call me al (206) 555-1212",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -12973,5 +12973,70 @@
         }
       }
     ]
+  },
+  {
+    "Input": "The ssn is 123-12-1234",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "The COVID-19 was very serious at 02-02-2020 - 03-03-2020",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "02-02-2020 - 03-03-2020",
+        "Start": 33,
+        "End": 55,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-02-02,2020-03-03,P30D)",
+              "type": "daterange",
+              "start": "2020-02-02",
+              "end": "2020-03-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The code of this object is 133-03-03-2020",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "The file's name is sales_report-2002-10-09.xlsx",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "2015-1-32 is a wrong date",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "Call me al (206) 555-1212",
+    "Context": {
+      "ReferenceDateTime": "2020-05-14T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": []
   }
 ]

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -676,24 +676,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Results": [
-      {
-        "Text": "2015-1",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2015-01",
-              "type": "daterange",
-              "start": "2015-01-01",
-              "end": "2015-02-01"
-            }
-          ]
-        },
-        "Start": 0,
-        "Length": 6
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "2017-13-12",

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -676,6 +676,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "Results": []
   },
   {

--- a/Specs/DateTime/French/MergedParser.json
+++ b/Specs/DateTime/French/MergedParser.json
@@ -272,24 +272,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Results": [
-      {
-        "Text": "2015-1",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2015-01",
-              "type": "daterange",
-              "start": "2015-01-01",
-              "end": "2015-02-01"
-            }
-          ]
-        },
-        "Start": 0,
-        "Length": 6
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "Je serais sorti 11 / 2016",

--- a/Specs/DateTime/French/MergedParser.json
+++ b/Specs/DateTime/French/MergedParser.json
@@ -272,6 +272,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "Results": []
   },
   {

--- a/Specs/DateTime/Hindi/MergedParser.json
+++ b/Specs/DateTime/Hindi/MergedParser.json
@@ -552,24 +552,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "2015-1",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2015-01",
-              "type": "daterange",
-              "start": "2015-01-01",
-              "end": "2015-02-01"
-            }
-          ]
-        },
-        "Start": 0,
-        "Length": 6
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "2017-13-12",

--- a/Specs/DateTime/Hindi/MergedParser.json
+++ b/Specs/DateTime/Hindi/MergedParser.json
@@ -551,6 +551,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },

--- a/Specs/DateTime/Italian/MergedParser.json
+++ b/Specs/DateTime/Italian/MergedParser.json
@@ -631,24 +631,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "python,javascript,java",
-    "Results": [
-      {
-        "Text": "2015-1",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2015-01",
-              "type": "daterange",
-              "start": "2015-01-01",
-              "end": "2015-02-01"
-            }
-          ]
-        },
-        "Start": 0,
-        "Length": 6
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "2017-13-12",

--- a/Specs/DateTime/Italian/MergedParser.json
+++ b/Specs/DateTime/Italian/MergedParser.json
@@ -630,6 +630,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "NotSupportedByDesign": "python,javascript,java",
     "Results": []
   },

--- a/Specs/DateTime/Turkish/MergedParser.json
+++ b/Specs/DateTime/Turkish/MergedParser.json
@@ -628,24 +628,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "1-2015",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2015-01",
-              "type": "daterange",
-              "start": "2015-01-01",
-              "end": "2015-02-01"
-            }
-          ]
-        },
-        "Start": 3,
-        "Length": 6
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "Kişisel takvimime Pazartesi ve Çarşamba saat 15'e yoga koy",

--- a/Specs/DateTime/Turkish/MergedParser.json
+++ b/Specs/DateTime/Turkish/MergedParser.json
@@ -627,6 +627,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupported": "javascript, java, python",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },


### PR DESCRIPTION
Fix the issue #2078 and more general issue.
Add a new filter to FilterAmbiguity function BaseMergedeDateTimeExtractor.cs.
Add test cases to DateTime/DateTimeModel.json and DateTimeModelComplexCalendar.json.
TODO: 
Refactor to remove this method and use the general ambiguity filter approach.