### PR TITLE
[EN Number] Add support for Indian numbering system in digits (#2112)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
       public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+(\s*(K|k|MM?|mil|G|T|B|b))?\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})";
+      public const string IndianNumberingSystemRegex = @"(?<=\b)((?:\d{1,2},(?:\d{2},)*\d{3})(?=\b))";
       public static readonly string NumbersWithSuffix = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string NumbersWithDozenSuffix = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s+dozen(s)?(?=\b)";
@@ -65,6 +66,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string DoubleExponentialNotationRegex = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)e([+-]*[1-9]\d*)(?=\b)";
       public static readonly string DoubleCaretExponentialNotationRegex = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)\^([+-]*[1-9]\d*)(?=\b)";
       public static readonly Func<string, string> DoubleDecimalPointRegex = (placeholder) => $@"(((?<!\d+(\s*(K|k|MM?|mil|G|T|B|b))?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
+      public const string DoubleIndianDecimalPointRegex = @"(?<=\b)((?:\d{1,2},(?:\d{2},)*\d{3})(?:\.\d{2})(?=\b))";
       public static readonly Func<string, string> DoubleWithoutIntegralRegex = (placeholder) => $@"(?<=\s|^)(?<!(\d+))[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
       public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string DoubleAllFloatRegex = $@"((?<=\b){AllFloatRegex}(?=\b))";

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
@@ -25,6 +25,10 @@ namespace Microsoft.Recognizers.Text.Number.English
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
+                    new Regex(NumbersDefinitions.DoubleIndianDecimalPointRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                },
+                {
                     new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Recognizers.Text.Number.English
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
+                    new Regex(NumbersDefinitions.IndianNumberingSystemRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
+                },
+                {
                     new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -36,6 +36,9 @@ PlaceHolderDefault: !simpleRegex
 NumbersWithPlaceHolder: !paramsRegex
   def: (((?<!\d+(\s*(K|k|MM?|mil|G|T|B|b))?\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})
   params: [ placeholder ]
+#Below Regex is used to catch comma separated digits in Hindi numbering system
+IndianNumberingSystemRegex: !simpleRegex
+  def: (?<=\b)((?:\d{1,2},(?:\d{2},)*\d{3})(?=\b))
 NumbersWithSuffix: !nestedRegex
   def: (((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)
   references: [ BaseNumbers.NumberMultiplierRegex ]
@@ -116,6 +119,9 @@ DoubleCaretExponentialNotationRegex: !nestedRegex
 DoubleDecimalPointRegex: !paramsRegex
   def: (((?<!\d+(\s*(K|k|MM?|mil|G|T|B|b))?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})
   params: [ placeholder ]
+#Below Regex is used to catch comma separated digits in Hindi numbering system
+DoubleIndianDecimalPointRegex: !simpleRegex
+  def: (?<=\b)((?:\d{1,2},(?:\d{2},)*\d{3})(?:\.\d{2})(?=\b))
 DoubleWithoutIntegralRegex: !paramsRegex
   def: (?<=\s|^)(?<!(\d+))[\.,]\d+(?!([\.,]\d+))(?={placeholder})
   params: [ placeholder ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2700,5 +2700,37 @@
         "End": 3
       }
     ]
+  },
+  {
+    "Input": "12,34,567.89",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "12,34,567.89",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1234567.89",
+          "subtype": "decimal"
+        },
+        "Start": 0,
+        "End": 11
+      }
+    ]
+  },
+  {
+    "Input": "12,567",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "12,567",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "12567",
+          "subtype": "integer"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2702,7 +2702,8 @@
     ]
   },
   {
-    "Input": "12,34,567.89",
+    "Input": "The result is 12,34,567.89",
+    "Comment": "Example of Indian numbering system, the format may not need to be supported in other languages.",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2712,13 +2713,14 @@
           "value": "1234567.89",
           "subtype": "decimal"
         },
-        "Start": 0,
-        "End": 11
+        "Start": 14,
+        "End": 25
       }
     ]
   },
   {
-    "Input": "12,567",
+    "Input": "There are 12,567 words in this document",
+    "Comment": "Example of Indian numbering system, the format may not need to be supported in other languages.",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2728,8 +2730,8 @@
           "value": "12567",
           "subtype": "integer"
         },
-        "Start": 0,
-        "End": 5
+        "Start": 10,
+        "End": 15
       }
     ]
   }

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2253,6 +2253,7 @@
   },
   {
     "Input": "Am I eligible for a lone of 12,34,567.89 rupees",
+    "Comment": "Example of Indian numbering system, the format may not need to be supported in other languages.",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2250,5 +2250,21 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Am I eligible for a lone of 12,34,567.89 rupees",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "12,34,567.89 rupees",
+        "Start": 28,
+        "End": 46,
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "1234567.89",
+          "unit": "Rupee"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Support for Indian numbering system in digits as requested in #2112.
Added test cases to NumberModel and CurrencyModel.

The digit notation "5,00,000" is not as common as the written form "5 lakh", but it is a government approved numbering system in India and is used, for example, in Indian transactions.