### PR TITLE
[KO Number] Coverage Improvement (Number, Ordinal, NumberRange) and Specs Update

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string PercentageRegex = @"(?<=백\s*분\s*의).+|.+(?=퍼\s*센\s*트)|.*(?=[％%])";
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[만억]{{1,2}}(\s*(이상))?";
       public const string FracSplitRegex = @"(와|과|분\s*의|중)";
-      public const string ZeroToNineIntegerRegex = @"(영|령|공|일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
+      public const string ZeroToNineIntegerRegex = @"(영|령|공|(?<!생)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
       public static readonly string TenToNinetySinoIntegerRegex = $@"({ZeroToNineIntegerRegex})?십";
       public const string TenToNinetyNativeIntegerRegex = @"(스무|열|스물|서른|마흔|쉰|예순|일흔|여든|아흔)";
       public static readonly string ElevenToNineteenSinoIntegerRegex = $@"십({ZeroToNineIntegerRegex})";
@@ -141,14 +141,14 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)|경|열)";
       public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/|만)";
       public static readonly string NotSingleRegex = $@"({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)";
-      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구|세|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
+      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(랑|주))|(?<![시])오(?!(월|늘))|육|칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
       public static readonly string NativeSingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})";
       public static readonly string NativeIntRegex = $@"((({ZeroToNineIntegerRegex}\s*)?({RoundNumberIntegerRegex}+\s*)?({TenToNinetyNativeIntegerRegex}\s*)?({ZeroToNineIntegerRegex}))|({TenToNinetyNativeIntegerRegex}))";
       public static readonly string AllIntRegex = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex})|{NativeIntRegex}+)";
       public static readonly string NativeCumKoreanRegex = $@"({ZeroToNineFullHalfRegex}+)\s*(({RoundNumberIntegerRegex}+)({ZeroToNineFullHalfRegex}+))+";
       public static readonly string NumbersWithDozen = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex}))?(다스)(?!{AllIntRegex})";
-      public static readonly string NumbersSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?{ZeroToNineFullHalfRegex}+)";
-      public static readonly string NumbersSpecialsCharsWithSuffix = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}";
+      public static readonly string NumbersSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))";
+      public static readonly string NumbersSpecialsCharsWithSuffix = $@"({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))";
       public static readonly string ZeroToNineIntegerSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*){ZeroToNineIntegerRegex}+)";
       public static readonly string DottedNumbersSpecialsChar = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+";
       public const string PointRegexStr = @"[점\.．]";
@@ -156,18 +156,18 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NumbersWithAllowListRegex = $@"((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(((?<!사)(과\s*))(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+";
       public static readonly string NumbersAggressiveRegex = $@"(?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점)";
       public static readonly string PointRegex = $@"{PointRegexStr}";
-      public static readonly string DoubleSpecialsChars = $@"(?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+))";
+      public static readonly string DoubleSpecialsChars = $@"((?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
       public static readonly string DoubleRoundNumberSpecialsChars = $@"(?<!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*))(({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]\s?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+(?!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+))";
-      public static readonly string DoubleSpecialsCharsWithNegatives = $@"(?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))";
-      public static readonly string SimpleDoubleSpecialsChars = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+";
-      public static readonly string DoubleWithMultiplierRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}";
+      public static readonly string DoubleSpecialsCharsWithNegatives = $@"((?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
+      public static readonly string SimpleDoubleSpecialsChars = $@"(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+)";
+      public static readonly string DoubleWithMultiplierRegex = $@"(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex})(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
       public static readonly string DoubleWithThousandsRegex = $@"{NegativeNumberTermsRegex}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?\s*?[백천만억]{{1,2}}";
       public static readonly string DoubleAllFloatRegex = $@"(?<!백\s*분\s*의\s*(({AllIntRegex}점*)|{AllFloatRegex})*){AllFloatRegex}(?!{ZeroToNineIntegerRegex}*\s*개\s*백\s*분\s*점)";
       public static readonly string DoubleExponentialNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)|[0０](?!{ZeroToNineFullHalfRegex}+))";
       public static readonly string DoubleScientificNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9１２３４５６７８９]{ZeroToNineFullHalfRegex}*)";
-      public static readonly string OrdinalRegex = $@"(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등";
-      public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))";
-      public static readonly string OrdinalNumbersRegex = $@"{ZeroToNineFullHalfRegex}+\s*(번째)";
+      public static readonly string OrdinalRegex = $@"((({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등)|((({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+)(?:일|등|번째))";
+      public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>((끝(에서)?\s*((세|두)번째)?(바로)?\s*(전의)?(\s*것)?)|뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))";
+      public static readonly string OrdinalNumbersRegex = $@"({ZeroToNineFullHalfRegex}+\s*(번째))|({ZeroToNineFullHalfRegex}+(?:일))";
       public static readonly string OrdinalKoreanRegex = $@"({OrdinalRegex}|{RelativeOrdinalRegex}|{OrdinalNumbersRegex})";
       public static readonly string AllFractionNumber = $@"(반)|({NegativeNumberTermsRegex}?((({ZeroToNineFullHalfRegex}+|{AllIntRegex}+|{ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+)\s*(와|과)\s*)+)?{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex}+|{ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+)\s*(분\s*의|중)\s*{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex}+|{ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+))";
       public static readonly string FractionNotationSpecialsCharsRegex = $@"(?<!(/|-|\d+))(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+\s+{ZeroToNineFullHalfRegex}+[/／]{ZeroToNineFullHalfRegex}+)(?!(/|\d+))";
@@ -201,20 +201,25 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string OneNumberRangeMoreSeparateRegex = @"^[.]";
       public const string OneNumberRangeLessSeparateRegex = @"^[.]";
       public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))";
+      public static readonly string OneNumberRangeEqualRegex2 = $@"((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))";
       public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
-      public static readonly string OneNumberRangeMoreRegex2 = $@"(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
+      public static readonly string OneNumberRangeMoreRegex2 = $@"(?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+))))|(사분의\s)).)+)(보다)?\s({MoreRegex})|(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
       public static readonly string OneNumberRangeMoreRegex3 = $@"({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))";
       public static readonly string OneNumberRangeMoreRegex4 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?";
-      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑|이하))";
+      public static readonly string OneNumberRangeMoreRegex5 = $@"(?<number1>((?![,.](?!\d+)).)+)\s*((또는)\s+(그){MoreOrEqualSuffix})";
+      public static readonly string OneNumberRangeMoreRegexFraction = $@"((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})";
+      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}";
       public static readonly string OneNumberRangeLessRegex2 = $@"((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)";
       public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))";
       public static readonly string OneNumberRangeLessRegex4 = $@"(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))";
+      public const string OneNumberRangeLessRegex5 = @"((?<number2>((이분의\s)|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다|보다)?\s*(미만|적게|밑|이하|작다))";
       public static readonly string TwoNumberRangeRegex1 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)";
       public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(까지)?";
       public static readonly string TwoNumberRangeRegex5 = $@"(?<number1>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*{TillRegex}\s*(?<number2>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+)";
       public static readonly string TwoNumberRangeRegex6 = $@"((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))";
+      public static readonly string TwoNumberRangeRegex7 = $@"({OneNumberRangeMoreRegex2}\s*{OneNumberRangeLessRegex5})";
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {
             { @"마지막", @"0" },
@@ -227,7 +232,11 @@ namespace Microsoft.Recognizers.Definitions.Korean
             { @"다음 것", @"1" },
             { @"마지막에서 바로 전", @"-1" },
             { @"지금의 것", @"0" },
-            { @"현재", @"0" }
+            { @"현재", @"0" },
+            { @"끝", @"0" },
+            { @"끝에서 세번째", @"-2" },
+            { @"끝에서 두번째", @"-1" },
+            { @"끝에서 바로 전의 것", @"-1" }
         };
       public static readonly Dictionary<string, string> RelativeReferenceRelativeToMap = new Dictionary<string, string>
         {
@@ -241,7 +250,11 @@ namespace Microsoft.Recognizers.Definitions.Korean
             { @"다음 것", @"current" },
             { @"마지막에서 바로 전", @"end" },
             { @"지금의 것", @"current" },
-            { @"현재", @"current" }
+            { @"현재", @"current" },
+            { @"끝", @"end" },
+            { @"끝에서 세번째", @"end" },
+            { @"끝에서 두번째", @"end" },
+            { @"끝에서 바로 전의 것", @"end" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     NumberRangeConstants.TWONUM
                 },
                 {
+                    // 이십보다 크고 삼십오보다 작다
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex7, RegexFlags),
+                    NumberRangeConstants.TWONUM
+                },
+                {
                     // ...에서..., 20~30
                     new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
@@ -64,6 +69,15 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     NumberRangeConstants.MORE
                 },
                 {
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex5, RegexFlags),
+                    NumberRangeConstants.MORE
+                },
+                {
+                   // >|≥...
+                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegexFraction, RegexFlags),
+                    NumberRangeConstants.MORE
+                },
+                {
                     new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
@@ -78,6 +92,11 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                 },
                 {
                     new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    NumberRangeConstants.EQUAL
+                },
+                {
+                    // >|≥...
+                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex2, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -132,7 +132,7 @@ DoubleAndRoundRegex: !nestedRegex
 FracSplitRegex: !simpleRegex
   def: '(와|과|분\s*의|중)'
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (영|령|공|일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!월)|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)
+  def: (영|령|공|(?<!생)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|칠|팔|구|한|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)
 TenToNinetySinoIntegerRegex: !nestedRegex
   def: ({ZeroToNineIntegerRegex})?십
   references: [ZeroToNineIntegerRegex]
@@ -161,7 +161,7 @@ NotSingleRegex: !nestedRegex
   def: ({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)
   references: [TenToNinetyNativeIntegerRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 SingleRegex: !nestedRegex
-  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|일|두|삼|사(?!(랑|주))|(?<![시])오|육|칠|팔|구|세|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))
+  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(랑|주))|(?<![시])오(?!(월|늘))|육|칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))
   references: [ZeroToNineIntegerRegex, AllowListRegex]
 NativeSingleRegex: !nestedRegex
   def: (?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})
@@ -179,10 +179,10 @@ NumbersWithDozen: !nestedRegex
   def: '(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){1,2}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex}))?(다스)(?!{AllIntRegex})'
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex, AllIntRegex]
 NumbersSpecialsChars: !nestedRegex
-  def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?{ZeroToNineFullHalfRegex}+)
+  def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, NegativeNumberTermsRegex]
 NumbersSpecialsCharsWithSuffix: !nestedRegex
-  def: '{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}'
+  def: '({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))'
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, BaseNumbers.NumberMultiplierRegex]
 ZeroToNineIntegerSpecialsChars: !nestedRegex
   def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*){ZeroToNineIntegerRegex}+)
@@ -206,19 +206,19 @@ PointRegex: !nestedRegex
   def: '{PointRegexStr}'
   references: [PointRegexStr]
 DoubleSpecialsChars: !nestedRegex
-  def: (?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+))
+  def: ((?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))
   references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
 DoubleRoundNumberSpecialsChars: !nestedRegex
   def: (?<!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*))(({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]\s?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+(?!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+))
   references: [NegativeNumberTermsRegexNum,NegativeNumberTermsRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex]
 DoubleSpecialsCharsWithNegatives: !nestedRegex
-  def: (?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))
+  def: ((?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))
   references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
 SimpleDoubleSpecialsChars: !nestedRegex
-  def: ({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+
+  def: (({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+)
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
 DoubleWithMultiplierRegex: !nestedRegex
-  def: ({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}
+  def: (({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex})(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, BaseNumbers.NumberMultiplierRegex]
 DoubleWithThousandsRegex: !nestedRegex
   def: '{NegativeNumberTermsRegex}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?\s*?[백천만억]{1,2}'
@@ -234,12 +234,12 @@ DoubleScientificNotationRegex: !nestedRegex
   references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
 #OrdinalExtractor
 OrdinalRegex: !nestedRegex
-  def: '(({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등'
-  references: [AllIntRegex,RoundNumberIntegerRegex]
+  def: '((({AllIntRegex}|{RoundNumberIntegerRegex}+)\s*(번째|위))|첫(음|번째)?|처음|일등)|((({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+)(?:일|등|번째))'
+  references: [AllIntRegex,RoundNumberIntegerRegex,ZeroToNineIntegerRegex]
 RelativeOrdinalRegex: !simpleRegex
-  def: (?<relativeOrdinal>(뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))
+  def: (?<relativeOrdinal>((끝(에서)?\s*((세|두)번째)?(바로)?\s*(전의)?(\s*것)?)|뒤에서 세번째|다음(\s*것)?|이전 것|현재|(((마지막)((에)?\s*((서)?\s*(두번째|((바로)?\s*(것|전)))|의 옆))?)|지금)(의 것)?))
 OrdinalNumbersRegex: !nestedRegex
-  def: '{ZeroToNineFullHalfRegex}+\s*(번째)'
+  def: '({ZeroToNineFullHalfRegex}+\s*(번째))|({ZeroToNineFullHalfRegex}+(?:일))'
   references: [ZeroToNineFullHalfRegex]
 OrdinalKoreanRegex: !nestedRegex
   def: '({OrdinalRegex}|{RelativeOrdinalRegex}|{OrdinalNumbersRegex})'
@@ -335,11 +335,14 @@ OneNumberRangeLessSeparateRegex: !simpleRegex
 OneNumberRangeEqualRegex: !nestedRegex
   def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))
   references: [EqualRegex,LessRegex]
+OneNumberRangeEqualRegex2: !nestedRegex
+  def: ((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))
+  references: [AllIntRegex]
 OneNumberRangeMoreRegex1: !nestedRegex
   def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
   references: [MoreOrEqual, MoreRegex, MoreOrEqualSuffix]
 OneNumberRangeMoreRegex2: !nestedRegex
-  def: (?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
+  def: (?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+))))|(사분의\s)).)+)(보다)?\s({MoreRegex})|(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
   references: [MoreRegex, MoreOrEqualSuffix]
 OneNumberRangeMoreRegex3: !nestedRegex
   def: ({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))
@@ -347,9 +350,15 @@ OneNumberRangeMoreRegex3: !nestedRegex
 OneNumberRangeMoreRegex4: !nestedRegex
   def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?
   references: [MoreOrEqual2,EqualRegex]
+OneNumberRangeMoreRegex5: !nestedRegex
+  def: (?<number1>((?![,.](?!\d+)).)+)\s*((또는)\s+(그){MoreOrEqualSuffix})
+  references: [MoreOrEqualSuffix]
+OneNumberRangeMoreRegexFraction: !nestedRegex
+  def: ((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})
+  references: [MoreRegex]
 OneNumberRangeLessRegex1: !nestedRegex
-  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|((?<number2>([영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다)?\s*(미만|적게|밑|이하))
-  references: [LessOrEqual, LessRegex]
+  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}
+  references: [LessOrEqual, LessRegex,OneNumberRangeLessRegex5]
 OneNumberRangeLessRegex2: !nestedRegex
   def: ((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)
   references: [EqualRegex]
@@ -359,6 +368,8 @@ OneNumberRangeLessRegex3: !nestedRegex
 OneNumberRangeLessRegex4: !nestedRegex
   def: (?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))
   references: [LessOrEqualSuffix]
+OneNumberRangeLessRegex5: !simpleRegex
+  def: ((?<number2>((이분의\s)|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다|보다)?\s*(미만|적게|밑|이하|작다))
 TwoNumberRangeRegex1: !nestedRegex
   def: (?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)
   references: [TillRegex]
@@ -377,6 +388,9 @@ TwoNumberRangeRegex5: !nestedRegex
 TwoNumberRangeRegex6: !nestedRegex
   def: ((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))
   references: [TillRegex]
+TwoNumberRangeRegex7: !nestedRegex
+  def: ({OneNumberRangeMoreRegex2}\s*{OneNumberRangeLessRegex5})
+  references: [OneNumberRangeMoreRegex2, OneNumberRangeLessRegex5]
 RelativeReferenceOffsetMap: !dictionary
   types: [ string, string ]
   entries:
@@ -391,6 +405,10 @@ RelativeReferenceOffsetMap: !dictionary
     마지막에서 바로 전: -1
     지금의 것: 0
     현재: 0
+    끝: 0
+    끝에서 세번째: -2
+    끝에서 두번째: -1
+    끝에서 바로 전의 것: -1
 RelativeReferenceRelativeToMap: !dictionary
   types: [ string, string ]
   entries:
@@ -405,4 +423,8 @@ RelativeReferenceRelativeToMap: !dictionary
     마지막에서 바로 전: end
     지금의 것: current
     현재: current
+    끝: end
+    끝에서 세번째: end
+    끝에서 두번째: end
+    끝에서 바로 전의 것: end
 ...

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -64,8 +64,9 @@
   },
   {
     "Input": "180.25ml의 액체",
-    "Comment": "PendingValidation",
+    "Comment": "PendingValidation, incorrect result set",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "180.25",
@@ -78,8 +79,9 @@
   },
   {
     "Input": "180ml의 액체",
-    "Comment": "PendingValidation",
+    "Comment": "PendingValidation, incorrect result set",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "180",
@@ -129,8 +131,9 @@
   },
   {
     "Input": ".25ml의 액체",
-    "Comment": "PendingValidation",
+    "Comment": "PendingValidation, incorrect result set",
     "NotSupportedByDesign": "javascript,python,java",
+    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": ".25",
@@ -2930,7 +2933,6 @@
     "Input": "백억분의 일만 주세요",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "백억분의 일",
@@ -3869,36 +3871,26 @@
   {
     "Input": "180.25ml  액체",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Need more research by language expert",
     "Results": []
   },
   {
     "Input": "180ml 액체",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Need more research by language expert",
     "Results": []
   },
   {
     "Input": "29km 길",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Need more research by language expert",
     "Results": []
   },
   {
     "Input": "내 생일은 오월 4일이다",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Need more research by language expert",
     "Results": []
   },
   {
     "Input": ".25ml 짜리 액체",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Need more research by language expert",
     "Results": []
   },
   {
@@ -4051,8 +4043,6 @@
     "Input": "사과 한 개",
     "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "PendingImplementation",
     "Results": [
       {
         "Text": "한",

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -57,7 +57,6 @@
     "IgnoreResolution": true,
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "십등에서 십오등 사이",
@@ -976,10 +975,7 @@
   },
   {
     "Input": "이 수는 사분의 일 초과 이분의 일 미만이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "사분의 일 초과 이분의 일 미만",
@@ -1024,10 +1020,7 @@
   },
   {
     "Input": "1/2이 넘는 사람들이 이곳에 왔다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1/2이 넘는",
@@ -1428,10 +1421,7 @@
   },
   {
     "Input": "5분의 2 또는 그 이상이 어때?",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "5분의 2 또는 그 이상",
@@ -1676,9 +1666,7 @@
   {
     "Input": "이 수는 이십보다 크고 삼십오보다 작다",
     "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "이십보다 크고 삼십오보다 작다",
@@ -1708,10 +1696,7 @@
   },
   {
     "Input": "이 수는 사분의 일보다 크고 이분의 일보다 작다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "사분의 일보다 크고 이분의 일보다 작다",
@@ -1757,10 +1742,7 @@
   },
   {
     "Input": "x는 백칠십이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "백칠십이다",
@@ -1802,10 +1784,7 @@
   },
   {
     "Input": "그 수는 20이다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "20이다",

--- a/Specs/Number/Korean/OrdinalModel.json
+++ b/Specs/Number/Korean/OrdinalModel.json
@@ -2,6 +2,7 @@
   {
     "Input": "3조 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -18,6 +19,7 @@
   {
     "Input": "조 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -34,6 +36,7 @@
   {
     "Input": "백조 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -50,6 +53,7 @@
   {
     "Input": "열한 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,6 +70,7 @@
   {
     "Input": "스물한 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -82,6 +87,7 @@
   {
     "Input": "서른 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -98,6 +104,7 @@
   {
     "Input": "두 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -114,6 +121,7 @@
   {
     "Input": "스무 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -130,6 +138,7 @@
   {
     "Input": "스물다섯 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -146,6 +155,7 @@
   {
     "Input": "백스물다섯 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -162,6 +172,7 @@
   {
     "Input": "백이십오 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -178,6 +189,7 @@
   {
     "Input": "조번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -194,6 +206,7 @@
   {
     "Input": "이십일조 삼백이십이 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -210,6 +223,7 @@
   {
     "Input": "이백 번째",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -226,6 +240,7 @@
   {
     "Input": "시애틀로 가는 일등석을 예약해주십시오.",
     "IgnoreResolution": true,
+    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -304,8 +319,6 @@
       }
     ]
   },
-
-
   {
     "Input": "마지막의 옆을 보여주세요",
     "IgnoreResolution": true,
@@ -450,7 +463,6 @@
       }
     ]
   },
-
   {
     "Input": "다음 아이템을 주세요",
     "IgnoreResolution": true,
@@ -507,7 +519,6 @@
   },
   {
     "Input": "나는 11번째이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -525,7 +536,6 @@
   },
   {
     "Input": "21번째 생일",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -543,7 +553,6 @@
   },
   {
     "Input": "그녀는 30번째를 기록했다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -561,7 +570,6 @@
   },
   {
     "Input": "여행 온지 2번째 날이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -667,7 +675,6 @@
       }
     ]
   },
-
   {
     "Input": "백화점을 방문한 일조번째 손님",
     "IgnoreResolution": true,
@@ -881,6 +888,326 @@
         },
         "Start": 0,
         "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "끝에 서주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "끝",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 0,
+        "End": 0
+      }
+    ]
+  },
+  {
+    "Input": "끝에서 세번째를 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "끝에서 세번째",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-2",
+          "relativeTo": "end",
+          "value": "end-2"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "끝에서 바로 전의 것을 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "끝에서 바로 전의 것",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "끝에서 두번째를 보여주세요",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "끝에서 두번째",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "end",
+          "value": "end-1"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "오늘은 오월 11일이다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "11일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "11",
+          "relativeTo": "start",
+          "value": "11"
+        },
+        "Start": 7,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "오늘은 사월 21일이다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "21일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "21",
+          "relativeTo": "start",
+          "value": "21"
+        },
+        "Start": 7,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "어제는 삼월 30일이었다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "30일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "30",
+          "relativeTo": "start",
+          "value": "30"
+        },
+        "Start": 7,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "사월 2일",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "2",
+          "relativeTo": "start",
+          "value": "2"
+        },
+        "Start": 3,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "오월 십일일",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "십일일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "11",
+          "relativeTo": "start",
+          "value": "11"
+        },
+        "Start": 3,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "유월 이십일",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이십일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "20",
+          "relativeTo": "start",
+          "value": "20"
+        },
+        "Start": 3,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "칠월 이십오일",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이십오일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "25",
+          "relativeTo": "start",
+          "value": "25"
+        },
+        "Start": 3,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "BTS는 이십일일에 새 앨범을 낸다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이십일일",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "21",
+          "relativeTo": "start",
+          "value": "21"
+        },
+        "Start": 5,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "전교 백이십오등",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "백이십오등",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "125",
+          "relativeTo": "start",
+          "value": "125"
+        },
+        "Start": 3,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "이백등은 순위에 들지 않는다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이백등",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "200",
+          "relativeTo": "start",
+          "value": "200"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "그녀는 이등으로 들어옵니다!",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이등",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "2",
+          "relativeTo": "start",
+          "value": "2"
+        },
+        "Start": 4,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "이등은 은메달을 수여받는다",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이등",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "2",
+          "relativeTo": "start",
+          "value": "2"
+        },
+        "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "삼조번째",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "삼조번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "3000000000000",
+          "relativeTo": "start",
+          "value": "3000000000000"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "백조번째",
+    "IgnoreResolution": true,
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "백조번째",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "100000000000000",
+          "relativeTo": "start",
+          "value": "100000000000000"
+        },
+        "Start": 0,
+        "End": 3
       }
     ]
   }


### PR DESCRIPTION
**PR Includes**
- Number Definitions
- Specs
   - NumberModel
   - NumberRangeModel
   - OrdinalModel

- Number Model Extractor
   - Total Cases 243: (Extractor Passed - 229, Full Passed - 101, Skipped - 14)
   - New Test Spec: Cases 135 (Extractor Passed - 134, Full Passed - 9, Skipped - 1)
   - Integer 56: Extraction Passed-56
   - Fraction 58: Extraction Passed-58
   - Decimal 9: Extraction Passed-9
   - Power 2: Extraction Passed-2
   - Negative 10 : Extraction Passed-9, Skipped-1

- Number Range Model Extractor
  - Total Test Cases 122: (Extractor Passed - 93, Full Passed - 64, Skipped - 29)
  - Existing Cases 53: Extractor Passed - 26, Full Passed - 22, Skipped- 27
  - New Cases 69: Extractor Passed - 66, Full Passed - 48, Skipped - 3

- Ordinal Model Extractor
  - Total Test Cases 68: (Extractor Passed - 68, Full Passed - 8, Skipped - 0)