### PR TITLE
[EN Number] Add support for Indian numbering system entities (#2112)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string LangMarker = @"Eng";
       public const bool CompoundNumberLanguage = false;
       public const bool MultiDecimalSeparatorCulture = true;
-      public const string RoundNumberIntegerRegex = @"(?:hundred|thousand|million|billion|trillion)";
+      public const string RoundNumberIntegerRegex = @"(?:hundred|thousand|million|billion|trillion|lakh|crore)";
       public const string ZeroToNineIntegerRegex = @"(?:three|seven|eight|four|five|zero|nine|one|two|six)";
       public const string TwoToNineIntegerRegex = @"(?:three|seven|eight|four|five|nine|two|six)";
       public const string NegativeNumberTermsRegex = @"(?<negTerm>(minus|negative)\s+)";
@@ -109,7 +109,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string[] WrittenIntegerSeparatorTexts = { @"and" };
       public static readonly string[] WrittenFractionSeparatorTexts = { @"and" };
       public const string HalfADozenRegex = @"half\s+a\s+dozen";
-      public static readonly string DigitalNumberRegex = $@"((?<=\b)(hundred|thousand|[mb]illion|trillion|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
+      public static readonly string DigitalNumberRegex = $@"((?<=\b)(hundred|thousand|[mb]illion|trillion|lakh|crore|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
       public static readonly Dictionary<string, long> CardinalNumberMap = new Dictionary<string, long>
         {
             { @"a", 1 },
@@ -148,7 +148,9 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"thousand", 1000 },
             { @"million", 1000000 },
             { @"billion", 1000000000 },
-            { @"trillion", 1000000000000 }
+            { @"trillion", 1000000000000 },
+            { @"lakh", 100000 },
+            { @"crore", 10000000 }
         };
       public static readonly Dictionary<string, long> OrdinalNumberMap = new Dictionary<string, long>
         {
@@ -228,6 +230,8 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"million", 1000000 },
             { @"billion", 1000000000 },
             { @"trillion", 1000000000000 },
+            { @"lakh", 100000 },
+            { @"crore", 10000000 },
             { @"hundredth", 100 },
             { @"thousandth", 1000 },
             { @"millionth", 1000000 },

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -7,7 +7,7 @@ CompoundNumberLanguage: !bool false
 MultiDecimalSeparatorCulture: !bool true
 #Integer Regex
 RoundNumberIntegerRegex: !simpleRegex
-  def: (?:hundred|thousand|million|billion|trillion)
+  def: (?:hundred|thousand|million|billion|trillion|lakh|crore)
 ZeroToNineIntegerRegex: !simpleRegex
   def: (?:three|seven|eight|four|five|zero|nine|one|two|six)
 TwoToNineIntegerRegex: !simpleRegex
@@ -222,7 +222,7 @@ WrittenFractionSeparatorTexts: [and]
 HalfADozenRegex: !simpleRegex
   def: half\s+a\s+dozen
 DigitalNumberRegex: !nestedRegex
-  def: ((?<=\b)(hundred|thousand|[mb]illion|trillion|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
+  def: ((?<=\b)(hundred|thousand|[mb]illion|trillion|lakh|crore|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
   references: [ BaseNumbers.MultiplierLookupRegex ]
 CardinalNumberMap: !dictionary
   types: [ string, long ]
@@ -264,6 +264,8 @@ CardinalNumberMap: !dictionary
     million: 1000000
     billion: 1000000000
     trillion: 1000000000000
+    lakh: 100000
+    crore: 10000000
 OrdinalNumberMap: !dictionary
   types: [ string, long ]
   entries:
@@ -343,6 +345,8 @@ RoundNumberMap: !dictionary
     million: 1000000
     billion: 1000000000
     trillion: 1000000000000
+    lakh: 100000
+    crore: 10000000
     hundredth: 100
     thousandth: 1000
     millionth: 1000000

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2612,7 +2612,6 @@
   },
   {
     "Input": "I can give you 13 lakh",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "13 lakh",
@@ -2628,7 +2627,6 @@
   },
   {
     "Input": "There are 1 crore boxes in this container",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 crore",
@@ -2644,7 +2642,6 @@
   },
   {
     "Input": "I count 6 crore and two hundred",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "6 crore and two hundred",
@@ -2654,6 +2651,21 @@
         },
         "Start": 8,
         "End": 30
+      }
+    ]
+  },
+  {
+    "Input": "The total is three lakh crore",
+    "Results": [
+      {
+        "Text": "three lakh crore",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "3000000000000"
+        },
+        "Start": 13,
+        "End": 28
       }
     ]
   }

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2609,5 +2609,52 @@
         "End": 25
       }
     ]
+  },
+  {
+    "Input": "I can give you 13 lakh",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "13 lakh",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "1300000"
+        },
+        "Start": 15,
+        "End": 21
+      }
+    ]
+  },
+  {
+    "Input": "There are 1 crore boxes in this container",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1 crore",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "10000000"
+        },
+        "Start": 10,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "I count 6 crore and two hundred",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "6 crore and two hundred",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "60000200"
+        },
+        "Start": 8,
+        "End": 30
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2642,6 +2642,7 @@
   },
   {
     "Input": "I count 6 crore and two hundred",
+    "NotSupported": "javascript, java, python",
     "Results": [
       {
         "Text": "6 crore and two hundred",

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2235,5 +2235,20 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Am I eligible for a lone of 35 lakh rupees",
+    "Results": [
+      {
+        "Text": "35 lakh rupees",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "3500000",
+          "unit": "Rupee",
+        },
+        "Start": 28,
+        "End": 41
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2241,13 +2241,13 @@
     "Results": [
       {
         "Text": "35 lakh rupees",
+        "Start": 28,
+        "End": 41,
         "TypeName": "currency",
         "Resolution": {
           "value": "3500000",
-          "unit": "Rupee",
-        },
-        "Start": 28,
-        "End": 41
+          "unit": "Rupee"
+        }
       }
     ]
   }

--- a/Specs/NumberWithUnit/English/DimensionModel.json
+++ b/Specs/NumberWithUnit/English/DimensionModel.json
@@ -883,5 +883,20 @@
         }
       }
     ]
+  },
+  {
+    "Input": "The submarine mein weigh 25 lakh tonnes",
+    "Results": [
+      {
+        "Text": "25 lakh tonnes",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "2500000",
+          "unit": "Ton"
+        },
+        "Start": 25,
+        "End": 38
+      }
+    ]
   }
 ]


### PR DESCRIPTION
fix to issue #2112 

Added support for lakh and crore in English Number (and relevant test cases in Number and NumberWithUnit).
There are other larger numbers in the Indian numbering system (arab, kharab, nil,...), but we did not implement them for the following reasons: 
- "these are not commonly used and are unfamiliar to most speakers" (wikipedia)
- they could give ambiguity issues (arab, nil)