### PR TITLE
[KO Number] Integer and NumberRange Coverage Improvement

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string PercentageRegex = @"(?<=백\s*분\s*의).+|.+(?=퍼\s*센\s*트)|.*(?=[％%])";
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[만억]{{1,2}}(\s*(이상))?";
       public const string FracSplitRegex = @"(와|과|분\s*의|중)";
-      public const string ZeroToNineIntegerRegex = @"(영|령|공|일|(?<!(율|답))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)";
+      public const string ZeroToNineIntegerRegex = @"(영|령|공|일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
       public static readonly string TenToNinetySinoIntegerRegex = $@"({ZeroToNineIntegerRegex})?십";
       public const string TenToNinetyNativeIntegerRegex = @"(스무|열|스물|서른|마흔|쉰|예순|일흔|여든|아흔)";
       public static readonly string ElevenToNineteenSinoIntegerRegex = $@"십({ZeroToNineIntegerRegex})";
@@ -138,10 +138,10 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}|^{NegativeNumberTermsRegexNum}";
       public static readonly string SpeGetNumberRegex = $@"{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[십반]";
       public const string PairRegex = @".*[쌍짝]$";
-      public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스))만(?![큼|을])|억|조(?!각)|경|열)";
-      public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/)";
-      public static readonly string NotSingleRegex = $@"((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십])\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|십|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)";
-      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구)(?={AllowListRegex}))";
+      public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)|경|열)";
+      public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/|만)";
+      public static readonly string NotSingleRegex = $@"({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)";
+      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구|세|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
       public static readonly string NativeSingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})";
       public static readonly string NativeIntRegex = $@"((({ZeroToNineIntegerRegex}\s*)?({RoundNumberIntegerRegex}+\s*)?({TenToNinetyNativeIntegerRegex}\s*)?({ZeroToNineIntegerRegex}))|({TenToNinetyNativeIntegerRegex}))";
       public static readonly string AllIntRegex = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex})|{NativeIntRegex}+)";
@@ -153,7 +153,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string DottedNumbersSpecialsChar = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+";
       public const string PointRegexStr = @"[점\.．]";
       public static readonly string AllFloatRegex = $@"{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[일이삼사오육칠팔구영](\s*{ZeroToNineIntegerRegex})*";
-      public static readonly string NumbersWithAllowListRegex = $@"((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(과\s*(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+";
+      public static readonly string NumbersWithAllowListRegex = $@"((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(((?<!사)(과\s*))(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+";
       public static readonly string NumbersAggressiveRegex = $@"(?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점)";
       public static readonly string PointRegex = $@"{PointRegexStr}";
       public static readonly string DoubleSpecialsChars = $@"(?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+))";
@@ -165,7 +165,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string DoubleAllFloatRegex = $@"(?<!백\s*분\s*의\s*(({AllIntRegex}점*)|{AllFloatRegex})*){AllFloatRegex}(?!{ZeroToNineIntegerRegex}*\s*개\s*백\s*분\s*점)";
       public static readonly string DoubleExponentialNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)|[0０](?!{ZeroToNineFullHalfRegex}+))";
       public static readonly string DoubleScientificNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)";
-      public static readonly string OrdinalRegex = $@"(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*번째)|첫(음|번째)?|처음|일등";
+      public static readonly string OrdinalRegex = $@"(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등";
       public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))";
       public static readonly string OrdinalNumbersRegex = $@"{ZeroToNineFullHalfRegex}+\s*(번째)";
       public static readonly string OrdinalKoreanRegex = $@"({OrdinalRegex}|{RelativeOrdinalRegex}|{OrdinalNumbersRegex})";
@@ -188,29 +188,33 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*개\s*백\s*분\s*점";
       public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d)({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})?({AllIntRegex}|{ZeroToNineFullHalfRegex}|{RoundNumberIntegerRegex})+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)([％%]|(퍼\s*센\s*트)|(프\s*로)|(퍼\s*센\s*티\s*지))(?!\d)";
       public const string TillRegex = @"(부터|에서|--|-|—|–|——|~)";
-      public const string MoreRegex = @"(초과|많|높|크|더많|더높|더크|>|넘는|초과이다|크고)";
+      public const string MoreRegex = @"(초과|많|높|더많|더높|더크|>|넘는|초과이다|크고|(을 초과하는)|크)";
       public const string LessRegex = @"(미만|적|낮|작|더적|더낮|더적|이하|이하이다|<|아래|작다)";
       public const string EqualRegex = @"(동일|같|=|(해당하는)|는|그와 같다)";
       public const string RangePrefixLessRegex = @"(까지최소|(?<!>|=)<|≤)";
       public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥)";
       public static readonly string MoreOrEqual = $@"(({MoreRegex}\s*(거나)?\s*{EqualRegex}))";
+      public static readonly string MoreOrEqual2 = $@"(\s*(거나)?\s*(그보다)\s*{MoreRegex})";
       public const string MoreOrEqualSuffix = @"\s*(이상)";
       public static readonly string LessOrEqual = $@"(?:(이|보다)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?))";
-      public const string LessOrEqualSuffix = @"\s*(이하)";
+      public const string LessOrEqualSuffix = @"\s*(이하|(달하는))";
       public const string OneNumberRangeMoreSeparateRegex = @"^[.]";
       public const string OneNumberRangeLessSeparateRegex = @"^[.]";
       public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))";
-      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
+      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
       public static readonly string OneNumberRangeMoreRegex2 = $@"(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
       public static readonly string OneNumberRangeMoreRegex3 = $@"({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))";
-      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑))";
-      public static readonly string OneNumberRangeLessRegex2 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나)\s*(최소)\s*(\d+)";
-      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number1>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))";
+      public static readonly string OneNumberRangeMoreRegex4 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?";
+      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑|이하))";
+      public static readonly string OneNumberRangeLessRegex2 = $@"((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)";
+      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))";
+      public static readonly string OneNumberRangeLessRegex4 = $@"(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))";
       public static readonly string TwoNumberRangeRegex1 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)";
-      public static readonly string TwoNumberRangeRegex2 = $@"({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1})";
+      public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(까지)?";
       public static readonly string TwoNumberRangeRegex5 = $@"(?<number1>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*{TillRegex}\s*(?<number2>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+)";
+      public static readonly string TwoNumberRangeRegex6 = $@"((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))";
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {
             { @"마지막", @"0" },

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
@@ -45,6 +45,10 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex6, RegexFlags),
+                    NumberRangeConstants.TWONUMTILL
+                },
+                {
                     // ...이상|초과|많|높|크|더많|더높|더크|>
                     new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
@@ -75,6 +79,15 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                 {
                     new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
+                },
+                {
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
+                    NumberRangeConstants.EQUAL
+                },
+                {
+                    // 700에 달하는
+                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex4, RegexFlags),
+                    NumberRangeConstants.LESS
                 },
         };
 

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -132,7 +132,7 @@ DoubleAndRoundRegex: !nestedRegex
 FracSplitRegex: !simpleRegex
   def: '(와|과|분\s*의|중)'
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (영|령|공|일|(?<!(율|답))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)
+  def: (영|령|공|일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)
 TenToNinetySinoIntegerRegex: !nestedRegex
   def: ({ZeroToNineIntegerRegex})?십
   references: [ZeroToNineIntegerRegex]
@@ -154,14 +154,14 @@ SpeGetNumberRegex: !nestedRegex
 PairRegex: .*[쌍짝]$
 #IntegerExtractor
 RoundNumberIntegerRegex: !simpleRegex
-  def: (십|백|천|(?<!(큼|\s일|다스))만(?![큼|을])|억|조(?!각)|경|열)
+  def: (십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)|경|열)
 AllowListRegex: !simpleRegex
-  def: (。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/)
+  def: (。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/|만)
 NotSingleRegex: !nestedRegex
-  def: ((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십])\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|십|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)
-  references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
+  def: ({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)
+  references: [TenToNinetyNativeIntegerRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 SingleRegex: !nestedRegex
-  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구)(?={AllowListRegex}))
+  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구|세|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))
   references: [ZeroToNineIntegerRegex, AllowListRegex]
 NativeSingleRegex: !nestedRegex
   def: (?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})
@@ -196,7 +196,7 @@ AllFloatRegex: !nestedRegex
   def: '{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[일이삼사오육칠팔구영](\s*{ZeroToNineIntegerRegex})*'
   references: [NegativeNumberTermsRegex, AllIntRegex, PointRegexStr, ZeroToNineIntegerRegex]
 NumbersWithAllowListRegex: !nestedRegex
-  def: ((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(과\s*(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+
+  def: ((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(((?<!사)(과\s*))(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+
   references: [AllIntRegex, AllFloatRegex, NegativeNumberTermsRegex, NotSingleRegex, SingleRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 NumbersAggressiveRegex: !nestedRegex
   def: (?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점)
@@ -234,7 +234,7 @@ DoubleScientificNotationRegex: !nestedRegex
   references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
 #OrdinalExtractor
 OrdinalRegex: !nestedRegex
-  def: '(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*번째)|첫(음|번째)?|처음|일등'
+  def: '(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등'
   references: [AllIntRegex,RoundNumberIntegerRegex]
 RelativeOrdinalRegex: !simpleRegex
   def: (?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))
@@ -304,7 +304,7 @@ SimpleIntegerPercentageRegex: !nestedRegex
 TillRegex: !simpleRegex
   def: (부터|에서|--|-|—|–|——|~)
 MoreRegex: !simpleRegex
-  def: (초과|많|높|크|더많|더높|더크|>|넘는|초과이다|크고)
+  def: (초과|많|높|더많|더높|더크|>|넘는|초과이다|크고|(을 초과하는)|크)
 LessRegex: !simpleRegex
   def: (미만|적|낮|작|더적|더낮|더적|이하|이하이다|<|아래|작다)
 EqualRegex: !simpleRegex
@@ -316,13 +316,16 @@ RangePrefixMoreRegex: !simpleRegex
 MoreOrEqual: !nestedRegex
   def: (({MoreRegex}\s*(거나)?\s*{EqualRegex}))
   references: [ MoreRegex, EqualRegex ]
+MoreOrEqual2: !nestedRegex
+  def: (\s*(거나)?\s*(그보다)\s*{MoreRegex})
+  references: [ MoreRegex, EqualRegex ]
 MoreOrEqualSuffix: !simpleRegex
   def: \s*(이상)
 LessOrEqual: !nestedRegex
   def: (?:(이|보다)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?))
   references: [ LessRegex, EqualRegex ]
 LessOrEqualSuffix: !simpleRegex
-  def: \s*(이하)
+  def: \s*(이하|(달하는))
 OneNumberRangeMoreSeparateRegex: !simpleRegex
   # TODO: Regex not applicable in Korean, references need to be adjusted
   def: ^[.]
@@ -333,7 +336,7 @@ OneNumberRangeEqualRegex: !nestedRegex
   def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))
   references: [EqualRegex,LessRegex]
 OneNumberRangeMoreRegex1: !nestedRegex
-  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
+  def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
   references: [MoreOrEqual, MoreRegex, MoreOrEqualSuffix]
 OneNumberRangeMoreRegex2: !nestedRegex
   def: (?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
@@ -341,20 +344,26 @@ OneNumberRangeMoreRegex2: !nestedRegex
 OneNumberRangeMoreRegex3: !nestedRegex
   def: ({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))
   references: [RangePrefixMoreRegex]
+OneNumberRangeMoreRegex4: !nestedRegex
+  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?
+  references: [MoreOrEqual2,EqualRegex]
 OneNumberRangeLessRegex1: !nestedRegex
-  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑))
+  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑|이하))
   references: [LessOrEqual, LessRegex]
 OneNumberRangeLessRegex2: !nestedRegex
-  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나)\s*(최소)\s*(\d+)
+  def: ((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)
   references: [EqualRegex]
 OneNumberRangeLessRegex3: !nestedRegex
-  def: (?:({RangePrefixLessRegex}))\s*(?<number1>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))
+  def: (?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))
   references: [RangePrefixLessRegex]
+OneNumberRangeLessRegex4: !nestedRegex
+  def: (?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))
+  references: [LessOrEqualSuffix]
 TwoNumberRangeRegex1: !nestedRegex
   def: (?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)
   references: [TillRegex]
 TwoNumberRangeRegex2: !nestedRegex
-  def: ({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1})
+  def: (({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})
   references: [ OneNumberRangeMoreRegex1, OneNumberRangeMoreRegex2, OneNumberRangeLessRegex1]
 TwoNumberRangeRegex3: !nestedRegex
   def: ({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})
@@ -364,6 +373,9 @@ TwoNumberRangeRegex4: !nestedRegex
   references: [TillRegex]
 TwoNumberRangeRegex5: !nestedRegex
   def: (?<number1>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*{TillRegex}\s*(?<number2>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+)
+  references: [TillRegex]
+TwoNumberRangeRegex6: !nestedRegex
+  def: ((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))
   references: [TillRegex]
 RelativeReferenceOffsetMap: !dictionary
   types: [ string, string ]

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -1545,6 +1545,7 @@
   },
   {
     "Input": "0은 영이다.",
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1565,6 +1566,7 @@
   },
   {
     "Input": "5/17/2018에 만날까요?",
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1592,6 +1594,7 @@
   },
   {
     "Input": "내 전화번호는 +1-222-2222/2222입니다.",
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3946,8 +3949,6 @@
     "Input": "셋에 출발하시면 됩니다",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "셋",
@@ -3965,8 +3966,6 @@
     "Input": "하나만 주세요",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "하나",
@@ -4001,8 +4000,6 @@
     "Input": "일흔 살",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "일흔",
@@ -4017,11 +4014,9 @@
     ]
   },
   {
-    "Input": "이 곱하기 십삼은 이십육이다",
+    "Input": "내가 가장 좋아하는 숫자는 이십육이다",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "이십육",
@@ -4030,8 +4025,8 @@
           "subtype": "integer",
           "value": "26"
         },
-        "Start": 10,
-        "End": 12
+        "Start": 15,
+        "End": 17
       }
     ]
   },
@@ -4039,8 +4034,6 @@
     "Input": "사과 세개",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "세",

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -133,10 +133,8 @@
   },
   {
     "Input": "이 숫자는 100보다 크고 300보다 작다.",
-    "IgnoreResolution": true,
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "100보다 크고 300보다 작다",
@@ -197,10 +195,8 @@
   },
   {
     "Input": "숫자의 범위는 20부터 100까지 이다.",
-    "IgnoreResolution": true,
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "20부터 100까지",
@@ -513,10 +509,8 @@
   },
   {
     "Input": "x는 10보다 크고 20보다 작다. y는 50 이하, 20 이상이다.",
-    "IgnoreResolution": true,
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "10보다 크고 20보다 작다",
@@ -825,10 +819,7 @@
   },
   {
     "Input": "이 숫자는 이십 초과 삼십오 이하이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "이십 초과 삼십오 이하",
@@ -860,9 +851,7 @@
   {
     "Input": "그는 십위와 십오위 사이에 있다",
     "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "십위와 십오위 사이",
@@ -912,9 +901,7 @@
   {
     "Input": "이 숫자는 백 이상, 삼백 이하이다",
     "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "백 이상, 삼백 이하",
@@ -959,10 +946,7 @@
   },
   {
     "Input": "이 수의 범위는 천에서 천오백까지이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "천에서 천오백까지",
@@ -1339,9 +1323,7 @@
   {
     "Input": "그의 점수는 5000과 같거나 그보다 많다",
     "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "5000과 같거나 그보다 많다",
@@ -1606,10 +1588,7 @@
   },
   {
     "Input": "그 수는 200에서부터 2008분의 3000000까지이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "200에서부터 2008분의 3000000까지",
@@ -1657,10 +1636,7 @@
   },
   {
     "Input": "닛산 모터 회사는 700에 달하는 계약직 노동자를 해고할 계획이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "700에 달하는",
@@ -1675,10 +1651,7 @@
   },
   {
     "Input": "700에 달하는 것이 >700으로 인식되어서는 안된다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "700에 달하는",
@@ -1720,10 +1693,7 @@
   },
   {
     "Input": "이 수는 1000보다 크고 1500보다 작다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1000보다 크고 1500보다 작다",
@@ -1851,9 +1821,7 @@
   {
     "Input": "그의 점수는 30이거나 최소 30이다",
     "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "30이거나 최소 30",
@@ -1884,10 +1852,7 @@
   },
   {
     "Input": "3000을 초과하는 기준",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "3000을 초과하는",


### PR DESCRIPTION
**PR Includes**
- Number Definitions

**Number Extractor (Integer Improvement)**
- Total Cases 244: (Extractor Passed - 226, Full Passed - 101, Skipped - 18)
- New Test Spec: Cases 135 (Extractor Passed - 128, Full Passed - 4, Skipped - 7)
- Integer 56: Extraction Passed-55, Skipped-1
- Fraction 58: Extraction Passed-58
- Decimal 9: Extraction Passed-9
- Power 2: Extraction Passed-2
- Negative 10 : Extraction Passed-4, Skipped-6

**Number Range Extractor**

- Total Test Cases 122: (Extractor Passed - 85, Full Passed - 64, Skipped - 37)
- Existing Cases 53: Extractor Passed - 26, Full Passed - 22, Skipped- 27
- New Cases 69: Extractor Passed - 59, Full Passed - 42, Skipped - 10

**Case input modified **"이 곱하기 십삼은 이십육이다"** to **"내가 가장 좋아하는 숫자는 이십육이다"**

**Reason:** Earlier input had 3 numbers but there was only 1 text in result set. So need to be modified either input or result set.