### PR TITLE
Java French DateTime Implementation

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/DateTimeRecognizer.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/DateTimeRecognizer.java
@@ -6,6 +6,8 @@ import com.microsoft.recognizers.text.Recognizer;
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishMergedExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.english.parsers.EnglishMergedParserConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseMergedDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchMergedExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchMergedParserConfiguration;
 import com.microsoft.recognizers.text.datetime.models.DateTimeModel;
 import com.microsoft.recognizers.text.datetime.parsers.BaseMergedDateTimeParser;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishMergedExtractorConfiguration;
@@ -82,5 +84,10 @@ public class DateTimeRecognizer extends Recognizer<DateTimeOptions> {
             (options) -> new DateTimeModel(
                 new BaseMergedDateTimeParser(new SpanishMergedParserConfiguration(options)),
                 new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(options))));
+
+        registerModel(DateTimeModel.class, Culture.French, dateTimeOptions -> new DateTimeModel(
+                new BaseMergedDateTimeParser(new FrenchMergedParserConfiguration(options)),
+                new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(options))
+        ));
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseSetExtractor.java
@@ -138,9 +138,9 @@ public class BaseSetExtractor implements IDateTimeExtractor {
         matches = RegExpUtility.getMatches(setWeekDayRegex, input);
         for (Match match : matches) {
             if (match != null) {
-                String trimedText = sb.delete(match.index, match.index + match.length).toString();
-                sb = new StringBuilder(trimedText);
-                trimedText = sb.insert(match.index, match.getGroup("weekday").value).toString();
+                sb = new StringBuilder(input);
+                sb.delete(match.index, match.index + match.length);
+                String trimedText = sb.insert(match.index, match.getGroup("weekday").value).toString();
 
                 List<ExtractResult> ers = extractor.extract(trimedText, reference);
                 for (ExtractResult er : ers) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
@@ -1,0 +1,242 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.utilities.FrenchDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.french.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateExtractorConfiguration {
+
+    public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthRegex);
+    public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthNumRegex);
+    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearRegex);
+    public static final Pattern WeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayRegex);
+    public static final Pattern SingleWeekDayRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
+    public static final Pattern OnRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OnRegex);
+    public static final Pattern RelaxedOnRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelaxedOnRegex);
+    public static final Pattern ThisRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisRegex);
+    public static final Pattern LastDateRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LastDateRegex);
+    public static final Pattern NextDateRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextDateRegex);
+    public static final Pattern StrictWeekDay = RegExpUtility.getSafeRegExp(FrenchDateTime.StrictWeekDay);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
+    public static final Pattern SpecialDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecialDayRegex);
+    public static final Pattern WeekDayOfMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayOfMonthRegex);
+    public static final Pattern RelativeWeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeWeekDayRegex);
+    public static final Pattern SpecialDate = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecialDate);
+    public static final Pattern SpecialDayWithNumRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SpecialDayWithNumRegex);
+    public static final Pattern ForTheRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ForTheRegex);
+    public static final Pattern WeekDayAndDayOfMonthRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.WeekDayAndDayOfMonthRegex);
+    public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeMonthRegex);
+    public static final Pattern StrictRelativeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.StrictRelativeRegex);
+    public static final Pattern PrefixArticleRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrefixArticleRegex);
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeUnitRegex);
+    public static final Pattern RangeConnectorSymbolRegex = RegExpUtility
+            .getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex);
+
+    public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
+        {
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor1));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor2));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor3));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor5));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor4));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor6));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor7));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor8));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor9));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractorA));
+        }
+    };
+
+    public static final List<Pattern> ImplicitDateList = new ArrayList<Pattern>() {
+        {
+            add(OnRegex);
+            add(RelaxedOnRegex);
+            add(SpecialDayRegex);
+            add(ThisRegex);
+            add(LastDateRegex);
+            add(NextDateRegex);
+            add(StrictWeekDay);
+            add(WeekDayOfMonthRegex);
+            add(SpecialDate);
+        }
+    };
+
+    public static final Pattern OfMonth = RegExpUtility.getSafeRegExp(FrenchDateTime.OfMonth);
+    public static final Pattern MonthEnd = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthEnd);
+    public static final Pattern WeekDayEnd = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayEnd);
+    public static final Pattern YearSuffix = RegExpUtility.getSafeRegExp(FrenchDateTime.YearSuffix);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MoreThanRegex);
+
+    public static final ImmutableMap<String, Integer> DayOfWeek = FrenchDateTime.DayOfWeek;
+    public static final ImmutableMap<String, Integer> MonthOfYear = FrenchDateTime.MonthOfYear;
+
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+    private final List<Pattern> implicitDateList;
+
+    public FrenchDateExtractorConfiguration(IOptionsConfiguration config) {
+        super(config.getOptions());
+        integerExtractor = new IntegerExtractor();
+        ordinalExtractor = new OrdinalExtractor();
+        numberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        utilityConfiguration = new FrenchDatetimeUtilityConfiguration();
+
+        implicitDateList = new ArrayList<>(ImplicitDateList);
+    }
+
+    @Override
+    public Iterable<Pattern> getDateRegexList() {
+        return DateRegexList;
+    }
+
+    @Override
+    public Iterable<Pattern> getImplicitDateList() {
+        return implicitDateList;
+    }
+
+    @Override
+    public Pattern getOfMonth() {
+        return OfMonth;
+    }
+
+    @Override
+    public Pattern getMonthEnd() {
+        return MonthEnd;
+    }
+
+    @Override
+    public Pattern getWeekDayEnd() {
+        return WeekDayEnd;
+    }
+
+    @Override
+    public Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public Pattern getForTheRegex() {
+        return ForTheRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayAndDayOfMonthRegex() {
+        return WeekDayAndDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getRelativeMonthRegex() {
+        return RelativeMonthRegex;
+    }
+
+    @Override
+    public Pattern getStrictRelativeRegex() {
+        return StrictRelativeRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return WeekDayRegex;
+    }
+
+    @Override
+    public Pattern getPrefixArticleRegex() {
+        return PrefixArticleRegex;
+    }
+
+    @Override
+    public Pattern getYearSuffix() {
+        return YearSuffix;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getInConnectorRegex() {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public Pattern getRangeUnitRegex() {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRangeConnectorSymbolRegex() {
+        return RangeConnectorSymbolRegex;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return DayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return MonthOfYear;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
@@ -1,14 +1,8 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
-import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -23,17 +17,20 @@ import com.microsoft.recognizers.text.number.french.extractors.OrdinalExtractor;
 import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 public class FrenchDateExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateExtractorConfiguration {
 
     public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthRegex);
     public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthNumRegex);
     public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearRegex);
     public static final Pattern WeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayRegex);
     public static final Pattern SingleWeekDayRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
+        .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
     public static final Pattern OnRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OnRegex);
     public static final Pattern RelaxedOnRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelaxedOnRegex);
     public static final Pattern ThisRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisRegex);
@@ -46,17 +43,17 @@ public class FrenchDateExtractorConfiguration
     public static final Pattern RelativeWeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeWeekDayRegex);
     public static final Pattern SpecialDate = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecialDate);
     public static final Pattern SpecialDayWithNumRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SpecialDayWithNumRegex);
+        .getSafeRegExp(FrenchDateTime.SpecialDayWithNumRegex);
     public static final Pattern ForTheRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ForTheRegex);
     public static final Pattern WeekDayAndDayOfMonthRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.WeekDayAndDayOfMonthRegex);
+        .getSafeRegExp(FrenchDateTime.WeekDayAndDayOfMonthRegex);
     public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeMonthRegex);
     public static final Pattern StrictRelativeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.StrictRelativeRegex);
     public static final Pattern PrefixArticleRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrefixArticleRegex);
     public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
     public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeUnitRegex);
     public static final Pattern RangeConnectorSymbolRegex = RegExpUtility
-            .getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex);
+        .getSafeRegExp(BaseDateTime.RangeConnectorSymbolRegex);
 
     public static final List<Pattern> DateRegexList = new ArrayList<Pattern>() {
         {
@@ -104,7 +101,7 @@ public class FrenchDateExtractorConfiguration
     private final IDateTimeUtilityConfiguration utilityConfiguration;
     private final List<Pattern> implicitDateList;
 
-    public FrenchDateExtractorConfiguration(IOptionsConfiguration config) {
+    public FrenchDateExtractorConfiguration(final IOptionsConfiguration config) {
         super(config.getOptions());
         integerExtractor = new IntegerExtractor();
         ordinalExtractor = new OrdinalExtractor();

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
@@ -21,9 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class FrenchDateExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateExtractorConfiguration {
+public class FrenchDateExtractorConfiguration extends BaseOptionsConfiguration implements IDateExtractorConfiguration {
 
     public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthRegex);
     public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthNumRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
@@ -1,0 +1,331 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.number.french.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDatePeriodExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IDatePeriodExtractorConfiguration {
+    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
+    public static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
+    public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DayRegex);
+    public static final Pattern MonthNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthNumRegex);
+    public static final Pattern IllegalYearRegex = RegExpUtility.getSafeRegExp(BaseDateTime.IllegalYearRegex);
+    public static final Pattern YearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearRegex);
+    public static final Pattern RelativeMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeMonthRegex);
+    public static final Pattern MonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthRegex);
+    public static final Pattern MonthSuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthSuffixRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
+    public static final Pattern PastRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PastSuffixRegex);
+    public static final Pattern FutureRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextSuffixRegex);
+    public static final Pattern FutureSuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FutureSuffixRegex);
+
+    // composite regexes
+    public static final Pattern SimpleCasesRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SimpleCasesRegex);
+    public static final Pattern MonthFrontSimpleCasesRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.MonthFrontSimpleCasesRegex);
+    public static final Pattern MonthFrontBetweenRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.MonthFrontBetweenRegex);
+    public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
+    public static final Pattern OneWordPeriodRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OneWordPeriodRegex);
+    public static final Pattern MonthWithYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthWithYear);
+    public static final Pattern MonthNumWithYearRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.MonthNumWithYear);
+    public static final Pattern WeekOfMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekOfMonthRegex);
+    public static final Pattern WeekOfYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekOfYearRegex);
+    public static final Pattern FollowedDateUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.FollowedDateUnit);
+    public static final Pattern NumberCombinedWithDateUnit = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.NumberCombinedWithDateUnit);
+    public static final Pattern QuarterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.QuarterRegex);
+    public static final Pattern QuarterRegexYearFront = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.QuarterRegexYearFront);
+    public static final Pattern AllHalfYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AllHalfYearRegex);
+    public static final Pattern SeasonRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SeasonRegex);
+    public static final Pattern WhichWeekRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WhichWeekRegex);
+    public static final Pattern WeekOfRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekOfRegex);
+    public static final Pattern MonthOfRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthOfRegex);
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeUnitRegex);
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+    public static final Pattern LaterEarlyPeriodRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.LaterEarlyPeriodRegex);
+    public static final Pattern RestOfDateRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RestOfDateRegex);
+    public static final Pattern WeekWithWeekDayRangeRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.WeekWithWeekDayRangeRegex);
+    public static final Pattern YearPlusNumberRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearPlusNumberRegex);
+    public static final Pattern DecadeWithCenturyRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.DecadeWithCenturyRegex);
+    public static final Pattern YearPeriodRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearPeriodRegex);
+    public static final Pattern ComplexDatePeriodRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.ComplexDatePeriodRegex);
+    public static final Pattern RelativeDecadeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeDecadeRegex);
+    public static final Pattern ReferenceDatePeriodRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.ReferenceDatePeriodRegex);
+    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AgoRegex);
+    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LaterRegex);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MoreThanRegex);
+    public static final Pattern CenturySuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.CenturySuffixRegex);
+    public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NowRegex);
+
+    public static final Iterable<Pattern> SimpleCasesRegexes = new ArrayList<Pattern>() {
+        {
+            add(SimpleCasesRegex);
+            add(BetweenRegex);
+            add(OneWordPeriodRegex);
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.MonthWithYear));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.MonthNumWithYear));
+            add(YearRegex);
+            add(YearPeriodRegex);
+            add(WeekOfYearRegex);
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayOfMonthRegex));
+            add(MonthFrontBetweenRegex);
+            add(MonthFrontSimpleCasesRegex);
+            add(QuarterRegex);
+            add(QuarterRegexYearFront);
+            add(SeasonRegex);
+            add(LaterEarlyPeriodRegex);
+            add(YearPlusNumberRegex);
+            add(DecadeWithCenturyRegex);
+            add(RelativeDecadeRegex);
+        }
+    };
+
+    private static final Pattern fromRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromRegex);
+    private static final Pattern betweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
+
+    private final IDateTimeExtractor datePointExtractor;
+    private final IExtractor cardinalExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IParser numberParser;
+    private final String[] durationDateRestrictions;
+
+    public FrenchDatePeriodExtractorConfiguration(IOptionsConfiguration config) {
+        super(config.getOptions());
+
+        datePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        cardinalExtractor = CardinalExtractor.getInstance();
+        ordinalExtractor = new OrdinalExtractor();
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        numberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+
+        durationDateRestrictions = FrenchDateTime.DurationDateRestrictions.toArray(new String[0]);
+    }
+
+    @Override
+    public Iterable<Pattern> getSimpleCasesRegexes() {
+        return SimpleCasesRegexes;
+    }
+
+    @Override
+    public Pattern getIllegalYearRegex() {
+        return IllegalYearRegex;
+    }
+
+    @Override
+    public Pattern getYearRegex() {
+        return YearRegex;
+    }
+
+    @Override
+    public Pattern getTillRegex() {
+        return TillRegex;
+    }
+
+    @Override
+    public Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public Pattern getTimeUnitRegex() {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getFollowedDateUnit() {
+        return FollowedDateUnit;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithDateUnit() {
+        return NumberCombinedWithDateUnit;
+    }
+
+    @Override
+    public Pattern getPastRegex() {
+        return PastRegex;
+    }
+
+    @Override
+    public Pattern getFutureRegex() {
+        return FutureRegex;
+    }
+
+    @Override
+    public Pattern getFutureSuffixRegex() {
+        return FutureSuffixRegex;
+    }
+
+    @Override
+    public Pattern getWeekOfRegex() {
+        return WeekOfRegex;
+    }
+
+    @Override
+    public Pattern getMonthOfRegex() {
+        return MonthOfRegex;
+    }
+
+    @Override
+    public Pattern getRangeUnitRegex() {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public Pattern getInConnectorRegex() {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public Pattern getWithinNextPrefixRegex() {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getYearPeriodRegex() {
+        return YearPeriodRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDecadeRegex() {
+        return RelativeDecadeRegex;
+    }
+
+    @Override
+    public Pattern getReferenceDatePeriodRegex() {
+        return ReferenceDatePeriodRegex;
+    }
+
+    @Override
+    public Pattern getAgoRegex() {
+        return AgoRegex;
+    }
+
+    @Override
+    public Pattern getLaterRegex() {
+        return LaterRegex;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public Pattern getCenturySuffixRegex() {
+        return CenturySuffixRegex;
+    }
+
+    @Override
+    public Pattern getNowRegex() {
+        return NowRegex;
+    }
+
+    @Override
+    public String[] getDurationDateRestrictions() {
+        return durationDateRestrictions;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = fromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = betweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+
+    @Override
+    public Pattern getComplexDatePeriodRegex() {
+        return ComplexDatePeriodRegex;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePointExtractor() {
+        return datePointExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
@@ -1,11 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -23,10 +17,15 @@ import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserCo
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FrenchDatePeriodExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IDatePeriodExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDatePeriodExtractorConfiguration {
     public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
     public static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
     public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DayRegex);
@@ -45,22 +44,22 @@ public class FrenchDatePeriodExtractorConfiguration
     // composite regexes
     public static final Pattern SimpleCasesRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SimpleCasesRegex);
     public static final Pattern MonthFrontSimpleCasesRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.MonthFrontSimpleCasesRegex);
+        .getSafeRegExp(FrenchDateTime.MonthFrontSimpleCasesRegex);
     public static final Pattern MonthFrontBetweenRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.MonthFrontBetweenRegex);
+        .getSafeRegExp(FrenchDateTime.MonthFrontBetweenRegex);
     public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
     public static final Pattern OneWordPeriodRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OneWordPeriodRegex);
     public static final Pattern MonthWithYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MonthWithYear);
     public static final Pattern MonthNumWithYearRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.MonthNumWithYear);
+        .getSafeRegExp(FrenchDateTime.MonthNumWithYear);
     public static final Pattern WeekOfMonthRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekOfMonthRegex);
     public static final Pattern WeekOfYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekOfYearRegex);
     public static final Pattern FollowedDateUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.FollowedDateUnit);
     public static final Pattern NumberCombinedWithDateUnit = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.NumberCombinedWithDateUnit);
+        .getSafeRegExp(FrenchDateTime.NumberCombinedWithDateUnit);
     public static final Pattern QuarterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.QuarterRegex);
     public static final Pattern QuarterRegexYearFront = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.QuarterRegexYearFront);
+        .getSafeRegExp(FrenchDateTime.QuarterRegexYearFront);
     public static final Pattern AllHalfYearRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AllHalfYearRegex);
     public static final Pattern SeasonRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SeasonRegex);
     public static final Pattern WhichWeekRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WhichWeekRegex);
@@ -69,21 +68,21 @@ public class FrenchDatePeriodExtractorConfiguration
     public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeUnitRegex);
     public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
     public static final Pattern WithinNextPrefixRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+        .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
     public static final Pattern LaterEarlyPeriodRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.LaterEarlyPeriodRegex);
+        .getSafeRegExp(FrenchDateTime.LaterEarlyPeriodRegex);
     public static final Pattern RestOfDateRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RestOfDateRegex);
     public static final Pattern WeekWithWeekDayRangeRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.WeekWithWeekDayRangeRegex);
+        .getSafeRegExp(FrenchDateTime.WeekWithWeekDayRangeRegex);
     public static final Pattern YearPlusNumberRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearPlusNumberRegex);
     public static final Pattern DecadeWithCenturyRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.DecadeWithCenturyRegex);
+        .getSafeRegExp(FrenchDateTime.DecadeWithCenturyRegex);
     public static final Pattern YearPeriodRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.YearPeriodRegex);
     public static final Pattern ComplexDatePeriodRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.ComplexDatePeriodRegex);
+        .getSafeRegExp(FrenchDateTime.ComplexDatePeriodRegex);
     public static final Pattern RelativeDecadeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeDecadeRegex);
     public static final Pattern ReferenceDatePeriodRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.ReferenceDatePeriodRegex);
+        .getSafeRegExp(FrenchDateTime.ReferenceDatePeriodRegex);
     public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AgoRegex);
     public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LaterRegex);
     public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanRegex);
@@ -124,7 +123,7 @@ public class FrenchDatePeriodExtractorConfiguration
     private final IParser numberParser;
     private final String[] durationDateRestrictions;
 
-    public FrenchDatePeriodExtractorConfiguration(IOptionsConfiguration config) {
+    public FrenchDatePeriodExtractorConfiguration(final IOptionsConfiguration config) {
         super(config.getOptions());
 
         datePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
@@ -267,10 +266,10 @@ public class FrenchDatePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getFromTokenIndex(String text) {
+    public ResultIndex getFromTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = fromRegex.matcher(text);
+        final Matcher matcher = fromRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -280,10 +279,10 @@ public class FrenchDatePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getBetweenTokenIndex(String text) {
+    public ResultIndex getBetweenTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = betweenRegex.matcher(text);
+        final Matcher matcher = betweenRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -293,8 +292,8 @@ public class FrenchDatePeriodExtractorConfiguration
     }
 
     @Override
-    public boolean hasConnectorToken(String text) {
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
+    public boolean hasConnectorToken(final String text) {
+        final Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
         return match.isPresent() && match.get().length == text.trim().length();
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDatePeriodExtractorConfiguration.java
@@ -23,9 +23,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class FrenchDatePeriodExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IDatePeriodExtractorConfiguration {
+public class FrenchDatePeriodExtractorConfiguration extends BaseOptionsConfiguration implements IDatePeriodExtractorConfiguration {
     public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
     public static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
     public static final Pattern DayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DayRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
@@ -1,8 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
@@ -12,10 +9,12 @@ import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimeAltExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class FrenchDateTimeAltExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateTimeAltExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateTimeAltExtractorConfiguration {
 
     public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisPrefixRegex);
     public static final Pattern PreviousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);
@@ -41,7 +40,7 @@ public class FrenchDateTimeAltExtractorConfiguration
     private final IDateExtractor dateExtractor;
     private final IDateTimeExtractor datePeriodExtractor;
 
-    public FrenchDateTimeAltExtractorConfiguration(IOptionsConfiguration config) {
+    public FrenchDateTimeAltExtractorConfiguration(final IOptionsConfiguration config) {
         super(config.getOptions());
         dateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
         datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
@@ -1,0 +1,89 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.config.IOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimeAltExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateTimeAltExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateTimeAltExtractorConfiguration {
+
+    public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisPrefixRegex);
+    public static final Pattern PreviousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);
+    public static final Pattern NextPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextPrefixRegex);
+    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmRegex);
+    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmRegex);
+    public static final Pattern RangePrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangePrefixRegex);
+    public static final Iterable<Pattern> RelativePrefixList = new ArrayList<Pattern>() {
+        {
+            add(ThisPrefixRegex);
+            add(PreviousPrefixRegex);
+            add(NextPrefixRegex);
+        }
+    };
+    public static final Iterable<Pattern> AmPmRegexList = new ArrayList<Pattern>() {
+        {
+            add(AmRegex);
+            add(PmRegex);
+        }
+    };
+    private static final Pattern OrRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OrRegex);
+    private static final Pattern DayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DayRegex);
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+
+    public FrenchDateTimeAltExtractorConfiguration(IOptionsConfiguration config) {
+        super(config.getOptions());
+        dateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public Iterable<Pattern> getRelativePrefixList() {
+        return RelativePrefixList;
+    }
+
+    @Override
+    public Iterable<Pattern> getAmPmRegexList() {
+        return AmPmRegexList;
+    }
+
+    @Override
+    public Pattern getOrRegex() {
+        return OrRegex;
+    }
+
+    @Override
+    public Pattern getThisPrefixRegex() {
+        return ThisPrefixRegex;
+    }
+
+    @Override
+    public Pattern getDayRegex() {
+        return DayRegex;
+    }
+
+    @Override
+    public Pattern getRangePrefixRegex() {
+        return RangePrefixRegex;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeAltExtractorConfiguration.java
@@ -12,9 +12,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-public class FrenchDateTimeAltExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateTimeAltExtractorConfiguration {
+public class FrenchDateTimeAltExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimeAltExtractorConfiguration {
 
     public static final Pattern ThisPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisPrefixRegex);
     public static final Pattern PreviousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
@@ -1,0 +1,174 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.utilities.FrenchDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.english.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+public class FrenchDateTimeExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateTimeExtractorConfiguration {
+
+    public static final Pattern PrepositionRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrepositionRegex);
+    public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NowRegex);
+    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixRegex);
+
+    //TODO: modify it according to the corresponding English regex
+
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeOfDayRegex);
+    public static final Pattern SpecificTimeOfDayRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SpecificTimeOfDayRegex);
+    public static final Pattern TimeOfTodayAfterRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.TimeOfTodayAfterRegex);
+    public static final Pattern TimeOfTodayBeforeRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.TimeOfTodayBeforeRegex);
+    public static final Pattern SimpleTimeOfTodayAfterRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayAfterRegex);
+    public static final Pattern SimpleTimeOfTodayBeforeRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayBeforeRegex);
+    public static final Pattern SpecificEndOfRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecificEndOfRegex);
+    public static final Pattern UnspecificEndOfRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.UnspecificEndOfRegex);
+
+    //TODO: add this for french
+    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
+    public static final Pattern ConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorRegex);
+    public static final Pattern NumberAsTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberAsTimeRegex);
+    public static final Pattern DateNumberConnectorRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.DateNumberConnectorRegex);
+    public static final Pattern SuffixAfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAfterRegex);
+    private IExtractor integerExtractor;
+    private IDateExtractor datePointExtractor;
+    private IDateTimeExtractor timePointExtractor;
+    private IDateTimeExtractor durationExtractor;
+    private IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public FrenchDateTimeExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        integerExtractor = IntegerExtractor.getInstance();
+        datePointExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        timePointExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(options));
+
+        utilityConfiguration = new FrenchDatetimeUtilityConfiguration();
+    }
+
+    public FrenchDateTimeExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IDateExtractor getDatePointExtractor() {
+        return datePointExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePointExtractor() {
+        return timePointExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public Pattern getNowRegex() {
+        return NowRegex;
+    }
+
+    @Override
+    public Pattern getSuffixRegex() {
+        return SuffixRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfTodayAfterRegex() {
+        return TimeOfTodayAfterRegex;
+    }
+
+    @Override
+    public Pattern getSimpleTimeOfTodayAfterRegex() {
+        return SimpleTimeOfTodayAfterRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfTodayBeforeRegex() {
+        return TimeOfTodayBeforeRegex;
+    }
+
+    @Override
+    public Pattern getSimpleTimeOfTodayBeforeRegex() {
+        return SimpleTimeOfTodayBeforeRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return TimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getSpecificEndOfRegex() {
+        return SpecificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnspecificEndOfRegex() {
+        return UnspecificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return UnitRegex;
+    }
+
+    @Override
+    public Pattern getNumberAsTimeRegex() {
+        return NumberAsTimeRegex;
+    }
+
+    @Override
+    public Pattern getDateNumberConnectorRegex() {
+        return DateNumberConnectorRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAfterRegex() {
+        return SuffixAfterRegex;
+    }
+
+    public boolean isConnector(String text) {
+
+        text = text.trim();
+
+        boolean isPreposition = Arrays.stream(RegExpUtility.getMatches(PrepositionRegex, text)).findFirst().isPresent();
+        boolean isConnector = Arrays.stream(RegExpUtility.getMatches(ConnectorRegex, text)).findFirst().isPresent();
+        return (StringUtility.isNullOrEmpty(text) || isPreposition || isConnector);
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
@@ -1,8 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.Arrays;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -18,10 +15,12 @@ import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfigu
 import com.microsoft.recognizers.text.number.english.extractors.IntegerExtractor;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class FrenchDateTimeExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateTimeExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateTimeExtractorConfiguration {
 
     public static final Pattern PrepositionRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrepositionRegex);
     public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NowRegex);
@@ -31,33 +30,33 @@ public class FrenchDateTimeExtractorConfiguration
 
     public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeOfDayRegex);
     public static final Pattern SpecificTimeOfDayRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SpecificTimeOfDayRegex);
+        .getSafeRegExp(FrenchDateTime.SpecificTimeOfDayRegex);
     public static final Pattern TimeOfTodayAfterRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.TimeOfTodayAfterRegex);
+        .getSafeRegExp(FrenchDateTime.TimeOfTodayAfterRegex);
     public static final Pattern TimeOfTodayBeforeRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.TimeOfTodayBeforeRegex);
+        .getSafeRegExp(FrenchDateTime.TimeOfTodayBeforeRegex);
     public static final Pattern SimpleTimeOfTodayAfterRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayAfterRegex);
+        .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayAfterRegex);
     public static final Pattern SimpleTimeOfTodayBeforeRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayBeforeRegex);
+        .getSafeRegExp(FrenchDateTime.SimpleTimeOfTodayBeforeRegex);
     public static final Pattern SpecificEndOfRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecificEndOfRegex);
     public static final Pattern UnspecificEndOfRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.UnspecificEndOfRegex);
+        .getSafeRegExp(FrenchDateTime.UnspecificEndOfRegex);
 
     //TODO: add this for french
     public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
     public static final Pattern ConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorRegex);
     public static final Pattern NumberAsTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberAsTimeRegex);
     public static final Pattern DateNumberConnectorRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.DateNumberConnectorRegex);
+        .getSafeRegExp(FrenchDateTime.DateNumberConnectorRegex);
     public static final Pattern SuffixAfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAfterRegex);
-    private IExtractor integerExtractor;
-    private IDateExtractor datePointExtractor;
-    private IDateTimeExtractor timePointExtractor;
-    private IDateTimeExtractor durationExtractor;
-    private IDateTimeUtilityConfiguration utilityConfiguration;
+    private final IExtractor integerExtractor;
+    private final IDateExtractor datePointExtractor;
+    private final IDateTimeExtractor timePointExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
 
-    public FrenchDateTimeExtractorConfiguration(DateTimeOptions options) {
+    public FrenchDateTimeExtractorConfiguration(final DateTimeOptions options) {
 
         super(options);
 
@@ -167,8 +166,8 @@ public class FrenchDateTimeExtractorConfiguration
 
         text = text.trim();
 
-        boolean isPreposition = Arrays.stream(RegExpUtility.getMatches(PrepositionRegex, text)).findFirst().isPresent();
-        boolean isConnector = Arrays.stream(RegExpUtility.getMatches(ConnectorRegex, text)).findFirst().isPresent();
+        final boolean isPreposition = Arrays.stream(RegExpUtility.getMatches(PrepositionRegex, text)).findFirst().isPresent();
+        final boolean isConnector = Arrays.stream(RegExpUtility.getMatches(ConnectorRegex, text)).findFirst().isPresent();
         return (StringUtility.isNullOrEmpty(text) || isPreposition || isConnector);
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimeExtractorConfiguration.java
@@ -18,9 +18,7 @@ import com.microsoft.recognizers.text.utilities.StringUtility;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-public class FrenchDateTimeExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateTimeExtractorConfiguration {
+public class FrenchDateTimeExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimeExtractorConfiguration {
 
     public static final Pattern PrepositionRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrepositionRegex);
     public static final Pattern NowRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NowRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
@@ -1,11 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -22,25 +16,30 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FrenchDateTimePeriodExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateTimePeriodExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateTimePeriodExtractorConfiguration {
 
     public static final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayRegex);
     public static final Pattern NumberCombinedWithUnit = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
+        .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
     public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RestOfDateTimeRegex);
     public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.PeriodTimeOfDayWithDateRegex);
+        .getSafeRegExp(FrenchDateTime.PeriodTimeOfDayWithDateRegex);
     public static final Pattern RelativeTimeUnitRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.RelativeTimeUnitRegex);
+        .getSafeRegExp(FrenchDateTime.RelativeTimeUnitRegex);
     public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.GeneralEndingRegex);
     public static final Pattern MiddlePauseRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MiddlePauseRegex);
     public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmDescRegex);
     public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmDescRegex);
     public static final Pattern WithinNextPrefixRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+        .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
     public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
     public static final Pattern PrefixDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrefixDayRegex);
     public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixRegex);
@@ -72,7 +71,7 @@ public class FrenchDateTimePeriodExtractorConfiguration
         this(DateTimeOptions.None);
     }
 
-    public FrenchDateTimePeriodExtractorConfiguration(DateTimeOptions options) {
+    public FrenchDateTimePeriodExtractorConfiguration(final DateTimeOptions options) {
 
         super(options);
         tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
@@ -253,10 +252,10 @@ public class FrenchDateTimePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getFromTokenIndex(String text) {
+    public ResultIndex getFromTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = FromRegex.matcher(text);
+        final Matcher matcher = FromRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -266,10 +265,10 @@ public class FrenchDateTimePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getBetweenTokenIndex(String text) {
+    public ResultIndex getBetweenTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = BetweenRegex.matcher(text);
+        final Matcher matcher = BetweenRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -279,8 +278,8 @@ public class FrenchDateTimePeriodExtractorConfiguration
     }
 
     @Override
-    public boolean hasConnectorToken(String text) {
-        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
+    public boolean hasConnectorToken(final String text) {
+        final Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
         return match.isPresent() && match.get().length == text.trim().length();
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
@@ -22,9 +22,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class FrenchDateTimePeriodExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateTimePeriodExtractorConfiguration {
+public class FrenchDateTimePeriodExtractorConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodExtractorConfiguration {
 
     public static final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayRegex);
     public static final Pattern NumberCombinedWithUnit = RegExpUtility

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateTimePeriodExtractorConfiguration.java
@@ -1,0 +1,286 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateTimePeriodExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateTimePeriodExtractorConfiguration {
+
+    public static final Pattern weekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WeekDayRegex);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
+    public static final Pattern RestOfDateTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RestOfDateTimeRegex);
+    public static final Pattern PeriodTimeOfDayWithDateRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.PeriodTimeOfDayWithDateRegex);
+    public static final Pattern RelativeTimeUnitRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.RelativeTimeUnitRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.GeneralEndingRegex);
+    public static final Pattern MiddlePauseRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MiddlePauseRegex);
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmDescRegex);
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmDescRegex);
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
+    public static final Pattern PrefixDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PrefixDayRegex);
+    public static final Pattern SuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixRegex);
+    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BeforeRegex);
+    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AfterRegex);
+    public static final Pattern FromRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromRegex2);
+    public static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
+    public static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeOfDayRegex);
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
+    public static final Pattern TimeFollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeFollowedUnit);
+    public static final Iterable<Pattern> SimpleCases = new ArrayList<Pattern>() {
+        {
+            add(FrenchTimePeriodExtractorConfiguration.PureNumFromTo);
+            add(FrenchTimePeriodExtractorConfiguration.PureNumBetweenAnd);
+            add(FrenchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex);
+        }
+    };
+    private final String tokenBeforeDate;
+    private final IExtractor cardinalExtractor;
+    private final IDateTimeExtractor singleDateExtractor;
+    private final IDateTimeExtractor singleTimeExtractor;
+    private final IDateTimeExtractor singleDateTimeExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor timeZoneExtractor;
+
+    public FrenchDateTimePeriodExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public FrenchDateTimePeriodExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+        tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+
+        singleDateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        singleTimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        singleDateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(options));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
+        timeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(options));
+    }
+
+    @Override
+    public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleDateExtractor() {
+        return singleDateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleTimeExtractor() {
+        return singleTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getSingleDateTimeExtractor() {
+        return singleDateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+    @Override
+    public Iterable<Pattern> getSimpleCasesRegex() {
+        return SimpleCases;
+    }
+
+    @Override
+    public Pattern getPrepositionRegex() {
+        return FrenchDateTimeExtractorConfiguration.PrepositionRegex;
+    }
+
+    @Override
+    public Pattern getTillRegex() {
+        return FrenchTimePeriodExtractorConfiguration.TillRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return FrenchDateTimeExtractorConfiguration.TimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return TimeFollowedUnit;
+    }
+
+    @Override
+    public Pattern getTimeUnitRegex() {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getPastPrefixRegex() {
+        return FrenchDatePeriodExtractorConfiguration.PastRegex;
+    }
+
+    @Override
+    public Pattern getNextPrefixRegex() {
+        return FrenchDatePeriodExtractorConfiguration.FutureRegex;
+    }
+
+    @Override
+    public Pattern getFutureSuffixRegex() {
+        return FrenchDatePeriodExtractorConfiguration.FutureSuffixRegex;
+    }
+
+    @Override
+    public Pattern getPrefixDayRegex() {
+        return PrefixDayRegex;
+    }
+
+    @Override
+    public Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return NumberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return weekDayRegex;
+    }
+
+    @Override
+    public Pattern getPeriodTimeOfDayWithDateRegex() {
+        return PeriodTimeOfDayWithDateRegex;
+    }
+
+    @Override
+    public Pattern getRelativeTimeUnitRegex() {
+        return RelativeTimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRestOfDateTimeRegex() {
+        return RestOfDateTimeRegex;
+    }
+
+    @Override
+    public Pattern getGeneralEndingRegex() {
+        return GeneralEndingRegex;
+    }
+
+    @Override
+    public Pattern getMiddlePauseRegex() {
+        return MiddlePauseRegex;
+    }
+
+    @Override
+    public Pattern getAmDescRegex() {
+        return AmDescRegex;
+    }
+
+    @Override
+    public Pattern getPmDescRegex() {
+        return PmDescRegex;
+    }
+
+    @Override
+    public Pattern getWithinNextPrefixRegex() {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getSuffixRegex() {
+        return SuffixRegex;
+    }
+
+    @Override
+    public Pattern getBeforeRegex() {
+        return BeforeRegex;
+    }
+
+    @Override
+    public Pattern getAfterRegex() {
+        return AfterRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeOfDayRegex() {
+        return FrenchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = FromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = BetweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text)).findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
@@ -1,0 +1,141 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.IDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDurationExtractorConfiguration
+        extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
+
+    // TODO: Investigate if required
+//    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
+    public static final Pattern SuffixAndRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAndRegex);
+    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.DurationFollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberCombinedWithDurationUnit);
+    public static final Pattern AnUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AnUnitRegex);
+    public static final Pattern DuringRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DuringRegex);
+    public static final Pattern AllRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AllRegex);
+    public static final Pattern HalfRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HalfRegex);
+    public static final Pattern ConjunctionRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ConjunctionRegex);
+    public static final Pattern InexactNumberRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InexactNumberRegex);
+    public static final Pattern InexactNumberUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InexactNumberUnitRegex);
+    public static final Pattern RelativeDurationUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeDurationUnitRegex);
+    public static final Pattern DurationUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DurationUnitRegex);
+    public static final Pattern DurationConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DurationConnectorRegex);
+    public static final Pattern MoreThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MoreThanRegex);
+    public static final Pattern LessThanRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanRegex);
+
+    private final IExtractor cardinalExtractor;
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+
+    public FrenchDurationExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public FrenchDurationExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        unitMap = FrenchDateTime.UnitMap;
+        unitValueMap = FrenchDateTime.UnitValueMap;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return FollowedUnit;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return NumberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return AnUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return DuringRegex;
+    }
+
+    @Override
+    public Pattern getAllRegex() {
+        return AllRegex;
+    }
+
+    @Override
+    public Pattern getHalfRegex() {
+        return HalfRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return SuffixAndRegex;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return ConjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return InexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return InexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDurationUnitRegex() {
+        return RelativeDurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return DurationUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationConnectorRegex() {
+        return DurationConnectorRegex;
+    }
+
+    @Override
+    public Pattern getLessThanRegex() {
+        return LessThanRegex;
+    }
+
+    @Override
+    public Pattern getMoreThanRegex() {
+        return MoreThanRegex;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
@@ -10,8 +10,7 @@ import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 
-public class FrenchDurationExtractorConfiguration
-    extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
+public class FrenchDurationExtractorConfiguration extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
 
     // TODO: Investigate if required
     //    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDurationExtractorConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
@@ -10,12 +8,13 @@ import com.microsoft.recognizers.text.datetime.extractors.config.IDurationExtrac
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
 
 public class FrenchDurationExtractorConfiguration
-        extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
+    extends BaseOptionsConfiguration implements IDurationExtractorConfiguration {
 
     // TODO: Investigate if required
-//    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
+    //    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
     public static final Pattern SuffixAndRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAndRegex);
     public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.DurationFollowedUnit);
     public static final Pattern NumberCombinedWithUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberCombinedWithDurationUnit);
@@ -40,7 +39,7 @@ public class FrenchDurationExtractorConfiguration
         this(DateTimeOptions.None);
     }
 
-    public FrenchDurationExtractorConfiguration(DateTimeOptions options) {
+    public FrenchDurationExtractorConfiguration(final DateTimeOptions options) {
 
         super(options);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
@@ -1,17 +1,16 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.config.IHolidayExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class FrenchHolidayExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IHolidayExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IHolidayExtractorConfiguration {
 
     public static final Pattern H1 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex1);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
@@ -8,9 +8,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-public class FrenchHolidayExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IHolidayExtractorConfiguration {
+public class FrenchHolidayExtractorConfiguration extends BaseOptionsConfiguration implements IHolidayExtractorConfiguration {
 
     public static final Pattern H1 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex1);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchHolidayExtractorConfiguration.java
@@ -1,0 +1,41 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.IHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchHolidayExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IHolidayExtractorConfiguration {
+
+    public static final Pattern H1 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex1);
+
+    public static final Pattern H2 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex2);
+
+    public static final Pattern H3 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex3);
+
+    public static final Pattern H4 = RegExpUtility.getSafeRegExp(FrenchDateTime.HolidayRegex4);
+
+    public static final Iterable<Pattern> HolidayRegexList = new ArrayList<Pattern>() {
+        {
+            add(H1);
+            add(H2);
+            add(H3);
+            add(H4);
+        }
+    };
+
+    public FrenchHolidayExtractorConfiguration() {
+        super(DateTimeOptions.None);
+    }
+
+    @Override
+    public Iterable<Pattern> getHolidayRegexes() {
+        return HolidayRegexList;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
@@ -26,9 +26,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 import org.javatuples.Pair;
 
-public class FrenchMergedExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements IMergedExtractorConfiguration {
+public class FrenchMergedExtractorConfiguration extends BaseOptionsConfiguration implements IMergedExtractorConfiguration {
 
     public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BeforeRegex);
     public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AfterRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
@@ -1,0 +1,192 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.regex.Pattern;
+
+import org.javatuples.Pair;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeAltExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseHolidayExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseSetExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeListExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.IMergedExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.matcher.StringMatcher;
+import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchMergedExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements IMergedExtractorConfiguration {
+
+    public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BeforeRegex);
+    public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AfterRegex);
+    public static final Pattern SinceRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SinceRegex);
+    public static final Pattern AroundRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AroundRegex);
+    public static final Pattern FromToRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromToRegex);
+    public static final Pattern SingleAmbiguousMonthRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
+    public static final Pattern PrepositionSuffixRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.PrepositionSuffixRegex);
+    public static final Pattern AmbiguousRangeModifierPrefix = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.AmbiguousRangeModifierPrefix);
+    public static final Pattern NumberEndingPattern = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberEndingPattern);
+    public static final Pattern SuffixAfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAfterRegex);
+    public static final Pattern UnspecificDatePeriodRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.UnspecificDatePeriodRegex);
+    public static final StringMatcher SuperfluousWordMatcher = new StringMatcher();
+    public final Iterable<Pair<Pattern, Pattern>> ambiguityFiltersDict = null;
+    private IDateExtractor dateExtractor;
+    private IDateTimeExtractor timeExtractor;
+    private IDateTimeExtractor dateTimeExtractor;
+    private IDateTimeExtractor datePeriodExtractor;
+    private IDateTimeExtractor timePeriodExtractor;
+    private IDateTimeExtractor dateTimePeriodExtractor;
+    private IDateTimeExtractor durationExtractor;
+    private IDateTimeExtractor setExtractor;
+    private IDateTimeExtractor holidayExtractor;
+    private IDateTimeZoneExtractor timeZoneExtractor;
+    private IDateTimeListExtractor dateTimeAltExtractor;
+    private IExtractor integerExtractor;
+
+    public FrenchMergedExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+
+        setExtractor = new BaseSetExtractor(new FrenchSetExtractorConfiguration(options));
+        dateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        timeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        holidayExtractor = new BaseHolidayExtractor(new FrenchHolidayExtractorConfiguration());
+        datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
+        dateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(options));
+        timeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(options));
+        dateTimeAltExtractor = new BaseDateTimeAltExtractor(new FrenchDateTimeAltExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
+                new FrenchDateTimePeriodExtractorConfiguration(options));
+        integerExtractor = new IntegerExtractor();
+    }
+
+    public final StringMatcher getSuperfluousWordMatcher() {
+        return SuperfluousWordMatcher;
+    }
+
+    public final IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    public final IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    public final IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    public final IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    public final IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    public final IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    public final IDateTimeExtractor getSetExtractor() {
+        return setExtractor;
+    }
+
+    public final IDateTimeExtractor getHolidayExtractor() {
+        return holidayExtractor;
+    }
+
+    public final IDateTimeZoneExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+    public final IDateTimeListExtractor getDateTimeAltExtractor() {
+        return dateTimeAltExtractor;
+    }
+
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    public final Iterable<Pair<Pattern, Pattern>> getAmbiguityFiltersDict() {
+        return ambiguityFiltersDict;
+    }
+
+    @Override
+    public Iterable<Pattern> getFilterWordRegexList() {
+        return null;
+    }
+
+    public final Pattern getAfterRegex() {
+        return AfterRegex;
+    }
+
+    public final Pattern getBeforeRegex() {
+        return BeforeRegex;
+    }
+
+    public final Pattern getSinceRegex() {
+        return SinceRegex;
+    }
+
+    public final Pattern getAroundRegex() {
+        return AroundRegex;
+    }
+
+    public final Pattern getFromToRegex() {
+        return FromToRegex;
+    }
+
+    public final Pattern getSingleAmbiguousMonthRegex() {
+        return SingleAmbiguousMonthRegex;
+    }
+
+    public final Pattern getPrepositionSuffixRegex() {
+        return PrepositionSuffixRegex;
+    }
+
+    public final Pattern getAmbiguousRangeModifierPrefix() {
+        return null;
+    }
+
+    public final Pattern getPotentialAmbiguousRangeRegex() {
+        return null;
+    }
+
+    public final Pattern getNumberEndingPattern() {
+        return NumberEndingPattern;
+    }
+
+    public final Pattern getSuffixAfterRegex() {
+        return SuffixAfterRegex;
+    }
+
+    public final Pattern getUnspecificDatePeriodRegex() {
+        return UnspecificDatePeriodRegex;
+    }
+
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
@@ -1,9 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.regex.Pattern;
-
-import org.javatuples.Pair;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -27,10 +23,12 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.matcher.StringMatcher;
 import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
+import org.javatuples.Pair;
 
 public class FrenchMergedExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements IMergedExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements IMergedExtractorConfiguration {
 
     public static final Pattern BeforeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BeforeRegex);
     public static final Pattern AfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AfterRegex);
@@ -38,31 +36,31 @@ public class FrenchMergedExtractorConfiguration
     public static final Pattern AroundRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AroundRegex);
     public static final Pattern FromToRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromToRegex);
     public static final Pattern SingleAmbiguousMonthRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
+        .getSafeRegExp(FrenchDateTime.SingleAmbiguousMonthRegex);
     public static final Pattern PrepositionSuffixRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.PrepositionSuffixRegex);
+        .getSafeRegExp(FrenchDateTime.PrepositionSuffixRegex);
     public static final Pattern AmbiguousRangeModifierPrefix = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.AmbiguousRangeModifierPrefix);
+        .getSafeRegExp(FrenchDateTime.AmbiguousRangeModifierPrefix);
     public static final Pattern NumberEndingPattern = RegExpUtility.getSafeRegExp(FrenchDateTime.NumberEndingPattern);
     public static final Pattern SuffixAfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SuffixAfterRegex);
     public static final Pattern UnspecificDatePeriodRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.UnspecificDatePeriodRegex);
+        .getSafeRegExp(FrenchDateTime.UnspecificDatePeriodRegex);
     public static final StringMatcher SuperfluousWordMatcher = new StringMatcher();
     public final Iterable<Pair<Pattern, Pattern>> ambiguityFiltersDict = null;
-    private IDateExtractor dateExtractor;
-    private IDateTimeExtractor timeExtractor;
-    private IDateTimeExtractor dateTimeExtractor;
-    private IDateTimeExtractor datePeriodExtractor;
-    private IDateTimeExtractor timePeriodExtractor;
-    private IDateTimeExtractor dateTimePeriodExtractor;
-    private IDateTimeExtractor durationExtractor;
-    private IDateTimeExtractor setExtractor;
-    private IDateTimeExtractor holidayExtractor;
-    private IDateTimeZoneExtractor timeZoneExtractor;
-    private IDateTimeListExtractor dateTimeAltExtractor;
-    private IExtractor integerExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor setExtractor;
+    private final IDateTimeExtractor holidayExtractor;
+    private final IDateTimeZoneExtractor timeZoneExtractor;
+    private final IDateTimeListExtractor dateTimeAltExtractor;
+    private final IExtractor integerExtractor;
 
-    public FrenchMergedExtractorConfiguration(DateTimeOptions options) {
+    public FrenchMergedExtractorConfiguration(final DateTimeOptions options) {
         super(options);
 
         setExtractor = new BaseSetExtractor(new FrenchSetExtractorConfiguration(options));
@@ -76,7 +74,7 @@ public class FrenchMergedExtractorConfiguration
         dateTimeAltExtractor = new BaseDateTimeAltExtractor(new FrenchDateTimeAltExtractorConfiguration(this));
         timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
-                new FrenchDateTimePeriodExtractorConfiguration(options));
+            new FrenchDateTimePeriodExtractorConfiguration(options));
         integerExtractor = new IntegerExtractor();
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
@@ -1,0 +1,116 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ISetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchSetExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements ISetExtractorConfiguration {
+
+    public static final Pattern PeriodicRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PeriodicRegex);
+    public static final Pattern EachUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.EachUnitRegex);
+    public static final Pattern EachPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.EachPrefixRegex);
+    public static final Pattern EachDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.EachDayRegex);
+    // TODO
+    public static final Pattern BeforeEachDayRegex = null;
+    public static final Pattern SetWeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SetWeekDayRegex);
+    public static final Pattern SetEachRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SetEachRegex);
+    private IDateTimeExtractor durationExtractor;
+    private IDateTimeExtractor timeExtractor;
+    private IDateExtractor dateExtractor;
+    private IDateTimeExtractor dateTimeExtractor;
+    private IDateTimeExtractor datePeriodExtractor;
+    private IDateTimeExtractor timePeriodExtractor;
+    private IDateTimeExtractor dateTimePeriodExtractor;
+
+    public FrenchSetExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public FrenchSetExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        timeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        dateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        dateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(options));
+        datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
+                new FrenchDateTimePeriodExtractorConfiguration(options));
+    }
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    public final IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    public final IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    public final IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    public final IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    public final IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    public final IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    public final Pattern getLastRegex() {
+        return FrenchDateExtractorConfiguration.LastDateRegex;
+    }
+
+    public final Pattern getEachPrefixRegex() {
+        return EachPrefixRegex;
+    }
+
+    public final Pattern getPeriodicRegex() {
+        return PeriodicRegex;
+    }
+
+    public final Pattern getEachUnitRegex() {
+        return EachUnitRegex;
+    }
+
+    public final Pattern getEachDayRegex() {
+        return EachDayRegex;
+    }
+
+    public final Pattern getBeforeEachDayRegex() {
+        return BeforeEachDayRegex;
+    }
+
+    public final Pattern getSetWeekDayRegex() {
+        return SetWeekDayRegex;
+    }
+
+    public final Pattern getSetEachRegex() {
+        return SetEachRegex;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
@@ -16,9 +16,7 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 
-public class FrenchSetExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements ISetExtractorConfiguration {
+public class FrenchSetExtractorConfiguration extends BaseOptionsConfiguration implements ISetExtractorConfiguration {
 
     public static final Pattern PeriodicRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PeriodicRegex);
     public static final Pattern EachUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.EachUnitRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchSetExtractorConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
@@ -16,10 +14,11 @@ import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.config.ISetExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
 
 public class FrenchSetExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements ISetExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements ISetExtractorConfiguration {
 
     public static final Pattern PeriodicRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PeriodicRegex);
     public static final Pattern EachUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.EachUnitRegex);
@@ -29,19 +28,19 @@ public class FrenchSetExtractorConfiguration
     public static final Pattern BeforeEachDayRegex = null;
     public static final Pattern SetWeekDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SetWeekDayRegex);
     public static final Pattern SetEachRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.SetEachRegex);
-    private IDateTimeExtractor durationExtractor;
-    private IDateTimeExtractor timeExtractor;
-    private IDateExtractor dateExtractor;
-    private IDateTimeExtractor dateTimeExtractor;
-    private IDateTimeExtractor datePeriodExtractor;
-    private IDateTimeExtractor timePeriodExtractor;
-    private IDateTimeExtractor dateTimePeriodExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
 
     public FrenchSetExtractorConfiguration() {
         this(DateTimeOptions.None);
     }
 
-    public FrenchSetExtractorConfiguration(DateTimeOptions options) {
+    public FrenchSetExtractorConfiguration(final DateTimeOptions options) {
         super(options);
 
         durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
@@ -51,7 +50,7 @@ public class FrenchSetExtractorConfiguration
         datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
         timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
-                new FrenchDateTimePeriodExtractorConfiguration(options));
+            new FrenchDateTimePeriodExtractorConfiguration(options));
     }
 
     public final IDateTimeExtractor getDurationExtractor() {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
@@ -1,0 +1,90 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchTimeExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements ITimeExtractorConfiguration {
+
+    public static final Pattern DescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DescRegex);
+    public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);
+    public static final Pattern MinuteNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.MinuteNumRegex);
+
+    public static final Pattern OclockRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.OclockRegex);
+    public static final Pattern PmRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmRegex);
+    public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmRegex);
+
+    public static final Pattern LessThanOneHour = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanOneHour);
+//     public static final Pattern TensTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TensTimeRegex);
+
+    public static final Pattern WrittenTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WrittenTimeRegex);
+    public static final Pattern TimePrefix = RegExpUtility.getSafeRegExp(FrenchDateTime.TimePrefix);
+    public static final Pattern TimeSuffix = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeSuffix);
+    public static final Pattern BasicTime = RegExpUtility.getSafeRegExp(FrenchDateTime.BasicTime);
+    public static final Pattern IshRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.IshRegex);
+
+    public static final Pattern AtRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AtRegex);
+    public static final Pattern ConnectNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectNumRegex);
+    public static final Pattern TimeBeforeAfterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeBeforeAfterRegex);
+    public static final Iterable<Pattern> TimeRegexList = new ArrayList<Pattern>() {
+        {
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex1));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex2));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex3));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex4));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex5));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex6));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex7));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex8));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex9));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.TimeRegex10));
+            add(ConnectNumRegex);
+        }
+    };
+    private IDateTimeExtractor durationExtractor;
+    private IDateTimeExtractor timeZoneExtractor;
+
+    public FrenchTimeExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public FrenchTimeExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        timeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(options));
+    }
+
+    public final Pattern getIshRegex() {
+        return IshRegex;
+    }
+
+    public final Iterable<Pattern> getTimeRegexList() {
+        return TimeRegexList;
+    }
+
+    public final Pattern getAtRegex() {
+        return AtRegex;
+    }
+
+    public final Pattern getTimeBeforeAfterRegex() {
+        return TimeBeforeAfterRegex;
+    }
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    public final IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
@@ -1,8 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -11,10 +8,12 @@ import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.config.ITimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class FrenchTimeExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements ITimeExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements ITimeExtractorConfiguration {
 
     public static final Pattern DescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DescRegex);
     public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);
@@ -25,7 +24,7 @@ public class FrenchTimeExtractorConfiguration
     public static final Pattern AmRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmRegex);
 
     public static final Pattern LessThanOneHour = RegExpUtility.getSafeRegExp(FrenchDateTime.LessThanOneHour);
-//     public static final Pattern TensTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TensTimeRegex);
+    //     public static final Pattern TensTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TensTimeRegex);
 
     public static final Pattern WrittenTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.WrittenTimeRegex);
     public static final Pattern TimePrefix = RegExpUtility.getSafeRegExp(FrenchDateTime.TimePrefix);
@@ -51,14 +50,14 @@ public class FrenchTimeExtractorConfiguration
             add(ConnectNumRegex);
         }
     };
-    private IDateTimeExtractor durationExtractor;
-    private IDateTimeExtractor timeZoneExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeExtractor timeZoneExtractor;
 
     public FrenchTimeExtractorConfiguration() {
         this(DateTimeOptions.None);
     }
 
-    public FrenchTimeExtractorConfiguration(DateTimeOptions options) {
+    public FrenchTimeExtractorConfiguration(final DateTimeOptions options) {
         super(options);
         durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
         timeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(options));

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeExtractorConfiguration.java
@@ -11,9 +11,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-public class FrenchTimeExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements ITimeExtractorConfiguration {
+public class FrenchTimeExtractorConfiguration extends BaseOptionsConfiguration implements ITimeExtractorConfiguration {
 
     public static final Pattern DescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DescRegex);
     public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
@@ -1,11 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -20,22 +14,27 @@ import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfigu
 import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FrenchTimePeriodExtractorConfiguration
-        extends BaseOptionsConfiguration
-        implements ITimePeriodExtractorConfiguration {
+    extends BaseOptionsConfiguration
+    implements ITimePeriodExtractorConfiguration {
 
     public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);
     public static final Pattern PureNumFromTo = RegExpUtility.getSafeRegExp(FrenchDateTime.PureNumFromTo);
     public static final Pattern PureNumBetweenAnd = RegExpUtility.getSafeRegExp(FrenchDateTime.PureNumBetweenAnd);
     public static final Pattern SpecificTimeFromTo = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecificTimeFromTo);
     public static final Pattern SpecificTimeBetweenAnd = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.SpecificTimeBetweenAnd);
-//    TODO: What are these?
-//    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
-//    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.FollowedUnit);
+        .getSafeRegExp(FrenchDateTime.SpecificTimeBetweenAnd);
+    //    TODO: What are these?
+    //    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
+    //    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.FollowedUnit);
     public static final Pattern NumberCombinedWithUnit = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
+        .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
     public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeOfDayRegex);
     public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.GeneralEndingRegex);
     public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
@@ -57,16 +56,16 @@ public class FrenchTimePeriodExtractorConfiguration
             add(PureNumBetweenAnd);
         }
     };
-    private String tokenBeforeDate;
-    private IDateTimeUtilityConfiguration utilityConfiguration;
-    private IDateTimeExtractor singleTimeExtractor;
-    private IExtractor integerExtractor;
+    private final String tokenBeforeDate;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+    private final IDateTimeExtractor singleTimeExtractor;
+    private final IExtractor integerExtractor;
 
     public FrenchTimePeriodExtractorConfiguration() {
         this(DateTimeOptions.None);
     }
 
-    public FrenchTimePeriodExtractorConfiguration(DateTimeOptions options) {
+    public FrenchTimePeriodExtractorConfiguration(final DateTimeOptions options) {
 
         super(options);
 
@@ -118,10 +117,10 @@ public class FrenchTimePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getFromTokenIndex(String text) {
+    public ResultIndex getFromTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = FromRegex.matcher(text);
+        final Matcher matcher = FromRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -131,10 +130,10 @@ public class FrenchTimePeriodExtractorConfiguration
     }
 
     @Override
-    public ResultIndex getBetweenTokenIndex(String text) {
+    public ResultIndex getBetweenTokenIndex(final String text) {
         int index = -1;
         boolean result = false;
-        Matcher matcher = BetweenRegex.matcher(text);
+        final Matcher matcher = BetweenRegex.matcher(text);
         if (matcher.find()) {
             result = true;
             index = matcher.start();
@@ -144,10 +143,10 @@ public class FrenchTimePeriodExtractorConfiguration
     }
 
     @Override
-    public boolean hasConnectorToken(String text) {
-        Optional<Match> match = Arrays
-                .stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text))
-                .findFirst();
+    public boolean hasConnectorToken(final String text) {
+        final Optional<Match> match = Arrays
+            .stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text))
+            .findFirst();
         return match.isPresent() && match.get().length == text.trim().length();
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
@@ -1,0 +1,153 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultIndex;
+import com.microsoft.recognizers.text.datetime.french.utilities.FrenchDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchTimePeriodExtractorConfiguration
+        extends BaseOptionsConfiguration
+        implements ITimePeriodExtractorConfiguration {
+
+    public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);
+    public static final Pattern PureNumFromTo = RegExpUtility.getSafeRegExp(FrenchDateTime.PureNumFromTo);
+    public static final Pattern PureNumBetweenAnd = RegExpUtility.getSafeRegExp(FrenchDateTime.PureNumBetweenAnd);
+    public static final Pattern SpecificTimeFromTo = RegExpUtility.getSafeRegExp(FrenchDateTime.SpecificTimeFromTo);
+    public static final Pattern SpecificTimeBetweenAnd = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.SpecificTimeBetweenAnd);
+//    TODO: What are these?
+//    public static final Pattern UnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.UnitRegex);
+//    public static final Pattern FollowedUnit = RegExpUtility.getSafeRegExp(FrenchDateTime.FollowedUnit);
+    public static final Pattern NumberCombinedWithUnit = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.TimeNumberCombinedWithUnit);
+    public static final Pattern TimeOfDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeOfDayRegex);
+    public static final Pattern GeneralEndingRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.GeneralEndingRegex);
+    public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
+    private static final Pattern FromRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromRegex2);
+    private static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
+    private static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
+    public final IDateTimeExtractor timeZoneExtractor;
+    public final Iterable<Pattern> getSimpleCasesRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.PmRegex));
+            add(RegExpUtility.getSafeRegExp(FrenchDateTime.AmRegex));
+        }
+    };
+    public final Iterable<Pattern> getPureNumberRegex = new ArrayList<Pattern>() {
+        {
+            add(PureNumFromTo);
+            add(PureNumBetweenAnd);
+        }
+    };
+    private String tokenBeforeDate;
+    private IDateTimeUtilityConfiguration utilityConfiguration;
+    private IDateTimeExtractor singleTimeExtractor;
+    private IExtractor integerExtractor;
+
+    public FrenchTimePeriodExtractorConfiguration() {
+        this(DateTimeOptions.None);
+    }
+
+    public FrenchTimePeriodExtractorConfiguration(DateTimeOptions options) {
+
+        super(options);
+
+        tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
+        singleTimeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        utilityConfiguration = new FrenchDatetimeUtilityConfiguration();
+        integerExtractor = new IntegerExtractor();
+        timeZoneExtractor = new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(options));
+    }
+
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    public final IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    public final IDateTimeExtractor getSingleTimeExtractor() {
+        return singleTimeExtractor;
+    }
+
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    public IDateTimeExtractor getTimeZoneExtractor() {
+        return timeZoneExtractor;
+    }
+
+    public Iterable<Pattern> getSimpleCasesRegex() {
+        return getSimpleCasesRegex;
+    }
+
+    public Iterable<Pattern> getPureNumberRegex() {
+        return getPureNumberRegex;
+    }
+
+    public final Pattern getTillRegex() {
+        return TillRegex;
+    }
+
+    public final Pattern getTimeOfDayRegex() {
+        return TimeOfDayRegex;
+    }
+
+    public final Pattern getGeneralEndingRegex() {
+        return GeneralEndingRegex;
+    }
+
+    @Override
+    public ResultIndex getFromTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = FromRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public ResultIndex getBetweenTokenIndex(String text) {
+        int index = -1;
+        boolean result = false;
+        Matcher matcher = BetweenRegex.matcher(text);
+        if (matcher.find()) {
+            result = true;
+            index = matcher.start();
+        }
+
+        return new ResultIndex(result, index);
+    }
+
+    @Override
+    public boolean hasConnectorToken(String text) {
+        Optional<Match> match = Arrays
+                .stream(RegExpUtility.getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.ConnectorAndRegex), text))
+                .findFirst();
+        return match.isPresent() && match.get().length == text.trim().length();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
@@ -20,9 +20,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class FrenchTimePeriodExtractorConfiguration
-    extends BaseOptionsConfiguration
-    implements ITimePeriodExtractorConfiguration {
+public class FrenchTimePeriodExtractorConfiguration extends BaseOptionsConfiguration implements ITimePeriodExtractorConfiguration {
 
     public static final Pattern HourNumRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.HourNumRegex);
     public static final Pattern PureNumFromTo = RegExpUtility.getSafeRegExp(FrenchDateTime.PureNumFromTo);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimePeriodExtractorConfiguration.java
@@ -40,7 +40,7 @@ public class FrenchTimePeriodExtractorConfiguration
     public static final Pattern TillRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TillRegex);
     private static final Pattern FromRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.FromRegex2);
     private static final Pattern RangeConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeConnectorRegex);
-    private static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BetweenRegex);
+    private static final Pattern BetweenRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.BeforeRegex2);
     public final IDateTimeExtractor timeZoneExtractor;
     public final Iterable<Pattern> getSimpleCasesRegex = new ArrayList<Pattern>() {
         {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
@@ -7,8 +7,7 @@ import com.microsoft.recognizers.text.matcher.StringMatcher;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-public class FrenchTimeZoneExtractorConfiguration
-    extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
+public class FrenchTimeZoneExtractorConfiguration extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
     public FrenchTimeZoneExtractorConfiguration(final DateTimeOptions options) {
         super(options);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
@@ -1,0 +1,45 @@
+package com.microsoft.recognizers.text.datetime.french.extractors;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.config.ITimeZoneExtractorConfiguration;
+import com.microsoft.recognizers.text.matcher.StringMatcher;
+
+public class FrenchTimeZoneExtractorConfiguration
+        extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
+    public FrenchTimeZoneExtractorConfiguration(DateTimeOptions options) {
+        super(options);
+
+    }
+
+    private Pattern directUtcRegex;
+
+    public final Pattern getDirectUtcRegex() {
+        return directUtcRegex;
+    }
+
+    private Pattern locationTimeSuffixRegex;
+
+    public final Pattern getLocationTimeSuffixRegex() {
+        return locationTimeSuffixRegex;
+    }
+
+    private StringMatcher locationMatcher;
+
+    public final StringMatcher getLocationMatcher() {
+        return locationMatcher;
+    }
+
+    private StringMatcher timeZoneMatcher;
+
+    public final StringMatcher getTimeZoneMatcher() {
+        return timeZoneMatcher;
+    }
+
+    public final ArrayList<String> getAmbiguousTimezoneList() {
+        return new ArrayList<>();
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchTimeZoneExtractorConfiguration.java
@@ -1,16 +1,15 @@
 package com.microsoft.recognizers.text.datetime.french.extractors;
 
-import java.util.ArrayList;
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.config.ITimeZoneExtractorConfiguration;
 import com.microsoft.recognizers.text.matcher.StringMatcher;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class FrenchTimeZoneExtractorConfiguration
-        extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
-    public FrenchTimeZoneExtractorConfiguration(DateTimeOptions options) {
+    extends BaseOptionsConfiguration implements ITimeZoneExtractorConfiguration {
+    public FrenchTimeZoneExtractorConfiguration(final DateTimeOptions options) {
         super(options);
 
     }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
@@ -113,10 +113,10 @@ public class FrenchCommonDateTimeParserConfiguration extends BaseDateParserConfi
             new FrenchDateTimePeriodExtractorConfiguration(options));
 
         timeZoneParser = new BaseTimeZoneParser();
+        durationParser = new BaseDurationParser(new FrenchDurationParserConfiguration(this));
         dateParser = new BaseDateParser(new FrenchDateParserConfiguration(this));
         timeParser = new FrenchTimeParser(new FrenchTimeParserConfiguration(this));
         dateTimeParser = new BaseDateTimeParser(new FrenchDateTimeParserConfiguration(this));
-        durationParser = new BaseDurationParser(new FrenchDurationParserConfiguration(this));
         datePeriodParser = new BaseDatePeriodParser(new FrenchDatePeriodParserConfiguration(this));
         timePeriodParser = new BaseTimePeriodParser(new FrenchTimePeriodParserConfiguration(this));
         dateTimePeriodParser = new BaseDateTimePeriodParser(new FrenchDateTimePeriodParserConfiguration(this));

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
@@ -1,0 +1,293 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.utilities.FrenchDatetimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDatePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeAltParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseDurationParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimePeriodParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.BaseDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.BaseDateTime;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.number.french.extractors.CardinalExtractor;
+import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
+import com.microsoft.recognizers.text.number.french.extractors.OrdinalExtractor;
+import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
+import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
+
+public class FrenchCommonDateTimeParserConfiguration
+        extends BaseDateParserConfiguration {
+
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, String> specialYearPrefixesMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Double> doubleNumbers;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IParser numberParser;
+
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+
+    private final IDateTimeParser timeZoneParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser durationParser;
+    private final IDateTimeParser datePeriodParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser dateTimePeriodParser;
+    private final IDateTimeParser dateTimeAltParser;
+
+    public FrenchCommonDateTimeParserConfiguration(final DateTimeOptions options) {
+
+        super(options);
+
+        utilityConfiguration = new FrenchDatetimeUtilityConfiguration();
+
+        unitMap = FrenchDateTime.UnitMap;
+        unitValueMap = FrenchDateTime.UnitValueMap;
+        seasonMap = FrenchDateTime.SeasonMap;
+        specialYearPrefixesMap = FrenchDateTime.SpecialYearPrefixesMap;
+        cardinalMap = FrenchDateTime.CardinalMap;
+        dayOfWeek = FrenchDateTime.DayOfWeek;
+        monthOfYear = FrenchDateTime.MonthOfYear;
+        numbers = FrenchDateTime.Numbers;
+        doubleNumbers = FrenchDateTime.DoubleNumbers;
+        writtenDecades = FrenchDateTime.WrittenDecades;
+        specialDecadeCases = FrenchDateTime.SpecialDecadeCases;
+
+        cardinalExtractor = CardinalExtractor.getInstance();
+        integerExtractor = new IntegerExtractor();
+        ordinalExtractor = new OrdinalExtractor();
+
+        numberParser = new BaseNumberParser(new FrenchNumberParserConfiguration());
+
+        dateExtractor = new BaseDateExtractor(new FrenchDateExtractorConfiguration(this));
+        timeExtractor = new BaseTimeExtractor(new FrenchTimeExtractorConfiguration(options));
+        dateTimeExtractor = new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration(options));
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
+        timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
+        dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
+                new FrenchDateTimePeriodExtractorConfiguration(options));
+
+        timeZoneParser = new BaseTimeZoneParser();
+        dateParser = new BaseDateParser(new FrenchDateParserConfiguration(this));
+        timeParser = new FrenchTimeParser(new FrenchTimeParserConfiguration(this));
+        dateTimeParser = new BaseDateTimeParser(new FrenchDateTimeParserConfiguration(this));
+        durationParser = new BaseDurationParser(new FrenchDurationParserConfiguration(this));
+        datePeriodParser = new BaseDatePeriodParser(new FrenchDatePeriodParserConfiguration(this));
+        timePeriodParser = new BaseTimePeriodParser(new FrenchTimePeriodParserConfiguration(this));
+        dateTimePeriodParser = new BaseDateTimePeriodParser(new FrenchDateTimePeriodParserConfiguration(this));
+        dateTimeAltParser = new BaseDateTimeAltParser(new FrenchDateTimeAltParserConfiguration(this));
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeAltParser() {
+        return dateTimeAltParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSpecialYearPrefixesMap() {
+        return specialYearPrefixesMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return ImmutableMap.<String, Integer>builder()
+                .putAll(BaseDateTime.DayOfMonthDictionary)
+                .putAll(FrenchDateTime.DayOfMonth).build();
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
@@ -40,8 +40,7 @@ import com.microsoft.recognizers.text.number.french.extractors.OrdinalExtractor;
 import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserConfiguration;
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
 
-public class FrenchCommonDateTimeParserConfiguration
-    extends BaseDateParserConfiguration {
+public class FrenchCommonDateTimeParserConfiguration extends BaseDateParserConfiguration {
 
     private final IDateTimeUtilityConfiguration utilityConfiguration;
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchCommonDateTimeParserConfiguration.java
@@ -41,7 +41,7 @@ import com.microsoft.recognizers.text.number.french.parsers.FrenchNumberParserCo
 import com.microsoft.recognizers.text.number.parsers.BaseNumberParser;
 
 public class FrenchCommonDateTimeParserConfiguration
-        extends BaseDateParserConfiguration {
+    extends BaseDateParserConfiguration {
 
     private final IDateTimeUtilityConfiguration utilityConfiguration;
 
@@ -111,7 +111,7 @@ public class FrenchCommonDateTimeParserConfiguration
         datePeriodExtractor = new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(this));
         timePeriodExtractor = new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration(options));
         dateTimePeriodExtractor = new BaseDateTimePeriodExtractor(
-                new FrenchDateTimePeriodExtractorConfiguration(options));
+            new FrenchDateTimePeriodExtractorConfiguration(options));
 
         timeZoneParser = new BaseTimeZoneParser();
         dateParser = new BaseDateParser(new FrenchDateParserConfiguration(this));
@@ -257,8 +257,8 @@ public class FrenchCommonDateTimeParserConfiguration
     @Override
     public ImmutableMap<String, Integer> getDayOfMonth() {
         return ImmutableMap.<String, Integer>builder()
-                .putAll(BaseDateTime.DayOfMonthDictionary)
-                .putAll(FrenchDateTime.DayOfMonth).build();
+            .putAll(BaseDateTime.DayOfMonthDictionary)
+            .putAll(FrenchDateTime.DayOfMonth).build();
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
@@ -1,0 +1,339 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.StringExtension;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateParserConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateParserConfiguration {
+
+    private final String dateTokenPrefix;
+    private final IExtractor integerExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IExtractor cardinalExtractor;
+    private final IParser numberParser;
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeParser durationParser;
+    private final ImmutableMap<String, String> unitMap;
+    private final Iterable<Pattern> dateRegexes;
+    private final Pattern onRegex;
+    private final Pattern specialDayRegex;
+    private final Pattern specialDayWithNumRegex;
+    private final Pattern nextRegex;
+    private final Pattern thisRegex;
+    private final Pattern lastRegex;
+    private final Pattern unitRegex;
+    private final Pattern weekDayRegex;
+    private final Pattern monthRegex;
+    private final Pattern weekDayOfMonthRegex;
+    private final Pattern forTheRegex;
+    private final Pattern weekDayAndDayOfMonthRegex;
+    private final Pattern relativeMonthRegex;
+    private final Pattern strictRelativeRegex;
+    private final Pattern yearSuffix;
+    private final Pattern relativeWeekDayRegex;
+    private final Pattern relativeDayRegex;
+    private final Pattern nextPrefixRegex;
+    private final Pattern previousPrefixRegex;
+
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> dayOfWeek;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final List<String> sameDayTerms;
+    private final List<String> plusOneDayTerms;
+    private final List<String> plusTwoDayTerms;
+    private final List<String> minusOneDayTerms;
+    private final List<String> minusTwoDayTerms;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public FrenchDateParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        dateTokenPrefix = FrenchDateTime.DateTokenPrefix;
+        integerExtractor = config.getIntegerExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateRegexes = Collections.unmodifiableList(FrenchDateExtractorConfiguration.DateRegexList);
+        onRegex = FrenchDateExtractorConfiguration.OnRegex;
+        specialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
+        specialDayWithNumRegex = FrenchDateExtractorConfiguration.SpecialDayWithNumRegex;
+        nextRegex = FrenchDateExtractorConfiguration.NextDateRegex;
+        thisRegex = FrenchDateExtractorConfiguration.ThisRegex;
+        lastRegex = FrenchDateExtractorConfiguration.LastDateRegex;
+        unitRegex = FrenchDateExtractorConfiguration.DateUnitRegex;
+        weekDayRegex = FrenchDateExtractorConfiguration.WeekDayRegex;
+        monthRegex = FrenchDateExtractorConfiguration.MonthRegex;
+        weekDayOfMonthRegex = FrenchDateExtractorConfiguration.WeekDayOfMonthRegex;
+        forTheRegex = FrenchDateExtractorConfiguration.ForTheRegex;
+        weekDayAndDayOfMonthRegex = FrenchDateExtractorConfiguration.WeekDayAndDayOfMonthRegex;
+        relativeMonthRegex = FrenchDateExtractorConfiguration.RelativeMonthRegex;
+        strictRelativeRegex = FrenchDateExtractorConfiguration.StrictRelativeRegex;
+        yearSuffix = FrenchDateExtractorConfiguration.YearSuffix;
+        relativeWeekDayRegex = FrenchDateExtractorConfiguration.RelativeWeekDayRegex;
+        relativeDayRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeDayRegex);
+        nextPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextPrefixRegex);
+        previousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);
+        dayOfMonth = config.getDayOfMonth();
+        dayOfWeek = config.getDayOfWeek();
+        monthOfYear = config.getMonthOfYear();
+        cardinalMap = config.getCardinalMap();
+        unitMap = config.getUnitMap();
+        utilityConfiguration = config.getUtilityConfiguration();
+        sameDayTerms = Collections.unmodifiableList(FrenchDateTime.SameDayTerms);
+        plusOneDayTerms = Collections.unmodifiableList(FrenchDateTime.PlusOneDayTerms);
+        plusTwoDayTerms = Collections.unmodifiableList(FrenchDateTime.PlusTwoDayTerms);
+        minusOneDayTerms = Collections.unmodifiableList(FrenchDateTime.MinusOneDayTerms);
+        minusTwoDayTerms = Collections.unmodifiableList(FrenchDateTime.MinusTwoDayTerms);
+    }
+
+    @Override
+    public String getDateTokenPrefix() {
+        return dateTokenPrefix;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public Iterable<Pattern> getDateRegexes() {
+        return dateRegexes;
+    }
+
+    @Override
+    public Pattern getOnRegex() {
+        return onRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayRegex() {
+        return specialDayRegex;
+    }
+
+    @Override
+    public Pattern getSpecialDayWithNumRegex() {
+        return specialDayWithNumRegex;
+    }
+
+    @Override
+    public Pattern getNextRegex() {
+        return nextRegex;
+    }
+
+    @Override
+    public Pattern getThisRegex() {
+        return thisRegex;
+    }
+
+    @Override
+    public Pattern getLastRegex() {
+        return lastRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayRegex() {
+        return weekDayRegex;
+    }
+
+    @Override
+    public Pattern getMonthRegex() {
+        return monthRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayOfMonthRegex() {
+        return weekDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getForTheRegex() {
+        return forTheRegex;
+    }
+
+    @Override
+    public Pattern getWeekDayAndDayOfMonthRegex() {
+        return weekDayAndDayOfMonthRegex;
+    }
+
+    @Override
+    public Pattern getRelativeMonthRegex() {
+        return relativeMonthRegex;
+    }
+
+    @Override
+    public Pattern getStrictRelativeRegex() {
+        return strictRelativeRegex;
+    }
+
+    @Override
+    public Pattern getYearSuffix() {
+        return yearSuffix;
+    }
+
+    @Override
+    public Pattern getRelativeWeekDayRegex() {
+        return relativeWeekDayRegex;
+    }
+
+    @Override
+    public Pattern getRelativeDayRegex() {
+        return relativeDayRegex;
+    }
+
+    @Override
+    public Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getPastPrefixRegex() {
+        return previousPrefixRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public List<String> getSameDayTerms() {
+        return sameDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusOneDayTerms() {
+        return plusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusOneDayTerms() {
+        return minusOneDayTerms;
+    }
+
+    @Override
+    public List<String> getPlusTwoDayTerms() {
+        return plusTwoDayTerms;
+    }
+
+    @Override
+    public List<String> getMinusTwoDayTerms() {
+        return minusTwoDayTerms;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public Integer getSwiftMonthOrYear(final String text) {
+        final String trimmedText = text.trim().toLowerCase(Locale.ROOT);
+        int swift = 0;
+
+        Matcher regexMatcher = nextPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = 1;
+        }
+
+        regexMatcher = previousPrefixRegex.matcher(trimmedText);
+        if (regexMatcher.find()) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public Boolean isCardinalLast(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+
+        return trimmedText.endsWith("dernière") || trimmedText.endsWith("dernières") || trimmedText.endsWith(
+                "derniere") || trimmedText.endsWith("dernieres");
+    }
+
+    @Override
+    public String normalize(final String text) {
+        return StringExtension.normalize(text, ImmutableMap.of());
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
@@ -20,9 +20,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class FrenchDateParserConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateParserConfiguration {
+public class FrenchDateParserConfiguration extends BaseOptionsConfiguration implements IDateParserConfiguration {
 
     private final String dateTokenPrefix;
     private final IExtractor integerExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateParserConfiguration.java
@@ -1,11 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
@@ -20,10 +14,15 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.StringExtension;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FrenchDateParserConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateParserConfiguration {
 
     private final String dateTokenPrefix;
     private final IExtractor integerExtractor;
@@ -329,7 +328,7 @@ public class FrenchDateParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         return trimmedText.endsWith("dernière") || trimmedText.endsWith("dernières") || trimmedText.endsWith(
-                "derniere") || trimmedText.endsWith("dernieres");
+            "derniere") || trimmedText.endsWith("dernieres");
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
@@ -1,9 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
@@ -18,10 +14,13 @@ import com.microsoft.recognizers.text.datetime.parsers.config.IDatePeriodParserC
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class FrenchDatePeriodParserConfiguration
-        extends BaseOptionsConfiguration
-        implements IDatePeriodParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDatePeriodParserConfiguration {
 
     public static final Pattern nextPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextPrefixRegex);
     public static final Pattern previousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);
@@ -30,7 +29,7 @@ public class FrenchDatePeriodParserConfiguration
     public static final Pattern pastSuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PastSuffixRegex);
     public static final Pattern relativeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeRegex);
     public static final Pattern unspecificEndOfRangeRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.UnspecificEndOfRangeRegex);
+        .getSafeRegExp(FrenchDateTime.UnspecificEndOfRangeRegex);
     private final String tokenBeforeDate;
 
     // Regex
@@ -469,9 +468,9 @@ public class FrenchDatePeriodParserConfiguration
         }
 
         if (trimmedText.endsWith("dernière") ||
-                trimmedText.endsWith("dernières") ||
-                trimmedText.endsWith("derniere") ||
-                trimmedText.endsWith("dernieres")
+            trimmedText.endsWith("dernières") ||
+            trimmedText.endsWith("derniere") ||
+            trimmedText.endsWith("dernieres")
         ) {
             swift = -1;
         }
@@ -490,7 +489,7 @@ public class FrenchDatePeriodParserConfiguration
         }
 
         if (trimmedText.endsWith("dernière") || trimmedText.endsWith("dernières") || trimmedText
-                .endsWith("derniere") || trimmedText.endsWith("dernieres")) {
+            .endsWith("derniere") || trimmedText.endsWith("dernieres")) {
             swift = -1;
         }
         else if (trimmedText.startsWith("cette")) {
@@ -505,7 +504,7 @@ public class FrenchDatePeriodParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         return FrenchDateTime.FutureStartTerms.stream().anyMatch(o -> trimmedText.startsWith(o))
-                || FrenchDateTime.FutureEndTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+            || FrenchDateTime.FutureEndTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
     }
 
     @Override
@@ -513,7 +512,7 @@ public class FrenchDatePeriodParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         final Optional<Match> matchLast = Arrays.stream(RegExpUtility.getMatches(previousPrefixRegex, trimmedText))
-                .findFirst();
+            .findFirst();
         return matchLast.isPresent();
     }
 
@@ -540,14 +539,14 @@ public class FrenchDatePeriodParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         final boolean nextPrefix = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText))
-                .findFirst().isPresent();
+            .findFirst().isPresent();
         final boolean pastSuffix = Arrays.stream(RegExpUtility.getMatches(pastSuffixRegex, trimmedText))
-                .findFirst().isPresent();
+            .findFirst().isPresent();
 
         return (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) || (
-                FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix)))
-                &&
-                !FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+            FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix)))
+            &&
+            !FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
     }
 
     @Override

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
@@ -534,13 +534,13 @@ public class FrenchDatePeriodParserConfiguration extends BaseOptionsConfiguratio
     public boolean isWeekOnly(final String text) {
         final String trimmedText = text.trim().toLowerCase();
 
-        final boolean nextPrefix = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText))
+        final boolean nextSuffix = Arrays.stream(RegExpUtility.getMatches(nextSuffixRegex, trimmedText))
             .findFirst().isPresent();
         final boolean pastSuffix = Arrays.stream(RegExpUtility.getMatches(pastSuffixRegex, trimmedText))
             .findFirst().isPresent();
 
         return (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) ||
-            (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix))) &&
+            (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextSuffix || pastSuffix))) &&
             !FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
@@ -491,8 +491,7 @@ public class FrenchDatePeriodParserConfiguration
         if (trimmedText.endsWith("dernière") || trimmedText.endsWith("dernières") || trimmedText
             .endsWith("derniere") || trimmedText.endsWith("dernieres")) {
             swift = -1;
-        }
-        else if (trimmedText.startsWith("cette")) {
+        } else if (trimmedText.startsWith("cette")) {
             swift = 0;
         }
 
@@ -503,8 +502,7 @@ public class FrenchDatePeriodParserConfiguration
     public boolean isFuture(final String text) {
         final String trimmedText = text.trim().toLowerCase();
 
-        return FrenchDateTime.FutureStartTerms.stream().anyMatch(o -> trimmedText.startsWith(o))
-            || FrenchDateTime.FutureEndTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+        return FrenchDateTime.FutureStartTerms.stream().anyMatch(o -> trimmedText.startsWith(o)) || FrenchDateTime.FutureEndTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
     }
 
     @Override
@@ -543,9 +541,8 @@ public class FrenchDatePeriodParserConfiguration
         final boolean pastSuffix = Arrays.stream(RegExpUtility.getMatches(pastSuffixRegex, trimmedText))
             .findFirst().isPresent();
 
-        return (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) || (
-            FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix)))
-            &&
+        return (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) ||
+            (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix))) &&
             !FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
     }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
@@ -18,9 +18,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-public class FrenchDatePeriodParserConfiguration
-    extends BaseOptionsConfiguration
-    implements IDatePeriodParserConfiguration {
+public class FrenchDatePeriodParserConfiguration extends BaseOptionsConfiguration implements IDatePeriodParserConfiguration {
 
     public static final Pattern nextPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextPrefixRegex);
     public static final Pattern previousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDatePeriodParserConfiguration.java
@@ -1,0 +1,565 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDatePeriodParserConfiguration
+        extends BaseOptionsConfiguration
+        implements IDatePeriodParserConfiguration {
+
+    public static final Pattern nextPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextPrefixRegex);
+    public static final Pattern previousPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PreviousPrefixRegex);
+    public static final Pattern thisPrefixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.ThisPrefixRegex);
+    public static final Pattern nextSuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.NextSuffixRegex);
+    public static final Pattern pastSuffixRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PastSuffixRegex);
+    public static final Pattern relativeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RelativeRegex);
+    public static final Pattern unspecificEndOfRangeRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.UnspecificEndOfRangeRegex);
+    private final String tokenBeforeDate;
+
+    // Regex
+    private final IDateExtractor dateExtractor;
+    private final IExtractor cardinalExtractor;
+    private final IExtractor ordinalExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IExtractor integerExtractor;
+    private final IParser numberParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser durationParser;
+    private final Pattern monthFrontBetweenRegex;
+    private final Pattern betweenRegex;
+    private final Pattern monthFrontSimpleCasesRegex;
+    private final Pattern simpleCasesRegex;
+    private final Pattern oneWordPeriodRegex;
+    private final Pattern monthWithYear;
+    private final Pattern monthNumWithYear;
+    private final Pattern yearRegex;
+    private final Pattern pastRegex;
+    private final Pattern futureRegex;
+    private final Pattern futureSuffixRegex;
+    private final Pattern numberCombinedWithUnit;
+    private final Pattern weekOfMonthRegex;
+    private final Pattern weekOfYearRegex;
+    private final Pattern quarterRegex;
+    private final Pattern quarterRegexYearFront;
+    private final Pattern allHalfYearRegex;
+    private final Pattern seasonRegex;
+    private final Pattern whichWeekRegex;
+    private final Pattern weekOfRegex;
+    private final Pattern monthOfRegex;
+    private final Pattern inConnectorRegex;
+    private final Pattern withinNextPrefixRegex;
+    private final Pattern restOfDateRegex;
+    private final Pattern laterEarlyPeriodRegex;
+    private final Pattern weekWithWeekDayRangeRegex;
+    private final Pattern yearPlusNumberRegex;
+    private final Pattern decadeWithCenturyRegex;
+    private final Pattern yearPeriodRegex;
+    private final Pattern complexDatePeriodRegex;
+    private final Pattern relativeDecadeRegex;
+    private final Pattern referenceDatePeriodRegex;
+    private final Pattern agoRegex;
+    private final Pattern laterRegex;
+    private final Pattern lessThanRegex;
+    private final Pattern moreThanRegex;
+    private final Pattern centurySuffixRegex;
+    private final Pattern nowRegex;
+    // Dictionaries
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Integer> cardinalMap;
+    private final ImmutableMap<String, Integer> dayOfMonth;
+    private final ImmutableMap<String, Integer> monthOfYear;
+    private final ImmutableMap<String, String> seasonMap;
+    private final ImmutableMap<String, String> specialYearPrefixesMap;
+    private final ImmutableMap<String, Integer> writtenDecades;
+    private final ImmutableMap<String, Integer> numbers;
+    private final ImmutableMap<String, Integer> specialDecadeCases;
+
+    public FrenchDatePeriodParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+
+        tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
+        cardinalExtractor = config.getCardinalExtractor();
+        ordinalExtractor = config.getOrdinalExtractor();
+        integerExtractor = config.getIntegerExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = config.getDurationExtractor();
+        dateExtractor = config.getDateExtractor();
+        durationParser = config.getDurationParser();
+        dateParser = config.getDateParser();
+        monthFrontBetweenRegex = FrenchDatePeriodExtractorConfiguration.MonthFrontBetweenRegex;
+        betweenRegex = FrenchDatePeriodExtractorConfiguration.BetweenRegex;
+        monthFrontSimpleCasesRegex = FrenchDatePeriodExtractorConfiguration.MonthFrontSimpleCasesRegex;
+        simpleCasesRegex = FrenchDatePeriodExtractorConfiguration.SimpleCasesRegex;
+        oneWordPeriodRegex = FrenchDatePeriodExtractorConfiguration.OneWordPeriodRegex;
+        monthWithYear = FrenchDatePeriodExtractorConfiguration.MonthWithYearRegex;
+        monthNumWithYear = FrenchDatePeriodExtractorConfiguration.MonthNumWithYearRegex;
+        yearRegex = FrenchDatePeriodExtractorConfiguration.YearRegex;
+        pastRegex = FrenchDatePeriodExtractorConfiguration.PastRegex;
+        futureRegex = FrenchDatePeriodExtractorConfiguration.FutureRegex;
+        futureSuffixRegex = FrenchDatePeriodExtractorConfiguration.FutureSuffixRegex;
+        numberCombinedWithUnit = FrenchDurationExtractorConfiguration.NumberCombinedWithUnit;
+        weekOfMonthRegex = FrenchDatePeriodExtractorConfiguration.WeekOfMonthRegex;
+        weekOfYearRegex = FrenchDatePeriodExtractorConfiguration.WeekOfYearRegex;
+        quarterRegex = FrenchDatePeriodExtractorConfiguration.QuarterRegex;
+        quarterRegexYearFront = FrenchDatePeriodExtractorConfiguration.QuarterRegexYearFront;
+        allHalfYearRegex = FrenchDatePeriodExtractorConfiguration.AllHalfYearRegex;
+        seasonRegex = FrenchDatePeriodExtractorConfiguration.SeasonRegex;
+        whichWeekRegex = FrenchDatePeriodExtractorConfiguration.WhichWeekRegex;
+        weekOfRegex = FrenchDatePeriodExtractorConfiguration.WeekOfRegex;
+        monthOfRegex = FrenchDatePeriodExtractorConfiguration.MonthOfRegex;
+        restOfDateRegex = FrenchDatePeriodExtractorConfiguration.RestOfDateRegex;
+        laterEarlyPeriodRegex = FrenchDatePeriodExtractorConfiguration.LaterEarlyPeriodRegex;
+        weekWithWeekDayRangeRegex = FrenchDatePeriodExtractorConfiguration.WeekWithWeekDayRangeRegex;
+        yearPlusNumberRegex = FrenchDatePeriodExtractorConfiguration.YearPlusNumberRegex;
+        decadeWithCenturyRegex = FrenchDatePeriodExtractorConfiguration.DecadeWithCenturyRegex;
+        yearPeriodRegex = FrenchDatePeriodExtractorConfiguration.YearPeriodRegex;
+        complexDatePeriodRegex = FrenchDatePeriodExtractorConfiguration.ComplexDatePeriodRegex;
+        relativeDecadeRegex = FrenchDatePeriodExtractorConfiguration.RelativeDecadeRegex;
+        inConnectorRegex = config.getUtilityConfiguration().getInConnectorRegex();
+        withinNextPrefixRegex = FrenchDatePeriodExtractorConfiguration.WithinNextPrefixRegex;
+        referenceDatePeriodRegex = FrenchDatePeriodExtractorConfiguration.ReferenceDatePeriodRegex;
+        agoRegex = FrenchDatePeriodExtractorConfiguration.AgoRegex;
+        laterRegex = FrenchDatePeriodExtractorConfiguration.LaterRegex;
+        lessThanRegex = FrenchDatePeriodExtractorConfiguration.LessThanRegex;
+        moreThanRegex = FrenchDatePeriodExtractorConfiguration.MoreThanRegex;
+        centurySuffixRegex = FrenchDatePeriodExtractorConfiguration.CenturySuffixRegex;
+        nowRegex = FrenchDatePeriodExtractorConfiguration.NowRegex;
+
+        unitMap = config.getUnitMap();
+        cardinalMap = config.getCardinalMap();
+        dayOfMonth = config.getDayOfMonth();
+        monthOfYear = config.getMonthOfYear();
+        seasonMap = config.getSeasonMap();
+        specialYearPrefixesMap = config.getSpecialYearPrefixesMap();
+        numbers = config.getNumbers();
+        writtenDecades = config.getWrittenDecades();
+        specialDecadeCases = config.getSpecialDecadeCases();
+    }
+
+    @Override
+    public final String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public final IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public final IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public final IExtractor getOrdinalExtractor() {
+        return ordinalExtractor;
+    }
+
+    @Override
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public final IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public final IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public final IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public final Pattern getMonthFrontBetweenRegex() {
+        return monthFrontBetweenRegex;
+    }
+
+    @Override
+    public final Pattern getBetweenRegex() {
+        return betweenRegex;
+    }
+
+    @Override
+    public final Pattern getMonthFrontSimpleCasesRegex() {
+        return monthFrontSimpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getSimpleCasesRegex() {
+        return simpleCasesRegex;
+    }
+
+    @Override
+    public final Pattern getOneWordPeriodRegex() {
+        return oneWordPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getMonthWithYear() {
+        return monthWithYear;
+    }
+
+    @Override
+    public final Pattern getMonthNumWithYear() {
+        return monthNumWithYear;
+    }
+
+    @Override
+    public final Pattern getYearRegex() {
+        return yearRegex;
+    }
+
+    @Override
+    public final Pattern getPastRegex() {
+        return pastRegex;
+    }
+
+    @Override
+    public final Pattern getFutureRegex() {
+        return futureRegex;
+    }
+
+    @Override
+    public final Pattern getFutureSuffixRegex() {
+        return futureSuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public final Pattern getWeekOfMonthRegex() {
+        return weekOfMonthRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfYearRegex() {
+        return weekOfYearRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegex() {
+        return quarterRegex;
+    }
+
+    @Override
+    public final Pattern getQuarterRegexYearFront() {
+        return quarterRegexYearFront;
+    }
+
+    @Override
+    public final Pattern getAllHalfYearRegex() {
+        return allHalfYearRegex;
+    }
+
+    @Override
+    public final Pattern getSeasonRegex() {
+        return seasonRegex;
+    }
+
+    @Override
+    public final Pattern getWhichWeekRegex() {
+        return whichWeekRegex;
+    }
+
+    @Override
+    public final Pattern getWeekOfRegex() {
+        return weekOfRegex;
+    }
+
+    @Override
+    public final Pattern getMonthOfRegex() {
+        return monthOfRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex() {
+        return inConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex() {
+        return withinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRestOfDateRegex() {
+        return restOfDateRegex;
+    }
+
+    @Override
+    public final Pattern getLaterEarlyPeriodRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getWeekWithWeekDayRangeRegex() {
+        return laterEarlyPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getYearPlusNumberRegex() {
+        return yearPlusNumberRegex;
+    }
+
+    @Override
+    public final Pattern getDecadeWithCenturyRegex() {
+        return decadeWithCenturyRegex;
+    }
+
+    @Override
+    public final Pattern getYearPeriodRegex() {
+        return yearPeriodRegex;
+    }
+
+    @Override
+    public final Pattern getComplexDatePeriodRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeDecadeRegex() {
+        return complexDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getReferenceDatePeriodRegex() {
+        return referenceDatePeriodRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex() {
+        return agoRegex;
+    }
+
+    @Override
+    public final Pattern getLaterRegex() {
+        return laterRegex;
+    }
+
+    @Override
+    public final Pattern getLessThanRegex() {
+        return lessThanRegex;
+    }
+
+    @Override
+    public final Pattern getMoreThanRegex() {
+        return moreThanRegex;
+    }
+
+    @Override
+    public final Pattern getCenturySuffixRegex() {
+        return centurySuffixRegex;
+    }
+
+    @Override
+    public final Pattern getNextPrefixRegex() {
+        return nextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getPastPrefixRegex() {
+        return previousPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getThisPrefixRegex() {
+        return thisPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getRelativeRegex() {
+        return relativeRegex;
+    }
+
+    @Override
+    public final Pattern getUnspecificEndOfRangeRegex() {
+        return unspecificEndOfRangeRegex;
+    }
+
+    @Override
+    public Pattern getNowRegex() {
+        return nowRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getCardinalMap() {
+        return cardinalMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getMonthOfYear() {
+        return monthOfYear;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSeasonMap() {
+        return seasonMap;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getSpecialYearPrefixesMap() {
+        return specialYearPrefixesMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getWrittenDecades() {
+        return writtenDecades;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getSpecialDecadeCases() {
+        return specialDecadeCases;
+    }
+
+    @Override
+    public int getSwiftDayOrMonth(final String text) {
+
+        final String trimmedText = text.trim().toLowerCase();
+        int swift = 0;
+
+        if (trimmedText.endsWith("prochain") || trimmedText.endsWith("prochaine")) {
+            swift = 1;
+        }
+
+        if (trimmedText.endsWith("dernière") ||
+                trimmedText.endsWith("dernières") ||
+                trimmedText.endsWith("derniere") ||
+                trimmedText.endsWith("dernieres")
+        ) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public int getSwiftYear(final String text) {
+
+        final String trimmedText = text.trim().toLowerCase();
+        int swift = -10;
+
+        if (trimmedText.endsWith("prochain") || trimmedText.endsWith("prochaine")) {
+            swift = 1;
+        }
+
+        if (trimmedText.endsWith("dernière") || trimmedText.endsWith("dernières") || trimmedText
+                .endsWith("derniere") || trimmedText.endsWith("dernieres")) {
+            swift = -1;
+        }
+        else if (trimmedText.startsWith("cette")) {
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    @Override
+    public boolean isFuture(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+
+        return FrenchDateTime.FutureStartTerms.stream().anyMatch(o -> trimmedText.startsWith(o))
+                || FrenchDateTime.FutureEndTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isLastCardinal(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+
+        final Optional<Match> matchLast = Arrays.stream(RegExpUtility.getMatches(previousPrefixRegex, trimmedText))
+                .findFirst();
+        return matchLast.isPresent();
+    }
+
+    @Override
+    public boolean isMonthOnly(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+        return FrenchDateTime.MonthTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isMonthToDate(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+        return FrenchDateTime.MonthToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekend(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+        return FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isWeekOnly(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+
+        final boolean nextPrefix = Arrays.stream(RegExpUtility.getMatches(nextPrefixRegex, trimmedText))
+                .findFirst().isPresent();
+        final boolean pastSuffix = Arrays.stream(RegExpUtility.getMatches(pastSuffixRegex, trimmedText))
+                .findFirst().isPresent();
+
+        return (FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.endsWith(o)) || (
+                FrenchDateTime.WeekTerms.stream().anyMatch(o -> trimmedText.contains(o)) && (nextPrefix || pastSuffix)))
+                &&
+                !FrenchDateTime.WeekendTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearOnly(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+        return FrenchDateTime.YearTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+
+    @Override
+    public boolean isYearToDate(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+
+        return FrenchDateTime.YearToDateTerms.stream().anyMatch(o -> trimmedText.endsWith(o));
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
@@ -4,8 +4,7 @@ import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeAltParserConfiguration;
 
-public class FrenchDateTimeAltParserConfiguration
-    implements IDateTimeAltParserConfiguration {
+public class FrenchDateTimeAltParserConfiguration implements IDateTimeAltParserConfiguration {
 
     private final IDateTimeParser dateTimeParser;
     private final IDateTimeParser dateParser;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
@@ -1,0 +1,49 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeAltParserConfiguration;
+
+public class FrenchDateTimeAltParserConfiguration
+        implements IDateTimeAltParserConfiguration {
+
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimePeriodParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser datePeriodParser;
+
+    public FrenchDateTimeAltParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+        dateTimeParser = config.getDateTimeParser();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        dateTimePeriodParser = config.getDateTimePeriodParser();
+        timePeriodParser = config.getTimePeriodParser();
+        datePeriodParser = config.getDatePeriodParser();
+    }
+
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    public IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    public IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeAltParserConfiguration.java
@@ -5,7 +5,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimePar
 import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeAltParserConfiguration;
 
 public class FrenchDateTimeAltParserConfiguration
-        implements IDateTimeAltParserConfiguration {
+    implements IDateTimeAltParserConfiguration {
 
     private final IDateTimeParser dateTimeParser;
     private final IDateTimeParser dateParser;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
@@ -89,8 +89,7 @@ public class FrenchDateTimeParserConfiguration
 
         if (trimmedText.endsWith("matin") && hour >= Constants.HalfDayHourCount) {
             result -= Constants.HalfDayHourCount;
-        }
-        else if (!trimmedText.endsWith("matin") && hour < Constants.HalfDayHourCount) {
+        } else if (!trimmedText.endsWith("matin") && hour < Constants.HalfDayHourCount) {
             result += Constants.HalfDayHourCount;
         }
 
@@ -105,15 +104,12 @@ public class FrenchDateTimeParserConfiguration
         final String timex;
         if (trimmedText.endsWith("maintenant")) {
             timex = "PRESENT_REF";
-        }
-        else if (trimmedText.equals("récemment") || trimmedText.equals("précédemment") || trimmedText
+        } else if (trimmedText.equals("récemment") || trimmedText.equals("précédemment") || trimmedText
             .equals("auparavant")) {
             timex = "PAST_REF";
-        }
-        else if (trimmedText.equals("dès que possible") || trimmedText.equals("dqp")) {
+        } else if (trimmedText.equals("dès que possible") || trimmedText.equals("dqp")) {
             timex = "FUTURE_REF";
-        }
-        else {
+        } else {
             timex = null;
             return new ResultTimex(false, null);
         }
@@ -130,8 +126,7 @@ public class FrenchDateTimeParserConfiguration
         if (trimmedText.startsWith("prochain") || trimmedText.startsWith("prochain") ||
             trimmedText.startsWith("prochaine") || trimmedText.startsWith("prochaine")) {
             swift = 1;
-        }
-        else if (trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière") ||
+        } else if (trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière") ||
             trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière")) {
             swift = -1;
         }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
@@ -16,10 +14,11 @@ import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeParserCon
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
 
 public class FrenchDateTimeParserConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateTimeParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateTimeParserConfiguration {
 
     public final String tokenBeforeDate;
     public final String tokenBeforeTime;
@@ -108,7 +107,7 @@ public class FrenchDateTimeParserConfiguration
             timex = "PRESENT_REF";
         }
         else if (trimmedText.equals("récemment") || trimmedText.equals("précédemment") || trimmedText
-                .equals("auparavant")) {
+            .equals("auparavant")) {
             timex = "PAST_REF";
         }
         else if (trimmedText.equals("dès que possible") || trimmedText.equals("dqp")) {
@@ -129,11 +128,11 @@ public class FrenchDateTimeParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         if (trimmedText.startsWith("prochain") || trimmedText.startsWith("prochain") ||
-                trimmedText.startsWith("prochaine") || trimmedText.startsWith("prochaine")) {
+            trimmedText.startsWith("prochaine") || trimmedText.startsWith("prochaine")) {
             swift = 1;
         }
         else if (trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière") ||
-                trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière")) {
+            trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière")) {
             swift = -1;
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
@@ -16,9 +16,7 @@ import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfigu
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 
-public class FrenchDateTimeParserConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateTimeParserConfiguration {
+public class FrenchDateTimeParserConfiguration extends BaseOptionsConfiguration implements IDateTimeParserConfiguration {
 
     public final String tokenBeforeDate;
     public final String tokenBeforeTime;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimeParserConfiguration.java
@@ -1,0 +1,266 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.config.ResultTimex;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateTimeParserConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateTimeParserConfiguration {
+
+    public final String tokenBeforeDate;
+    public final String tokenBeforeTime;
+
+    public final IDateTimeExtractor dateExtractor;
+    public final IDateTimeExtractor timeExtractor;
+    public final IDateTimeParser dateParser;
+    public final IDateTimeParser timeParser;
+    public final IExtractor cardinalExtractor;
+    public final IExtractor integerExtractor;
+    public final IParser numberParser;
+    public final IDateTimeExtractor durationExtractor;
+    public final IDateTimeParser durationParser;
+
+    public final ImmutableMap<String, String> unitMap;
+    public final ImmutableMap<String, Integer> numbers;
+
+    public final Pattern nowRegex;
+    public final Pattern amTimeRegex;
+    public final Pattern pmTimeRegex;
+    public final Pattern simpleTimeOfTodayAfterRegex;
+    public final Pattern simpleTimeOfTodayBeforeRegex;
+    public final Pattern specificTimeOfDayRegex;
+    public final Pattern specificEndOfRegex;
+    public final Pattern unspecificEndOfRegex;
+    public final Pattern unitRegex;
+    public final Pattern dateNumberConnectorRegex;
+
+    public final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public FrenchDateTimeParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+        super(config.getOptions());
+
+        unitMap = config.getUnitMap();
+        numbers = config.getNumbers();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        numberParser = config.getNumberParser();
+        dateExtractor = config.getDateExtractor();
+        timeExtractor = config.getTimeExtractor();
+        durationParser = config.getDurationParser();
+        integerExtractor = config.getIntegerExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        durationExtractor = config.getDurationExtractor();
+        utilityConfiguration = config.getUtilityConfiguration();
+
+        tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
+        tokenBeforeTime = FrenchDateTime.TokenBeforeTime;
+
+        nowRegex = FrenchDateTimeExtractorConfiguration.NowRegex;
+        unitRegex = FrenchDateTimeExtractorConfiguration.UnitRegex;
+        specificEndOfRegex = FrenchDateTimeExtractorConfiguration.SpecificEndOfRegex;
+        unspecificEndOfRegex = FrenchDateTimeExtractorConfiguration.UnspecificEndOfRegex;
+        specificTimeOfDayRegex = FrenchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+        dateNumberConnectorRegex = FrenchDateTimeExtractorConfiguration.DateNumberConnectorRegex;
+        simpleTimeOfTodayAfterRegex = FrenchDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
+        simpleTimeOfTodayBeforeRegex = FrenchDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
+
+        pmTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmRegex);
+        amTimeRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AMTimeRegex);
+    }
+
+    @Override
+    public int getHour(final String text, final int hour) {
+        int result = hour;
+
+        final String trimmedText = text.trim().toLowerCase();
+
+        if (trimmedText.endsWith("matin") && hour >= Constants.HalfDayHourCount) {
+            result -= Constants.HalfDayHourCount;
+        }
+        else if (!trimmedText.endsWith("matin") && hour < Constants.HalfDayHourCount) {
+            result += Constants.HalfDayHourCount;
+        }
+
+        return result;
+    }
+
+    @Override
+    public ResultTimex getMatchedNowTimex(final String text) {
+
+        final String trimmedText = text.trim().toLowerCase();
+
+        final String timex;
+        if (trimmedText.endsWith("maintenant")) {
+            timex = "PRESENT_REF";
+        }
+        else if (trimmedText.equals("récemment") || trimmedText.equals("précédemment") || trimmedText
+                .equals("auparavant")) {
+            timex = "PAST_REF";
+        }
+        else if (trimmedText.equals("dès que possible") || trimmedText.equals("dqp")) {
+            timex = "FUTURE_REF";
+        }
+        else {
+            timex = null;
+            return new ResultTimex(false, null);
+        }
+
+        return new ResultTimex(true, timex);
+    }
+
+    @Override
+    public int getSwiftDay(final String text) {
+        int swift = 0;
+
+        final String trimmedText = text.trim().toLowerCase();
+
+        if (trimmedText.startsWith("prochain") || trimmedText.startsWith("prochain") ||
+                trimmedText.startsWith("prochaine") || trimmedText.startsWith("prochaine")) {
+            swift = 1;
+        }
+        else if (trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière") ||
+                trimmedText.startsWith("dernier") || trimmedText.startsWith("dernière")) {
+            swift = -1;
+        }
+
+        return swift;
+
+    }
+
+    @Override
+    public boolean containsAmbiguousToken(final String text, final String matchedText) {
+        return false;
+    }
+
+    @Override
+    public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public String getTokenBeforeTime() {
+        return tokenBeforeTime;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public Pattern getNowRegex() {
+        return nowRegex;
+    }
+
+    public Pattern getAMTimeRegex() {
+        return amTimeRegex;
+    }
+
+    public Pattern getPMTimeRegex() {
+        return pmTimeRegex;
+    }
+
+    @Override
+    public Pattern getSimpleTimeOfTodayAfterRegex() {
+        return simpleTimeOfTodayAfterRegex;
+    }
+
+    @Override
+    public Pattern getSimpleTimeOfTodayBeforeRegex() {
+        return simpleTimeOfTodayBeforeRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeOfDayRegex() {
+        return specificTimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getSpecificEndOfRegex() {
+        return specificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnspecificEndOfRegex() {
+        return unspecificEndOfRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getDateNumberConnectorRegex() {
+        return dateNumberConnectorRegex;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
@@ -291,28 +291,24 @@ public class FrenchDateTimePeriodParserConfiguration
             timeStr = "TMO";
             beginHour = 8;
             endHour = Constants.HalfDayHourCount;
-        }
-        else if (RegExpUtility
+        } else if (RegExpUtility
             .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.AfternoonStartEndRegex), trimmedText).length
             > 0) {
             timeStr = "TAF";
             beginHour = Constants.HalfDayHourCount;
             endHour = 16;
-        }
-        else if (RegExpUtility
+        } else if (RegExpUtility
             .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.EveningStartEndRegex), trimmedText).length > 0) {
             timeStr = "TEV";
             beginHour = 16;
             endHour = 20;
-        }
-        else if (RegExpUtility
+        } else if (RegExpUtility
             .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.NightStartEndRegex), trimmedText).length > 0) {
             timeStr = "TNI";
             beginHour = 20;
             endHour = 23;
             endMin = 59;
-        }
-        else {
+        } else {
             return new MatchedTimeRangeResult(false, null, beginHour, endHour, endMin);
         }
 
@@ -327,8 +323,7 @@ public class FrenchDateTimePeriodParserConfiguration
         if (trimmedText.startsWith("prochain") || trimmedText.endsWith("prochain") ||
             trimmedText.startsWith("prochaine") || trimmedText.endsWith("prochaine")) {
             swift = 1;
-        }
-        else if (trimmedText.startsWith("derniere") || trimmedText.startsWith("dernier") ||
+        } else if (trimmedText.startsWith("derniere") || trimmedText.startsWith("dernier") ||
             trimmedText.endsWith("derniere") || trimmedText.endsWith("dernier")) {
             swift = -1;
         }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
@@ -18,10 +16,11 @@ import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimePeriodPar
 import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
 
 public class FrenchDateTimePeriodParserConfiguration
-        extends BaseOptionsConfiguration
-        implements IDateTimePeriodParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDateTimePeriodParserConfiguration {
 
     private final String tokenBeforeDate;
 
@@ -288,26 +287,26 @@ public class FrenchDateTimePeriodParserConfiguration
         final String trimmedText = text.trim().toLowerCase();
 
         if (RegExpUtility
-                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.MorningStartEndRegex), trimmedText).length > 0) {
+            .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.MorningStartEndRegex), trimmedText).length > 0) {
             timeStr = "TMO";
             beginHour = 8;
             endHour = Constants.HalfDayHourCount;
         }
         else if (RegExpUtility
-                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.AfternoonStartEndRegex), trimmedText).length
-                > 0) {
+            .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.AfternoonStartEndRegex), trimmedText).length
+            > 0) {
             timeStr = "TAF";
             beginHour = Constants.HalfDayHourCount;
             endHour = 16;
         }
         else if (RegExpUtility
-                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.EveningStartEndRegex), trimmedText).length > 0) {
+            .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.EveningStartEndRegex), trimmedText).length > 0) {
             timeStr = "TEV";
             beginHour = 16;
             endHour = 20;
         }
         else if (RegExpUtility
-                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.NightStartEndRegex), trimmedText).length > 0) {
+            .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.NightStartEndRegex), trimmedText).length > 0) {
             timeStr = "TNI";
             beginHour = 20;
             endHour = 23;
@@ -326,11 +325,11 @@ public class FrenchDateTimePeriodParserConfiguration
         int swift = 0;
 
         if (trimmedText.startsWith("prochain") || trimmedText.endsWith("prochain") ||
-                trimmedText.startsWith("prochaine") || trimmedText.endsWith("prochaine")) {
+            trimmedText.startsWith("prochaine") || trimmedText.endsWith("prochaine")) {
             swift = 1;
         }
         else if (trimmedText.startsWith("derniere") || trimmedText.startsWith("dernier") ||
-                trimmedText.endsWith("derniere") || trimmedText.endsWith("dernier")) {
+            trimmedText.endsWith("derniere") || trimmedText.endsWith("dernier")) {
             swift = -1;
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
@@ -18,9 +18,7 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 
-public class FrenchDateTimePeriodParserConfiguration
-    extends BaseOptionsConfiguration
-    implements IDateTimePeriodParserConfiguration {
+public class FrenchDateTimePeriodParserConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodParserConfiguration {
 
     private final String tokenBeforeDate;
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDateTimePeriodParserConfiguration.java
@@ -1,0 +1,339 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDateTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDateTimePeriodParserConfiguration
+        extends BaseOptionsConfiguration
+        implements IDateTimePeriodParserConfiguration {
+
+    private final String tokenBeforeDate;
+
+    private final IDateTimeExtractor dateExtractor;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeExtractor durationExtractor;
+    private final IExtractor cardinalExtractor;
+
+    private final IParser numberParser;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeParser timeParser;
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeParser durationParser;
+    private final IDateTimeParser timeZoneParser;
+
+    private final Pattern pureNumberFromToRegex;
+    private final Pattern pureNumberBetweenAndRegex;
+    private final Pattern specificTimeOfDayRegex;
+    private final Pattern timeOfDayRegex;
+    private final Pattern pastRegex;
+    private final Pattern futureRegex;
+    private final Pattern futureSuffixRegex;
+    private final Pattern numberCombinedWithUnitRegex;
+    private final Pattern unitRegex;
+    private final Pattern periodTimeOfDayWithDateRegex;
+    private final Pattern relativeTimeUnitRegex;
+    private final Pattern restOfDateTimeRegex;
+    private final Pattern amDescRegex;
+    private final Pattern pmDescRegex;
+    private final Pattern withinNextPrefixRegex;
+    private final Pattern prefixDayRegex;
+    private final Pattern beforeRegex;
+    private final Pattern afterRegex;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Integer> numbers;
+
+    public FrenchDateTimePeriodParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        tokenBeforeDate = FrenchDateTime.TokenBeforeDate;
+
+        dateExtractor = config.getDateExtractor();
+        timeExtractor = config.getTimeExtractor();
+        dateTimeExtractor = config.getDateTimeExtractor();
+        timePeriodExtractor = config.getTimePeriodExtractor();
+        cardinalExtractor = config.getCardinalExtractor();
+        durationExtractor = config.getDurationExtractor();
+        numberParser = config.getNumberParser();
+        dateParser = config.getDateParser();
+        timeParser = config.getTimeParser();
+        timePeriodParser = config.getTimePeriodParser();
+        durationParser = config.getDurationParser();
+        dateTimeParser = config.getDateTimeParser();
+        timeZoneParser = config.getTimeZoneParser();
+
+        pureNumberFromToRegex = FrenchTimePeriodExtractorConfiguration.PureNumFromTo;
+        pureNumberBetweenAndRegex = FrenchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+        specificTimeOfDayRegex = FrenchDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
+        timeOfDayRegex = FrenchDateTimeExtractorConfiguration.TimeOfDayRegex;
+        pastRegex = FrenchDatePeriodExtractorConfiguration.PastRegex;
+        futureRegex = FrenchDatePeriodExtractorConfiguration.FutureRegex;
+        futureSuffixRegex = FrenchDatePeriodExtractorConfiguration.FutureSuffixRegex;
+        numberCombinedWithUnitRegex = FrenchDateTimePeriodExtractorConfiguration.NumberCombinedWithUnit;
+        unitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
+        periodTimeOfDayWithDateRegex = FrenchDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
+        relativeTimeUnitRegex = FrenchDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
+        restOfDateTimeRegex = FrenchDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
+        amDescRegex = FrenchDateTimePeriodExtractorConfiguration.AmDescRegex;
+        pmDescRegex = FrenchDateTimePeriodExtractorConfiguration.PmDescRegex;
+        withinNextPrefixRegex = FrenchDateTimePeriodExtractorConfiguration.WithinNextPrefixRegex;
+        prefixDayRegex = FrenchDateTimePeriodExtractorConfiguration.PrefixDayRegex;
+        beforeRegex = FrenchDateTimePeriodExtractorConfiguration.BeforeRegex;
+        afterRegex = FrenchDateTimePeriodExtractorConfiguration.AfterRegex;
+
+        unitMap = config.getUnitMap();
+        numbers = config.getNumbers();
+    }
+
+    @Override
+    public String getTokenBeforeDate() {
+        return tokenBeforeDate;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    @Override
+    public IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    @Override
+    public IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public Pattern getPureNumberFromToRegex() {
+        return pureNumberFromToRegex;
+    }
+
+    @Override
+    public Pattern getPureNumberBetweenAndRegex() {
+        return pureNumberBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeOfDayRegex() {
+        return specificTimeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return timeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getPastRegex() {
+        return pastRegex;
+    }
+
+    @Override
+    public Pattern getFutureRegex() {
+        return futureRegex;
+    }
+
+    @Override
+    public Pattern getFutureSuffixRegex() {
+        return futureSuffixRegex;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnitRegex() {
+        return numberCombinedWithUnitRegex;
+    }
+
+    @Override
+    public Pattern getUnitRegex() {
+        return unitRegex;
+    }
+
+    @Override
+    public Pattern getPeriodTimeOfDayWithDateRegex() {
+        return periodTimeOfDayWithDateRegex;
+    }
+
+    @Override
+    public Pattern getRelativeTimeUnitRegex() {
+        return relativeTimeUnitRegex;
+    }
+
+    @Override
+    public Pattern getRestOfDateTimeRegex() {
+        return restOfDateTimeRegex;
+    }
+
+    @Override
+    public Pattern getAmDescRegex() {
+        return amDescRegex;
+    }
+
+    @Override
+    public Pattern getPmDescRegex() {
+        return pmDescRegex;
+    }
+
+    @Override
+    public Pattern getWithinNextPrefixRegex() {
+        return withinNextPrefixRegex;
+    }
+
+    @Override
+    public Pattern getPrefixDayRegex() {
+        return prefixDayRegex;
+    }
+
+    @Override
+    public Pattern getBeforeRegex() {
+        return beforeRegex;
+    }
+
+    @Override
+    public Pattern getAfterRegex() {
+        return afterRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public MatchedTimeRangeResult getMatchedTimeRange(final String text,
+                                                      String timeStr,
+                                                      int beginHour,
+                                                      int endHour,
+                                                      int endMin) {
+        beginHour = 0;
+        endHour = 0;
+        endMin = 0;
+
+        final String trimmedText = text.trim().toLowerCase();
+
+        if (RegExpUtility
+                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.MorningStartEndRegex), trimmedText).length > 0) {
+            timeStr = "TMO";
+            beginHour = 8;
+            endHour = Constants.HalfDayHourCount;
+        }
+        else if (RegExpUtility
+                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.AfternoonStartEndRegex), trimmedText).length
+                > 0) {
+            timeStr = "TAF";
+            beginHour = Constants.HalfDayHourCount;
+            endHour = 16;
+        }
+        else if (RegExpUtility
+                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.EveningStartEndRegex), trimmedText).length > 0) {
+            timeStr = "TEV";
+            beginHour = 16;
+            endHour = 20;
+        }
+        else if (RegExpUtility
+                .getMatches(RegExpUtility.getSafeRegExp(FrenchDateTime.NightStartEndRegex), trimmedText).length > 0) {
+            timeStr = "TNI";
+            beginHour = 20;
+            endHour = 23;
+            endMin = 59;
+        }
+        else {
+            return new MatchedTimeRangeResult(false, null, beginHour, endHour, endMin);
+        }
+
+        return new MatchedTimeRangeResult(true, timeStr, beginHour, endHour, endMin);
+    }
+
+    @Override
+    public int getSwiftPrefix(final String text) {
+        final String trimmedText = text.trim().toLowerCase();
+        int swift = 0;
+
+        if (trimmedText.startsWith("prochain") || trimmedText.endsWith("prochain") ||
+                trimmedText.startsWith("prochaine") || trimmedText.endsWith("prochaine")) {
+            swift = 1;
+        }
+        else if (trimmedText.startsWith("derniere") || trimmedText.startsWith("dernier") ||
+                trimmedText.endsWith("derniere") || trimmedText.endsWith("dernier")) {
+            swift = -1;
+        }
+
+        return swift;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.IParser;
@@ -10,10 +8,11 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
+import java.util.regex.Pattern;
 
 public class FrenchDurationParserConfiguration
-        extends BaseOptionsConfiguration
-        implements IDurationParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements IDurationParserConfiguration {
 
     private final IExtractor cardinalExtractor;
     private final IExtractor durationExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
@@ -1,0 +1,147 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.IParser;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
+
+public class FrenchDurationParserConfiguration
+        extends BaseOptionsConfiguration
+        implements IDurationParserConfiguration {
+
+    private final IExtractor cardinalExtractor;
+    private final IExtractor durationExtractor;
+    private final IParser numberParser;
+
+    private final Pattern numberCombinedWithUnit;
+    private final Pattern anUnitRegex;
+    private final Pattern duringRegex;
+    private final Pattern allDateUnitRegex;
+    private final Pattern halfDateUnitRegex;
+    private final Pattern suffixAndRegex;
+    private final Pattern followedUnit;
+    private final Pattern conjunctionRegex;
+    private final Pattern inexactNumberRegex;
+    private final Pattern inexactNumberUnitRegex;
+    private final Pattern durationUnitRegex;
+
+    private final ImmutableMap<String, String> unitMap;
+    private final ImmutableMap<String, Long> unitValueMap;
+    private final ImmutableMap<String, Double> doubleNumbers;
+
+    public FrenchDurationParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        cardinalExtractor = config.getCardinalExtractor();
+        numberParser = config.getNumberParser();
+        durationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(), false);
+        numberCombinedWithUnit = FrenchDurationExtractorConfiguration.NumberCombinedWithUnit;
+
+        anUnitRegex = FrenchDurationExtractorConfiguration.AnUnitRegex;
+        duringRegex = FrenchDurationExtractorConfiguration.DuringRegex;
+        allDateUnitRegex = FrenchDurationExtractorConfiguration.AllRegex;
+        halfDateUnitRegex = FrenchDurationExtractorConfiguration.HalfRegex;
+        suffixAndRegex = FrenchDurationExtractorConfiguration.SuffixAndRegex;
+        followedUnit = FrenchDurationExtractorConfiguration.FollowedUnit;
+        conjunctionRegex = FrenchDurationExtractorConfiguration.ConjunctionRegex;
+        inexactNumberRegex = FrenchDurationExtractorConfiguration.InexactNumberRegex;
+        inexactNumberUnitRegex = FrenchDurationExtractorConfiguration.InexactNumberUnitRegex;
+        durationUnitRegex = FrenchDurationExtractorConfiguration.DurationUnitRegex;
+
+        unitMap = config.getUnitMap();
+        unitValueMap = config.getUnitValueMap();
+        doubleNumbers = config.getDoubleNumbers();
+    }
+
+    @Override
+    public IExtractor getCardinalExtractor() {
+        return cardinalExtractor;
+    }
+
+    @Override
+    public IExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    @Override
+    public IParser getNumberParser() {
+        return numberParser;
+    }
+
+    @Override
+    public Pattern getNumberCombinedWithUnit() {
+        return numberCombinedWithUnit;
+    }
+
+    @Override
+    public Pattern getAnUnitRegex() {
+        return anUnitRegex;
+    }
+
+    @Override
+    public Pattern getDuringRegex() {
+        return duringRegex;
+    }
+
+    @Override
+    public Pattern getAllDateUnitRegex() {
+        return allDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getHalfDateUnitRegex() {
+        return halfDateUnitRegex;
+    }
+
+    @Override
+    public Pattern getSuffixAndRegex() {
+        return suffixAndRegex;
+    }
+
+    @Override
+    public Pattern getFollowedUnit() {
+        return followedUnit;
+    }
+
+    @Override
+    public Pattern getConjunctionRegex() {
+        return conjunctionRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberRegex() {
+        return inexactNumberRegex;
+    }
+
+    @Override
+    public Pattern getInexactNumberUnitRegex() {
+        return inexactNumberUnitRegex;
+    }
+
+    @Override
+    public Pattern getDurationUnitRegex() {
+        return durationUnitRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Long> getUnitValueMap() {
+        return unitValueMap;
+    }
+
+    @Override
+    public ImmutableMap<String, Double> getDoubleNumbers() {
+        return doubleNumbers;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchDurationParserConfiguration.java
@@ -10,9 +10,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimePar
 import com.microsoft.recognizers.text.datetime.parsers.config.IDurationParserConfiguration;
 import java.util.regex.Pattern;
 
-public class FrenchDurationParserConfiguration
-    extends BaseOptionsConfiguration
-    implements IDurationParserConfiguration {
+public class FrenchDurationParserConfiguration extends BaseOptionsConfiguration implements IDurationParserConfiguration {
 
     private final IExtractor cardinalExtractor;
     private final IExtractor durationExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
@@ -162,12 +162,10 @@ public class FrenchHolidayParserConfiguration
         if (trimmedText.endsWith("prochain")) {
             // next - 'l'annee prochain'
             swift = 1;
-        }
-        else if (trimmedText.endsWith("dernier")) {
+        } else if (trimmedText.endsWith("dernier")) {
             // last - 'l'annee dernier'
             swift = -1;
-        }
-        else if (trimmedText.endsWith("cette")) {
+        } else if (trimmedText.endsWith("cette")) {
             // this - 'cette annees'
             swift = 0;
         }
@@ -183,46 +181,47 @@ public class FrenchHolidayParserConfiguration
 
     protected HashMap<String, IntFunction<LocalDateTime>> initHolidayFuncs() {
         return new HashMap<String, IntFunction<LocalDateTime>>(super.initHolidayFuncs()) {{
-            put("maosbirthday", FrenchHolidayParserConfiguration::maoBirthday);
-            put("yuandan", FrenchHolidayParserConfiguration::newYear);
-            put("teachersday", FrenchHolidayParserConfiguration::teacherDay);
-            put("singleday", FrenchHolidayParserConfiguration::singlesDay);
-            put("allsaintsday", FrenchHolidayParserConfiguration::halloweenDay);
-            put("youthday", FrenchHolidayParserConfiguration::youthDay);
-            put("childrenday", FrenchHolidayParserConfiguration::childrenDay);
-            put("femaleday", FrenchHolidayParserConfiguration::femaleDay);
-            put("treeplantingday", FrenchHolidayParserConfiguration::treePlantDay);
-            put("arborday", FrenchHolidayParserConfiguration::treePlantDay);
-            put("girlsday", FrenchHolidayParserConfiguration::girlsDay);
-            put("whiteloverday", FrenchHolidayParserConfiguration::whiteLoverDay);
-            put("loverday", FrenchHolidayParserConfiguration::valentinesDay);
-            put("christmas", FrenchHolidayParserConfiguration::christmasDay);
-            put("xmas", FrenchHolidayParserConfiguration::christmasDay);
-            put("newyear", FrenchHolidayParserConfiguration::newYear);
-            put("newyearday", FrenchHolidayParserConfiguration::newYear);
-            put("newyearsday", FrenchHolidayParserConfiguration::newYear);
-            put("inaugurationday", FrenchHolidayParserConfiguration::inaugurationDay);
-            put("groundhougday", FrenchHolidayParserConfiguration::groundhogDay);
-            put("valentinesday", FrenchHolidayParserConfiguration::valentinesDay);
-            put("stpatrickday", FrenchHolidayParserConfiguration::stPatrickDay);
-            put("aprilfools", FrenchHolidayParserConfiguration::foolDay);
-            put("stgeorgeday", FrenchHolidayParserConfiguration::stGeorgeDay);
-            put("mayday", FrenchHolidayParserConfiguration::mayday);
-            put("cincodemayoday", FrenchHolidayParserConfiguration::cincoDeMayoday);
-            put("baptisteday", FrenchHolidayParserConfiguration::baptisteDay);
-            put("usindependenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
-            put("independenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
-            put("bastilleday", FrenchHolidayParserConfiguration::bastilleDay);
-            put("halloweenday", FrenchHolidayParserConfiguration::halloweenDay);
-            put("allhallowday", FrenchHolidayParserConfiguration::allHallowDay);
-            put("allsoulsday", FrenchHolidayParserConfiguration::allSoulsday);
-            put("guyfawkesday", FrenchHolidayParserConfiguration::guyFawkesDay);
-            put("veteransday", FrenchHolidayParserConfiguration::veteransday);
-            put("christmaseve", FrenchHolidayParserConfiguration::christmasEve);
-            put("newyeareve", FrenchHolidayParserConfiguration::newYearEve);
-            put("fathersday", FrenchHolidayParserConfiguration::fathersDay);
-            put("mothersday", FrenchHolidayParserConfiguration::mothersDay);
-            put("labourday", FrenchHolidayParserConfiguration::labourDay);
-        }};
+                put("maosbirthday", FrenchHolidayParserConfiguration::maoBirthday);
+                put("yuandan", FrenchHolidayParserConfiguration::newYear);
+                put("teachersday", FrenchHolidayParserConfiguration::teacherDay);
+                put("singleday", FrenchHolidayParserConfiguration::singlesDay);
+                put("allsaintsday", FrenchHolidayParserConfiguration::halloweenDay);
+                put("youthday", FrenchHolidayParserConfiguration::youthDay);
+                put("childrenday", FrenchHolidayParserConfiguration::childrenDay);
+                put("femaleday", FrenchHolidayParserConfiguration::femaleDay);
+                put("treeplantingday", FrenchHolidayParserConfiguration::treePlantDay);
+                put("arborday", FrenchHolidayParserConfiguration::treePlantDay);
+                put("girlsday", FrenchHolidayParserConfiguration::girlsDay);
+                put("whiteloverday", FrenchHolidayParserConfiguration::whiteLoverDay);
+                put("loverday", FrenchHolidayParserConfiguration::valentinesDay);
+                put("christmas", FrenchHolidayParserConfiguration::christmasDay);
+                put("xmas", FrenchHolidayParserConfiguration::christmasDay);
+                put("newyear", FrenchHolidayParserConfiguration::newYear);
+                put("newyearday", FrenchHolidayParserConfiguration::newYear);
+                put("newyearsday", FrenchHolidayParserConfiguration::newYear);
+                put("inaugurationday", FrenchHolidayParserConfiguration::inaugurationDay);
+                put("groundhougday", FrenchHolidayParserConfiguration::groundhogDay);
+                put("valentinesday", FrenchHolidayParserConfiguration::valentinesDay);
+                put("stpatrickday", FrenchHolidayParserConfiguration::stPatrickDay);
+                put("aprilfools", FrenchHolidayParserConfiguration::foolDay);
+                put("stgeorgeday", FrenchHolidayParserConfiguration::stGeorgeDay);
+                put("mayday", FrenchHolidayParserConfiguration::mayday);
+                put("cincodemayoday", FrenchHolidayParserConfiguration::cincoDeMayoday);
+                put("baptisteday", FrenchHolidayParserConfiguration::baptisteDay);
+                put("usindependenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
+                put("independenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
+                put("bastilleday", FrenchHolidayParserConfiguration::bastilleDay);
+                put("halloweenday", FrenchHolidayParserConfiguration::halloweenDay);
+                put("allhallowday", FrenchHolidayParserConfiguration::allHallowDay);
+                put("allsoulsday", FrenchHolidayParserConfiguration::allSoulsday);
+                put("guyfawkesday", FrenchHolidayParserConfiguration::guyFawkesDay);
+                put("veteransday", FrenchHolidayParserConfiguration::veteransday);
+                put("christmaseve", FrenchHolidayParserConfiguration::christmasEve);
+                put("newyeareve", FrenchHolidayParserConfiguration::newYearEve);
+                put("fathersday", FrenchHolidayParserConfiguration::fathersDay);
+                put("mothersday", FrenchHolidayParserConfiguration::mothersDay);
+                put("labourday", FrenchHolidayParserConfiguration::labourDay);
+            }
+        };
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
@@ -1,19 +1,18 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
 
-import com.google.common.collect.ImmutableMap;
-import com.microsoft.recognizers.text.datetime.french.extractors.FrenchHolidayExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParserConfiguration;
-import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
-import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
-
 public class FrenchHolidayParserConfiguration
-        extends BaseHolidayParserConfiguration {
+    extends BaseHolidayParserConfiguration {
 
     public FrenchHolidayParserConfiguration() {
 
@@ -178,8 +177,8 @@ public class FrenchHolidayParserConfiguration
 
     public String sanitizeHolidayToken(final String holiday) {
         return holiday
-                .replaceAll(" ", "")
-                .replaceAll("'", "");
+            .replaceAll(" ", "")
+            .replaceAll("'", "");
     }
 
     protected HashMap<String, IntFunction<LocalDateTime>> initHolidayFuncs() {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
@@ -1,0 +1,229 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+
+public class FrenchHolidayParserConfiguration
+        extends BaseHolidayParserConfiguration {
+
+    public FrenchHolidayParserConfiguration() {
+
+        setHolidayRegexList(FrenchHolidayExtractorConfiguration.HolidayRegexList);
+
+        final HashMap<String, Iterable<String>> holidayNamesMap = new HashMap<>();
+        for (final Map.Entry<String, String[]> entry : FrenchDateTime.HolidayNames.entrySet()) {
+            if (entry.getValue() instanceof String[]) {
+                holidayNamesMap.put(entry.getKey(), Arrays.asList(entry.getValue()));
+            }
+        }
+        setHolidayNames(ImmutableMap.copyOf(holidayNamesMap));
+    }
+
+    private static LocalDateTime newYear(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 1, 1);
+    }
+
+    private static LocalDateTime newYearEve(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 31);
+    }
+
+    private static LocalDateTime christmasDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 25);
+    }
+
+    private static LocalDateTime christmasEve(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 24);
+    }
+
+    private static LocalDateTime valentinesDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 2, 14);
+    }
+
+    private static LocalDateTime whiteLoverDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 14);
+    }
+
+    private static LocalDateTime foolDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 4, 1);
+    }
+
+    private static LocalDateTime girlsDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 7);
+    }
+
+    private static LocalDateTime treePlantDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 12);
+    }
+
+    private static LocalDateTime femaleDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 8);
+    }
+
+    private static LocalDateTime childrenDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 6, 1);
+    }
+
+    private static LocalDateTime youthDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 5, 4);
+    }
+
+    private static LocalDateTime teacherDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 9, 10);
+    }
+
+    private static LocalDateTime singlesDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 11, 11);
+    }
+
+    private static LocalDateTime maoBirthday(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 12, 26);
+    }
+
+    private static LocalDateTime inaugurationDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 1, 20);
+    }
+
+    private static LocalDateTime groundhogDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 2, 2);
+    }
+
+    private static LocalDateTime stPatrickDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 3, 17);
+    }
+
+    private static LocalDateTime stGeorgeDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 4, 23);
+    }
+
+    private static LocalDateTime mayday(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 5, 1);
+    }
+
+    private static LocalDateTime cincoDeMayoday(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 5, 5);
+    }
+
+    private static LocalDateTime baptisteDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 6, 24);
+    }
+
+    private static LocalDateTime usaIndependenceDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 7, 4);
+    }
+
+    private static LocalDateTime bastilleDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 7, 14);
+    }
+
+    private static LocalDateTime halloweenDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 10, 31);
+    }
+
+    private static LocalDateTime allHallowDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 11, 1);
+    }
+
+    private static LocalDateTime allSoulsday(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 11, 2);
+    }
+
+    private static LocalDateTime guyFawkesDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 11, 5);
+    }
+
+    private static LocalDateTime veteransday(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 11, 11);
+    }
+
+    protected static LocalDateTime fathersDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 6, 17);
+    }
+
+    protected static LocalDateTime mothersDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 5, 27);
+    }
+
+    protected static LocalDateTime labourDay(final int year) {
+        return DateUtil.safeCreateFromMinValue(year, 5, 1);
+    }
+
+    @Override
+    public int getSwiftYear(final String text) {
+        final String trimmedText = text.trim();
+        int swift = -10;
+        if (trimmedText.endsWith("prochain")) {
+            // next - 'l'annee prochain'
+            swift = 1;
+        }
+        else if (trimmedText.endsWith("dernier")) {
+            // last - 'l'annee dernier'
+            swift = -1;
+        }
+        else if (trimmedText.endsWith("cette")) {
+            // this - 'cette annees'
+            swift = 0;
+        }
+
+        return swift;
+    }
+
+    public String sanitizeHolidayToken(final String holiday) {
+        return holiday
+                .replaceAll(" ", "")
+                .replaceAll("'", "");
+    }
+
+    protected HashMap<String, IntFunction<LocalDateTime>> initHolidayFuncs() {
+        return new HashMap<String, IntFunction<LocalDateTime>>(super.initHolidayFuncs()) {{
+            put("maosbirthday", FrenchHolidayParserConfiguration::maoBirthday);
+            put("yuandan", FrenchHolidayParserConfiguration::newYear);
+            put("teachersday", FrenchHolidayParserConfiguration::teacherDay);
+            put("singleday", FrenchHolidayParserConfiguration::singlesDay);
+            put("allsaintsday", FrenchHolidayParserConfiguration::halloweenDay);
+            put("youthday", FrenchHolidayParserConfiguration::youthDay);
+            put("childrenday", FrenchHolidayParserConfiguration::childrenDay);
+            put("femaleday", FrenchHolidayParserConfiguration::femaleDay);
+            put("treeplantingday", FrenchHolidayParserConfiguration::treePlantDay);
+            put("arborday", FrenchHolidayParserConfiguration::treePlantDay);
+            put("girlsday", FrenchHolidayParserConfiguration::girlsDay);
+            put("whiteloverday", FrenchHolidayParserConfiguration::whiteLoverDay);
+            put("loverday", FrenchHolidayParserConfiguration::valentinesDay);
+            put("christmas", FrenchHolidayParserConfiguration::christmasDay);
+            put("xmas", FrenchHolidayParserConfiguration::christmasDay);
+            put("newyear", FrenchHolidayParserConfiguration::newYear);
+            put("newyearday", FrenchHolidayParserConfiguration::newYear);
+            put("newyearsday", FrenchHolidayParserConfiguration::newYear);
+            put("inaugurationday", FrenchHolidayParserConfiguration::inaugurationDay);
+            put("groundhougday", FrenchHolidayParserConfiguration::groundhogDay);
+            put("valentinesday", FrenchHolidayParserConfiguration::valentinesDay);
+            put("stpatrickday", FrenchHolidayParserConfiguration::stPatrickDay);
+            put("aprilfools", FrenchHolidayParserConfiguration::foolDay);
+            put("stgeorgeday", FrenchHolidayParserConfiguration::stGeorgeDay);
+            put("mayday", FrenchHolidayParserConfiguration::mayday);
+            put("cincodemayoday", FrenchHolidayParserConfiguration::cincoDeMayoday);
+            put("baptisteday", FrenchHolidayParserConfiguration::baptisteDay);
+            put("usindependenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
+            put("independenceday", FrenchHolidayParserConfiguration::usaIndependenceDay);
+            put("bastilleday", FrenchHolidayParserConfiguration::bastilleDay);
+            put("halloweenday", FrenchHolidayParserConfiguration::halloweenDay);
+            put("allhallowday", FrenchHolidayParserConfiguration::allHallowDay);
+            put("allsoulsday", FrenchHolidayParserConfiguration::allSoulsday);
+            put("guyfawkesday", FrenchHolidayParserConfiguration::guyFawkesDay);
+            put("veteransday", FrenchHolidayParserConfiguration::veteransday);
+            put("christmaseve", FrenchHolidayParserConfiguration::christmasEve);
+            put("newyeareve", FrenchHolidayParserConfiguration::newYearEve);
+            put("fathersday", FrenchHolidayParserConfiguration::fathersDay);
+            put("mothersday", FrenchHolidayParserConfiguration::mothersDay);
+            put("labourday", FrenchHolidayParserConfiguration::labourDay);
+        }};
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchHolidayParserConfiguration.java
@@ -11,8 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
 
-public class FrenchHolidayParserConfiguration
-    extends BaseHolidayParserConfiguration {
+public class FrenchHolidayParserConfiguration extends BaseHolidayParserConfiguration {
 
     public FrenchHolidayParserConfiguration() {
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.DateTimeOptions;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchMergedExtractorConfiguration;
@@ -10,10 +8,11 @@ import com.microsoft.recognizers.text.datetime.parsers.BaseSetParser;
 import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.parsers.config.IMergedParserConfiguration;
 import com.microsoft.recognizers.text.matcher.StringMatcher;
+import java.util.regex.Pattern;
 
 public class FrenchMergedParserConfiguration
-        extends FrenchCommonDateTimeParserConfiguration
-        implements IMergedParserConfiguration {
+    extends FrenchCommonDateTimeParserConfiguration
+    implements IMergedParserConfiguration {
 
     public FrenchMergedParserConfiguration(final DateTimeOptions options) {
         super(options);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
@@ -10,9 +10,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.IMergedParserConfi
 import com.microsoft.recognizers.text.matcher.StringMatcher;
 import java.util.regex.Pattern;
 
-public class FrenchMergedParserConfiguration
-    extends FrenchCommonDateTimeParserConfiguration
-    implements IMergedParserConfiguration {
+public class FrenchMergedParserConfiguration extends FrenchCommonDateTimeParserConfiguration implements IMergedParserConfiguration {
 
     public FrenchMergedParserConfiguration(final DateTimeOptions options) {
         super(options);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchMergedParserConfiguration.java
@@ -1,0 +1,78 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.DateTimeOptions;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchMergedExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseHolidayParser;
+import com.microsoft.recognizers.text.datetime.parsers.BaseSetParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.IMergedParserConfiguration;
+import com.microsoft.recognizers.text.matcher.StringMatcher;
+
+public class FrenchMergedParserConfiguration
+        extends FrenchCommonDateTimeParserConfiguration
+        implements IMergedParserConfiguration {
+
+    public FrenchMergedParserConfiguration(final DateTimeOptions options) {
+        super(options);
+
+        beforeRegex = FrenchMergedExtractorConfiguration.BeforeRegex;
+        afterRegex = FrenchMergedExtractorConfiguration.AfterRegex;
+        sinceRegex = FrenchMergedExtractorConfiguration.SinceRegex;
+        aroundRegex = FrenchMergedExtractorConfiguration.AroundRegex;
+        suffixAfterRegex = FrenchMergedExtractorConfiguration.SuffixAfterRegex;
+        yearRegex = FrenchDatePeriodExtractorConfiguration.YearRegex;
+        superfluousWordMatcher = FrenchMergedExtractorConfiguration.SuperfluousWordMatcher;
+
+        getParser = new BaseSetParser(new FrenchSetParserConfiguration(this));
+        holidayParser = new BaseHolidayParser(new FrenchHolidayParserConfiguration());
+    }
+
+    private final Pattern beforeRegex;
+    private final Pattern afterRegex;
+    private final Pattern sinceRegex;
+    private final Pattern aroundRegex;
+    private final Pattern suffixAfterRegex;
+    private final Pattern yearRegex;
+    private final IDateTimeParser getParser;
+    private final IDateTimeParser holidayParser;
+    private final StringMatcher superfluousWordMatcher;
+
+    public Pattern getBeforeRegex() {
+        return beforeRegex;
+    }
+
+    public Pattern getAfterRegex() {
+        return afterRegex;
+    }
+
+    public Pattern getSinceRegex() {
+        return sinceRegex;
+    }
+
+    public Pattern getAroundRegex() {
+        return aroundRegex;
+    }
+
+    public Pattern getSuffixAfterRegex() {
+        return suffixAfterRegex;
+    }
+
+    public Pattern getYearRegex() {
+        return yearRegex;
+    }
+
+    public IDateTimeParser getGetParser() {
+        return getParser;
+    }
+
+    public IDateTimeParser getHolidayParser() {
+        return holidayParser;
+    }
+
+    public StringMatcher getSuperfluousWordMatcher() {
+        return superfluousWordMatcher;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
@@ -11,10 +9,11 @@ import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
 import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.config.ISetParserConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.MatchedTimexResult;
+import java.util.regex.Pattern;
 
 public class FrenchSetParserConfiguration
-        extends BaseOptionsConfiguration
-        implements ISetParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements ISetParserConfiguration {
 
     private final IDateTimeExtractor durationExtractor;
     private final IDateTimeParser durationParser;
@@ -155,7 +154,7 @@ public class FrenchSetParserConfiguration
         final String trimmedText = text.trim();
         final String timex;
         if (trimmedText.equals("quotidien") || trimmedText.equals("quotidienne") ||
-                trimmedText.equals("jours") || trimmedText.equals("journellement")) {
+            trimmedText.equals("jours") || trimmedText.equals("journellement")) {
             // daily
             timex = "P1D";
         }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
@@ -1,0 +1,207 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchSetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ISetParserConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.MatchedTimexResult;
+
+public class FrenchSetParserConfiguration
+        extends BaseOptionsConfiguration
+        implements ISetParserConfiguration {
+
+    private final IDateTimeExtractor durationExtractor;
+    private final IDateTimeParser durationParser;
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeParser timeParser;
+    private final IDateExtractor dateExtractor;
+    private final IDateTimeParser dateParser;
+    private final IDateTimeExtractor dateTimeExtractor;
+    private final IDateTimeParser dateTimeParser;
+    private final IDateTimeExtractor datePeriodExtractor;
+    private final IDateTimeParser datePeriodParser;
+    private final IDateTimeExtractor timePeriodExtractor;
+    private final IDateTimeParser timePeriodParser;
+    private final IDateTimeExtractor dateTimePeriodExtractor;
+    private final IDateTimeParser dateTimePeriodParser;
+    private final ImmutableMap<String, String> unitMap;
+    private final Pattern eachPrefixRegex;
+    private final Pattern periodicRegex;
+    private final Pattern eachUnitRegex;
+    private final Pattern eachDayRegex;
+    private final Pattern setWeekDayRegex;
+    private final Pattern setEachRegex;
+
+    public FrenchSetParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        durationExtractor = config.getDurationExtractor();
+        timeExtractor = config.getTimeExtractor();
+        dateExtractor = config.getDateExtractor();
+        dateTimeExtractor = config.getDateTimeExtractor();
+        datePeriodExtractor = config.getDatePeriodExtractor();
+        timePeriodExtractor = config.getTimePeriodExtractor();
+        dateTimePeriodExtractor = config.getDateTimePeriodExtractor();
+
+        durationParser = config.getDurationParser();
+        timeParser = config.getTimeParser();
+        dateParser = config.getDateParser();
+        dateTimeParser = config.getDateTimeParser();
+        datePeriodParser = config.getDatePeriodParser();
+        timePeriodParser = config.getTimePeriodParser();
+        dateTimePeriodParser = config.getDateTimePeriodParser();
+        unitMap = config.getUnitMap();
+
+        eachPrefixRegex = FrenchSetExtractorConfiguration.EachPrefixRegex;
+        periodicRegex = FrenchSetExtractorConfiguration.PeriodicRegex;
+        eachUnitRegex = FrenchSetExtractorConfiguration.EachUnitRegex;
+        eachDayRegex = FrenchSetExtractorConfiguration.EachDayRegex;
+        setWeekDayRegex = FrenchSetExtractorConfiguration.SetWeekDayRegex;
+        setEachRegex = FrenchSetExtractorConfiguration.SetEachRegex;
+    }
+
+    public final IDateTimeExtractor getDurationExtractor() {
+        return durationExtractor;
+    }
+
+    public final IDateTimeParser getDurationParser() {
+        return durationParser;
+    }
+
+    public final IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    public final IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    public final IDateExtractor getDateExtractor() {
+        return dateExtractor;
+    }
+
+    public final IDateTimeParser getDateParser() {
+        return dateParser;
+    }
+
+    public final IDateTimeExtractor getDateTimeExtractor() {
+        return dateTimeExtractor;
+    }
+
+    public final IDateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    public final IDateTimeExtractor getDatePeriodExtractor() {
+        return datePeriodExtractor;
+    }
+
+    public final IDateTimeParser getDatePeriodParser() {
+        return datePeriodParser;
+    }
+
+    public final IDateTimeExtractor getTimePeriodExtractor() {
+        return timePeriodExtractor;
+    }
+
+    public final IDateTimeParser getTimePeriodParser() {
+        return timePeriodParser;
+    }
+
+    public final IDateTimeExtractor getDateTimePeriodExtractor() {
+        return dateTimePeriodExtractor;
+    }
+
+    public final IDateTimeParser getDateTimePeriodParser() {
+        return dateTimePeriodParser;
+    }
+
+    public final ImmutableMap<String, String> getUnitMap() {
+        return unitMap;
+    }
+
+    public final Pattern getEachPrefixRegex() {
+        return eachPrefixRegex;
+    }
+
+    public final Pattern getPeriodicRegex() {
+        return periodicRegex;
+    }
+
+    public final Pattern getEachUnitRegex() {
+        return eachUnitRegex;
+    }
+
+    public final Pattern getEachDayRegex() {
+        return eachDayRegex;
+    }
+
+    public final Pattern getSetWeekDayRegex() {
+        return setWeekDayRegex;
+    }
+
+    public final Pattern getSetEachRegex() {
+        return setEachRegex;
+    }
+
+    public MatchedTimexResult getMatchedDailyTimex(final String text) {
+        final String trimmedText = text.trim();
+        final String timex;
+        if (trimmedText.equals("quotidien") || trimmedText.equals("quotidienne") ||
+                trimmedText.equals("jours") || trimmedText.equals("journellement")) {
+            // daily
+            timex = "P1D";
+        }
+        else if (trimmedText.equals("hebdomadaire")) {
+            // weekly
+            timex = "P1W";
+        }
+        else if (trimmedText.equals("bihebdomadaire")) {
+            // bi weekly
+            timex = "P2W";
+        }
+        else if (trimmedText.equals("mensuel") || trimmedText.equals("mensuelle")) {
+            // monthly
+            timex = "P1M";
+        }
+        else if (trimmedText.equals("annuel") || trimmedText.equals("annuellement")) {
+            // yearly/annually
+            timex = "P1Y";
+        }
+        else {
+            return new MatchedTimexResult(false, null);
+        }
+
+        return new MatchedTimexResult(true, timex);
+    }
+
+    public MatchedTimexResult getMatchedUnitTimex(final String text) {
+        final String trimmedText = text.trim();
+        final String timex;
+        if (trimmedText.equals("jour") || trimmedText.equals("journee")) {
+            timex = "P1D";
+        }
+        else if (trimmedText.equals("semaine")) {
+            timex = "P1W";
+        }
+        else if (trimmedText.equals("mois")) {
+            timex = "P1M";
+        }
+        else if (trimmedText.equals("an") || trimmedText.equals("annee")) {
+            // year
+            timex = "P1Y";
+        }
+        else {
+            return new MatchedTimexResult(false, null);
+        }
+
+        return new MatchedTimexResult(true, timex);
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
@@ -157,24 +157,19 @@ public class FrenchSetParserConfiguration
             trimmedText.equals("jours") || trimmedText.equals("journellement")) {
             // daily
             timex = "P1D";
-        }
-        else if (trimmedText.equals("hebdomadaire")) {
+        } else if (trimmedText.equals("hebdomadaire")) {
             // weekly
             timex = "P1W";
-        }
-        else if (trimmedText.equals("bihebdomadaire")) {
+        } else if (trimmedText.equals("bihebdomadaire")) {
             // bi weekly
             timex = "P2W";
-        }
-        else if (trimmedText.equals("mensuel") || trimmedText.equals("mensuelle")) {
+        } else if (trimmedText.equals("mensuel") || trimmedText.equals("mensuelle")) {
             // monthly
             timex = "P1M";
-        }
-        else if (trimmedText.equals("annuel") || trimmedText.equals("annuellement")) {
+        } else if (trimmedText.equals("annuel") || trimmedText.equals("annuellement")) {
             // yearly/annually
             timex = "P1Y";
-        }
-        else {
+        } else {
             return new MatchedTimexResult(false, null);
         }
 
@@ -186,18 +181,14 @@ public class FrenchSetParserConfiguration
         final String timex;
         if (trimmedText.equals("jour") || trimmedText.equals("journee")) {
             timex = "P1D";
-        }
-        else if (trimmedText.equals("semaine")) {
+        } else if (trimmedText.equals("semaine")) {
             timex = "P1W";
-        }
-        else if (trimmedText.equals("mois")) {
+        } else if (trimmedText.equals("mois")) {
             timex = "P1M";
-        }
-        else if (trimmedText.equals("an") || trimmedText.equals("annee")) {
+        } else if (trimmedText.equals("an") || trimmedText.equals("annee")) {
             // year
             timex = "P1Y";
-        }
-        else {
+        } else {
             return new MatchedTimexResult(false, null);
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchSetParserConfiguration.java
@@ -11,9 +11,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.ISetParserConfigur
 import com.microsoft.recognizers.text.datetime.utilities.MatchedTimexResult;
 import java.util.regex.Pattern;
 
-public class FrenchSetParserConfiguration
-    extends BaseOptionsConfiguration
-    implements ISetParserConfiguration {
+public class FrenchSetParserConfiguration extends BaseOptionsConfiguration implements ISetParserConfiguration {
 
     private final IDateTimeExtractor durationExtractor;
     private final IDateTimeParser durationParser;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
@@ -1,0 +1,59 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.time.LocalDateTime;
+
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ITimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.ConditionalMatch;
+import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResult;
+import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+public class FrenchTimeParser
+        extends BaseTimeParser {
+
+    public FrenchTimeParser(final ITimeParserConfiguration config) {
+        super(config);
+    }
+
+    @Override
+    protected DateTimeResolutionResult internalParse(final String text, final LocalDateTime referenceTime) {
+        DateTimeResolutionResult innerResult = super.internalParse(text, referenceTime);
+
+        if (!innerResult.getSuccess()) {
+            innerResult = parseIsh(text, referenceTime);
+        }
+
+        return innerResult;
+    }
+
+    // parse "noonish", "11-ish"
+    private DateTimeResolutionResult parseIsh(final String text, final LocalDateTime referenceTime) {
+        final DateTimeResolutionResult result = new DateTimeResolutionResult();
+
+        final ConditionalMatch match = RegexExtension.matchExact(FrenchTimeExtractorConfiguration.IshRegex, text, true);
+        if (match.getSuccess()) {
+            final String hourStr = match.getMatch().get().getGroup(Constants.HourGroupName).value;
+            int hour = Constants.HalfDayHourCount;
+
+            if (!StringUtility.isNullOrEmpty(hourStr)) {
+                hour = Integer.parseInt(hourStr);
+            }
+
+            result.setTimex(String.format("T%02d", hour));
+            final LocalDateTime resultTime = DateUtil.safeCreateFromMinValue(
+                    referenceTime.getYear(),
+                    referenceTime.getMonthValue(),
+                    referenceTime.getDayOfMonth(),
+                    hour, 0, 0);
+            result.setFutureValue(resultTime);
+            result.setPastValue(resultTime);
+            result.setSuccess(true);
+        }
+
+        return result;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.time.LocalDateTime;
-
 import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.BaseTimeParser;
@@ -11,9 +9,10 @@ import com.microsoft.recognizers.text.datetime.utilities.DateTimeResolutionResul
 import com.microsoft.recognizers.text.datetime.utilities.DateUtil;
 import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.utilities.StringUtility;
+import java.time.LocalDateTime;
 
 public class FrenchTimeParser
-        extends BaseTimeParser {
+    extends BaseTimeParser {
 
     public FrenchTimeParser(final ITimeParserConfiguration config) {
         super(config);
@@ -45,10 +44,10 @@ public class FrenchTimeParser
 
             result.setTimex(String.format("T%02d", hour));
             final LocalDateTime resultTime = DateUtil.safeCreateFromMinValue(
-                    referenceTime.getYear(),
-                    referenceTime.getMonthValue(),
-                    referenceTime.getDayOfMonth(),
-                    hour, 0, 0);
+                referenceTime.getYear(),
+                referenceTime.getMonthValue(),
+                referenceTime.getDayOfMonth(),
+                hour, 0, 0);
             result.setFutureValue(resultTime);
             result.setPastValue(resultTime);
             result.setSuccess(true);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParser.java
@@ -11,8 +11,7 @@ import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.utilities.StringUtility;
 import java.time.LocalDateTime;
 
-public class FrenchTimeParser
-    extends BaseTimeParser {
+public class FrenchTimeParser extends BaseTimeParser {
 
     public FrenchTimeParser(final ITimeParserConfiguration config) {
         super(config);

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
@@ -1,0 +1,164 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.BaseTimeZoneParser;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ITimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.PrefixAdjustResult;
+import com.microsoft.recognizers.text.datetime.parsers.config.SuffixAdjustResult;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.ConditionalMatch;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
+import com.microsoft.recognizers.text.utilities.Match;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import com.microsoft.recognizers.text.utilities.StringUtility;
+
+public class FrenchTimeParserConfiguration
+        extends BaseOptionsConfiguration
+        implements ITimeParserConfiguration {
+
+    public final Pattern atRegex;
+    private final Iterable<Pattern> timeRegexes;
+    private final ImmutableMap<String, Integer> numbers;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+    private final IDateTimeParser timeZoneParser;
+    public String timeTokenPrefix = FrenchDateTime.TimeTokenPrefix;
+    public Pattern mealTimeRegex;
+
+    public FrenchTimeParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        numbers = config.getNumbers();
+        utilityConfiguration = config.getUtilityConfiguration();
+        timeZoneParser = new BaseTimeZoneParser();
+
+        atRegex = FrenchTimeExtractorConfiguration.AtRegex;
+        timeRegexes = FrenchTimeExtractorConfiguration.TimeRegexList;
+    }
+
+    @Override
+    public String getTimeTokenPrefix() {
+        return timeTokenPrefix;
+    }
+
+    @Override
+    public Pattern getAtRegex() {
+        return atRegex;
+    }
+
+    @Override
+    public Iterable<Pattern> getTimeRegexes() {
+        return timeRegexes;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public PrefixAdjustResult adjustByPrefix(final String prefix, int hour, int min, final boolean hasMin) {
+
+        int deltaMin = 0;
+        final String trimmedPrefix = prefix.trim();
+
+        // c'este 8 heures et demie, - "it's half past 8"
+        if (trimmedPrefix.endsWith("demie")) {
+            deltaMin = 30;
+        }
+        else if (trimmedPrefix.endsWith("un quart") || trimmedPrefix.endsWith("quart")) {
+            deltaMin = 15;
+        }
+        else if (trimmedPrefix.endsWith("trois quarts")) {
+            deltaMin = 45;
+        }
+        else {
+            final Match[] match = RegExpUtility
+                    .getMatches(FrenchTimeExtractorConfiguration.LessThanOneHour, trimmedPrefix);
+            String minStr;
+            if (match.length > 0) {
+                minStr = match[0].getGroup("deltamin").value;
+                if (!StringUtility.isNullOrEmpty(minStr)) {
+                    deltaMin = Integer.parseInt(minStr);
+                }
+                else {
+                    minStr = match[0].getGroup("deltaminnum").value;
+                    deltaMin = numbers.get(minStr);
+                }
+            }
+
+        }
+
+        // 'to' i.e 'one to five' = 'un à cinq'
+        if (trimmedPrefix.endsWith("à")) {
+            deltaMin = -deltaMin;
+        }
+
+        min += deltaMin;
+        if (min < 0) {
+            min += 60;
+            hour -= 1;
+        }
+
+        return new PrefixAdjustResult(hour, min, true);
+    }
+
+    @Override
+    public SuffixAdjustResult adjustBySuffix(final String suffix,
+                                             int hour,
+                                             final int min,
+                                             final boolean hasMin,
+                                             boolean hasAm,
+                                             boolean hasPm) {
+
+        int deltaHour = 0;
+        final ConditionalMatch match = RegexExtension
+                .matchExact(FrenchTimeExtractorConfiguration.TimeSuffix, suffix, true);
+
+        if (match.getSuccess()) {
+            final String oclockStr = match.getMatch().get().getGroup("heures").value;
+            if (StringUtility.isNullOrEmpty(oclockStr)) {
+                final String matchAmStr = match.getMatch().get().getGroup(Constants.AmGroupName).value;
+                if (!StringUtility.isNullOrEmpty(matchAmStr)) {
+                    if (hour >= Constants.HalfDayHourCount) {
+                        deltaHour = -Constants.HalfDayHourCount;
+                    }
+
+                    hasAm = true;
+                }
+
+                final String matchPmStr = match.getMatch().get().getGroup(Constants.PmGroupName).value;
+                if (!StringUtility.isNullOrEmpty(matchPmStr)) {
+                    if (hour < Constants.HalfDayHourCount) {
+                        deltaHour = Constants.HalfDayHourCount;
+                    }
+
+                    hasPm = true;
+                }
+            }
+        }
+
+        hour = (hour + deltaHour) % 24;
+
+        return new SuffixAdjustResult(hour, min, hasMin, hasAm, hasPm);
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
@@ -1,8 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.datetime.Constants;
 import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
@@ -20,10 +17,11 @@ import com.microsoft.recognizers.text.datetime.utilities.RegexExtension;
 import com.microsoft.recognizers.text.utilities.Match;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
+import java.util.regex.Pattern;
 
 public class FrenchTimeParserConfiguration
-        extends BaseOptionsConfiguration
-        implements ITimeParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements ITimeParserConfiguration {
 
     public final Pattern atRegex;
     private final Iterable<Pattern> timeRegexes;
@@ -93,7 +91,7 @@ public class FrenchTimeParserConfiguration
         }
         else {
             final Match[] match = RegExpUtility
-                    .getMatches(FrenchTimeExtractorConfiguration.LessThanOneHour, trimmedPrefix);
+                .getMatches(FrenchTimeExtractorConfiguration.LessThanOneHour, trimmedPrefix);
             String minStr;
             if (match.length > 0) {
                 minStr = match[0].getGroup("deltamin").value;
@@ -132,7 +130,7 @@ public class FrenchTimeParserConfiguration
 
         int deltaHour = 0;
         final ConditionalMatch match = RegexExtension
-                .matchExact(FrenchTimeExtractorConfiguration.TimeSuffix, suffix, true);
+            .matchExact(FrenchTimeExtractorConfiguration.TimeSuffix, suffix, true);
 
         if (match.getSuccess()) {
             final String oclockStr = match.getMatch().get().getGroup("heures").value;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
@@ -82,14 +82,11 @@ public class FrenchTimeParserConfiguration
         // c'este 8 heures et demie, - "it's half past 8"
         if (trimmedPrefix.endsWith("demie")) {
             deltaMin = 30;
-        }
-        else if (trimmedPrefix.endsWith("un quart") || trimmedPrefix.endsWith("quart")) {
+        } else if (trimmedPrefix.endsWith("un quart") || trimmedPrefix.endsWith("quart")) {
             deltaMin = 15;
-        }
-        else if (trimmedPrefix.endsWith("trois quarts")) {
+        } else if (trimmedPrefix.endsWith("trois quarts")) {
             deltaMin = 45;
-        }
-        else {
+        } else {
             final Match[] match = RegExpUtility
                 .getMatches(FrenchTimeExtractorConfiguration.LessThanOneHour, trimmedPrefix);
             String minStr;
@@ -97,8 +94,7 @@ public class FrenchTimeParserConfiguration
                 minStr = match[0].getGroup("deltamin").value;
                 if (!StringUtility.isNullOrEmpty(minStr)) {
                     deltaMin = Integer.parseInt(minStr);
-                }
-                else {
+                } else {
                     minStr = match[0].getGroup("deltaminnum").value;
                     deltaMin = numbers.get(minStr);
                 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimeParserConfiguration.java
@@ -19,9 +19,7 @@ import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import com.microsoft.recognizers.text.utilities.StringUtility;
 import java.util.regex.Pattern;
 
-public class FrenchTimeParserConfiguration
-    extends BaseOptionsConfiguration
-    implements ITimeParserConfiguration {
+public class FrenchTimeParserConfiguration extends BaseOptionsConfiguration implements ITimeParserConfiguration {
 
     public final Pattern atRegex;
     private final Iterable<Pattern> timeRegexes;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
@@ -16,9 +16,7 @@ import com.microsoft.recognizers.text.datetime.utilities.TimeOfDayResolutionResu
 import com.microsoft.recognizers.text.datetime.utilities.TimexUtility;
 import java.util.regex.Pattern;
 
-public class FrenchTimePeriodParserConfiguration
-    extends BaseOptionsConfiguration
-    implements ITimePeriodParserConfiguration {
+public class FrenchTimePeriodParserConfiguration extends BaseOptionsConfiguration implements ITimePeriodParserConfiguration {
 
     private final IDateTimeExtractor timeExtractor;
     private final IDateTimeParser timeParser;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
@@ -140,20 +140,15 @@ public class FrenchTimePeriodParserConfiguration
         String timeOfDay = "";
         if (FrenchDateTime.MorningTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
             timeOfDay = Constants.Morning;
-        }
-        else if (FrenchDateTime.AfternoonTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+        } else if (FrenchDateTime.AfternoonTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
             timeOfDay = Constants.Afternoon;
-        }
-        else if (FrenchDateTime.EveningTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+        } else if (FrenchDateTime.EveningTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
             timeOfDay = Constants.Evening;
-        }
-        else if (FrenchDateTime.DaytimeTermList.stream().anyMatch(o -> trimmedText.equals(o))) {
+        } else if (FrenchDateTime.DaytimeTermList.stream().anyMatch(o -> trimmedText.equals(o))) {
             timeOfDay = Constants.Daytime;
-        }
-        else if (FrenchDateTime.NightTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+        } else if (FrenchDateTime.NightTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
             timeOfDay = Constants.Night;
-        }
-        else {
+        } else {
             return new MatchedTimeRangeResult(false, null, beginHour, endHour, endMin);
         }
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
@@ -1,0 +1,166 @@
+package com.microsoft.recognizers.text.datetime.french.parsers;
+
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
+import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.datetime.Constants;
+import com.microsoft.recognizers.text.datetime.config.BaseOptionsConfiguration;
+import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.IDateTimeParser;
+import com.microsoft.recognizers.text.datetime.parsers.config.ICommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.ITimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeResult;
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.datetime.utilities.TimeOfDayResolutionResult;
+import com.microsoft.recognizers.text.datetime.utilities.TimexUtility;
+
+public class FrenchTimePeriodParserConfiguration
+        extends BaseOptionsConfiguration
+        implements ITimePeriodParserConfiguration {
+
+    private final IDateTimeExtractor timeExtractor;
+    private final IDateTimeParser timeParser;
+    private final IExtractor integerExtractor;
+    private final IDateTimeParser timeZoneParser;
+
+    private final Pattern pureNumberFromToRegex;
+    private final Pattern pureNumberBetweenAndRegex;
+    private final Pattern specificTimeFromToRegex;
+    private final Pattern specificTimeBetweenAndRegex;
+    private final Pattern timeOfDayRegex;
+    private final Pattern generalEndingRegex;
+    private final Pattern tillRegex;
+
+    private final ImmutableMap<String, Integer> numbers;
+    private final IDateTimeUtilityConfiguration utilityConfiguration;
+
+    public FrenchTimePeriodParserConfiguration(final ICommonDateTimeParserConfiguration config) {
+
+        super(config.getOptions());
+
+        timeExtractor = config.getTimeExtractor();
+        integerExtractor = config.getIntegerExtractor();
+        timeParser = config.getTimeParser();
+        timeZoneParser = config.getTimeZoneParser();
+        pureNumberFromToRegex = FrenchTimePeriodExtractorConfiguration.PureNumFromTo;
+        pureNumberBetweenAndRegex = FrenchTimePeriodExtractorConfiguration.PureNumBetweenAnd;
+        specificTimeFromToRegex = FrenchTimePeriodExtractorConfiguration.SpecificTimeFromTo;
+        specificTimeBetweenAndRegex = FrenchTimePeriodExtractorConfiguration.SpecificTimeBetweenAnd;
+        timeOfDayRegex = FrenchTimePeriodExtractorConfiguration.TimeOfDayRegex;
+        generalEndingRegex = FrenchTimePeriodExtractorConfiguration.GeneralEndingRegex;
+        tillRegex = FrenchTimePeriodExtractorConfiguration.TillRegex;
+        numbers = config.getNumbers();
+        utilityConfiguration = config.getUtilityConfiguration();
+    }
+
+    @Override
+    public IDateTimeExtractor getTimeExtractor() {
+        return timeExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getTimeParser() {
+        return timeParser;
+    }
+
+    @Override
+    public IExtractor getIntegerExtractor() {
+        return integerExtractor;
+    }
+
+    @Override
+    public IDateTimeParser getTimeZoneParser() {
+        return timeZoneParser;
+    }
+
+    @Override
+    public Pattern getPureNumberFromToRegex() {
+        return pureNumberFromToRegex;
+    }
+
+    @Override
+    public Pattern getPureNumberBetweenAndRegex() {
+        return pureNumberBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeFromToRegex() {
+        return specificTimeFromToRegex;
+    }
+
+    @Override
+    public Pattern getSpecificTimeBetweenAndRegex() {
+        return specificTimeBetweenAndRegex;
+    }
+
+    @Override
+    public Pattern getTimeOfDayRegex() {
+        return timeOfDayRegex;
+    }
+
+    @Override
+    public Pattern getGeneralEndingRegex() {
+        return generalEndingRegex;
+    }
+
+    @Override
+    public Pattern getTillRegex() {
+        return tillRegex;
+    }
+
+    @Override
+    public ImmutableMap<String, Integer> getNumbers() {
+        return numbers;
+    }
+
+    @Override
+    public IDateTimeUtilityConfiguration getUtilityConfiguration() {
+        return utilityConfiguration;
+    }
+
+    @Override
+    public MatchedTimeRangeResult getMatchedTimexRange(final String text,
+                                                       final String timex,
+                                                       int beginHour,
+                                                       int endHour,
+                                                       int endMin) {
+        String mutatedText = text.trim();
+        if (mutatedText.endsWith("s")) {
+            mutatedText = mutatedText.substring(0, mutatedText.length() - 1);
+        }
+
+        final String trimmedText = mutatedText;
+
+        beginHour = 0;
+        endHour = 0;
+        endMin = 0;
+
+        String timeOfDay = "";
+        if (FrenchDateTime.MorningTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+            timeOfDay = Constants.Morning;
+        }
+        else if (FrenchDateTime.AfternoonTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+            timeOfDay = Constants.Afternoon;
+        }
+        else if (FrenchDateTime.EveningTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+            timeOfDay = Constants.Evening;
+        }
+        else if (FrenchDateTime.DaytimeTermList.stream().anyMatch(o -> trimmedText.equals(o))) {
+            timeOfDay = Constants.Daytime;
+        }
+        else if (FrenchDateTime.NightTermList.stream().anyMatch(o -> trimmedText.endsWith(o))) {
+            timeOfDay = Constants.Night;
+        }
+        else {
+            return new MatchedTimeRangeResult(false, null, beginHour, endHour, endMin);
+        }
+
+        final TimeOfDayResolutionResult result = TimexUtility.parseTimeOfDay(timeOfDay);
+
+        return new MatchedTimeRangeResult(true, result.getTimex(), result.getBeginHour(), result.getEndHour(),
+                result.getEndMin());
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/parsers/FrenchTimePeriodParserConfiguration.java
@@ -1,7 +1,5 @@
 package com.microsoft.recognizers.text.datetime.french.parsers;
 
-import java.util.regex.Pattern;
-
 import com.google.common.collect.ImmutableMap;
 import com.microsoft.recognizers.text.IExtractor;
 import com.microsoft.recognizers.text.datetime.Constants;
@@ -16,10 +14,11 @@ import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
 import com.microsoft.recognizers.text.datetime.utilities.TimeOfDayResolutionResult;
 import com.microsoft.recognizers.text.datetime.utilities.TimexUtility;
+import java.util.regex.Pattern;
 
 public class FrenchTimePeriodParserConfiguration
-        extends BaseOptionsConfiguration
-        implements ITimePeriodParserConfiguration {
+    extends BaseOptionsConfiguration
+    implements ITimePeriodParserConfiguration {
 
     private final IDateTimeExtractor timeExtractor;
     private final IDateTimeParser timeParser;
@@ -161,6 +160,6 @@ public class FrenchTimePeriodParserConfiguration
         final TimeOfDayResolutionResult result = TimexUtility.parseTimeOfDay(timeOfDay);
 
         return new MatchedTimeRangeResult(true, result.getTimex(), result.getBeginHour(), result.getEndHour(),
-                result.getEndMin());
+            result.getEndMin());
     }
 }

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
@@ -1,0 +1,89 @@
+package com.microsoft.recognizers.text.datetime.french.utilities;
+
+import java.util.regex.Pattern;
+
+import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
+import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
+import com.microsoft.recognizers.text.utilities.RegExpUtility;
+
+public class FrenchDatetimeUtilityConfiguration
+        implements IDateTimeUtilityConfiguration {
+    public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AgoRegex);
+
+    public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LaterRegex);
+
+    public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
+
+    public static final Pattern WithinNextPrefixRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+
+    public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmDescRegex);
+
+    public static final Pattern PmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.PmDescRegex);
+
+    public static final Pattern AmPmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmPmDescRegex);
+
+    public static final Pattern RangeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.RangeUnitRegex);
+
+    public static final Pattern TimeUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.TimeUnitRegex);
+
+    public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
+
+    public static final Pattern CommonDatePrefixRegex = RegExpUtility
+            .getSafeRegExp(FrenchDateTime.CommonDatePrefixRegex);
+
+    @Override
+    public final Pattern getLaterRegex() {
+        return LaterRegex;
+    }
+
+    @Override
+    public final Pattern getAgoRegex() {
+        return AgoRegex;
+    }
+
+    @Override
+    public final Pattern getInConnectorRegex() {
+        return InConnectorRegex;
+    }
+
+    @Override
+    public final Pattern getWithinNextPrefixRegex() {
+        return WithinNextPrefixRegex;
+    }
+
+    @Override
+    public final Pattern getAmDescRegex() {
+        return AmDescRegex;
+    }
+
+    @Override
+    public final Pattern getPmDescRegex() {
+        return PmDescRegex;
+    }
+
+    @Override
+    public final Pattern getAmPmDescRegex() {
+        return AmPmDescRegex;
+    }
+
+    @Override
+    public final Pattern getRangeUnitRegex() {
+        return RangeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getTimeUnitRegex() {
+        return TimeUnitRegex;
+    }
+
+    @Override
+    public final Pattern getDateUnitRegex() {
+        return DateUnitRegex;
+    }
+
+    @Override
+    public final Pattern getCommonDatePrefixRegex() {
+        return CommonDatePrefixRegex;
+    }
+}

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
@@ -1,13 +1,12 @@
 package com.microsoft.recognizers.text.datetime.french.utilities;
 
-import java.util.regex.Pattern;
-
 import com.microsoft.recognizers.text.datetime.resources.FrenchDateTime;
 import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfiguration;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
+import java.util.regex.Pattern;
 
 public class FrenchDatetimeUtilityConfiguration
-        implements IDateTimeUtilityConfiguration {
+    implements IDateTimeUtilityConfiguration {
     public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AgoRegex);
 
     public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LaterRegex);
@@ -15,7 +14,7 @@ public class FrenchDatetimeUtilityConfiguration
     public static final Pattern InConnectorRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.InConnectorRegex);
 
     public static final Pattern WithinNextPrefixRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
+        .getSafeRegExp(FrenchDateTime.WithinNextPrefixRegex);
 
     public static final Pattern AmDescRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AmDescRegex);
 
@@ -30,7 +29,7 @@ public class FrenchDatetimeUtilityConfiguration
     public static final Pattern DateUnitRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.DateUnitRegex);
 
     public static final Pattern CommonDatePrefixRegex = RegExpUtility
-            .getSafeRegExp(FrenchDateTime.CommonDatePrefixRegex);
+        .getSafeRegExp(FrenchDateTime.CommonDatePrefixRegex);
 
     @Override
     public final Pattern getLaterRegex() {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/utilities/FrenchDatetimeUtilityConfiguration.java
@@ -5,8 +5,7 @@ import com.microsoft.recognizers.text.datetime.utilities.IDateTimeUtilityConfigu
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
 
-public class FrenchDatetimeUtilityConfiguration
-    implements IDateTimeUtilityConfiguration {
+public class FrenchDatetimeUtilityConfiguration implements IDateTimeUtilityConfiguration {
     public static final Pattern AgoRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.AgoRegex);
 
     public static final Pattern LaterRegex = RegExpUtility.getSafeRegExp(FrenchDateTime.LaterRegex);

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/french/parsers/FrenchNumberParserConfiguration.java
@@ -20,7 +20,7 @@ public class FrenchNumberParserConfiguration extends BaseNumberParserConfigurati
     }
 
     public FrenchNumberParserConfiguration(NumberOptions options) {
-        this(new CultureInfo(Culture.Portuguese), options);
+        this(new CultureInfo(Culture.French), options);
     }
 
     public FrenchNumberParserConfiguration(CultureInfo cultureInfo, NumberOptions options) {

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
@@ -419,9 +419,9 @@ public class BaseNumberParser implements IParser {
         // Special cases for multi-language countries where decimal separators can be used interchangeably. Mostly informally.
         // Ex: South Africa, Namibia; Puerto Rico in ES; or in Canada for EN and FR.
         // "me pidio $5.00 prestados" and "me pidio $5,00 prestados" -> currency $5
-        Pattern cultureRegex = Pattern.compile("^(en|es|fr)(-)?\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+        Pattern cultureRegex = Pattern.compile("^(en|es|fr)(-)?\\b", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 
-        return (ch == config.getNonDecimalSeparatorChar() && !(distance <= decimalLength && cultureRegex.matcher(culture.cultureCode).matches()));
+        return (ch == config.getNonDecimalSeparatorChar() && !(distance <= decimalLength && cultureRegex.matcher(culture.cultureCode).find()));
     }
 
     protected double getDigitalValue(String digitsStr, double power) {

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/parsers/BaseNumberParser.java
@@ -416,6 +416,7 @@ public class BaseNumberParser implements IParser {
     private boolean skipNonDecimalSeparator(char ch, int distance, CultureInfo culture) {
         int decimalLength = 3;
 
+        // @TODO: Add this to project level configuration file to be kept in sync
         // Special cases for multi-language countries where decimal separators can be used interchangeably. Mostly informally.
         // Ex: South Africa, Namibia; Puerto Rico in ES; or in Canada for EN and FR.
         // "me pidio $5.00 prestados" and "me pidio $5,00 prestados" -> currency $5

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -1,15 +1,5 @@
 package com.microsoft.recognizers.text.tests.datetime;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.IntStream;
-
-import org.javatuples.Pair;
-import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
-import org.junit.runners.Parameterized;
-
 import com.microsoft.recognizers.text.Culture;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ModelResult;
@@ -29,6 +19,7 @@ import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimePer
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimeZoneExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
+import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeAltExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -41,6 +32,7 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeAltExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
@@ -49,6 +41,7 @@ import com.microsoft.recognizers.text.datetime.french.extractors.FrenchMergedExt
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchSetExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeZoneExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
@@ -62,23 +55,37 @@ import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePer
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
-public class DateTimeExtractorTest
-        extends AbstractTest {
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.runners.Parameterized;
+
+public class DateTimeExtractorTest extends AbstractTest {
 
     private static final String recognizerType = "DateTime";
-
-    public DateTimeExtractorTest(TestCase currentCase) {
-        super(currentCase);
-    }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestCase> testCases() {
         return AbstractTest.enumerateTestCases(recognizerType, "Extractor");
     }
 
+    public DateTimeExtractorTest(TestCase currentCase) {
+        super(currentCase);
+    }
+
     @Override
     protected List<ModelResult> recognize(TestCase currentCase) {
         return null;
+    }
+
+    protected List<ExtractResult> extract(TestCase currentCase) {
+        IDateTimeExtractor extractor = getExtractor(currentCase);
+        return extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), currentCase.getReferenceDateTime());
     }
 
     @Override
@@ -99,18 +106,10 @@ public class DateTimeExtractorTest
                     ExtractResult actual = t.getValue1();
 
                     Assert.assertEquals(getMessage(currentCase, "type"), expected.getType(), actual.getType());
-                    Assert.assertTrue(
-                            String.format("%s: Text was \"%s\", expected \"%s\"", getMessage(currentCase, "text"),
-                                    actual.getText(), expected.getText()),
-                            expected.getText().equalsIgnoreCase(actual.getText()));
+                    Assert.assertTrue(getMessage(currentCase, "text"), expected.getText().equalsIgnoreCase(actual.getText()));
                     Assert.assertEquals(getMessage(currentCase, "start"), expected.getStart(), actual.getStart());
                     Assert.assertEquals(getMessage(currentCase, "length"), expected.getLength(), actual.getLength());
                 });
-    }
-
-    protected List<ExtractResult> extract(TestCase currentCase) {
-        IDateTimeExtractor extractor = getExtractor(currentCase);
-        return extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), currentCase.getReferenceDateTime());
     }
 
     public static IDateTimeExtractor getExtractor(TestCase currentCase) {
@@ -131,8 +130,7 @@ public class DateTimeExtractorTest
             default:
                 throw new AssumptionViolatedException("Extractor Type/Name not supported.");
             }
-        }
-        catch (IllegalArgumentException ex) {
+        } catch (IllegalArgumentException ex) {
             throw new AssumptionViolatedException(ex.getMessage(), ex);
         }
     }
@@ -141,36 +139,35 @@ public class DateTimeExtractorTest
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-        case "DateExtractor":
-            return new BaseDateExtractor(new EnglishDateExtractorConfiguration(config));
-        case "DatePeriodExtractor":
-            return new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration(config));
-        //case "DateTimeAltExtractor":
-        //    return new BaseDateTimeAltExtractor(new EnglishDateTimeAltExtractorConfiguration());
-        case "DateTimeExtractor":
-            return new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());
-        case "DateTimePeriodExtractor":
-            return new BaseDateTimePeriodExtractor(new EnglishDateTimePeriodExtractorConfiguration());
-        case "DurationExtractor":
-            return new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
-        case "HolidayExtractor":
-            return new BaseHolidayExtractor(new EnglishHolidayExtractorConfiguration());
-        case "MergedExtractor":
-            return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.None));
-        case "MergedExtractorSkipFromTo":
-            return new BaseMergedDateTimeExtractor(
-                    new EnglishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
-        case "SetExtractor":
-            return new BaseSetExtractor(new EnglishSetExtractorConfiguration());
-        case "TimeExtractor":
-            return new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
-        case "TimePeriodExtractor":
-            return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
-        case "TimeZoneExtractor":
-            return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+            case "DateExtractor":
+                return new BaseDateExtractor(new EnglishDateExtractorConfiguration(config));
+            case "DatePeriodExtractor":
+                return new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration(config));
+            //case "DateTimeAltExtractor":
+            //    return new BaseDateTimeAltExtractor(new EnglishDateTimeAltExtractorConfiguration());
+            case "DateTimeExtractor":
+                return new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());
+            case "DateTimePeriodExtractor":
+                return new BaseDateTimePeriodExtractor(new EnglishDateTimePeriodExtractorConfiguration());
+            case "DurationExtractor":
+                return new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
+            case "HolidayExtractor":
+                return new BaseHolidayExtractor(new EnglishHolidayExtractorConfiguration());
+            case "MergedExtractor":
+                return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.None));
+            case "MergedExtractorSkipFromTo":
+                return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+            case "SetExtractor":
+                return new BaseSetExtractor(new EnglishSetExtractorConfiguration());
+            case "TimeExtractor":
+                return new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
+            case "TimePeriodExtractor":
+                return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
+            case "TimeZoneExtractor":
+                return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
-        default:
-            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
         }
     }
 
@@ -178,65 +175,71 @@ public class DateTimeExtractorTest
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-        case "DateExtractor":
-            return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
-        case "DatePeriodExtractor":
-            return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(config));
-        //case "DateTimeAltExtractor":
-        //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
-        case "DateTimeExtractor":
-            return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
-        case "DateTimePeriodExtractor":
-            return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
-        case "DurationExtractor":
-            return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
-        case "HolidayExtractor":
-            return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
-        case "MergedExtractor":
-            return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
-        //case "MergedExtractorSkipFromTo":
-        //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
-        case "SetExtractor":
-            return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
-        case "TimeExtractor":
-            return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
-        case "TimePeriodExtractor":
-            return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
-        //case "TimeZoneExtractor":
-        //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+            case "DateExtractor":
+                return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
+            case "DatePeriodExtractor":
+                return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(config));
+            //case "DateTimeAltExtractor":
+            //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
+            case "DateTimeExtractor":
+                return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
+            case "DateTimePeriodExtractor":
+                return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
+            case "DurationExtractor":
+                return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+            case "HolidayExtractor":
+                return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
+            case "MergedExtractor":
+               return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
+            //case "MergedExtractorSkipFromTo":
+            //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+            case "SetExtractor":
+                return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
+            case "TimeExtractor":
+                return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
+            case "TimePeriodExtractor":
+                return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+            //case "TimeZoneExtractor":
+            //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
-        default:
-            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
         }
     }
 
-    public static IDateTimeExtractor getFrenchExtractor(String name) {
+    private static IDateTimeExtractor getFrenchExtractor(String name) {
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-        case "DateExtractor":
-            return new BaseDateExtractor(new FrenchDateExtractorConfiguration(config));
-        case "DatePeriodExtractor":
-            return new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(config));
-        case "DateTimeExtractor":
-            return new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration());
-        case "DateTimePeriodExtractor":
-            return new BaseDateTimePeriodExtractor(new FrenchDateTimePeriodExtractorConfiguration());
-        case "DurationExtractor":
-            return new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
-        case "HolidayExtractor":
-            return new BaseHolidayExtractor(new FrenchHolidayExtractorConfiguration());
-        case "MergedExtractor":
-            return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.None));
-        case "SetExtractor":
-            return new BaseSetExtractor(new FrenchSetExtractorConfiguration());
-        case "TimeExtractor":
-            return new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());
-        case "TimePeriodExtractor":
-            return new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration());
+            case "DateExtractor":
+                return new BaseDateExtractor(new FrenchDateExtractorConfiguration(config));
+            case "DatePeriodExtractor":
+                return new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(config));
+//            case "DateTimeAltExtractor":
+//                return new BaseDateTimeAltExtractor(new FrenchDateTimeAltExtractorConfiguration(config));
+            case "DateTimeExtractor":
+                return new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration());
+            case "DateTimePeriodExtractor":
+                return new BaseDateTimePeriodExtractor(new FrenchDateTimePeriodExtractorConfiguration());
+            case "DurationExtractor":
+                return new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+            case "HolidayExtractor":
+                return new BaseHolidayExtractor(new FrenchHolidayExtractorConfiguration());
+            case "MergedExtractor":
+                return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.None));
+            case "MergedExtractorSkipFromTo":
+                return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+            case "SetExtractor":
+                return new BaseSetExtractor(new FrenchSetExtractorConfiguration());
+            case "TimeExtractor":
+                return new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());
+            case "TimePeriodExtractor":
+                return new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration());
+            case "TimeZoneExtractor":
+                return new BaseTimeZoneExtractor(new FrenchTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
-        default:
-            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
         }
     }
 }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -19,7 +19,6 @@ import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimePer
 import com.microsoft.recognizers.text.datetime.english.extractors.EnglishTimeZoneExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDatePeriodExtractor;
-import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeAltExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDateTimePeriodExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseDurationExtractor;
@@ -32,7 +31,6 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
-import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeAltExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -119,14 +119,14 @@ public class DateTimeExtractorTest extends AbstractTest {
         try {
             String culture = getCultureCode(language);
             switch (culture) {
-            case Culture.English:
-                return getEnglishExtractor(modelName);
-            case Culture.Spanish:
-                return getSpanishExtractor(modelName);
-            case Culture.French:
-                return getFrenchExtractor(modelName);
-            default:
-                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+                case Culture.English:
+                    return getEnglishExtractor(modelName);
+                case Culture.Spanish:
+                    return getSpanishExtractor(modelName);
+                case Culture.French:
+                    return getFrenchExtractor(modelName);
+                default:
+                    throw new AssumptionViolatedException("Extractor Type/Name not supported.");
             }
         } catch (IllegalArgumentException ex) {
             throw new AssumptionViolatedException(ex.getMessage(), ex);

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeExtractorTest.java
@@ -1,5 +1,15 @@
 package com.microsoft.recognizers.text.tests.datetime;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.IntStream;
+
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.AssumptionViolatedException;
+import org.junit.runners.Parameterized;
+
 import com.microsoft.recognizers.text.Culture;
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.ModelResult;
@@ -29,6 +39,16 @@ import com.microsoft.recognizers.text.datetime.extractors.BaseTimeExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimePeriodExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.BaseTimeZoneExtractor;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDatePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDateTimePeriodExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchDurationExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchHolidayExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchMergedExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchSetExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimeExtractorConfiguration;
+import com.microsoft.recognizers.text.datetime.french.extractors.FrenchTimePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDatePeriodExtractorConfiguration;
 import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishDateTimeExtractorConfiguration;
@@ -42,37 +62,23 @@ import com.microsoft.recognizers.text.datetime.spanish.extractors.SpanishTimePer
 import com.microsoft.recognizers.text.tests.AbstractTest;
 import com.microsoft.recognizers.text.tests.TestCase;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.IntStream;
-
-import org.javatuples.Pair;
-import org.junit.Assert;
-import org.junit.AssumptionViolatedException;
-import org.junit.runners.Parameterized;
-
-public class DateTimeExtractorTest extends AbstractTest {
+public class DateTimeExtractorTest
+        extends AbstractTest {
 
     private static final String recognizerType = "DateTime";
+
+    public DateTimeExtractorTest(TestCase currentCase) {
+        super(currentCase);
+    }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestCase> testCases() {
         return AbstractTest.enumerateTestCases(recognizerType, "Extractor");
     }
 
-    public DateTimeExtractorTest(TestCase currentCase) {
-        super(currentCase);
-    }
-
     @Override
     protected List<ModelResult> recognize(TestCase currentCase) {
         return null;
-    }
-
-    protected List<ExtractResult> extract(TestCase currentCase) {
-        IDateTimeExtractor extractor = getExtractor(currentCase);
-        return extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), currentCase.getReferenceDateTime());
     }
 
     @Override
@@ -93,10 +99,18 @@ public class DateTimeExtractorTest extends AbstractTest {
                     ExtractResult actual = t.getValue1();
 
                     Assert.assertEquals(getMessage(currentCase, "type"), expected.getType(), actual.getType());
-                    Assert.assertTrue(getMessage(currentCase, "text"), expected.getText().equalsIgnoreCase(actual.getText()));
+                    Assert.assertTrue(
+                            String.format("%s: Text was \"%s\", expected \"%s\"", getMessage(currentCase, "text"),
+                                    actual.getText(), expected.getText()),
+                            expected.getText().equalsIgnoreCase(actual.getText()));
                     Assert.assertEquals(getMessage(currentCase, "start"), expected.getStart(), actual.getStart());
                     Assert.assertEquals(getMessage(currentCase, "length"), expected.getLength(), actual.getLength());
                 });
+    }
+
+    protected List<ExtractResult> extract(TestCase currentCase) {
+        IDateTimeExtractor extractor = getExtractor(currentCase);
+        return extractor.extract(currentCase.input.toLowerCase(Locale.ROOT), currentCase.getReferenceDateTime());
     }
 
     public static IDateTimeExtractor getExtractor(TestCase currentCase) {
@@ -108,14 +122,17 @@ public class DateTimeExtractorTest extends AbstractTest {
         try {
             String culture = getCultureCode(language);
             switch (culture) {
-                case Culture.English:
-                    return getEnglishExtractor(modelName);
-                case Culture.Spanish:
-                    return getSpanishExtractor(modelName);
-                default:
-                    throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+            case Culture.English:
+                return getEnglishExtractor(modelName);
+            case Culture.Spanish:
+                return getSpanishExtractor(modelName);
+            case Culture.French:
+                return getFrenchExtractor(modelName);
+            default:
+                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
             }
-        } catch (IllegalArgumentException ex) {
+        }
+        catch (IllegalArgumentException ex) {
             throw new AssumptionViolatedException(ex.getMessage(), ex);
         }
     }
@@ -124,35 +141,36 @@ public class DateTimeExtractorTest extends AbstractTest {
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-            case "DateExtractor":
-                return new BaseDateExtractor(new EnglishDateExtractorConfiguration(config));
-            case "DatePeriodExtractor":
-                return new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration(config));
-            //case "DateTimeAltExtractor":
-            //    return new BaseDateTimeAltExtractor(new EnglishDateTimeAltExtractorConfiguration());
-            case "DateTimeExtractor":
-                return new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());
-            case "DateTimePeriodExtractor":
-                return new BaseDateTimePeriodExtractor(new EnglishDateTimePeriodExtractorConfiguration());
-            case "DurationExtractor":
-                return new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
-            case "HolidayExtractor":
-                return new BaseHolidayExtractor(new EnglishHolidayExtractorConfiguration());
-            case "MergedExtractor":
-                return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.None));
-            case "MergedExtractorSkipFromTo":
-                return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
-            case "SetExtractor":
-                return new BaseSetExtractor(new EnglishSetExtractorConfiguration());
-            case "TimeExtractor":
-                return new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
-            case "TimePeriodExtractor":
-                return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
-            case "TimeZoneExtractor":
-                return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+        case "DateExtractor":
+            return new BaseDateExtractor(new EnglishDateExtractorConfiguration(config));
+        case "DatePeriodExtractor":
+            return new BaseDatePeriodExtractor(new EnglishDatePeriodExtractorConfiguration(config));
+        //case "DateTimeAltExtractor":
+        //    return new BaseDateTimeAltExtractor(new EnglishDateTimeAltExtractorConfiguration());
+        case "DateTimeExtractor":
+            return new BaseDateTimeExtractor(new EnglishDateTimeExtractorConfiguration());
+        case "DateTimePeriodExtractor":
+            return new BaseDateTimePeriodExtractor(new EnglishDateTimePeriodExtractorConfiguration());
+        case "DurationExtractor":
+            return new BaseDurationExtractor(new EnglishDurationExtractorConfiguration());
+        case "HolidayExtractor":
+            return new BaseHolidayExtractor(new EnglishHolidayExtractorConfiguration());
+        case "MergedExtractor":
+            return new BaseMergedDateTimeExtractor(new EnglishMergedExtractorConfiguration(DateTimeOptions.None));
+        case "MergedExtractorSkipFromTo":
+            return new BaseMergedDateTimeExtractor(
+                    new EnglishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+        case "SetExtractor":
+            return new BaseSetExtractor(new EnglishSetExtractorConfiguration());
+        case "TimeExtractor":
+            return new BaseTimeExtractor(new EnglishTimeExtractorConfiguration());
+        case "TimePeriodExtractor":
+            return new BaseTimePeriodExtractor(new EnglishTimePeriodExtractorConfiguration());
+        case "TimeZoneExtractor":
+            return new BaseTimeZoneExtractor(new EnglishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
-            default:
-                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+        default:
+            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
         }
     }
 
@@ -160,35 +178,65 @@ public class DateTimeExtractorTest extends AbstractTest {
 
         IOptionsConfiguration config = new BaseOptionsConfiguration();
         switch (name) {
-            case "DateExtractor":
-                return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
-            case "DatePeriodExtractor":
-                return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(config));
-            //case "DateTimeAltExtractor":
-            //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
-            case "DateTimeExtractor":
-                return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
-            case "DateTimePeriodExtractor":
-                return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
-            case "DurationExtractor":
-                return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
-            case "HolidayExtractor":
-                return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
-            case "MergedExtractor":
-               return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
-            //case "MergedExtractorSkipFromTo":
-            //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
-            case "SetExtractor":
-                return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
-            case "TimeExtractor":
-                return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
-            case "TimePeriodExtractor":
-                return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
-            //case "TimeZoneExtractor":
-            //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
+        case "DateExtractor":
+            return new BaseDateExtractor(new SpanishDateExtractorConfiguration(config));
+        case "DatePeriodExtractor":
+            return new BaseDatePeriodExtractor(new SpanishDatePeriodExtractorConfiguration(config));
+        //case "DateTimeAltExtractor":
+        //    return new BaseDateTimeAltExtractor(new SpanishDateTimeAltExtractorConfiguration());
+        case "DateTimeExtractor":
+            return new BaseDateTimeExtractor(new SpanishDateTimeExtractorConfiguration());
+        case "DateTimePeriodExtractor":
+            return new BaseDateTimePeriodExtractor(new SpanishDateTimePeriodExtractorConfiguration());
+        case "DurationExtractor":
+            return new BaseDurationExtractor(new SpanishDurationExtractorConfiguration());
+        case "HolidayExtractor":
+            return new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration());
+        case "MergedExtractor":
+            return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.None));
+        //case "MergedExtractorSkipFromTo":
+        //    return new BaseMergedDateTimeExtractor(new SpanishMergedExtractorConfiguration(DateTimeOptions.SkipFromToMerge));
+        case "SetExtractor":
+            return new BaseSetExtractor(new SpanishSetExtractorConfiguration());
+        case "TimeExtractor":
+            return new BaseTimeExtractor(new SpanishTimeExtractorConfiguration());
+        case "TimePeriodExtractor":
+            return new BaseTimePeriodExtractor(new SpanishTimePeriodExtractorConfiguration());
+        //case "TimeZoneExtractor":
+        //    return new BaseTimeZoneExtractor(new SpanishTimeZoneExtractorConfiguration(DateTimeOptions.EnablePreview));
 
-            default:
-                throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+        default:
+            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
+        }
+    }
+
+    public static IDateTimeExtractor getFrenchExtractor(String name) {
+
+        IOptionsConfiguration config = new BaseOptionsConfiguration();
+        switch (name) {
+        case "DateExtractor":
+            return new BaseDateExtractor(new FrenchDateExtractorConfiguration(config));
+        case "DatePeriodExtractor":
+            return new BaseDatePeriodExtractor(new FrenchDatePeriodExtractorConfiguration(config));
+        case "DateTimeExtractor":
+            return new BaseDateTimeExtractor(new FrenchDateTimeExtractorConfiguration());
+        case "DateTimePeriodExtractor":
+            return new BaseDateTimePeriodExtractor(new FrenchDateTimePeriodExtractorConfiguration());
+        case "DurationExtractor":
+            return new BaseDurationExtractor(new FrenchDurationExtractorConfiguration());
+        case "HolidayExtractor":
+            return new BaseHolidayExtractor(new FrenchHolidayExtractorConfiguration());
+        case "MergedExtractor":
+            return new BaseMergedDateTimeExtractor(new FrenchMergedExtractorConfiguration(DateTimeOptions.None));
+        case "SetExtractor":
+            return new BaseSetExtractor(new FrenchSetExtractorConfiguration());
+        case "TimeExtractor":
+            return new BaseTimeExtractor(new FrenchTimeExtractorConfiguration());
+        case "TimePeriodExtractor":
+            return new BaseTimePeriodExtractor(new FrenchTimePeriodExtractorConfiguration());
+
+        default:
+            throw new AssumptionViolatedException("Extractor Type/Name not supported.");
         }
     }
 }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -22,6 +22,17 @@ import com.microsoft.recognizers.text.datetime.english.parsers.EnglishTimeParser
 import com.microsoft.recognizers.text.datetime.english.parsers.EnglishTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.english.parsers.TimeParser;
 import com.microsoft.recognizers.text.datetime.extractors.IDateTimeExtractor;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchCommonDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDateParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDatePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDateTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDateTimePeriodParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDurationParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchSetParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchTimeParser;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchTimeParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.parsers.BaseDateParser;
 import com.microsoft.recognizers.text.datetime.parsers.BaseDatePeriodParser;
 import com.microsoft.recognizers.text.datetime.parsers.BaseDateTimeAltParser;
@@ -114,7 +125,7 @@ public class DateTimeParserTest extends AbstractTest {
                     DateTimeParseResult actual = t.getValue1();
 
                     Assert.assertEquals(getMessage(currentCase, "type"), expected.getType(), actual.getType());
-                    Assert.assertTrue(getMessage(currentCase, "text"), expected.getText().equalsIgnoreCase(actual.getText()));
+                    Assert.assertTrue(getMessage(currentCase, "text") + String.format(" expected: \"%s\" actual: \"%s\"", expected.getText(), actual.getText()), expected.getText().equalsIgnoreCase(actual.getText()));
 
                     Assert.assertEquals(getMessage(currentCase, "start"), expected.getStart(), actual.getStart());
                     Assert.assertEquals(getMessage(currentCase, "length"), expected.getLength(), actual.getLength());
@@ -178,6 +189,8 @@ public class DateTimeParserTest extends AbstractTest {
                     return getEnglishParser(name);
                 case Culture.Spanish:
                     return getSpanishParser(name);
+                case Culture.French:
+                    return getFrenchParser(name);
                 default:
                     throw new AssumptionViolatedException("Parser Type/Name not supported.");
             }
@@ -243,6 +256,35 @@ public class DateTimeParserTest extends AbstractTest {
                 return new TimeParser(new SpanishTimeParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "TimePeriodParser":
                 return new BaseTimePeriodParser(new SpanishTimePeriodParserConfiguration(new SpanishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            default:
+                throw new AssumptionViolatedException("Parser Type/Name not supported.");
+        }
+    }
+    private static IDateTimeParser getFrenchParser(String name) {
+
+        switch (name) {
+            case "DateParser":
+                return new BaseDateParser(new FrenchDateParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DatePeriodParser":
+                return new BaseDatePeriodParser(new FrenchDatePeriodParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "DateTimeAltParser":
+            //    return new BaseDateTimeAltParser(new FrenchDateTimeAltParserConfiguration(new EnglishCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateTimeParser":
+                return new BaseDateTimeParser(new FrenchDateTimeParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DateTimePeriodParser":
+                return new BaseDateTimePeriodParser(new FrenchDateTimePeriodParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "DurationParser":
+                return new BaseDurationParser(new FrenchDurationParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "HolidayParser":
+                return new BaseHolidayParser(new FrenchHolidayParserConfiguration());
+            case "SetParser":
+                return new BaseSetParser(new FrenchSetParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            //case "MergedParser":
+            //    return new BaseMergedDateTimeParser(new FrenchMergedParserConfiguration(DateTimeOptions.None));
+            case "TimeParser":
+                return new FrenchTimeParser(new FrenchTimeParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
+            case "TimePeriodParser":
+                return new BaseTimePeriodParser(new FrenchTimePeriodParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             default:
                 throw new AssumptionViolatedException("Parser Type/Name not supported.");
         }

--- a/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
+++ b/Java/tests/src/test/java/com/microsoft/recognizers/text/tests/datetime/DateTimeParserTest.java
@@ -29,6 +29,7 @@ import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDateTimePars
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDateTimePeriodParserConfiguration;
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchDurationParserConfiguration;
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchHolidayParserConfiguration;
+import com.microsoft.recognizers.text.datetime.french.parsers.FrenchMergedParserConfiguration;
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchSetParserConfiguration;
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchTimeParser;
 import com.microsoft.recognizers.text.datetime.french.parsers.FrenchTimeParserConfiguration;
@@ -279,8 +280,8 @@ public class DateTimeParserTest extends AbstractTest {
                 return new BaseHolidayParser(new FrenchHolidayParserConfiguration());
             case "SetParser":
                 return new BaseSetParser(new FrenchSetParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
-            //case "MergedParser":
-            //    return new BaseMergedDateTimeParser(new FrenchMergedParserConfiguration(DateTimeOptions.None));
+            case "MergedParser":
+                return new BaseMergedDateTimeParser(new FrenchMergedParserConfiguration(DateTimeOptions.None));
             case "TimeParser":
                 return new FrenchTimeParser(new FrenchTimeParserConfiguration(new FrenchCommonDateTimeParserConfiguration(DateTimeOptions.None)));
             case "TimePeriodParser":

--- a/Specs/DateTime/French/DateExtractor.json
+++ b/Specs/DateTime/French/DateExtractor.json
@@ -947,7 +947,7 @@
   },
   {
     "Input": "Qui ai-je envoye un mois il y a",
-    "NotSupported": "javascript, dotnet, python",
+    "NotSupported": "javascript, dotnet, python, java",
     "Results": [
       {
         "Text": "un mois il y a",

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -95,7 +95,7 @@
     ]
   },
   {
-    "Input": "Je vais partir pour 3.5ans",
+    "Input": "Je vais partir pour 3,5ans",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -101,7 +101,7 @@
     },
     "Results": [
       {
-        "Text": "3.5ans",
+        "Text": "3,5ans",
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -95,13 +95,13 @@
     ]
   },
   {
-    "Input": "Je vais partir pour 3,5ans",
+    "Input": "Je vais partir pour 3.5ans",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "Results": [
       {
-        "Text": "3,5ans",
+        "Text": "3.5ans",
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [

--- a/Specs/DateTime/French/DurationExtractor.json
+++ b/Specs/DateTime/French/DurationExtractor.json
@@ -22,10 +22,10 @@
     ]
   },
   {
-    "Input": "je partirai pour 3.5ans",
+    "Input": "je partirai pour 3,5ans",
     "Results": [
       {
-        "Text": "3.5ans",
+        "Text": "3,5ans",
         "Type": "duration",
         "Start": 17,
         "Length": 6

--- a/Specs/DateTime/French/DurationExtractor.json
+++ b/Specs/DateTime/French/DurationExtractor.json
@@ -22,10 +22,10 @@
     ]
   },
   {
-    "Input": "je partirai pour 3,5ans",
+    "Input": "je partirai pour 3.5ans",
     "Results": [
       {
-        "Text": "3,5ans",
+        "Text": "3.5ans",
         "Type": "duration",
         "Start": 17,
         "Length": 6

--- a/Specs/DateTime/French/SetParser.json
+++ b/Specs/DateTime/French/SetParser.json
@@ -2,7 +2,7 @@
   {
     "Input": "Je vais partir a 9am Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:16.6159645+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:16.6159645-03:00"
     },
     "Results": [
       {
@@ -25,7 +25,7 @@
   {
     "Input": "Je vais partir chaque de matin a 9am",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.4550127+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.4550127-03:00"
     },
     "Results": [
       {
@@ -48,7 +48,7 @@
   {
     "Input": "Je vais partir chaque apres-midi a 4pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.4900115+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.4900115-03:00"
     },
     "Results": [
       {
@@ -71,7 +71,7 @@
   {
     "Input": "Je vais partir chaque nuit a 9pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5265112+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5265112-03:00"
     },
     "Results": [
       {
@@ -94,7 +94,7 @@
   {
     "Input": "Je vais partir chaque nuit 9",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5560123+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5560123-03:00"
     },
     "Results": [
       {
@@ -117,7 +117,7 @@
   {
     "Input": "Je vais partir chaque nuit a 21",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5920118+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5920118-03:00"
     },
     "Results": [
       {
@@ -140,7 +140,7 @@
   {
     "Input": "Je vais partir chaque nuit 21",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.621011+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.621011-03:00"
     },
     "Results": [
       {
@@ -163,7 +163,7 @@
   {
     "Input": "Je vais partir tous les de matin 9am",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.6610194+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.6610194-03:00"
     },
     "Results": [
       {
@@ -186,7 +186,7 @@
   {
     "Input": "Je vais partir a Lundis",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7045166+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7045166-03:00"
     },
     "Results": [
       {
@@ -209,7 +209,7 @@
   {
     "Input": "Je vais partir Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7260153+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7260153-03:00"
     },
     "Results": [
       {
@@ -232,7 +232,7 @@
   {
     "Input": "Je vais partir tous les Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7855155+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7855155-03:00"
     },
     "Results": [
       {
@@ -255,7 +255,7 @@
   {
     "Input": "Je vais partir chaque Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.8420111+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.8420111-03:00"
     },
     "Results": [
       {
@@ -278,7 +278,7 @@
   {
     "Input": "Je vais partir chaque semaine",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3570246+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3570246-03:00"
     },
     "Results": [
       {
@@ -301,7 +301,7 @@
   {
     "Input": "Je vais partir bihebdomadaire",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3580267+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3580267-03:00"
     },
     "Results": [
       {
@@ -324,7 +324,7 @@
   {
     "Input": "Je vais partir hebdomadaire",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3590265+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3590265-03:00"
     },
     "Results": [
       {
@@ -347,7 +347,7 @@
   {
     "Input": "Je vais partir quotidien",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3600258+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3600258-03:00"
     },
     "Results": [
       {
@@ -370,7 +370,7 @@
   {
     "Input": "Je vais partir journellement",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3610265+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3610265-03:00"
     },
     "Results": [
       {
@@ -393,7 +393,7 @@
   {
     "Input": "Je vais partir chaque mois",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3775441+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3775441-03:00"
     },
     "Results": [
       {
@@ -416,7 +416,7 @@
   {
     "Input": "Je vais partir annuellement",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3785448+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3785448-03:00"
     },
     "Results": [
       {
@@ -439,7 +439,7 @@
   {
     "Input": "Je vais partir annuel",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3795446+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3795446-03:00"
     },
     "Results": [
       {
@@ -462,7 +462,7 @@
   {
     "Input": "Je vais partir chaque deux jours",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4010443+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4010443-03:00"
     },
     "Results": [
       {
@@ -485,7 +485,7 @@
   {
     "Input": "Je vais partir chaque trois semaine",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4250441+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4250441-03:00"
     },
     "Results": [
       {
@@ -508,7 +508,7 @@
   {
     "Input": "Je vais partir chaque  15/4",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.447021+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.447021-03:00"
     },
     "Results": [
       {
@@ -531,7 +531,7 @@
   {
     "Input": "Je vais partir chaque Lundi",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.469026+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.469026-03:00"
     },
     "Results": [
       {
@@ -554,7 +554,7 @@
   {
     "Input": "Je vais partir chaque Lundi 4pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4960223+03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4960223-03:00"
     },
     "Results": [
       {

--- a/Specs/DateTime/French/SetParser.json
+++ b/Specs/DateTime/French/SetParser.json
@@ -2,7 +2,7 @@
   {
     "Input": "Je vais partir a 9am Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:16.6159645-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:16.6159645+03:00"
     },
     "Results": [
       {
@@ -25,7 +25,7 @@
   {
     "Input": "Je vais partir chaque de matin a 9am",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.4550127-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.4550127+03:00"
     },
     "Results": [
       {
@@ -48,7 +48,7 @@
   {
     "Input": "Je vais partir chaque apres-midi a 4pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.4900115-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.4900115+03:00"
     },
     "Results": [
       {
@@ -71,7 +71,7 @@
   {
     "Input": "Je vais partir chaque nuit a 9pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5265112-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5265112+03:00"
     },
     "Results": [
       {
@@ -94,7 +94,7 @@
   {
     "Input": "Je vais partir chaque nuit 9",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5560123-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5560123+03:00"
     },
     "Results": [
       {
@@ -117,7 +117,7 @@
   {
     "Input": "Je vais partir chaque nuit a 21",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.5920118-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.5920118+03:00"
     },
     "Results": [
       {
@@ -140,7 +140,7 @@
   {
     "Input": "Je vais partir chaque nuit 21",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.621011-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.621011+03:00"
     },
     "Results": [
       {
@@ -163,7 +163,7 @@
   {
     "Input": "Je vais partir tous les de matin 9am",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:19.6610194-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:19.6610194+03:00"
     },
     "Results": [
       {
@@ -186,7 +186,7 @@
   {
     "Input": "Je vais partir a Lundis",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7045166-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7045166+03:00"
     },
     "Results": [
       {
@@ -209,7 +209,7 @@
   {
     "Input": "Je vais partir Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7260153-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7260153+03:00"
     },
     "Results": [
       {
@@ -232,7 +232,7 @@
   {
     "Input": "Je vais partir tous les Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.7855155-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.7855155+03:00"
     },
     "Results": [
       {
@@ -255,7 +255,7 @@
   {
     "Input": "Je vais partir chaque Dimanches",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:21.8420111-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:21.8420111+03:00"
     },
     "Results": [
       {
@@ -278,7 +278,7 @@
   {
     "Input": "Je vais partir chaque semaine",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3570246-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3570246+03:00"
     },
     "Results": [
       {
@@ -301,7 +301,7 @@
   {
     "Input": "Je vais partir bihebdomadaire",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3580267-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3580267+03:00"
     },
     "Results": [
       {
@@ -324,7 +324,7 @@
   {
     "Input": "Je vais partir hebdomadaire",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3590265-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3590265+03:00"
     },
     "Results": [
       {
@@ -347,7 +347,7 @@
   {
     "Input": "Je vais partir quotidien",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3600258-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3600258+03:00"
     },
     "Results": [
       {
@@ -370,7 +370,7 @@
   {
     "Input": "Je vais partir journellement",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3610265-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3610265+03:00"
     },
     "Results": [
       {
@@ -393,7 +393,7 @@
   {
     "Input": "Je vais partir chaque mois",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3775441-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3775441+03:00"
     },
     "Results": [
       {
@@ -416,7 +416,7 @@
   {
     "Input": "Je vais partir annuellement",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3785448-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3785448+03:00"
     },
     "Results": [
       {
@@ -439,7 +439,7 @@
   {
     "Input": "Je vais partir annuel",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.3795446-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.3795446+03:00"
     },
     "Results": [
       {
@@ -462,7 +462,7 @@
   {
     "Input": "Je vais partir chaque deux jours",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4010443-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4010443+03:00"
     },
     "Results": [
       {
@@ -485,7 +485,7 @@
   {
     "Input": "Je vais partir chaque trois semaine",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4250441-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4250441+03:00"
     },
     "Results": [
       {
@@ -508,7 +508,7 @@
   {
     "Input": "Je vais partir chaque  15/4",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.447021-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.447021+03:00"
     },
     "Results": [
       {
@@ -531,7 +531,7 @@
   {
     "Input": "Je vais partir chaque Lundi",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.469026-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.469026+03:00"
     },
     "Results": [
       {
@@ -554,7 +554,7 @@
   {
     "Input": "Je vais partir chaque Lundi 4pm",
     "Context": {
-      "ReferenceDateTime": "2017-10-09T12:21:35.4960223-03:00"
+      "ReferenceDateTime": "2017-10-09T12:21:35.4960223+03:00"
     },
     "Results": [
       {


### PR DESCRIPTION
This implements French DateTime parsing in Java, largely by filling in from the C# version where necessary. It appears to be passing all of the test cases that are passing on master, with the sole exception of `"Je vais partir pour 3.5ans"` which I'm not sure _should_ be passing, since I think that the French number recognizer expects a format of "3,5" for the fractional part. Additionally, it appears that some `OrdinalModel` and `NumberModel tests are failing, in particular:
```
  test[NumberRecognizer - French - NumberModel - "sous la pluie et un vent glacial"](com.microsoft.recognizers.text.tests.number.NumberTest): Does not match text on Input: "sous la pluie et un vent glacial" expected:<[]un> but was:<[et ]un>
  test[NumberRecognizer - French - OrdinalModel - "Son dizième anniversaire"](com.microsoft.recognizers.text.tests.number.NumberTest): Does not match "Result Count" on Input: "Son dizième anniversaire" expected:<1> but was:<0>
  test[NumberRecognizer - French - OrdinalModel - "1ère femme"](com.microsoft.recognizers.text.tests.number.NumberTest): Does not match "Result Count" on Input: "1ère femme" expected:<1> but was:<0>
  test[NumberRecognizer - French - OrdinalModel - "quinzième, dix-huirième, dix-septième, septième"](com.microsoft.recognizers.text.tests.number.NumberTest): Does not match "Result Count" on Input: "quinzième, dix-huirième, dix-septième, septième" expected:<4> but was:<2>
  test[NumberRecognizer - French - OrdinalModel - "Le vingt et unième jour"](com.microsoft.recognizers.text.tests.number.NumberTest): Does not match resolution.value on Input: "Le vingt et unième jour" expected:<2[1]> but was:<2[0]>
```
but these all appear to be failing on the latest master as well.

Additionally, I need to address some checkstyle issues, but while I do that, I would like any and all feedback on the code. Thank you!