### PR TITLE
[KO Ordinal] Relative Ordinal Extractor and Spec

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -156,7 +156,9 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string DoubleExponentialNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)|[0０](?!{ZeroToNineFullHalfRegex}+))";
       public static readonly string DoubleScientificNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)";
       public static readonly string OrdinalRegex = $@"{AllIntRegex}번째";
+      public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))";
       public static readonly string OrdinalNumbersRegex = $@"{ZeroToNineFullHalfRegex}+번째";
+      public static readonly string OrdinalKoreanRegex = $@"({OrdinalRegex}|{RelativeOrdinalRegex}|{OrdinalNumbersRegex})";
       public static readonly string AllFractionNumber = $@"{NegativeNumberTermsRegex}?(({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*[와|과]\s*)?{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*분\s*의\s*{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})";
       public static readonly string FractionNotationSpecialsCharsRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+\s+{ZeroToNineFullHalfRegex}+[/／]{ZeroToNineFullHalfRegex}+";
       public static readonly string FractionNotationRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[/／]{ZeroToNineFullHalfRegex}+";
@@ -185,11 +187,31 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string LessOrEqualSuffix = @"\s*(이상)";
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {
-            { @"", @"" }
+            { @"마지막", @"0" },
+            { @"다음", @"1" },
+            { @"뒤에서 세번째", @"-2" },
+            { @"마지막에서 두번째", @"-1" },
+            { @"마지막의 옆", @"-1" },
+            { @"마지막에서 바로 전의 것", @"-1" },
+            { @"이전 것", @"-1" },
+            { @"다음 것", @"1" },
+            { @"마지막에서 바로 전", @"-1" },
+            { @"지금의 것", @"0" },
+            { @"현재", @"0" }
         };
       public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
         {
-            { @"", @"" }
+            { @"마지막", @"end" },
+            { @"다음", @"current" },
+            { @"뒤에서 세번째", @"end" },
+            { @"마지막에서 두번째", @"end" },
+            { @"마지막의 옆", @"end" },
+            { @"마지막에서 바로 전의 것", @"end" },
+            { @"이전 것", @"current" },
+            { @"다음 것", @"current" },
+            { @"마지막에서 바로 전", @"end" },
+            { @"지금의 것", @"current" },
+            { @"현재", @"current" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/OrdinalExtractor.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+using Microsoft.Recognizers.Definitions.Korean;
+
+namespace Microsoft.Recognizers.Text.Number.Korean
+{
+    public class OrdinalExtractor : BaseNumberExtractor
+    {
+
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+        public OrdinalExtractor()
+        {
+            var regexes = new Dictionary<Regex, TypeTag>
+            {
+                {
+                    new Regex(NumbersDefinitions.OrdinalKoreanRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
+                },
+
+            };
+
+            Regexes = regexes.ToImmutableDictionary();
+        }
+
+        internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_ORDINAL;
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/NumberRecognizer.cs
@@ -320,6 +320,13 @@ namespace Microsoft.Recognizers.Text.Number
                                                               new BaseNumberOptionsConfiguration(Culture.Korean, options))),
                     new Korean.NumberExtractor()));
 
+            RegisterModel<OrdinalModel>(
+                Culture.Korean,
+                (options) => new OrdinalModel(
+                    AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Ordinal, new KoreanNumberParserConfiguration(
+                                                              new BaseNumberOptionsConfiguration(Culture.Korean, options))),
+                    new Korean.OrdinalExtractor()));
+
             RegisterModel<NumberModel>(
                 Culture.Dutch,
                 (options) => new NumberModel(

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -212,9 +212,14 @@ DoubleScientificNotationRegex: !nestedRegex
 OrdinalRegex: !nestedRegex
   def: '{AllIntRegex}번째'
   references: [AllIntRegex]
+RelativeOrdinalRegex: !simpleRegex
+  def: (?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))
 OrdinalNumbersRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}+번째'
   references: [ZeroToNineFullHalfRegex]
+OrdinalKoreanRegex: !nestedRegex
+  def: '({OrdinalRegex}|{RelativeOrdinalRegex}|{OrdinalNumbersRegex})'
+  references: [OrdinalRegex, RelativeOrdinalRegex, OrdinalNumbersRegex]
 #FractionExtractor
 AllFractionNumber: !nestedRegex
   def: '{NegativeNumberTermsRegex}?(({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*[와|과]\s*)?{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*분\s*의\s*{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})'
@@ -290,24 +295,32 @@ LessOrEqual: !nestedRegex
   references: [ LessRegex, EqualRegex ]
 LessOrEqualSuffix: !simpleRegex
   def: \s*(이상)
-
 RelativeReferenceOffsetMap: !dictionary
   types: [ string, string ]
-# TODO: modify below regex according to the counterpart in English
   entries:
-    '': ''
+    마지막: 0
+    다음: 1
+    뒤에서 세번째: -2
+    마지막에서 두번째: -1
+    마지막의 옆: -1
+    마지막에서 바로 전의 것: -1
+    이전 것: -1
+    다음 것: 1
+    마지막에서 바로 전: -1
+    지금의 것: 0
+    현재: 0
 RelativeReferenceRelativeToMap: !dictionary
   types: [ string, string ]
-# TODO: modify below regex according to the counterpart in English
   entries:
-    '': ''
-
-# Original code from English
-# IntegerRegexDefinition: !paramsRegex
-#   def: (((?<!\d+\s*)-\s*)|((?<=\b)(?<!(\d+\.|\d+,))))\d{1,3}({thousandsmark}\d{3})+(?={placeholder})
-#   params: [ placeholder, thousandsmark  ]
-# DoubleRegexDefinition: !paramsRegex
-#   def: (((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+\.|\d+,)))\d{1,3}({thousandsmark}\d{3})+{decimalmark}\d+(?={placeholder})
-#   params: [ placeholder, thousandsmark, decimalmark ]
-# PlaceHolderDefault: \D|\b
+    마지막: end
+    다음: current
+    뒤에서 세번째: end
+    마지막에서 두번째: end
+    마지막의 옆: end
+    마지막에서 바로 전의 것: end
+    이전 것: current
+    다음 것: current
+    마지막에서 바로 전: end
+    지금의 것: current
+    현재: current
 ...

--- a/Specs/Number/Korean/OrdinalModel.json
+++ b/Specs/Number/Korean/OrdinalModel.json
@@ -2,14 +2,15 @@
   {
     "Input": "3조 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "3조 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "3000000000000",
-          "offset":"3000000000000",
-          "relativeTo":"start"
+          "offset": "3000000000000",
+          "relativeTo": "start"
         }
       }
     ]
@@ -17,14 +18,15 @@
   {
     "Input": "조 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "조 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000000000000",
-          "offset":"1000000000000",
-          "relativeTo":"start"
+          "offset": "1000000000000",
+          "relativeTo": "start"
         }
       }
     ]
@@ -32,14 +34,15 @@
   {
     "Input": "백조 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "백조 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "100000000000000",
-          "offset":"100000000000000",
-          "relativeTo":"start"
+          "offset": "100000000000000",
+          "relativeTo": "start"
         }
       }
     ]
@@ -47,14 +50,15 @@
   {
     "Input": "열한 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "열한 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "11",
-          "offset":"11",
-          "relativeTo":"start"
+          "offset": "11",
+          "relativeTo": "start"
         }
       }
     ]
@@ -62,14 +66,15 @@
   {
     "Input": "스물한 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "스물한 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21",
-          "offset":"21",
-          "relativeTo":"start"
+          "offset": "21",
+          "relativeTo": "start"
         }
       }
     ]
@@ -77,14 +82,15 @@
   {
     "Input": "서른 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "서른 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "30",
-          "offset":"30",
-          "relativeTo":"start"
+          "offset": "30",
+          "relativeTo": "start"
         }
       }
     ]
@@ -92,14 +98,15 @@
   {
     "Input": "두 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "두 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "2",
-          "offset":"2",
-          "relativeTo":"start"
+          "offset": "2",
+          "relativeTo": "start"
         }
       }
     ]
@@ -107,14 +114,15 @@
   {
     "Input": "스무 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "스무 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "20",
-          "offset":"20",
-          "relativeTo":"start"
+          "offset": "20",
+          "relativeTo": "start"
         }
       }
     ]
@@ -122,14 +130,15 @@
   {
     "Input": "스물다섯 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "스물다섯 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "25",
-          "offset":"25",
-          "relativeTo":"start"
+          "offset": "25",
+          "relativeTo": "start"
         }
       }
     ]
@@ -137,14 +146,15 @@
   {
     "Input": "백스물다섯 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "백스물다섯 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"125",
-          "relativeTo":"start"
+          "offset": "125",
+          "relativeTo": "start"
         }
       }
     ]
@@ -152,14 +162,15 @@
   {
     "Input": "백이십오 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "백이십오 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "125",
-          "offset":"125",
-          "relativeTo":"start"
+          "offset": "125",
+          "relativeTo": "start"
         }
       }
     ]
@@ -167,14 +178,15 @@
   {
     "Input": "조번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "조번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1000000000000",
-          "offset":"1000000000000",
-          "relativeTo":"start"
+          "offset": "1000000000000",
+          "relativeTo": "start"
         }
       }
     ]
@@ -182,14 +194,15 @@
   {
     "Input": "이십일조 삼백이십이 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "이십일조 삼백이십이 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "21000000000322",
-          "offset":"21000000000322",
-          "relativeTo":"start"
+          "offset": "21000000000322",
+          "relativeTo": "start"
         }
       }
     ]
@@ -197,14 +210,15 @@
   {
     "Input": "이백 번째",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "이백 번째",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "200",
-          "offset":"200",
-          "relativeTo":"start"
+          "offset": "200",
+          "relativeTo": "start"
         }
       }
     ]
@@ -212,15 +226,661 @@
   {
     "Input": "시애틀로 가는 일등석을 예약해주십시오.",
     "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Comment": "PendingValidation",
     "Results": [
       {
         "Text": "일등",
         "TypeName": "ordinal",
         "Resolution": {
           "value": "1",
-          "offset":"1",
-          "relativeTo":"start"
+          "offset": "1",
+          "relativeTo": "start"
         }
+      }
+    ]
+  },
+  {
+    "Input": "노트에 있는 마지막 문장을 지우세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 7,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "\"다음\"인가요 아니면 \"마지막\"인가요?",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "다음",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 1,
+        "End": 2
+      },
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 13,
+        "End": 15
+      }
+    ]
+  },
+  {
+    "Input": "뒤에서 세번째를 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "뒤에서 세번째",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-2",
+          "relativeTo": "end",
+          "value": "end-2"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
+  },
+
+
+  {
+    "Input": "마지막의 옆을 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막의 옆",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "마지막에서 바로 전의 것을 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막에서 바로 전의 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "마지막에서 두번째를 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막에서 두번째",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "마지막 문장을 지우세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "이전 것을 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이전 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "current",
+          "value": "current-1"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "다음 것을 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "다음 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "마지막 두 책을 가지고 싶다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "마지막 한 책을 가지고 싶다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+
+  {
+    "Input": "다음 아이템을 주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "다음",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "마지막 쿠키를 원합니다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "나는 마지막의 옆에 있는 걸 원합니다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막의 옆",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 3,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "나는 11번째이다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "11번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "11",
+          "relativeTo": "start",
+          "value": "11"
+        },
+        "Start": 3,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "21번째 생일",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "21번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "21",
+          "relativeTo": "start",
+          "value": "21"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "그녀는 30번째를 기록했다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "30번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "30",
+          "relativeTo": "start",
+          "value": "30"
+        },
+        "Start": 4,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "여행 온지 2번째 날이다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "2",
+          "relativeTo": "start",
+          "value": "2"
+        },
+        "Start": 6,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "열한번째 날",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "열한번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "11",
+          "relativeTo": "start",
+          "value": "11"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "스무번째 밤",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "스무번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "20",
+          "relativeTo": "start",
+          "value": "20"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "스물 다섯번째 생일",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "스물 다섯번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "25",
+          "relativeTo": "start",
+          "value": "25"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "스물 한번째 식사",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "스물 한번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "21",
+          "relativeTo": "start",
+          "value": "21"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "백스물다섯번째 생신",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "백스물다섯번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "125",
+          "relativeTo": "start",
+          "value": "125"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
+  },
+
+  {
+    "Input": "백화점을 방문한 일조번째 손님",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "일조번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "1000000000000",
+          "relativeTo": "start",
+          "value": "1000000000000"
+        },
+        "Start": 9,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "이십일조 삼백스물두번째 밤",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "이십일조 삼백스물두번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "21000000000322",
+          "relativeTo": "start",
+          "value": "21000000000322"
+        },
+        "Start": 0,
+        "End": 11
+      }
+    ]
+  },
+  {
+    "Input": "이백번째 개최",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이백번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "200",
+          "relativeTo": "start",
+          "value": "200"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "나는 처음 두권이 좋았습니다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "처음",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "start",
+          "value": "1"
+        },
+        "Start": 3,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "나는 첫번째가 좋다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "첫번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "start",
+          "value": "1"
+        },
+        "Start": 3,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "첫 단어를 말해봐",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "첫",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "start",
+          "value": "1"
+        },
+        "Start": 0,
+        "End": 0
+      }
+    ]
+  },
+  {
+    "Input": "다음 세권의 책을 가지고 싶다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "다음",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "그녀는 두번째로 들어옵니다!",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "Results": [
+      {
+        "Text": "두번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "2",
+          "relativeTo": "start",
+          "value": "2"
+        },
+        "Start": 4,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "마지막에서 바로 전의 것이 맞는 거야",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막에서 바로 전의 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "마지막에서 바로 전을 말하는 거였어",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "마지막에서 바로 전",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "지금의 것을 말하는 거였어",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "지금의 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "current",
+          "value": "current+0"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "현재 페이지를 보세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "현재",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "current",
+          "value": "current+0"
+        },
+        "Start": 0,
+        "End": 1
       }
     ]
   }


### PR DESCRIPTION
**PR Includes:**
- Relative Ordinal Extractor
- Ordinal Spec (51 Cases)
   - Existing: 15
   - New: 40 (Relative: 20, Ordinal: 16)
- Number Definitions