### PR TITLE
[.NET] Dutch DateTime Duration support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
-      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|decennia|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b";
+      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|jr|decennia|maand(en)?|mnd|week|weken|(?<business>(werk))?dag(en)?|dgn)\b";
       public const string DateTokenPrefix = @"op ";
       public const string TimeTokenPrefix = @"om ";
       public const string TokenBeforeDate = @"op ";
@@ -292,12 +292,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"decennia", @"10Y" },
             { @"jaren", @"Y" },
             { @"jaar", @"Y" },
+            { @"jr", @"Y" },
             { @"maanden", @"MON" },
             { @"maand", @"MON" },
+            { @"mnd", @"MON" },
             { @"weken", @"W" },
             { @"week", @"W" },
             { @"dagen", @"D" },
             { @"dag", @"D" },
+            { @"dgn", @"D" },
             { @"uren", @"H" },
             { @"uur", @"H" },
             { @"u", @"H" },
@@ -321,12 +324,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"decenniën", 315360000 },
             { @"jaren", 31536000 },
             { @"jaar", 31536000 },
+            { @"jr", 31536000 },
             { @"maanden", 2592000 },
             { @"maand", 2592000 },
+            { @"mnd", 2592000 },
             { @"weken", 604800 },
             { @"week", 604800 },
             { @"dagen", 86400 },
             { @"dag", 86400 },
+            { @"dgn", 86400 },
             { @"werkdagen", 86400 },
             { @"werkdag", 86400 },
             { @"uren", 3600 },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
-      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b";
+      public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|decennia|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b";
       public const string DateTokenPrefix = @"op ";
       public const string TimeTokenPrefix = @"om ";
       public const string TokenBeforeDate = @"op ";
@@ -138,10 +138,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
       public static readonly string WeekDayEnd = $@"(deze\s+)?{WeekDayRegex}\s*,?\s*$";
       public const string WeekDayStart = @"^[\.]";
-      public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maanden|maand|weken|week)\b";
+      public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maanden|maand|weken|week|dagen|dag)\b";
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
-      public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)";
-      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
+      public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)";
+      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
       public const string PmRegex = @"(?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
       public const string PmRegexFull = @"(?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
       public const string AmRegex = @"(?<am>(((’|‘|'|ʼ)\s*s|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))";
@@ -161,9 +161,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
       public static readonly string AtRegex = $@"(((?<=\bom\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
       public static readonly string IshRegex = $@"\b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b";
-      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>uren|uur|u|minuten|minuut|min\.?|mins|secondes|seconden|seconde|secs|sec\.?)\b";
+      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|uur|u|minuten|minuut|mins|min|secondes|seconden|seconde|secs|sec)\b)))";
       public const string RestrictedTimeUnitRegex = @"(?<unit>uur|minuut)\b";
-      public const string FivesRegex = @"(?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b";
+      public const string FivesRegex = @"(?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|vijventwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string PeriodHourNumRegex = @"\b(?<hour>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
       public static readonly string ConnectNumRegex = $@"\b{BaseDateTime.HourRegex}(?<min>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59)\s*{DescRegex}";
@@ -208,8 +208,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b";
       public const string LessThanRegex = @"\b(minder\s+dan)\b";
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|uur|uren|u|minuten|mins|m|secondes|secs|s)\b";
-      public const string SuffixAndRegex = @"(?<suffix>\s*(en)\s+(een\s+)?(?<suffix_num>half|kwart))";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
+      public const string SuffixAndRegex = @"(?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart))";
       public const string PeriodicRegex = @"\b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b";
       public static readonly string EachUnitRegex = $@"(?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(iedere|elke)\s*$)";
@@ -218,10 +218,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string EachDayRegex = @"^\s*(elke)\s*dag\b";
       public static readonly string DurationFollowedUnit = $@"^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex}";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}";
-      public static readonly string AnUnitRegex = $@"\b(?<half>(een\s(half|halve)))\s+{DurationUnitRegex}";
+      public static readonly string AnUnitRegex = $@"\b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}";
       public const string DuringRegex = @"\b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b";
-      public const string AllRegex = @"\b(?<all>((ge)?hele|volledige|ganse|heel|volledig)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
-      public const string HalfRegex = @"(((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur))\b";
+      public const string AllRegex = @"\b(?<all>((de|het|een)(\s+))?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
+      public const string HalfRegex = @"(((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b";
       public const string ConjunctionRegex = @"\b((en(\s+voor)?)|plus)\b";
       public static readonly string HolidayRegex1 = $@"\b(?<holiday>(goede\s+vrijdag|pasen|kerst|kerstavond|kerstmis|thanksgiving|halloween|nieuwjaar|bevrijdingsdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b";
       public static readonly string HolidayRegex2 = $@"\b(?<holiday>(nationale dodenherdenking|nationale herdenking|dodenherdenking|dag van de leraar|dag van de arbeid|martin luther kingdag|mlkdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b";
@@ -242,7 +242,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string AfternoonStartEndRegex = $@"(^(('s|des)\s+middags|in de (na)?middag|{PmDescRegex}))|((('s|des)\s+middags|in de (na)?middag|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(avond|('s|des)?\s+avonds))|((avond|('s|des)?\s+avonds)$)";
       public const string NightStartEndRegex = @"(^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)";
-      public const string InexactNumberRegex = @"\b(een aantal|meerdere|enkele|verscheidene|(een\s+)?paar)\b";
+      public const string InexactNumberRegex = @"\b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+({DurationUnitRegex})";
       public static readonly string RelativeTimeUnitRegex = $@"((({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({TimeUnitRegex}))|((de|het|mijn))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string RelativeDurationUnitRegex = $@"(((?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
@@ -278,7 +278,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+op)\s*$";
       public const string DecadeRegex = @"(?<decade>(de\s+jaren\s+(vijftig|zestig|zeventig|tachtig|negentig))|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e eeuw|(ee|éé)nentwintigste eeuw))";
       public static readonly string DecadeWithCenturyRegex = $@"(de\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?s)|(({CenturyRegex}(\s+|-)(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(en\s+)?(?<decade>tien|honderd)))";
-      public static readonly string RelativeDecadeRegex = $@"\b((de\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decennia?)\b";
+      public static readonly string RelativeDecadeRegex = $@"\b((de\s+)?{RelativeRegex}((?<number>[\w,]+)\s+)?decennia?)\b";
       public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b";
       public const string DateAfterRegex = @"\b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b";
       public static readonly string YearPeriodRegex = $@"((((vanaf|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
@@ -304,10 +304,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"minuten", @"M" },
             { @"minuut", @"M" },
             { @"min", @"M" },
+            { @"min.", @"M" },
             { @"secondes", @"S" },
+            { @"seconden", @"S" },
             { @"seconde", @"S" },
             { @"secs", @"S" },
-            { @"sec", @"S" }
+            { @"sec", @"S" },
+            { @"kwartier", @"H" },
+            { @"kwartier uur", @"H" },
+            { @"halfuur", @"H" }
         };
       public static readonly Dictionary<string, long> UnitValueMap = new Dictionary<string, long>
         {
@@ -330,11 +335,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"minuten", 60 },
             { @"minuut", 60 },
             { @"min", 60 },
+            { @"min.", 60 },
             { @"secondes", 1 },
             { @"seconden", 1 },
             { @"seconde", 1 },
             { @"secs", 1 },
-            { @"sec", 1 }
+            { @"sec", 1 },
+            { @"kwartier", 3600 },
+            { @"kwartier uur", 3600 },
+            { @"halfuur", 3600 }
         };
       public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
         {
@@ -528,6 +537,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"drieëntwintig", 23 },
             { @"vierentwintig", 24 },
             { @"vijfentwintig", 25 },
+            { @"vijventwintig", 25 },
             { @"zesentwintig", 26 },
             { @"zevenentwintig", 27 },
             { @"achtentwintig", 28 },
@@ -658,9 +668,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly Dictionary<string, double> DoubleNumbers = new Dictionary<string, double>
         {
             { @"half", 0.5 },
+            { @"anderhalf", 1.5 },
+            { @"anderhalve", 1.5 },
             { @"halve", 0.5 },
-            { @"kwart", 0.25 },
             { @"kwartier", 0.25 },
+            { @"kwart", 0.25 },
+            { @"driekwart", 0.75 },
+            { @"drie kwart", 0.75 },
             { @"kwartaal", 0.25 }
         };
       public static readonly Dictionary<string, IEnumerable<string>> HolidayNames = new Dictionary<string, IEnumerable<string>>
@@ -846,7 +860,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         };
       public static readonly IList<string> YearTerms = new List<string>
         {
-            @"jaar"
+            @"jaar",
+            @"jaren"
         };
       public static readonly IList<string> GenericYearTerms = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -208,15 +208,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b";
       public const string LessThanRegex = @"\b(minder\s+dan)\b";
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
-      public const string SuffixAndRegex = @"(?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart))";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier(\s+uur)?)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
+      public const string SuffixAndRegex = @"(?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
       public const string PeriodicRegex = @"\b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b";
       public static readonly string EachUnitRegex = $@"(?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(iedere|elke)\s*$)";
       public const string SetEachRegex = @"\b(?<each>(iedere|elke)\s*)";
       public const string SetLastRegex = @"(?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorig|verleden|vorige|laatste)";
       public const string EachDayRegex = @"^\s*(elke)\s*dag\b";
-      public static readonly string DurationFollowedUnit = $@"^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex}";
+      public static readonly string DurationFollowedUnit = $@"^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}";
       public static readonly string AnUnitRegex = $@"\b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}";
       public const string DuringRegex = @"\b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b";
@@ -677,6 +677,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"anderhalf", 1.5 },
             { @"anderhalve", 1.5 },
             { @"halve", 0.5 },
+            { @"een kwartier", 0.25 },
             { @"kwartier", 0.25 },
             { @"kwart", 0.25 },
             { @"driekwart", 0.75 },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string OrdinalDutchRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart|kwartier)";
+      public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)";
       public const string FractionHalfRegex = @"(ënhalf|enhalve|ëneenhalf|ëneenhalf)$";
       public static readonly string[] OneHalfTokens = { @"een", @"half" };
       public static readonly string FractionNounRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s+)?)?(({AllIntRegex})(\s+|\s*-\s*|\s*/\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))n?|halven|vierdes|kwart)|{FractionUnitsRegex}))(?=\b)";
@@ -165,7 +165,6 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"derde", 3 },
             { @"vierde", 4 },
             { @"kwart", 4 },
-            { @"kwartier", 4 },
             { @"vijfde", 5 },
             { @"vijfden", 5 },
             { @"zesde", 6 },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string OrdinalDutchRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)";
-      public const string FractionHalfRegex = @"(ënhalf|enhalve|ëneenhalf)$";
+      public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart|kwartier)";
+      public const string FractionHalfRegex = @"(ënhalf|enhalve|ëneenhalf|ëneenhalf)$";
       public static readonly string[] OneHalfTokens = { @"een", @"half" };
       public static readonly string FractionNounRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s+)?)?(({AllIntRegex})(\s+|\s*-\s*|\s*/\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))n?|halven|vierdes|kwart)|{FractionUnitsRegex}))(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s)?)?(een)(\s+|\s*-\s*|\s*/\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|({FractionUnitsRegex}))|{AllIntRegex}[eë]n(half|halve|helft|kwart))(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s)?)?(een)(\s+|\s*-\s*|\s*/\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|({FractionUnitsRegex}))|{AllIntRegex}[eë]n(eenhalf|half|halve|helft|kwart))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!,)\d+))\s+(op|op\s+de|van\s+de|uit|uit\s+de)\s+(?<denominator>({AllIntRegex})|(\d+)(?!,))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!,)\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?!,))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";
@@ -165,6 +165,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"derde", 3 },
             { @"vierde", 4 },
             { @"kwart", 4 },
+            { @"kwartier", 4 },
             { @"vijfde", 5 },
             { @"vijfden", 5 },
             { @"zesde", 6 },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
             var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
 
-            CardinalExtractor = Number.Dutch.CardinalExtractor.GetInstance(numConfig);
+            CardinalExtractor = Number.Dutch.NumberExtractor.GetInstance(numConfig);
 
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDurationParserConfiguration.cs
@@ -11,7 +11,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public DutchDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
-            CardinalExtractor = config.CardinalExtractor;
+            var numOptions = NumberOptions.None;
+            if ((config.Options & DateTimeOptions.NoProtoCache) != 0)
+            {
+                numOptions = NumberOptions.NoProtoCache;
+            }
+
+            var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
+
+            CardinalExtractor = Number.Dutch.NumberExtractor.GetInstance(numConfig);
             NumberParser = config.NumberParser;
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this), false);
             NumberCombinedWithUnit = DutchDurationExtractorConfiguration.NumberCombinedWithDurationUnit;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
@@ -191,7 +191,17 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 if (this.config.UnitMap.TryGetValue(srcUnit, out var unitStr))
                 {
-                    var numVal = double.Parse(pr.Value.ToString(), CultureInfo.InvariantCulture) + ParseNumberWithUnitAndSuffix(suffixStr);
+                    // First try to parse combined expression 'num + suffix'
+                    double numVal;
+                    var combStr = pr.Text + " " + suffixStr;
+                    if (this.config.DoubleNumbers.ContainsKey(combStr))
+                    {
+                        numVal = ParseNumberWithUnitAndSuffix(combStr);
+                    }
+                    else
+                    {
+                        numVal = double.Parse(pr.Value.ToString(), CultureInfo.InvariantCulture) + ParseNumberWithUnitAndSuffix(suffixStr);
+                    }
 
                     ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
                     ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -487,10 +487,10 @@ LessThanRegex: !simpleRegex
 MoreThanRegex: !simpleRegex
   def: \b(meer\s+dan)\b
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
+  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier(\s+uur)?)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
   references: [ DateUnitRegex ]
 SuffixAndRegex: !simpleRegex
-  def: (?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart))
+  def: (?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
 PeriodicRegex: !simpleRegex
   def: \b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b
 EachUnitRegex: !nestedRegex
@@ -505,7 +505,7 @@ SetLastRegex: !simpleRegex
 EachDayRegex: !simpleRegex
   def: ^\s*(elke)\s*dag\b
 DurationFollowedUnit: !nestedRegex
-  def: ^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex}
+  def: ^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})
   references: [ SuffixAndRegex, DurationUnitRegex ]
 NumberCombinedWithDurationUnit: !nestedRegex
   def: \b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}
@@ -1067,6 +1067,7 @@ DoubleNumbers: !dictionary
     anderhalf: 1.5
     anderhalve: 1.5
     halve: 0.5
+    een kwartier: 0.25
     kwartier: 0.25
     kwart: 0.25
     driekwart: 0.75

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -110,7 +110,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>eeuw(en)?|jaar|jaren|decennia|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b
+  def: (?<unit>eeuw(en)?|jaar|jaren|jr|decennia|maand(en)?|mnd|week|weken|(?<business>(werk))?dag(en)?|dgn)\b
 DateTokenPrefix: 'op '
 TimeTokenPrefix: 'om '
 TokenBeforeDate: 'op '
@@ -681,12 +681,15 @@ UnitMap: !dictionary
     decennia: 10Y
     jaren: Y
     jaar: Y
+    jr: Y
     maanden: MON
     maand: MON
+    mnd: MON
     weken: W
     week: W
     dagen: D
     dag: D
+    dgn: D
     uren: H
     uur: H
     u: H
@@ -710,12 +713,15 @@ UnitValueMap: !dictionary
     decenniën: 315360000
     jaren: 31536000
     jaar: 31536000
+    jr: 31536000
     maanden: 2592000
     maand: 2592000
+    mnd: 2592000
     weken: 604800
     week: 604800
     dagen: 86400
     dag: 86400
+    dgn: 86400
     werkdagen: 86400
     werkdag: 86400
     uren: 3600

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -110,7 +110,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>eeuw(en)?|jaar|jaren|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b
+  def: (?<unit>eeuw(en)?|jaar|jaren|decennia|maand(en)?|week|weken|(?<business>(werk))?dag(en)?)\b
 DateTokenPrefix: 'op '
 TimeTokenPrefix: 'om '
 TokenBeforeDate: 'op '
@@ -310,13 +310,13 @@ WeekDayEnd: !nestedRegex
 WeekDayStart: !simpleRegex
   def: ^[\.]
 RangeUnitRegex: !simpleRegex
-  def: \b(?<unit>jaren|jaar|maanden|maand|weken|week)\b
+  def: \b(?<unit>jaren|jaar|maanden|maand|weken|week|dagen|dag)\b
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b
 MinuteNumRegex: !simpleRegex
-  def: (?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)
+  def: (?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)
 DeltaMinuteNumRegex: !simpleRegex
-  def: (?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
+  def: (?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
 PmRegex: !simpleRegex
   def: (?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))
 PmRegexFull: !simpleRegex
@@ -365,11 +365,11 @@ IshRegex: !nestedRegex
   def: \b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b
   references: [ BaseDateTime.HourRegex ]
 TimeUnitRegex: !simpleRegex
-  def: ([^A-Za-z]{1,}|\b)(?<unit>uren|uur|u|minuten|minuut|min\.?|mins|secondes|seconden|seconde|secs|sec\.?)\b
+  def: ([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|uur|u|minuten|minuut|mins|min|secondes|seconden|seconde|secs|sec)\b)))
 RestrictedTimeUnitRegex: !simpleRegex
   def: (?<unit>uur|minuut)\b
 FivesRegex: !simpleRegex
-  def: (?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b
+  def: (?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|vijventwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -487,10 +487,10 @@ LessThanRegex: !simpleRegex
 MoreThanRegex: !simpleRegex
   def: \b(meer\s+dan)\b
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|uur|uren|u|minuten|mins|m|secondes|secs|s)\b
+  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
   references: [ DateUnitRegex ]
 SuffixAndRegex: !simpleRegex
-  def: (?<suffix>\s*(en)\s+(een\s+)?(?<suffix_num>half|kwart))
+  def: (?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart))
 PeriodicRegex: !simpleRegex
   def: \b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b
 EachUnitRegex: !nestedRegex
@@ -511,14 +511,14 @@ NumberCombinedWithDurationUnit: !nestedRegex
   def: \b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 AnUnitRegex: !nestedRegex
-  def: \b(?<half>(een\s(half|halve)))\s+{DurationUnitRegex}
+  def: \b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 DuringRegex: !simpleRegex
   def: \b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b
 AllRegex: !simpleRegex
-  def: \b(?<all>((ge)?hele|volledige|ganse|heel|volledig)(\s+|-)(?<unit>jaar|maand|week|dag))\b
+  def: \b(?<all>((de|het|een)(\s+))?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b
 HalfRegex: !simpleRegex
-  def: (((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur))\b
+  def: (((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b
 ConjunctionRegex: !simpleRegex
   def: \b((en(\s+voor)?)|plus)\b
 HolidayRegex1: !nestedRegex
@@ -571,7 +571,7 @@ EveningStartEndRegex: !simpleRegex
 NightStartEndRegex: !simpleRegex
   def: (^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)
 InexactNumberRegex: !simpleRegex
-  def: \b(een aantal|meerdere|enkele|verscheidene|(een\s+)?paar)\b
+  def: \b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b
 InexactNumberUnitRegex: !nestedRegex
   def: ({InexactNumberRegex})\s+({DurationUnitRegex})
   references: [InexactNumberRegex, DurationUnitRegex]
@@ -659,7 +659,7 @@ DecadeWithCenturyRegex: !nestedRegex
   def: (de\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?s)|(({CenturyRegex}(\s+|-)(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(en\s+)?(?<decade>tien|honderd)))
   references: [ CenturyRegex, DecadeRegex ]
 RelativeDecadeRegex: !nestedRegex
-  def: \b((de\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decennia?)\b
+  def: \b((de\s+)?{RelativeRegex}((?<number>[\w,]+)\s+)?decennia?)\b
   references: [ RelativeRegex ]
 SuffixAfterRegex: !simpleRegex
   def: \b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b
@@ -693,10 +693,15 @@ UnitMap: !dictionary
     minuten: M
     minuut: M
     min: M
+    min.: M
     secondes: S
+    seconden: S
     seconde: S
     secs: S
     sec: S
+    kwartier: H
+    kwartier uur: H
+    halfuur: H
 UnitValueMap: !dictionary
   types: [ string, long ]
   entries:
@@ -719,11 +724,15 @@ UnitValueMap: !dictionary
     minuten: 60
     minuut: 60
     min: 60
+    min.: 60
     secondes: 1
     seconden: 1
     seconde: 1
     secs: 1
     sec: 1
+    kwartier: 3600
+    kwartier uur: 3600
+    halfuur: 3600
 # TODO: modify below regex according to the counterpart in English
 SpecialYearPrefixesMap: !dictionary
   types: [ string, string ]
@@ -918,6 +927,7 @@ Numbers: !dictionary
     'drieëntwintig': 23
     'vierentwintig': 24
     'vijfentwintig': 25
+    'vijventwintig': 25
     'zesentwintig': 26
     'zevenentwintig': 27
     'achtentwintig': 28
@@ -1048,9 +1058,13 @@ DoubleNumbers: !dictionary
   types: [ string, double ]
   entries:
     half: 0.5
+    anderhalf: 1.5
+    anderhalve: 1.5
     halve: 0.5
-    kwart: 0.25
     kwartier: 0.25
+    kwart: 0.25
+    driekwart: 0.75
+    'drie kwart': 0.75
     kwartaal: 0.25
 HolidayNames: !dictionary
   types: [ string, 'string[]' ]
@@ -1245,6 +1259,7 @@ YearTerms: !list
   types: [ string ]
   entries:
     - jaar
+    - jaren
 GenericYearTerms: !list
   types: [ string ]
   entries:

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -80,15 +80,15 @@ FractionNotationWithSpacesRegex: !simpleRegex
 FractionNotationRegex: !simpleRegex         
   def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
 FractionUnitsRegex: !simpleRegex
-  def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)
+  def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart|kwartier)
 FractionHalfRegex: !simpleRegex
-  def: (ënhalf|enhalve|ëneenhalf)$
+  def: (ënhalf|enhalve|ëneenhalf|ëneenhalf)$
 OneHalfTokens: [een, half]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}\s+(en\s+)?)?(({AllIntRegex})(\s+|\s*-\s*|\s*/\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))n?|halven|vierdes|kwart)|{FractionUnitsRegex}))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, FractionUnitsRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)(({AllIntRegex}\s+(en\s)?)?(een)(\s+|\s*-\s*|\s*/\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|({FractionUnitsRegex}))|{AllIntRegex}[eë]n(half|halve|helft|kwart))(?=\b)
+  def: (?<=\b)(({AllIntRegex}\s+(en\s)?)?(een)(\s+|\s*-\s*|\s*/\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|({FractionUnitsRegex}))|{AllIntRegex}[eë]n(eenhalf|half|halve|helft|kwart))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, FractionUnitsRegex ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!,)\d+))\s+(op|op\s+de|van\s+de|uit|uit\s+de)\s+(?<denominator>({AllIntRegex})|(\d+)(?!,))(?=\b)
@@ -279,6 +279,7 @@ OrdinalNumberMap: !dictionary
     derde: 3
     vierde: 4
     kwart: 4
+    kwartier: 4
     vijfde: 5
     vijfden: 5
     zesde: 6

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -80,7 +80,7 @@ FractionNotationWithSpacesRegex: !simpleRegex
 FractionNotationRegex: !simpleRegex         
   def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
 FractionUnitsRegex: !simpleRegex
-  def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart|kwartier)
+  def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)
 FractionHalfRegex: !simpleRegex
   def: (ënhalf|enhalve|ëneenhalf|ëneenhalf)$
 OneHalfTokens: [een, half]
@@ -279,7 +279,6 @@ OrdinalNumberMap: !dictionary
     derde: 3
     vierde: 4
     kwart: 4
-    kwartier: 4
     vijfde: 5
     vijfden: 5
     zesde: 6

--- a/Specs/DateTime/Dutch/DateParser.json
+++ b/Specs/DateTime/Dutch/DateParser.json
@@ -1224,14 +1224,14 @@
     ]
   },
   {
-    "Input": "Wie heb ik een paar maanden geleden een email gestuurd",
+    "Input": "Wie heb ik enkele maanden geleden een email gestuurd",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een paar maanden geleden",
+        "Text": "enkele maanden geleden",
         "Type": "date",
         "Value": {
           "Timex": "2016-08-07",
@@ -1243,19 +1243,19 @@
           }
         },
         "Start": 11,
-        "Length": 24
+        "Length": 22
       }
     ]
   },
   {
-    "Input": "wie heb ik een paar dagen geleden een email gestuurd",
+    "Input": "wie heb ik enkele dagen geleden een email gestuurd",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een paar dagen geleden",
+        "Text": "enkele dagen geleden",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-04",
@@ -1267,7 +1267,7 @@
           }
         },
         "Start": 11,
-        "Length": 22
+        "Length": 20
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -10,7 +10,7 @@
       {
         "Text": "4e jan 2019",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -35,7 +35,7 @@
       {
         "Text": "3e jan 2019",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -60,7 +60,7 @@
       {
         "Text": "2e jan 2019 ",
         "Start": 6,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -85,7 +85,7 @@
       {
         "Text": "1e jan 2019",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -110,7 +110,7 @@
       {
         "Text": "jaren '90",
         "Start": 37,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -136,7 +136,7 @@
       {
         "Text": "2/okt",
         "Start": 6,
-        "End": 11,
+        "End": 10,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -166,7 +166,7 @@
       {
         "Text": "22/04",
         "Start": 6,
-        "End": 11,
+        "End": 10,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -196,7 +196,7 @@
       {
         "Text": "negenentwintig mei",
         "Start": 6,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -226,7 +226,7 @@
       {
         "Text": "de tweede van augustus",
         "Start": 6,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -256,7 +256,7 @@
       {
         "Text": "vandaag",
         "Start": 6,
-        "End": 13,
+        "End": 12,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -281,7 +281,7 @@
       {
         "Text": "morgen",
         "Start": 6,
-        "End": 12,
+        "End": 11,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -306,7 +306,7 @@
       {
         "Text": "gisteren",
         "Start": 6,
-        "End": 14,
+        "End": 13,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -331,7 +331,7 @@
       {
         "Text": "vrijdag",
         "Start": 9,
-        "End": 16,
+        "End": 15,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -361,7 +361,7 @@
       {
         "Text": "volgende maand van 4-23",
         "Start": 7,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -387,7 +387,7 @@
       {
         "Text": "tussen 3 en 12 sept",
         "Start": 7,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -419,7 +419,7 @@
       {
         "Text": "aanstaande september",
         "Start": 7,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -445,7 +445,7 @@
       {
         "Text": "12 januari, 2016 - 22/01/2016 ",
         "Start": 7,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -471,7 +471,7 @@
       {
         "Text": "komende drie dagen",
         "Start": 6,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -497,7 +497,7 @@
       {
         "Text": "de laatste week van juli",
         "Start": 7,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -529,7 +529,7 @@
       {
         "Text": "2015-3",
         "Start": 7,
-        "End": 13,
+        "End": 12,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -555,7 +555,7 @@
       {
         "Text": "deze zomer",
         "Start": 6,
-        "End": 16,
+        "End": 15,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -580,7 +580,7 @@
       {
         "Text": "sinds morgen",
         "Start": 6,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -606,7 +606,7 @@
       {
         "Text": "sinds augustus",
         "Start": 6,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -638,7 +638,7 @@
       {
         "Text": "sinds aanstaande augustus",
         "Start": 6,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -664,7 +664,7 @@
       {
         "Text": "nu",
         "Start": 6,
-        "End": 8,
+        "End": 7,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -689,7 +689,7 @@
       {
         "Text": "14 oktober om 8:00:31",
         "Start": 6,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -719,7 +719,7 @@
       {
         "Text": "morgen 8:00",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -744,7 +744,7 @@
       {
         "Text": "10, vanavond",
         "Start": 9,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -769,7 +769,7 @@
       {
         "Text": "8 vanmorgen",
         "Start": 9,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -794,7 +794,7 @@
       {
         "Text": "eind van morgen",
         "Start": 6,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -819,7 +819,7 @@
       {
         "Text": "eind van de zondag",
         "Start": 6,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -849,7 +849,7 @@
       {
         "Text": "eind van deze zondag",
         "Start": 6,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -874,7 +874,7 @@
       {
         "Text": "vandaag van vijf tot zeven",
         "Start": 7,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -906,7 +906,7 @@
       {
         "Text": "22 april van 5 tot 6 's middags",
         "Start": 7,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -938,7 +938,7 @@
       {
         "Text": "morgen 3:00 tot 4:00",
         "Start": 7,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -970,7 +970,7 @@
       {
         "Text": "deze avond",
         "Start": 6,
-        "End": 16,
+        "End": 15,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -996,7 +996,7 @@
       {
         "Text": "morgenavond",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -1022,7 +1022,7 @@
       {
         "Text": "komende maandagmiddag",
         "Start": 6,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -1048,7 +1048,7 @@
       {
         "Text": "aankomende uur",
         "Start": 10,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -1074,7 +1074,7 @@
       {
         "Text": "dinsdag in de ochtend",
         "Start": 6,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -1106,7 +1106,7 @@
       {
         "Text": "3u",
         "Start": 16,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1131,7 +1131,7 @@
       {
         "Text": "3,5 jaar",
         "Start": 16,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1156,7 +1156,7 @@
       {
         "Text": "3 minuten",
         "Start": 16,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1181,7 +1181,7 @@
       {
         "Text": "123,45 sec",
         "Start": 16,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1206,7 +1206,7 @@
       {
         "Text": "de hele dag",
         "Start": 16,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1231,7 +1231,7 @@
       {
         "Text": "vierentwintig uur",
         "Start": 16,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1256,7 +1256,7 @@
       {
         "Text": "hele maand",
         "Start": 19,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1281,7 +1281,7 @@
       {
         "Text": "een uur",
         "Start": 16,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1306,7 +1306,7 @@
       {
         "Text": "paar uur",
         "Start": 16,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1331,7 +1331,7 @@
       {
         "Text": "een paar minuten",
         "Start": 16,
-        "End": 32,
+        "End": 31,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1356,7 +1356,7 @@
       {
         "Text": "wat dagen",
         "Start": 16,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1381,7 +1381,7 @@
       {
         "Text": "enige weken",
         "Start": 16,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -1406,7 +1406,7 @@
       {
         "Text": "wekelijks",
         "Start": 11,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1431,7 +1431,7 @@
       {
         "Text": "elke dag",
         "Start": 11,
-        "End": 19,
+        "End": 18,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1456,7 +1456,7 @@
       {
         "Text": "jaarlijks",
         "Start": 11,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1481,7 +1481,7 @@
       {
         "Text": "elke twee dagen",
         "Start": 11,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1506,7 +1506,7 @@
       {
         "Text": "elke drie weken",
         "Start": 11,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1531,7 +1531,7 @@
       {
         "Text": "elke dag 15.00",
         "Start": 11,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1556,7 +1556,7 @@
       {
         "Text": "elke maandag",
         "Start": 11,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1581,7 +1581,7 @@
       {
         "Text": "elke maandag om 16.00",
         "Start": 11,
-        "End": 32,
+        "End": 31,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -1631,7 +1631,7 @@
       {
         "Text": "half acht",
         "Start": 7,
-        "End": 16,
+        "End": 15,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1661,7 +1661,7 @@
       {
         "Text": "10 voor half negen 's avonds",
         "Start": 7,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1686,7 +1686,7 @@
       {
         "Text": "s morgens om 7 uur",
         "Start": 8,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1711,7 +1711,7 @@
       {
         "Text": "s middags om 7 uur",
         "Start": 8,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1736,7 +1736,7 @@
       {
         "Text": "rond de middag",
         "Start": 7,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1761,7 +1761,7 @@
       {
         "Text": "rond 11 uur",
         "Start": 7,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1811,7 +1811,7 @@
       {
         "Text": "het middaguur",
         "Start": 0,
-        "End": 13,
+        "End": 12,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1836,7 +1836,7 @@
       {
         "Text": "5 tot 6 's middags",
         "Start": 7,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1862,7 +1862,7 @@
       {
         "Text": "s middags 5 tot zeven",
         "Start": 8,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1888,7 +1888,7 @@
       {
         "Text": "tussen 5 en 6 's middags",
         "Start": 7,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1914,7 +1914,7 @@
       {
         "Text": "4:00 tot 7",
         "Start": 7,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1946,7 +1946,7 @@
       {
         "Text": "van 3 uur 's ochtends tot 5 uur 's middags",
         "Start": 7,
-        "End": 49,
+        "End": 48,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1972,7 +1972,7 @@
       {
         "Text": "tussen 4 en 5 's middags",
         "Start": 7,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -1998,7 +1998,7 @@
       {
         "Text": "s morgens",
         "Start": 10,
-        "End": 19,
+        "End": 18,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -2024,7 +2024,7 @@
       {
         "Text": "s avonds",
         "Start": 10,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -2050,7 +2050,7 @@
       {
         "Text": "over 5 minuten",
         "Start": 7,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -2075,7 +2075,7 @@
       {
         "Text": "over 5 minuten",
         "Start": 0,
-        "End": 14,
+        "End": 13,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -2140,7 +2140,7 @@
       {
         "Text": "volgende week maandag",
         "Start": 31,
-        "End": 52,
+        "End": 51,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2185,7 +2185,7 @@
       {
         "Text": " 's ochtends om 9 uur",
         "Start": 4,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -2230,7 +2230,7 @@
       {
         "Text": "volgende maandag 13:00-15:00",
         "Start": 31,
-        "End": 59,
+        "End": 58,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2271,7 +2271,7 @@
     "Results": [
       {
         "Text": "maandag 8-9 's ochtends ",
-        "Start": -1,
+        "Start": 0,
         "End": 23,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
@@ -2320,7 +2320,7 @@
       {
         "Text": "volgende week op dinsdag",
         "Start": 49,
-        "End": 73,
+        "End": 72,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2365,7 +2365,7 @@
       {
         "Text": "volgende week op dinsdag 9 uur 's ochtends",
         "Start": 49,
-        "End": 91,
+        "End": 90,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -2428,7 +2428,7 @@
       {
         "Text": "dinsdag 9 mei",
         "Start": 33,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2458,7 +2458,7 @@
       {
         "Text": "mei",
         "Start": 20,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2490,7 +2490,7 @@
       {
         "Text": "1 uur",
         "Start": 9,
-        "End": 14,
+        "End": 13,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -2535,7 +2535,7 @@
       {
         "Text": "de week van 10 april",
         "Start": 45,
-        "End": 65,
+        "End": 64,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2612,7 +2612,7 @@
       {
         "Text": "vandaag",
         "Start": 59,
-        "End": 66,
+        "End": 65,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2664,7 +2664,7 @@
       {
         "Text": "binnen 9 maanden",
         "Start": 13,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2706,7 +2706,7 @@
       {
         "Text": "over twee weken",
         "Start": 36,
-        "End": 51,
+        "End": 50,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2720,8 +2720,8 @@
       },
       {
         "Text": "over twee weken",
-        "Start": 79,
-        "End": 88,
+        "Start": 36,
+        "End": 50,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2746,7 +2746,7 @@
       {
         "Text": "komende vijf dagen",
         "Start": 10,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2788,7 +2788,7 @@
       {
         "Text": "1 juli",
         "Start": 7,
-        "End": 13,
+        "End": 12,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2818,7 +2818,7 @@
       {
         "Text": "2 uren",
         "Start": 13,
-        "End": 19,
+        "End": 18,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -2859,7 +2859,7 @@
       {
         "Text": "maandag 12-4",
         "Start": 49,
-        "End": 61,
+        "End": 60,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2903,7 +2903,7 @@
       {
         "Text": "maandag 11-4",
         "Start": 49,
-        "End": 61,
+        "End": 60,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2947,7 +2947,7 @@
       {
         "Text": "andere dag",
         "Start": 20,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -2971,7 +2971,7 @@
     "Results": [
       {
         "Text": "elke week",
-        "Start": -1,
+        "Start": 0,
         "End": 8,
         "TypeName": "datetimeV2.set",
         "Resolution": {
@@ -3013,7 +3013,7 @@
       {
         "Text": "dezelfde week",
         "Start": 17,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3040,7 +3040,7 @@
       {
         "Text": "dezelfde maand",
         "Start": 17,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3094,7 +3094,7 @@
       {
         "Text": "hetzelfde jaar",
         "Start": 20,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3121,7 +3121,7 @@
       {
         "Text": "de dag",
         "Start": 16,
-        "End": 22,
+        "End": 21,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3146,7 +3146,7 @@
       {
         "Text": "de maand",
         "Start": 7,
-        "End": 15,
+        "End": 14,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3172,7 +3172,7 @@
       {
         "Text": "woensdag vroeg op de dag",
         "Start": 7,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3199,7 +3199,7 @@
       {
         "Text": "halverwege vandaag",
         "Start": 7,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3226,7 +3226,7 @@
       {
         "Text": "later op de dag",
         "Start": 7,
-        "End": 22,
+        "End": 21,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3253,7 +3253,7 @@
       {
         "Text": "het jaar",
         "Start": 34,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3332,7 +3332,7 @@
       {
         "Text": "2017 april",
         "Start": 11,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3358,7 +3358,7 @@
       {
         "Text": "eerder in de week",
         "Start": 47,
-        "End": 64,
+        "End": 63,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3384,7 +3384,7 @@
       {
         "Text": "eerder deze maand",
         "Start": 47,
-        "End": 64,
+        "End": 63,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3410,7 +3410,7 @@
       {
         "Text": "eerder dit jaar",
         "Start": 47,
-        "End": 62,
+        "End": 61,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3436,7 +3436,7 @@
       {
         "Text": "later deze week",
         "Start": 40,
-        "End": 55,
+        "End": 54,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3462,7 +3462,7 @@
       {
         "Text": "later deze maand",
         "Start": 40,
-        "End": 56,
+        "End": 55,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3488,7 +3488,7 @@
       {
         "Text": "later dit jaar",
         "Start": 40,
-        "End": 54,
+        "End": 53,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3514,7 +3514,7 @@
       {
         "Text": "later in het jaar",
         "Start": 40,
-        "End": 57,
+        "End": 56,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3540,7 +3540,7 @@
       {
         "Text": "twee dagen na vandaag",
         "Start": 7,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3565,7 +3565,7 @@
       {
         "Text": "drie weken vanaf morgen",
         "Start": 7,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3590,7 +3590,7 @@
       {
         "Text": "twee dagen voor gisteren?",
         "Start": 12,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3615,7 +3615,7 @@
       {
         "Text": "31 dec. 1994",
         "Start": 27,
-        "End": 39,
+        "End": 38,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3640,7 +3640,7 @@
       {
         "Text": "5-3-'18 om 17:49:19",
         "Start": 6,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -3665,7 +3665,7 @@
       {
         "Text": "tussen 10 en 11:30 op 1-1-2015",
         "Start": 17,
-        "End": 47,
+        "End": 46,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3697,7 +3697,7 @@
       {
         "Text": "1-1-2015 tussen 10 en 11:30",
         "Start": 8,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3729,7 +3729,7 @@
       {
         "Text": "van 10:30 tot 15.00 op 1-1-2015",
         "Start": 17,
-        "End": 48,
+        "End": 47,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3755,7 +3755,7 @@
       {
         "Text": "tussen 3 en 5 op 1-1-2015",
         "Start": 17,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3787,7 +3787,7 @@
       {
         "Text": "van 3:30 tot 5.55 op 1-1-2015",
         "Start": 17,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -3819,7 +3819,7 @@
       {
         "Text": "voor 2010",
         "Start": 28,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3861,7 +3861,7 @@
       {
         "Text": "na 2010",
         "Start": 28,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3908,8 +3908,8 @@
       },
       {
         "Text": "1998",
-        "Start": 64,
-        "End": 67,
+        "Start": 73,
+        "End": 76,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3935,7 +3935,7 @@
       {
         "Text": "meer dan 4 dagen",
         "Start": 22,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -3977,7 +3977,7 @@
       {
         "Text": " langer dan 1 uur en 30 minuten",
         "Start": 22,
-        "End": 53,
+        "End": 52,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -4003,7 +4003,7 @@
       {
         "Text": "langer dan 2 weken voor vandaag",
         "Start": 31,
-        "End": 62,
+        "End": 61,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4029,7 +4029,7 @@
       {
         "Text": "dan 2 dagen voor gisteren ",
         "Start": 19,
-        "End": 45,
+        "End": 44,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4055,7 +4055,7 @@
       {
         "Text": "minder dan 3 dagen na morgen",
         "Start": 14,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4081,7 +4081,7 @@
       {
         "Text": "meer dan 2 weken na vandaag ",
         "Start": 14,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4107,7 +4107,7 @@
       {
         "Text": "3 minuten vanaf nu",
         "Start": 14,
-        "End": 32,
+        "End": 31,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -4132,7 +4132,7 @@
       {
         "Text": "3 minuten",
         "Start": 14,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -4172,7 +4172,7 @@
       {
         "Text": " de 9e van mei",
         "Start": 32,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4218,7 +4218,7 @@
       {
         "Text": "15e eeuw",
         "Start": 15,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4244,7 +4244,7 @@
       {
         "Text": "21e eeuw",
         "Start": 29,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4270,7 +4270,7 @@
       {
         "Text": "na 2018",
         "Start": 20,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4296,7 +4296,7 @@
       {
         "Text": "na feb 2018",
         "Start": 20,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4322,7 +4322,7 @@
       {
         "Text": "na feb",
         "Start": 20,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4354,7 +4354,7 @@
       {
         "Text": "1-1-2015 na 2:00",
         "Start": 8,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4386,7 +4386,7 @@
       {
         "Text": "vandaag voor 16:00 ",
         "Start": 8,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4412,7 +4412,7 @@
       {
         "Text": "volgende week woensdag later dan 10 uur 's morgens",
         "Start": 8,
-        "End": 58,
+        "End": 57,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4438,7 +4438,7 @@
       {
         "Text": "vorige week dinsdag om 2 uur 's middags",
         "Start": 16,
-        "End": 55,
+        "End": 54,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4464,7 +4464,7 @@
       {
         "Text": "1 feb niet later dan 6:00 ",
         "Start": 23,
-        "End": 49,
+        "End": 48,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4508,7 +4508,7 @@
       {
         "Text": "volgende week",
         "Start": 16,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4556,7 +4556,7 @@
       {
         "Text": "2007",
         "Start": 16,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4571,8 +4571,8 @@
       },
       {
         "Text": "2009",
-        "Start": 23,
-        "End": 26,
+        "Start": 24,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4598,7 +4598,7 @@
       {
         "Text": "tussen 2007 en 2009",
         "Start": 13,
-        "End": 32,
+        "End": 31,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4624,7 +4624,7 @@
       {
         "Text": "vandaag om 9:00 ",
         "Start": 4,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -4649,7 +4649,7 @@
       {
         "Text": "vandaag om 21:00",
         "Start": 4,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -4700,7 +4700,7 @@
       {
         "Text": "het jaar",
         "Start": 16,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4726,7 +4726,7 @@
       {
         "Text": "de week",
         "Start": 16,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4752,7 +4752,7 @@
       {
         "Text": "de week na volgende",
         "Start": 16,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4778,7 +4778,7 @@
       {
         "Text": "week 31",
         "Start": 19,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4839,7 +4839,7 @@
       {
         "Text": "over 2 minuten",
         "Start": 11,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -4864,7 +4864,7 @@
       {
         "Text": "over twee maanden",
         "Start": 11,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4889,7 +4889,7 @@
       {
         "Text": "over twee weken",
         "Start": 11,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4914,7 +4914,7 @@
       {
         "Text": "over twee jaar",
         "Start": 11,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4939,7 +4939,7 @@
       {
         "Text": "twee dagen na vandaag",
         "Start": 16,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4964,7 +4964,7 @@
       {
         "Text": " 2014-2018",
         "Start": 13,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4990,7 +4990,7 @@
       {
         "Text": "2014~2018",
         "Start": 14,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5016,7 +5016,7 @@
       {
         "Text": "2014 tot 2018",
         "Start": 14,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5042,7 +5042,7 @@
       {
         "Text": "tussen 2014-2018",
         "Start": 14,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5068,7 +5068,7 @@
       {
         "Text": "tussen 2014~2018",
         "Start": 14,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5094,7 +5094,7 @@
       {
         "Text": "tussen 2014 en 2018",
         "Start": 14,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5120,7 +5120,7 @@
       {
         "Text": "van 2014 tot 2018",
         "Start": 14,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5146,7 +5146,7 @@
       {
         "Text": "van 2014-2018",
         "Start": 14,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5172,7 +5172,7 @@
       {
         "Text": "van 2014~2018",
         "Start": 14,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5198,7 +5198,7 @@
       {
         "Text": "van 2014 tot en met 2018",
         "Start": 14,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5224,7 +5224,7 @@
       {
         "Text": "in 2014 tot en met 2018",
         "Start": 14,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5250,7 +5250,7 @@
       {
         "Text": "2014 tot en met mei 2018",
         "Start": 17,
-        "End": 41,
+        "End": 40,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5276,7 +5276,7 @@
       {
         "Text": "2014 tot en met 2 mei 2018",
         "Start": 17,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5302,7 +5302,7 @@
       {
         "Text": "2008",
         "Start": 36,
-        "End": 40,
+        "End": 39,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5328,7 +5328,7 @@
       {
         "Text": "vierentwintig januari half twee 's middags",
         "Start": 16,
-        "End": 58,
+        "End": 57,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -5358,7 +5358,7 @@
       {
         "Text": "half november",
         "Start": 23,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5392,7 +5392,7 @@
       {
         "Text": "zat. om 5 uur",
         "Start": 40,
-        "End": 53,
+        "End": 52,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -5431,7 +5431,7 @@
     "Results": [
       {
         "Text": "gisterenavond",
-        "Start": -1,
+        "Start": 0,
         "End": 12,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
@@ -5458,7 +5458,7 @@
       {
         "Text": "het jaar",
         "Start": 21,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5484,7 +5484,7 @@
       {
         "Text": "onafhankelijksdag van dit jaar",
         "Start": 22,
-        "End": 52,
+        "End": 51,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -5509,7 +5509,7 @@
       {
         "Text": "voor onafhankelijkheidsdag",
         "Start": 28,
-        "End": 54,
+        "End": 53,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5541,7 +5541,7 @@
       {
         "Text": "komende week",
         "Start": 22,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5567,7 +5567,7 @@
       {
         "Text": "komende weken",
         "Start": 26,
-        "End": 39,
+        "End": 38,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5593,7 +5593,7 @@
       {
         "Text": "op volgende week maandag",
         "Start": 7,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -5618,7 +5618,7 @@
       {
         "Text": "22 mei (dins) - 11:30",
         "Start": 14,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -5648,7 +5648,7 @@
       {
         "Text": "het middaguur vandaag",
         "Start": 22,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5708,7 +5708,7 @@
       {
         "Text": "deze week",
         "Start": 16,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5750,7 +5750,7 @@
       {
         "Text": "al zo laat als 7 uur 's ochtends",
         "Start": 11,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -5776,7 +5776,7 @@
       {
         "Text": "van 15 minuten",
         "Start": 23,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -5838,7 +5838,7 @@
       {
         "Text": "5 aankomende jaren ",
         "Start": 17,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5864,7 +5864,7 @@
       {
         "Text": "2 aankomende maanden ",
         "Start": 17,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5890,7 +5890,7 @@
       {
         "Text": " 2 aankomende dagen ",
         "Start": 16,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5916,7 +5916,7 @@
       {
         "Text": "5 aankomende minuten ",
         "Start": 17,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5942,7 +5942,7 @@
       {
         "Text": "afgelopen 5 minuten ",
         "Start": 16,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5968,7 +5968,7 @@
       {
         "Text": "afgelopen 5 jaren",
         "Start": 16,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5994,7 +5994,7 @@
       {
         "Text": "afgelopen 10 weken",
         "Start": 16,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6020,7 +6020,7 @@
       {
         "Text": "morgen van 10 tot 12 uur 's ochtends",
         "Start": 39,
-        "End": 75,
+        "End": 74,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -6061,7 +6061,7 @@
       {
         "Text": "zo vroeg als het eerste kwartaal van volgend jaar",
         "Start": 6,
-        "End": 55,
+        "End": 54,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6087,7 +6087,7 @@
       {
         "Text": "voor het jaar hoger dan 2012",
         "Start": 18,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6113,7 +6113,7 @@
       {
         "Text": "jaar 2012 of later",
         "Start": 20,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6139,7 +6139,7 @@
       {
         "Text": "jaar 2016 en hoger",
         "Start": 16,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6165,7 +6165,7 @@
       {
         "Text": "1-1-2016 en later",
         "Start": 29,
-        "End": 46,
+        "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6191,7 +6191,7 @@
       {
         "Text": "1-1-2016 en daarna",
         "Start": 29,
-        "End": 47,
+        "End": 46,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6218,7 +6218,7 @@
       {
         "Text": "1-1-2016",
         "Start": 28,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -6243,7 +6243,7 @@
       {
         "Text": "1-1-2016",
         "Start": 28,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -6284,7 +6284,7 @@
       {
         "Text": "jaar tot op heden",
         "Start": 46,
-        "End": 63,
+        "End": 62,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6310,7 +6310,7 @@
       {
         "Text": "2018 of later",
         "Start": 24,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6336,7 +6336,7 @@
       {
         "Text": "tussen 2015 en 2018",
         "Start": 23,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6378,7 +6378,7 @@
       {
         "Text": "deze week",
         "Start": 9,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6420,7 +6420,7 @@
       {
         "Text": "later dan 2018",
         "Start": 0,
-        "End": 14,
+        "End": 13,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6446,7 +6446,7 @@
       {
         "Text": "voor maandag om half 3 's middags",
         "Start": 32,
-        "End": 65,
+        "End": 64,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -6486,7 +6486,7 @@
       {
         "Text": "voor half 3 's middags",
         "Start": 10,
-        "End": 32,
+        "End": 31,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -6512,7 +6512,7 @@
       {
         "Text": "donderdag 29-3 11 uur 's ochtends ",
         "Start": 3,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -6542,7 +6542,7 @@
       {
         "Text": "6-4 tussen 9.30-16.30",
         "Start": 31,
-        "End": 52,
+        "End": 51,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -6574,7 +6574,7 @@
       {
         "Text": "van maart tot mei",
         "Start": 12,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6606,7 +6606,7 @@
       {
         "Text": "tussen augustus en oktober",
         "Start": 21,
-        "End": 47,
+        "End": 46,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6632,7 +6632,7 @@
       {
         "Text": "mei tot maart",
         "Start": 21,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6658,7 +6658,7 @@
       {
         "Text": "van sep tot nov",
         "Start": 21,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6690,7 +6690,7 @@
       {
         "Text": "van mei tot september",
         "Start": 21,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6716,7 +6716,7 @@
       {
         "Text": "van nov tot maart",
         "Start": 21,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6757,7 +6757,7 @@
       {
         "Text": "om 6.45",
         "Start": 10,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -6787,7 +6787,7 @@
       {
         "Text": "over twee dagen",
         "Start": 19,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -6836,7 +6836,7 @@
       {
         "Text": "van 1-10 tot 7-11",
         "Start": 0,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6862,7 +6862,7 @@
       {
         "Text": "van 25-10 tot 25-1",
         "Start": 0,
-        "End": 18,
+        "End": 17,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6894,7 +6894,7 @@
       {
         "Text": "van 10-1-2018-10-7-2018",
         "Start": 17,
-        "End": 40,
+        "End": 39,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6920,7 +6920,7 @@
       {
         "Text": "van 10-1-2018 - 10-7-2018",
         "Start": 17,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6946,7 +6946,7 @@
       {
         "Text": "tussen 1-10 en 7-11",
         "Start": 26,
-        "End": 45,
+        "End": 44,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6972,7 +6972,7 @@
       {
         "Text": "jan-feb 2017",
         "Start": 31,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6998,7 +6998,7 @@
       {
         "Text": "nov-feb 2017",
         "Start": 31,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7024,7 +7024,7 @@
       {
         "Text": "nov-5 feb 2017",
         "Start": 31,
-        "End": 45,
+        "End": 44,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7050,7 +7050,7 @@
       {
         "Text": "18 nov-19 dec, 2015",
         "Start": 31,
-        "End": 50,
+        "End": 49,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7076,7 +7076,7 @@
       {
         "Text": "18 nov 2014-19 dec 2015",
         "Start": 31,
-        "End": 54,
+        "End": 53,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7102,7 +7102,7 @@
       {
         "Text": "op 18-19 november",
         "Start": 31,
-        "End": 48,
+        "End": 47,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7134,7 +7134,7 @@
       {
         "Text": "van aanstaande mei tot okt 2020",
         "Start": 18,
-        "End": 49,
+        "End": 48,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7160,7 +7160,7 @@
       {
         "Text": "van mei tot okt 2020",
         "Start": 18,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7186,7 +7186,7 @@
       {
         "Text": "van 1-5 - 7-5, 2020",
         "Start": 18,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7212,7 +7212,7 @@
       {
         "Text": "van 1-5 - 7-5-2020",
         "Start": 18,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7238,7 +7238,7 @@
       {
         "Text": "van 1-5-2019 - 7-5-2020",
         "Start": 18,
-        "End": 41,
+        "End": 40,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7289,7 +7289,7 @@
       {
         "Text": "maandagmorgen van 10:00 tot 12:00",
         "Start": 22,
-        "End": 55,
+        "End": 54,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7321,7 +7321,7 @@
       {
         "Text": "10:00 tot 12:00 maandagmorgen",
         "Start": 19,
-        "End": 48,
+        "End": 47,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7353,7 +7353,7 @@
       {
         "Text": "gisterenmiddag van 15:00-20:00",
         "Start": 12,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7379,7 +7379,7 @@
       {
         "Text": "van 15:00-20:00 gisterenmiddag",
         "Start": 12,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7405,7 +7405,7 @@
       {
         "Text": "van 8 uur 's morgens-15:00 gisterenmiddag",
         "Start": 12,
-        "End": 53,
+        "End": 52,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7431,7 +7431,7 @@
       {
         "Text": "maandag 3-8",
         "Start": 12,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7475,7 +7475,7 @@
       {
         "Text": "gisteren tussen 3 en 8",
         "Start": 12,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7507,7 +7507,7 @@
       {
         "Text": "volgende maandag tussen 3 en 8 uur 's morgens",
         "Start": 7,
-        "End": 52,
+        "End": 51,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7533,7 +7533,7 @@
       {
         "Text": " volgende maandag tussen 3 uur 's middags - 12 uur 's middags",
         "Start": 6,
-        "End": 67,
+        "End": 66,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7559,7 +7559,7 @@
       {
         "Text": "volgende maandag tussen 6-8 ",
         "Start": 7,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7591,7 +7591,7 @@
       {
         "Text": "volgende maandag 6-8",
         "Start": 7,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7623,7 +7623,7 @@
       {
         "Text": "volgende maandagmorgen 6-8",
         "Start": 7,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7649,7 +7649,7 @@
       {
         "Text": "dec-2018",
         "Start": 20,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7701,7 +7701,7 @@
       {
         "Text": "dec, 2018",
         "Start": 20,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7727,7 +7727,7 @@
       {
         "Text": "dec/2018-mei/2019",
         "Start": 20,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -7753,7 +7753,7 @@
       {
         "Text": "de dag ervoor",
         "Start": 7,
-        "End": 20,
+        "End": 19,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7778,7 +7778,7 @@
       {
         "Text": "de dag erna",
         "Start": 20,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7812,7 +7812,7 @@
       {
         "Text": "volgende maandag",
         "Start": 38,
-        "End": 54,
+        "End": 53,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7852,7 +7852,7 @@
       {
         "Text": "volgende maandag",
         "Start": 39,
-        "End": 55,
+        "End": 54,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7892,7 +7892,7 @@
       {
         "Text": "volgende week woensdag",
         "Start": 20,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7917,7 +7917,7 @@
       {
         "Text": "vorige week - maandag",
         "Start": 16,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7942,7 +7942,7 @@
       {
         "Text": "deze week maandag",
         "Start": 16,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7967,7 +7967,7 @@
       {
         "Text": "eind van de dag ",
         "Start": 34,
-        "End": 50,
+        "End": 49,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -7992,7 +7992,7 @@
       {
         "Text": "het eind van de dag",
         "Start": 65,
-        "End": 84,
+        "End": 83,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -8017,7 +8017,7 @@
       {
         "Text": "eind van het jaar",
         "Start": 8,
-        "End": 25,
+        "End": 24,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8044,7 +8044,7 @@
       {
         "Text": "20-11",
         "Start": 18,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8094,7 +8094,7 @@
       {
         "Text": "eind van de maand",
         "Start": 50,
-        "End": 67,
+        "End": 66,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8121,7 +8121,7 @@
       {
         "Text": "eind van de week",
         "Start": 80,
-        "End": 96,
+        "End": 95,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8149,7 +8149,7 @@
       {
         "Text": "woensdag",
         "Start": 72,
-        "End": 80,
+        "End": 79,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8220,7 +8220,7 @@
       {
         "Text": "tussen 6:30 tot 9 pst",
         "Start": 3,
-        "End": 24,
+        "End": 23,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -8259,7 +8259,7 @@
       {
         "Text": "tussen 9 tot 10:30",
         "Start": 3,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -8291,7 +8291,7 @@
       {
         "Text": "de eerste week van 2015",
         "Start": 3,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8317,7 +8317,7 @@
       {
         "Text": "eerste week van jan 2015",
         "Start": 6,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8343,7 +8343,7 @@
       {
         "Text": "laatste week van 2016",
         "Start": 6,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8369,7 +8369,7 @@
       {
         "Text": "laatste week van dec 2016",
         "Start": 3,
-        "End": 28,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8473,7 +8473,7 @@
       {
         "Text": "de 3e week van jan",
         "Start": 3,
-        "End": 21,
+        "End": 20,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8505,7 +8505,7 @@
       {
         "Text": "eerder vorige week",
         "Start": 20,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8532,7 +8532,7 @@
       {
         "Text": "later deze week",
         "Start": 16,
-        "End": 31,
+        "End": 30,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8583,7 +8583,7 @@
       {
         "Text": "anderhalf uur",
         "Start": 16,
-        "End": 29,
+        "End": 28,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -8608,7 +8608,7 @@
       {
         "Text": "een jaar en een kwart jaar ",
         "Start": 10,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -8645,8 +8645,8 @@
     "Context": {
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "Comment": "Not extracted may as a datetime range is not supported for now",
+    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8670,7 +8670,7 @@
       {
         "Text": "dinsdag",
         "Start": 8,
-        "End": 15,
+        "End": 14,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8700,7 +8700,7 @@
       {
         "Text": "maandag 21",
         "Start": 26,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8730,7 +8730,7 @@
       {
         "Text": "zondag 31",
         "Start": 26,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8760,7 +8760,7 @@
       {
         "Text": "vrijdag 31",
         "Start": 26,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8790,7 +8790,7 @@
       {
         "Text": "na half mei",
         "Start": 16,
-        "End": 27,
+        "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8822,7 +8822,7 @@
       {
         "Text": "voor begin september",
         "Start": 16,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8854,7 +8854,7 @@
       {
         "Text": "sinds eind juli",
         "Start": 18,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8886,7 +8886,7 @@
       {
         "Text": "deze aankomende vrijdag",
         "Start": 26,
-        "End": 49,
+        "End": 48,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8911,7 +8911,7 @@
       {
         "Text": "aanstaande vrijdag",
         "Start": 26,
-        "End": 44,
+        "End": 43,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8936,7 +8936,7 @@
       {
         "Text": "volgende vrijdag",
         "Start": 26,
-        "End": 42,
+        "End": 41,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8961,7 +8961,7 @@
       {
         "Text": "komende donderdag",
         "Start": 26,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8986,7 +8986,7 @@
       {
         "Text": "deze afgelopen woensdag",
         "Start": 15,
-        "End": 38,
+        "End": 37,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9011,7 +9011,7 @@
       {
         "Text": "afgelopen woensdag",
         "Start": 15,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9036,7 +9036,7 @@
       {
         "Text": "vorige woensdag",
         "Start": 15,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9061,7 +9061,7 @@
       {
         "Text": "tussen 07:30-09:00",
         "Start": 19,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -9093,7 +9093,7 @@
       {
         "Text": "tussen 07:30-09:30",
         "Start": 12,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -9125,7 +9125,7 @@
       {
         "Text": "tussen 09:30-07:30",
         "Start": 12,
-        "End": 30,
+        "End": 29,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -9166,7 +9166,7 @@
       {
         "Text": "maandag 21 tussen 9:30 en 15:00",
         "Start": 25,
-        "End": 56,
+        "End": 55,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -9198,7 +9198,7 @@
       {
         "Text": "dinsdag, 15 jan, 13:00 - 13.15",
         "Start": 15,
-        "End": 45,
+        "End": 44,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -9230,7 +9230,7 @@
       {
         "Text": "18 januari, 2019",
         "Start": 3,
-        "End": 19,
+        "End": 18,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9270,7 +9270,7 @@
       {
         "Text": "elke dinsdag",
         "Start": 31,
-        "End": 43,
+        "End": 42,
         "TypeName": "datetimeV2.set",
         "Resolution": {
           "values": [
@@ -9317,7 +9317,7 @@
       {
         "Text": "12-2015",
         "Start": 26,
-        "End": 33,
+        "End": 32,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -9378,8 +9378,8 @@
     "Results": [
       {
         "Text": "tussen 16:00 en 17:00 vandaag",
-        "Start":7,
-        "End": 38,
+        "Start": 7,
+        "End": 35,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [

--- a/Specs/DateTime/Dutch/DurationExtractor.json
+++ b/Specs/DateTime/Dutch/DurationExtractor.json
@@ -1,6 +1,7 @@
 [
   {
     "Input": "Ik ga 3u weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3u",
@@ -8,38 +9,35 @@
         "Start": 6,
         "Length": 2
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
-    "Input": "Ik ga 3 dgn weg",
+    "Input": "Ik ga 3dagen weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3 dgn",
-        "Type": "duration",
-        "Start": 6,
-        "Length": 5
-      }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
-  },
-  {
-    "Input": "Ik ga 3,5 jr weg",
-    "Results": [
-      {
-        "Text": "3,5 jr",
+        "Text": "3dagen",
         "Type": "duration",
         "Start": 6,
         "Length": 6
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ga 3,5 jaar weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3,5 jaar",
+        "Type": "duration",
+        "Start": 6,
+        "Length": 8
+      }
+    ]
   },
   {
     "Input": "Ik ga 3 u weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 u",
@@ -47,12 +45,11 @@
         "Start": 6,
         "Length": 3
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 uur",
@@ -60,12 +57,11 @@
         "Start": 6,
         "Length": 5
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 uren weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 uren",
@@ -73,12 +69,11 @@
         "Start": 6,
         "Length": 6
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 dagen weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 dagen",
@@ -86,12 +81,11 @@
         "Start": 6,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 maanden weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 maanden",
@@ -99,12 +93,11 @@
         "Start": 6,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 minuten weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 minuten",
@@ -112,12 +105,11 @@
         "Start": 6,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 min weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 min",
@@ -125,12 +117,11 @@
         "Start": 6,
         "Length": 5
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 123,45 seconden weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "123,45 seconden",
@@ -138,12 +129,11 @@
         "Start": 6,
         "Length": 15
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga twee weken weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee weken",
@@ -151,12 +141,11 @@
         "Start": 6,
         "Length": 10
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga twintig minuten weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twintig minuten",
@@ -164,12 +153,11 @@
         "Start": 6,
         "Length": 15
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga vierentwintig uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vierentwintig uur",
@@ -177,12 +165,11 @@
         "Start": 6,
         "Length": 17
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de hele dag weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele dag",
@@ -190,12 +177,11 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de hele week weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele week",
@@ -203,12 +189,11 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de hele maand weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele maand",
@@ -216,12 +201,11 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga het hele jaar weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het hele jaar",
@@ -229,12 +213,11 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een hele dag weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een hele dag",
@@ -242,12 +225,11 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een hele week weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een hele week",
@@ -255,12 +237,11 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een hele maand weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een hele maand",
@@ -268,12 +249,11 @@
         "Start": 6,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een heel jaar weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een heel jaar",
@@ -281,12 +261,11 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een uur",
@@ -294,12 +273,11 @@
         "Start": 6,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een jaar weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een jaar",
@@ -307,12 +285,11 @@
         "Start": 6,
         "Length": 8
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "half jaar",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "half jaar",
@@ -320,12 +297,11 @@
         "Start": 0,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "een half jaar",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een half jaar",
@@ -333,12 +309,11 @@
         "Start": 0,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 min. weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 min.",
@@ -346,12 +321,11 @@
         "Start": 6,
         "Length": 6
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 30 min. weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "30 min.",
@@ -359,12 +333,11 @@
         "Start": 6,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een half uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een half uur",
@@ -372,12 +345,11 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een halfuur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een halfuur",
@@ -385,12 +357,11 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga anderhalf uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "anderhalf uur",
@@ -398,12 +369,11 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga twee uren weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee uren",
@@ -411,12 +381,11 @@
         "Start": 6,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga tweeëneenhalf uur weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tweeëneenhalf uur",
@@ -424,12 +393,11 @@
         "Start": 6,
         "Length": 17
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "over een week",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een week",
@@ -437,12 +405,11 @@
         "Start": 5,
         "Length": 8
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Over een dag",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een dag",
@@ -450,12 +417,11 @@
         "Start": 5,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "een uur lang",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een uur lang",
@@ -463,12 +429,11 @@
         "Start": 0,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "een maand lang",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een maand lang",
@@ -476,12 +441,11 @@
         "Start": 0,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een paar uur lang weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar uur lang",
@@ -489,12 +453,11 @@
         "Start": 6,
         "Length": 17
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een paar minuten lang weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar minuten lang",
@@ -502,12 +465,11 @@
         "Start": 6,
         "Length": 21
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga een paar dagen weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar dagen",
@@ -515,12 +477,11 @@
         "Start": 6,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga enkele dagen weg",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "enkele dagen",
@@ -528,13 +489,11 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 1 jaar, 1 maand en 21 dagen weg",
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 jaar, 1 maand en 21 dagen",
@@ -542,12 +501,11 @@
         "Start": 6,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 1 maand en 2 dagen weg",
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 maand en 2 dagen",
@@ -555,11 +513,11 @@
         "Start": 6,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik realiseerde me dat jij nog een week weg bent.",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een week",
@@ -567,12 +525,11 @@
         "Start": 26,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kunnen we nog een maand wachten?",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een maand",
@@ -580,13 +537,10 @@
         "Start": 10,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik vertrek voor 3u",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -599,20 +553,18 @@
   },
   {
     "Input": "Ik vertrek voor 3,5jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3,5jaar",
         "Type": "duration",
         "Start": 16,
-        "Length": 8
+        "Length": 7
       }
     ]
   },
   {
     "Input": "Ik vertrek voor 3 u",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -625,33 +577,30 @@
   },
   {
     "Input": "Ik vertrek voor 3 uren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 uren",
         "Type": "duration",
         "Start": 16,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
   {
     "Input": "Ik vertrek voor 3 maanden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 maanden",
         "Type": "duration",
         "Start": 16,
-        "Length": 8
+        "Length": 9
       }
     ]
   },
   {
     "Input": "Ik vertrek voor 3 minuten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -664,7 +613,6 @@
   },
   {
     "Input": "Ik vertrek voor 3 min",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -677,7 +625,6 @@
   },
   {
     "Input": "Ik vertrek voor 123,45 sec",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -690,137 +637,126 @@
   },
   {
     "Input": "Ik vertrek voor twee weken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee weken",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
   {
     "Input": "Ik vertrek voor twintig minuten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twintig minuten",
         "Type": "duration",
         "Start": 16,
-        "Length": 10
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de hele dag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele dag",
         "Type": "duration",
         "Start": 16,
-        "Length": 7
+        "Length": 11
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de hele week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele week",
         "Type": "duration",
         "Start": 16,
-        "Length": 8
+        "Length": 12
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de hele maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele maand",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor het hele jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het hele jaar",
         "Type": "duration",
         "Start": 16,
-        "Length": 8
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de gehele dag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de gehele dag",
         "Type": "duration",
         "Start": 16,
-        "Length": 8
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de gehele week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de gehele week",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik vertrek voor de gehele maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de gehele maand",
         "Type": "duration",
         "Start": 16,
-        "Length": 10
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek voor het gehele jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het gehele jaar",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek voor een uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -833,20 +769,18 @@
   },
   {
     "Input": "Ik vertrek voor een jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een jaar",
         "Type": "duration",
         "Start": 16,
-        "Length": 6
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Ik vertrek voor 30 minuten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -859,24 +793,10 @@
   },
   {
     "Input": "Ik vertrek voor een half uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een half uur",
-        "Type": "duration",
-        "Start": 16,
-        "Length": 11
-      }
-    ]
-  },
-  {
-    "Input": "Ik vertrek voor een halfuur",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "een halfuur",
         "Type": "duration",
         "Start": 16,
         "Length": 12
@@ -884,34 +804,43 @@
     ]
   },
   {
+    "Input": "Ik vertrek voor een halfuur",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "een halfuur",
+        "Type": "duration",
+        "Start": 16,
+        "Length": 11
+      }
+    ]
+  },
+  {
     "Input": "Ik vertrek voor anderhalf uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "anderhalf uur",
         "Type": "duration",
         "Start": 16,
-        "Length": 16
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor halfuur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "halfuur",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 7
       }
     ]
   },
   {
     "Input": "Ik vertrek voor twee uren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -924,33 +853,30 @@
   },
   {
     "Input": "Ik vertrek voor tweeënhalf uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tweeënhalf uur",
         "Type": "duration",
         "Start": 16,
-        "Length": 20
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Over een week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een week",
         "Type": "duration",
         "Start": 5,
-        "Length": 6
+        "Length": 8
       }
     ]
   },
   {
     "Input": "voor een uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -963,20 +889,18 @@
   },
   {
     "Input": "voor een maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een maand",
         "Type": "duration",
         "Start": 5,
-        "Length": 7
+        "Length": 9
       }
     ]
   },
   {
     "Input": "Ik vertrek voor paar uren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -989,33 +913,30 @@
   },
   {
     "Input": "Ik vertrek voor een paar minuten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar minuten",
         "Type": "duration",
         "Start": 16,
-        "Length": 13
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Ik vertrek voor aantal dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "aantal dagen",
         "Type": "duration",
         "Start": 16,
-        "Length": 9
+        "Length": 12
       }
     ]
   },
   {
     "Input": "Ik vertrek voor enkele dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1028,33 +949,30 @@
   },
   {
     "Input": "Ik vertrek voor 1 jaar, 1 maand, 21 dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 jaar, 1 maand, 21 dagen",
         "Type": "duration",
         "Start": 16,
-        "Length": 22
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik vertrek voor 2 dagen, 1 maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 dagen, 1 maand",
         "Type": "duration",
         "Start": 16,
-        "Length": 14
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Ik besefte dat je nog een week weg bent",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1067,40 +985,37 @@
   },
   {
     "Input": "Kunnen we nog een werkdag wachten?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een werkdag",
         "Type": "duration",
         "Start": 10,
-        "Length": 20
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek voor twee decennia",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee decennia",
         "Type": "duration",
         "Start": 16,
-        "Length": 11
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor veertien dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "veertien dagen",
         "Type": "duration",
         "Start": 16,
-        "Length": 11
+        "Length": 14
       }
     ]
   }

--- a/Specs/DateTime/Dutch/DurationExtractor.json
+++ b/Specs/DateTime/Dutch/DurationExtractor.json
@@ -12,6 +12,18 @@
     ]
   },
   {
+    "Input": "Ik ga 3 dgn weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 dgn",
+        "Type": "duration",
+        "Start": 6,
+        "Length": 5
+      }
+    ]
+  },
+  {
     "Input": "Ik ga 3dagen weg",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -32,6 +44,18 @@
         "Type": "duration",
         "Start": 6,
         "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga 3,5 jr weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3,5 jr",
+        "Type": "duration",
+        "Start": 6,
+        "Length": 6
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -4,6 +4,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3u",
@@ -20,15 +21,14 @@
         "Start": 7,
         "Length": 2
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 dagen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 dagen",
@@ -45,15 +45,14 @@
         "Start": 7,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3,5 jaar weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3,5 jaar",
@@ -70,15 +69,14 @@
         "Start": 7,
         "Length": 8
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 u weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 u",
@@ -95,15 +93,14 @@
         "Start": 7,
         "Length": 3
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 uur",
@@ -120,15 +117,14 @@
         "Start": 7,
         "Length": 5
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 maanden weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 maanden",
@@ -145,15 +141,14 @@
         "Start": 7,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 minuten weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 minuten",
@@ -170,15 +165,14 @@
         "Start": 7,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3 min weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 min",
@@ -195,15 +189,14 @@
         "Start": 7,
         "Length": 5
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 123,45 sec weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "123,45 sec",
@@ -220,15 +213,14 @@
         "Start": 7,
         "Length": 10
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben twee weken weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee weken",
@@ -245,15 +237,14 @@
         "Start": 7,
         "Length": 10
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "I'k ben twintig min weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twintig min",
@@ -270,18 +261,17 @@
         "Start": 8,
         "Length": 11
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben vierentwintig uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vierentwintig",
+        "Text": "vierentwintig uur",
         "Type": "duration",
         "Value": {
           "Timex": "PT24H",
@@ -293,17 +283,16 @@
           }
         },
         "Start": 7,
-        "Length": 13
+        "Length": 17
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de hele dag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele dag",
@@ -320,15 +309,14 @@
         "Start": 7,
         "Length": 11
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de hele week weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele week",
@@ -345,15 +333,14 @@
         "Start": 7,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de hele maand weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de hele maand",
@@ -370,15 +357,14 @@
         "Start": 7,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben het hele jaar weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het hele jaar",
@@ -395,15 +381,14 @@
         "Start": 7,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de volle dag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de volle dag",
@@ -420,15 +405,14 @@
         "Start": 7,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de volle week weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de volle week",
@@ -445,15 +429,14 @@
         "Start": 7,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben de volle maand weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de volle maand",
@@ -470,15 +453,14 @@
         "Start": 7,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben het volle jaar weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het volle jaar",
@@ -495,15 +477,14 @@
         "Start": 7,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben een uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een uur",
@@ -520,15 +501,14 @@
         "Start": 7,
         "Length": 7
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "half jaar",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "half jaar",
@@ -545,15 +525,14 @@
         "Start": 0,
         "Length": 9
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "een half jaar",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een half jaar",
@@ -570,15 +549,14 @@
         "Start": 0,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben anderhalf uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "anderhalf uur",
@@ -595,15 +573,14 @@
         "Start": 7,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben anderhalve dag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "anderhalve dag",
@@ -611,27 +588,26 @@
         "Value": {
           "Timex": "P1.5D",
           "FutureResolution": {
-            "duration": "7776000"
+            "duration": "129600"
           },
           "PastResolution": {
-            "duration": "7776000"
+            "duration": "129600"
           }
         },
         "Start": 7,
         "Length": 14
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben een kwartier uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "kwartier",
+        "Text": "een kwartier uur",
         "Type": "duration",
         "Value": {
           "Timex": "PT0.25H",
@@ -642,21 +618,20 @@
             "duration": "900"
           }
         },
-        "Start": 11,
-        "Length": 8
+        "Start": 7,
+        "Length": 16
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben een half uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "half uur",
+        "Text": "een half uur",
         "Type": "duration",
         "Value": {
           "Timex": "PT0.5H",
@@ -667,18 +642,17 @@
             "duration": "1800"
           }
         },
-        "Start": 11,
-        "Length": 8
+        "Start": 7,
+        "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben twee uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "twee uur",
@@ -695,15 +669,14 @@
         "Start": 7,
         "Length": 8
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben tweeëneenhalf uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tweeëneenhalf uur",
@@ -720,16 +693,14 @@
         "Start": 7,
         "Length": 17
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 1 jaar, 1 maand en 21 dagen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 jaar, 1 maand en 21 dagen",
@@ -746,15 +717,14 @@
         "Start": 7,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 2 dagen en 1 maand weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 dagen en 1 maand",
@@ -771,15 +741,14 @@
         "Start": 7,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben een week en drie dagen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een week en drie dagen",
@@ -796,15 +765,14 @@
         "Start": 7,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben een paar weken weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar weken",
@@ -821,15 +789,14 @@
         "Start": 7,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben een paar dagen weg.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar dagen",
@@ -846,15 +813,14 @@
         "Start": 7,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben minder dan een paar dagen weg.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "minder dan een paar dagen",
@@ -872,15 +838,14 @@
         "Start": 7,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben meer dan een uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "meer dan een uur",
@@ -898,14 +863,14 @@
         "Start": 7,
         "Length": 16
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben nog een uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een uur",
@@ -922,15 +887,14 @@
         "Start": 7,
         "Length": 11
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik bedacht me dat je nog een week weg bent",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een week",
@@ -947,15 +911,14 @@
         "Start": 21,
         "Length": 12
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kunnen we nog een maand wachten?",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nog een maand",
@@ -972,16 +935,13 @@
         "Start": 10,
         "Length": 13
       }
-    ],
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik vertrek voor 3u",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1006,7 +966,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1022,7 +981,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 7
       }
     ]
   },
@@ -1031,7 +990,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1056,7 +1014,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1072,7 +1029,7 @@
           }
         },
         "Start": 16,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
@@ -1081,7 +1038,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1097,7 +1053,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 9
       }
     ]
   },
@@ -1106,7 +1062,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1131,7 +1086,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1156,7 +1110,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1181,7 +1134,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1197,7 +1149,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -1206,7 +1158,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1222,7 +1173,7 @@
           }
         },
         "Start": 16,
-        "Length": 10
+        "Length": 15
       }
     ]
   },
@@ -1231,7 +1182,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1247,7 +1197,7 @@
           }
         },
         "Start": 16,
-        "Length": 7
+        "Length": 11
       }
     ]
   },
@@ -1256,7 +1206,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1272,7 +1221,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 12
       }
     ]
   },
@@ -1281,7 +1230,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1297,7 +1245,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 13
       }
     ]
   },
@@ -1306,7 +1254,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1322,7 +1269,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 13
       }
     ]
   },
@@ -1331,7 +1278,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1347,7 +1293,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 13
       }
     ]
   },
@@ -1356,7 +1302,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1372,7 +1317,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 14
       }
     ]
   },
@@ -1381,7 +1326,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1397,7 +1341,7 @@
           }
         },
         "Start": 16,
-        "Length": 10
+        "Length": 15
       }
     ]
   },
@@ -1406,7 +1350,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1422,7 +1365,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 15
       }
     ]
   },
@@ -1431,7 +1374,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1456,7 +1398,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1472,7 +1413,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -1481,7 +1422,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1506,7 +1446,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1522,7 +1461,7 @@
           }
         },
         "Start": 16,
-        "Length": 18
+        "Length": 13
       }
     ]
   },
@@ -1531,7 +1470,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1547,7 +1485,7 @@
           }
         },
         "Start": 16,
-        "Length": 9
+        "Length": 7
       }
     ]
   },
@@ -1556,7 +1494,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1572,7 +1509,7 @@
           }
         },
         "Start": 16,
-        "Length": 8
+        "Length": 9
       }
     ]
   },
@@ -1581,7 +1518,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1597,7 +1533,7 @@
           }
         },
         "Start": 16,
-        "Length": 20
+        "Length": 14
       }
     ]
   },
@@ -1606,7 +1542,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1622,7 +1557,7 @@
           }
         },
         "Start": 16,
-        "Length": 22
+        "Length": 25
       }
     ]
   },
@@ -1631,7 +1566,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1647,7 +1581,7 @@
           }
         },
         "Start": 16,
-        "Length": 14
+        "Length": 16
       }
     ]
   },
@@ -1656,7 +1590,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1672,7 +1605,7 @@
           }
         },
         "Start": 16,
-        "Length": 19
+        "Length": 22
       }
     ]
   },
@@ -1681,23 +1614,22 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een aantal weken",
         "Type": "duration",
         "Value": {
-          "Timex": "P2W",
+          "Timex": "P3W",
           "FutureResolution": {
-            "duration": "1209600"
+            "duration": "1814400"
           },
           "PastResolution": {
-            "duration": "1209600"
+            "duration": "1814400"
           }
         },
         "Start": 16,
-        "Length": 15
+        "Length": 16
       }
     ]
   },
@@ -1706,19 +1638,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een aantal dagen",
         "Type": "duration",
         "Value": {
-          "Timex": "P2D",
+          "Timex": "P3D",
           "FutureResolution": {
-            "duration": "172800"
+            "duration": "259200"
           },
           "PastResolution": {
-            "duration": "172800"
+            "duration": "259200"
           }
         },
         "Start": 7,
@@ -1731,7 +1662,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1739,16 +1669,16 @@
         "Type": "duration",
         "Value": {
           "Mod": "less",
-          "Timex": "P2D",
+          "Timex": "P3D",
           "FutureResolution": {
-            "duration": "172800"
+            "duration": "259200"
           },
           "PastResolution": {
-            "duration": "172800"
+            "duration": "259200"
           }
         },
         "Start": 7,
-        "Length": 26
+        "Length": 27
       }
     ]
   },
@@ -1757,7 +1687,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1774,7 +1703,7 @@
           }
         },
         "Start": 16,
-        "Length": 17
+        "Length": 16
       }
     ]
   },
@@ -1783,7 +1712,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1799,7 +1727,7 @@
           }
         },
         "Start": 16,
-        "Length": 12
+        "Length": 11
       }
     ]
   },
@@ -1808,7 +1736,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1833,7 +1760,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1849,13 +1775,12 @@
           }
         },
         "Start": 10,
-        "Length": 20
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek voor twee decennia",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1871,20 +1796,19 @@
           }
         },
         "Start": 16,
-        "Length": 11
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik vertrek voor veertien dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "veertien dagen",
         "Type": "duration",
         "Value": {
-          "Timex": "P2W",
+          "Timex": "P14D",
           "FutureResolution": {
             "duration": "1209600"
           },
@@ -1893,7 +1817,7 @@
           }
         },
         "Start": 16,
-        "Length": 11
+        "Length": 14
       }
     ]
   }

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -624,6 +624,30 @@
     ]
   },
   {
+    "Input": "Ik ben een kwart uur weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "een kwart uur",
+        "Type": "duration",
+        "Value": {
+          "Timex": "PT0.25H",
+          "FutureResolution": {
+            "duration": "900"
+          },
+          "PastResolution": {
+            "duration": "900"
+          }
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
     "Input": "Ik ben een half uur weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -600,14 +600,14 @@
     ]
   },
   {
-    "Input": "Ik ben een kwartier uur weg",
+    "Input": "Ik ben een kwartier weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een kwartier uur",
+        "Text": "een kwartier",
         "Type": "duration",
         "Value": {
           "Timex": "PT0.25H",
@@ -619,7 +619,7 @@
           }
         },
         "Start": 7,
-        "Length": 16
+        "Length": 12
       }
     ]
   },


### PR DESCRIPTION
All test cases pass.

Added variations of test cases with abbreviations 'dgn' (dagen) and 'jr' (jaar).

Two cases were updated in DateParser because they used "couple of" instead of "few" which has a different resolution.

In DateTimeModel, 125 pass, 217 fail.