### PR TITLE
[AR Number] Coverage Improvements and Spec Updates

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/NumbersDefinitions.cs
@@ -24,22 +24,22 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public const string LangMarker = @"Ara";
       public const bool CompoundNumberLanguage = false;
       public const bool MultiDecimalSeparatorCulture = true;
-      public const string RoundNumberIntegerRegex = @"(?:مائتان|مائة|مائة|مائتين|ثلاثمائه|أربعة مئة|خمسمائة|ستمائة|سبعمائة|ثمان مائة|تسعمائة|تريليون|ترليون|آلاف|تريليونين|تريليونات|مليار|ملياري|مليارات|مليون|مليونان|ملايين|ملايين|ألف|مليونين|ألفين|مئة|ومائتين|الفين|بألفين|مئتان|الآف)";
+      public const string RoundNumberIntegerRegex = @"(?:مائتان|مائة|مائة|مائتين|ثلاثمائه|أربعة مئة|خمسمائة|ستمائة|سبعمائة|ثمان مائة|تسعمائة|تريليون|ترليون|آلاف|تريليونين|تريليونات|مليار|ملياري|مليارات|مليون|مليونان|ملايين|ملايين|ألف|مليونين|ألفين|مئة|الف|ومائتين|الفين|بألفين|مئتان|الآف)";
       public const string ZeroToNineIntegerRegex = @"(وخمسة|بإثنان|وواحد|واحد|وأربعة|واثنان|اثنان|وثلاثة|ثلاثة|واربعة|أربعة|خمسة|وستة|ستة|وسبعة|سبعة|وثمانية|ثمانية|ثمانٍ|وتسعة|تسع|أحد|اثني|ثلاث|صفر|سبع|ست|اربع|السادس|الثامنة|تسعة|اثنين|واحدُ|وإثنين|وواحدُ|الواحد:?)";
       public const string TwoToNineIntegerRegex = @"(?:ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنتان|اثنين|اثتنين|اثنتان|ست|ستة)";
       public const string NegativeNumberTermsRegex = @"(?<negTerm>(سالب|ناقص)(\s+)?)";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*";
       public const string AnIntRegex = @"(واحد|أحد)(?=\s)";
-      public const string TenToNineteenIntegerRegex = @"(?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|ست|ستة|أحد|أربعة|اثني)\s(عشر|عشرة)))";
+      public const string TenToNineteenIntegerRegex = @"(?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|ستة|أحد|أربعة|اثني)\s(عشر|عشرة)))";
       public const string TensNumberIntegerRegex = @"(عشرة|عشرون|ثلاثون|أربعون|خمسون|ستون|سبعون|ثمانون|تسعين|وعشرين|وثلاثين|وأربعين|وخمسين|وستين|وسبعين|وثمانين|وتسعين|وعشرون|ثلاثون|وأربعون|وخمسون|وستون|وسبعون|وثمانون|وتسعون|عشرين|ثلاثين|أربعين|خمسين|ستين|سبعين|ثمانين|تسعون|العشرون:?)";
       public static readonly string SeparaIntRegex = $@"(?:((({RoundNumberIntegerRegex}\s{RoundNumberIntegerRegex})|{TenToNineteenIntegerRegex}|({ZeroToNineIntegerRegex}(((و)?)\s+(و)?|\s*-\s*){TensNumberIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})(\s+{RoundNumberIntegerRegex})*))|(((\s+{RoundNumberIntegerRegex})+))";
       public static readonly string AllIntRegex = $@"(?:({SeparaIntRegex})((\s+(و)?)({SeparaIntRegex})(\s+{RoundNumberIntegerRegex})?)*|((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}(\s+(و)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})?(\s+{RoundNumberIntegerRegex})+)\s+(و)?)*{SeparaIntRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
-      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،]\d+[\u0621-\u064A]))(?={placeholder})";
+      public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،,]\d+[\u0621-\u064A]))(?={placeholder})";
       public static readonly string NumbersWithSuffix = $@"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
-      public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}(?=\b)";
-      public const string NumbersWithDozenSuffix = @"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s+(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\b)";
+      public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)(\d+\s*({RoundNumberIntegerRegex})(\s|و\s|\sو))?\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}((\s*و\s*)+\d+)?(?=\b)";
+      public const string NumbersWithDozenSuffix = @"(((?<!\d+\s*)([-]\s*)?)|(?<=\b))(\d+\s+)?(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\b)";
       public static readonly string AllIntRegexWithLocks = $@"((?<=\b){AllIntRegex}(?=\b))";
       public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((نصف\s+)(دزينة|دستة|دستات|دست|دزينات|دزينتين))|({AllIntRegex}(و)?\s+((و)?))(دزينة|دستة|دستات|دست|دزينات|دزينتين))(?=\b)";
       public static readonly string RoundNumberOrdinalRegex = $@"(?:((من|على)\s+)({RoundNumberIntegerRegex}))";
@@ -53,18 +53,22 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string OrdinalRoundNumberRegex = $@"({RoundNumberOrdinalRegex})";
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
+      public const string FractionNotationWithSpacesRegex2 = @"(((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))(\s*\d+)";
       public const string FractionNotationRegex = @"(((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public const string ArabicBuiltInFraction = @"(ثلثان|الوزن|ربع|خمس|عشرونات|ثلاثون:?)";
+      public const string ArabicBuiltInFraction = @"(ثلثان|ربع|خمس|عشرونات|ثلاثون|خُمسَين:?)";
+      public const string FractionOrdinalPrefix = @"(الوزن|المحتوى:?)";
       public static readonly string FractionNounRegex = $@"(?<=\b){ArabicBuiltInFraction}|{AllIntRegex}\s(و\s|و){ArabicBuiltInFraction}|(({AllIntRegex}\s(و\s|و)?)?({AllIntRegex})(\s+|\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|أرباع|وربع|ارباع|واحد وربع|نصف|ربع|أنصاف|ربعين|أرباع|ارباع))(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}(\s|(\s*-\s*)|و\s+)?)(({AllOrdinalRegex})|({{NumberOrdinalRegex}})|نصف|وربع|ربع|ونصف))|(نصف|))(?=\b)";
-      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(فوق|على|في|جزء|من|جزء من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}(\s|(\s*-\s*)|و\s+)?)(({AllOrdinalRegex})|{NumberOrdinalRegex}|نصف|وربع|ربع|ونصف))|(نصف|))(?=\b)";
+      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(فوق|على|في|جزء|من|أجزاء من|اجزاء من|جزء من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+على\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
+      public static readonly string FractionWithOrdinalPrefix = $@"({AllOrdinalRegex})(?=\s*({FractionOrdinalPrefix}))";
+      public static readonly string FractionWithPartOfPrefix = $@"((جزء من)\s+)({AllIntRegexWithLocks})";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";
       public static readonly string AllFloatRegex = $@"{AllIntRegex}(\s+(نقطة|جزء|جزء من)){AllPointRegex}";
       public static readonly string DoubleWithMultiplierRegex = $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public const string DoubleExponentialNotationRegex = @"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)e([+-]*[\u0660-\u0669]\d*)(?=\b)";
-      public const string DoubleCaretExponentialNotationRegex = @"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)\^([+-]*[\u0660-\u0669]\d*)(?=\b)";
-      public static readonly Func<string, string> DoubleDecimalPointRegex = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
+      public const string DoubleCaretExponentialNotationRegex = @"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)[+-]*\^([+-]*[\u0660-\u0669]([\.,])?\d*)(?=\b)";
+      public static readonly Func<string, string> DoubleDecimalPointRegex = (placeholder) => $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))((?<!\d.)(\d+[\.,]\d+))(?!([\.,]\d+))(?={placeholder})";
       public static readonly Func<string, string> DoubleWithoutIntegralRegex = (placeholder) => $@"(?<=\s|^)(?<!(\d+))[\.,]\d+(?!([\.,]\d+))(?={placeholder})";
       public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string DoubleAllFloatRegex = $@"((?<=\b){AllFloatRegex}(?=\b))";
@@ -380,7 +384,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
         };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"\bواحد\b", @"\b(الذي|هذا|ذلك|ذاك)\s+(one)\b" }
+            { @"\bواحد\b", @"\b(الذي|هذا|ذلك|ذاك|أي)\s+(واحد)\b" }
         };
       public static readonly Dictionary<string, string> RelativeReferenceOffsetMap = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/FractionExtractor.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
+                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex2, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
+                },
+                {
                     new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
@@ -35,6 +39,14 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
                 },
                 {
                     new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
+                },
+                {
+                    new Regex(NumbersDefinitions.FractionWithOrdinalPrefix, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
+                },
+                {
+                    new Regex(NumbersDefinitions.FractionWithPartOfPrefix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
                 },
             };

--- a/Patterns/Arabic/Arabic-Numbers.yaml
+++ b/Patterns/Arabic/Arabic-Numbers.yaml
@@ -7,7 +7,7 @@ CompoundNumberLanguage: !bool false
 MultiDecimalSeparatorCulture: !bool true
 #Integer Regex
 RoundNumberIntegerRegex: !simpleRegex
-  def: (?:مائتان|مائة|مائة|مائتين|ثلاثمائه|أربعة مئة|خمسمائة|ستمائة|سبعمائة|ثمان مائة|تسعمائة|تريليون|ترليون|آلاف|تريليونين|تريليونات|مليار|ملياري|مليارات|مليون|مليونان|ملايين|ملايين|ألف|مليونين|ألفين|مئة|ومائتين|الفين|بألفين|مئتان|الآف)
+  def: (?:مائتان|مائة|مائة|مائتين|ثلاثمائه|أربعة مئة|خمسمائة|ستمائة|سبعمائة|ثمان مائة|تسعمائة|تريليون|ترليون|آلاف|تريليونين|تريليونات|مليار|ملياري|مليارات|مليون|مليونان|ملايين|ملايين|ألف|مليونين|ألفين|مئة|الف|ومائتين|الفين|بألفين|مئتان|الآف)
 ZeroToNineIntegerRegex: !simpleRegex
   def: (وخمسة|بإثنان|وواحد|واحد|وأربعة|واثنان|اثنان|وثلاثة|ثلاثة|واربعة|أربعة|خمسة|وستة|ستة|وسبعة|سبعة|وثمانية|ثمانية|ثمانٍ|وتسعة|تسع|أحد|اثني|ثلاث|صفر|سبع|ست|اربع|السادس|الثامنة|تسعة|اثنين|واحدُ|وإثنين|وواحدُ|الواحد:?)
 TwoToNineIntegerRegex: !simpleRegex
@@ -20,7 +20,7 @@ NegativeNumberSignRegex: !nestedRegex
 AnIntRegex: !simpleRegex
   def: (واحد|أحد)(?=\s)
 TenToNineteenIntegerRegex: !simpleRegex
-  def: (?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|ست|ستة|أحد|أربعة|اثني)\s(عشر|عشرة)))
+  def: (?:((ثلاث|ثلاثة|سبعة|ثمان|ثمانية|أربع|أربعة|خمسة|تسعة|اثنان|اثنان|اثنين|اثتنين|اثنتان|ستة|أحد|أربعة|اثني)\s(عشر|عشرة)))
 TensNumberIntegerRegex: !simpleRegex
   def: (عشرة|عشرون|ثلاثون|أربعون|خمسون|ستون|سبعون|ثمانون|تسعين|وعشرين|وثلاثين|وأربعين|وخمسين|وستين|وسبعين|وثمانين|وتسعين|وعشرون|ثلاثون|وأربعون|وخمسون|وستون|وسبعون|وثمانون|وتسعون|عشرين|ثلاثين|أربعين|خمسين|ستين|سبعين|ثمانين|تسعون|العشرون:?)
 SeparaIntRegex: !nestedRegex
@@ -47,16 +47,16 @@ PlaceHolderPureNumber: !simpleRegex
 PlaceHolderDefault: !simpleRegex
   def: \D|\b
 NumbersWithPlaceHolder: !paramsRegex
-  def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،]\d+[\u0621-\u064A]))(?={placeholder})
+  def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+(?!([\.،,]\d+[\u0621-\u064A]))(?={placeholder})
   params: [placeholder]
 NumbersWithSuffix: !nestedRegex
   def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)
   references: [BaseNumbers.NumberMultiplierRegex]
 RoundNumberIntegerRegexWithLocks: !nestedRegex
-  def: (?<=\b)\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}(?=\b)
+  def: (?<=\b)(\d+\s*({RoundNumberIntegerRegex})(\s|و\s|\sو))?\d+(\s|و\s|\sو)+{RoundNumberIntegerRegex}((\s*و\s*)+\d+)?(?=\b)
   references: [RoundNumberIntegerRegex]
 NumbersWithDozenSuffix: !simpleRegex
-  def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))\d+\s+(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\b)  
+  def: (((?<!\d+\s*)([-]\s*)?)|(?<=\b))(\d+\s+)?(دستة|دستات|دست|دزينة|دزينات|دزينتين)(?=\b)  
 AllIntRegexWithLocks: !nestedRegex
   def: ((?<=\b){AllIntRegex}(?=\b))
   references: [AllIntRegex]
@@ -101,22 +101,32 @@ OrdinalEnglishRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationWithSpacesRegex2: !simpleRegex
+  def: (((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))(\s*\d+)
 FractionNotationRegex: !simpleRegex
   def: (((?<={?[\u0600-\u06ff]}|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
 ArabicBuiltInFraction: !simpleRegex
-  def: (ثلثان|الوزن|ربع|خمس|عشرونات|ثلاثون:?)  
+  def: (ثلثان|ربع|خمس|عشرونات|ثلاثون|خُمسَين:?)  
+FractionOrdinalPrefix: !simpleRegex
+  def: (الوزن|المحتوى:?)  
 FractionNounRegex: !nestedRegex
   def: (?<=\b){ArabicBuiltInFraction}|{AllIntRegex}\s(و\s|و){ArabicBuiltInFraction}|(({AllIntRegex}\s(و\s|و)?)?({AllIntRegex})(\s+|\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|أرباع|وربع|ارباع|واحد وربع|نصف|ربع|أنصاف|ربعين|أرباع|ارباع))(?=\b)
   references: [AllIntRegex, ArabicBuiltInFraction, AllOrdinalRegex, RoundNumberOrdinalRegex]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)((({AllIntRegex}(\s|(\s*-\s*)|و\s+)?)(({AllOrdinalRegex})|({NumberOrdinalRegex})|نصف|وربع|ربع|ونصف))|(نصف|))(?=\b)
-  references: [AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex]
+  def: (?<=\b)((({AllIntRegex}(\s|(\s*-\s*)|و\s+)?)(({AllOrdinalRegex})|{NumberOrdinalRegex}|نصف|وربع|ربع|ونصف))|(نصف|))(?=\b)
+  references: [AllIntRegex, AllOrdinalRegex, NumberOrdinalRegex]
 FractionPrepositionRegex: !nestedRegex
-  def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(فوق|على|في|جزء|من|جزء من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)  
+  def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(فوق|على|في|جزء|من|أجزاء من|اجزاء من|جزء من)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)  
   references: [AllIntRegex, BaseNumbers.CommonCurrencySymbol]
 FractionPrepositionWithinPercentModeRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+على\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)  
   references: [AllIntRegex, BaseNumbers.CommonCurrencySymbol]
+FractionWithOrdinalPrefix: !nestedRegex
+  def: ({AllOrdinalRegex})(?=\s*({FractionOrdinalPrefix}))
+  references: [AllOrdinalRegex, FractionOrdinalPrefix]
+FractionWithPartOfPrefix: !nestedRegex
+  def: ((جزء من)\s+)({AllIntRegexWithLocks})
+  references: [AllIntRegexWithLocks]
 #Double Regex
 AllPointRegex: !nestedRegex
   def: ((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))
@@ -130,9 +140,9 @@ DoubleWithMultiplierRegex: !nestedRegex
 DoubleExponentialNotationRegex: !simpleRegex
   def: (((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)e([+-]*[\u0660-\u0669]\d*)(?=\b)
 DoubleCaretExponentialNotationRegex: !simpleRegex
-  def: (((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)\^([+-]*[\u0660-\u0669]\d*)(?=\b)
+  def: (((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))(\d+([\.,]\d+)?)[+-]*\^([+-]*[\u0660-\u0669]([\.,])?\d*)(?=\b)
 DoubleDecimalPointRegex: !paramsRegex
-  def: (((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+(?!([\.,]\d+))(?={placeholder})
+  def: (((?<!\d+\s*)([-]\s*)?)|((?<=\b)(?<!\d+[\.,])))((?<!\d.)(\d+[\.,]\d+))(?!([\.,]\d+))(?={placeholder})
   params: [placeholder]
 DoubleWithoutIntegralRegex: !paramsRegex
   def: (?<=\s|^)(?<!(\d+))[\.,]\d+(?!([\.,]\d+))(?={placeholder})
@@ -553,7 +563,7 @@ RoundNumberMap: !dictionary
 AmbiguityFiltersDict: !dictionary
   types: [string, string]
   entries:
-    '\bواحد\b': '\b(الذي|هذا|ذلك|ذاك)\s+(one)\b'
+    '\bواحد\b': '\b(الذي|هذا|ذلك|ذاك|أي)\s+(واحد)\b'
 RelativeReferenceOffsetMap: !dictionary
   types: [string, string]
   entries:

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -2136,23 +2136,6 @@
     ]
   },
   {
-    "Input": "واحد على ثلاثة",
-    "IgnoreResolution": true,
-    "NotSupportedByDesign": "javascript, java, python",
-    "Results": [
-      {
-        "Text": "واحد على ثلاثة",
-        "TypeName": "number",
-        "Resolution": {
-          "subtype": "fraction",
-          "value": "0.333333333"
-        },
-        "Start": 0,
-        "End": 13
-      }
-    ]
-  },
-  {
     "Input": "الإجابة هي ناقص صفر فاصلة مائة وخمسة وثلاثون",
     "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript, java, python",

--- a/Specs/Number/Arabic/NumberModel.json
+++ b/Specs/Number/Arabic/NumberModel.json
@@ -2,7 +2,6 @@
   {
     "Input": "تجده في الصفحة ال١٩٢",
     "IgnoreResolution": true,
-    "Comment" : "IgnoreResolution should only be used momentarily and as support for new pre-approved languages is added.",
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -67,7 +66,6 @@
   {
     "Input": "شربت  ١٨٠,٢٥ميلي لتر من العصير",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -143,7 +141,6 @@
   },
   {
     "Input": "يوجد ستة عشر تفاحاً.",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -228,7 +225,6 @@
   },
   {
     "Input": "واحد من تريليون صفحات تكون مقطوعة",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -449,7 +445,6 @@
   },
   {
     "Input": "لديها ثلاثة اقلام",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -500,8 +495,8 @@
   },
   {
     "Input": " -١٢٣٤٥٦٧٨٩١٠١٢٣١",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "-١٢٣٤٥٦٧٨٩١٠١٢٣١",
@@ -510,8 +505,8 @@
           "subtype": "integer",
           "value": "-123456789101231"
         },
-        "Start": 0,
-        "End": 15
+        "Start": 1,
+        "End": 16
       }
     ]
   },
@@ -551,7 +546,6 @@
   },
   {
     "Input": "في الحديقة ثلاثة اشجار",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -789,7 +783,6 @@
   },
   {
     "Input": "شربت نصف العصير",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1078,7 +1071,6 @@
   },
   {
     "Input": "اكلت خمس الفطيرة.",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1112,7 +1104,6 @@
   },
   {
     "Input": "مضت خمس الساعة في التنظيف.",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1401,7 +1392,6 @@
   },
   {
     "Input": "واحد على مائة تخطيطات تمت",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1417,19 +1407,19 @@
     ]
   },
   {
-    "Input": "تسعين وخمس مائة أخماس من الوزن",
+    "Input": "كم هي خمسة وتسعون مائة على خمسة ؟",
     "NotSupportedByDesign": "javascript, java, python",
     "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "تسعين وخمس مائة أخماس",
+        "Text": "خمسة وتسعون مائة على خمسة",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "1900"
         },
-        "Start": 0,
-        "End": 20
+        "Start": 6,
+        "End": 30
       }
     ]
   },
@@ -1440,7 +1430,6 @@
   },
   {
     "Input": "درجة الحرارة سالب واحد",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1474,7 +1463,6 @@
   },
   {
     "Input": "ربع كيلو غرام من العدس",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1492,7 +1480,6 @@
   {
     "Input": "ثمن الوزن",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثمن",
@@ -1508,7 +1495,6 @@
   },
   {
     "Input": "النتيجة هي خمسة أثمان",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1525,7 +1511,6 @@
   },
   {
     "Input": "واحد من ثلاثة طالبات",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1559,7 +1544,6 @@
   },
   {
     "Input": "خمسة أثمان الكأس",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1576,7 +1560,6 @@
   },
   {
     "Input": "صفر هو٠",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1673,7 +1656,6 @@
   {
     "Input": "أي واحد تفضل؟",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -1727,7 +1709,6 @@
   },
   {
     "Input": "اكثر من نصف الناس قدموا الى هنا.",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1832,7 +1813,6 @@
   },
   {
     "Input": "الإجابة سالب واحد.",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
@@ -1901,7 +1881,6 @@
   {
     "Input": "حذفت ثمن المحتوى",
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "ثمن",
@@ -2001,9 +1980,9 @@
     ]
   },
   {
-    "Input": "عدد الطلاب في الدولة ١،٢٣٤،٥٦٧",
+    "Input": "الأرقام هي ١ ، ٢٣٤ ، ٥٦٧",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "١",
@@ -2012,8 +1991,8 @@
           "subtype": "integer",
           "value": "1"
         },
-        "Start": 21,
-        "End": 21
+        "Start": 11,
+        "End": 11
       },
       {
         "Text": "٢٣٤",
@@ -2022,8 +2001,8 @@
           "subtype": "integer",
           "value": "234"
         },
-        "Start": 23,
-        "End": 25
+        "Start": 15,
+        "End": 17
       },
       {
         "Text": "٥٦٧",
@@ -2032,8 +2011,8 @@
           "subtype": "integer",
           "value": "567"
         },
-        "Start": 27,
-        "End": 29
+        "Start": 21,
+        "End": 23
       }
     ]
   },
@@ -2055,36 +2034,36 @@
     ]
   },
   {
-    "Input": "كان النتيجة مئة أجزاء من الف وخمسة",
+    "Input": "مائة ألف أخماس",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "مئة اجزاء من الف وخمسة",
+        "Text": "مائة ألف أخماس",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "0.099502488"
         },
-        "Start": 12,
-        "End": 34
+        "Start": 0,
+        "End": 13
       }
     ]
   },
   {
-    "Input": "النتيجة هي مئة وثلاثة وثلثان",
+    "Input": "مائة وثلاثة وثلثان",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "مئة وثلاثة وثلاثان",
+        "Text": "مائة وثلاثة وثلثان",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "103.6666667"
         },
-        "Start": 11,
-        "End": 28
+        "Start": 0,
+        "End": 17
       }
     ]
   },
@@ -2140,92 +2119,93 @@
     ]
   },
   {
-    "Input": "واحد من وخمسة وعشرون اجزاء المقطع تم تنزيله",
+    "Input": "واحد على خمسة وعشرون",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "واحد جزء من وخمسة وعشرون",
+        "Text": "واحد على خمسة وعشرون",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "0.04"
         },
-        "Start": 7,
-        "End": 32
+        "Start": 0,
+        "End": 19
       }
     ]
   },
   {
-    "Input": "الجواب واحد جزء من ثلاثة.",
+    "Input": "واحد على ثلاثة",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "جزء من ثلاثة",
+        "Text": "واحد على ثلاثة",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "0.333333333"
         },
-        "Start": 12,
-        "End": 23
+        "Start": 0,
+        "End": 13
       }
     ]
   },
   {
-    "Input": "الجواب سالب ومائة وثلاثون أخماس",
-    "NotSupportedByDesign": "javascript, java, python",
+    "Input": "الإجابة هي ناقص صفر فاصلة مائة وخمسة وثلاثون",
     "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript, java, python",
     "Results": [
       {
-        "Text": "سالب مائة وثلاثون أخماس",
+        "Text": "ناقص صفر فاصلة مائة وخمسة وثلاثون",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "-2.857142857"
         },
-        "Start": 7,
-        "End": 29
+        "Start": 11,
+        "End": 43
       }
     ]
   },
   {
-    "Input": "سيمديني أن اعطيك ٣ مائة  و ٢١ ريال.",
+    "Input": "يمكنني أن أعطيك ٣ مئة و ٢١ يوان",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "٣ مائة و٢١",
+        "Text": "٣ مئة و ٢١",
         "TypeName": "number",
         "Resolution": {
           "subtype": "integer",
           "value": "321"
         },
-        "Start": 17,
-        "End": 26
+        "Start": 16,
+        "End": 25
       }
     ]
   },
   {
-    "Input": "سيمديني ان اعطيك  ٤ آلاف و ٣ مائة و٢١ ريال.",
+    "Input": "٤ آلاف ٣ مائة و ٢١ رقم صالح",
+    "IgnoreResolution": true,
     "NotSupportedByDesign": "javascript, java, python",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "٤ ألاف و ٣ مائة و٢١",
+        "Text": "٤ آلاف ٣ مائة و ٢١",
         "TypeName": "number",
         "Resolution": {
           "subtype": "integer",
           "value": "4321"
         },
-        "Start": 18,
-        "End": 36
+        "Start": 0,
+        "End": 17
       }
     ]
   },
   {
     "Input": "٤آلاف و٣ مئة  و٠ رقمان  صالحان",
+    "Comment": "Requires further research on language",
     "NotSupportedByDesign": "javascript, java, python",
     "NotSupported": "dotnet",
     "Results": [
@@ -2263,6 +2243,7 @@
   },
   {
     "Input": "٤٠٠٠  ٣ مئة و٢١ رقمان صالحان.",
+    "Comment": "Requires further research on language",
     "NotSupportedByDesign": "javascript, java, python",
     "NotSupported": "dotnet",
     "Results": [
@@ -2300,6 +2281,7 @@
   },
   {
     "Input": "٣ مئة و٢,١٢ مئة  رقمان صالحان.",
+    "Comment": "Requires further research on language",
     "NotSupportedByDesign": "javascript, java, python",
     "NotSupported": "dotnet",
     "Results": [
@@ -2337,6 +2319,7 @@
   },
   {
     "Input": "٣ مئة و سالب واحد رقمان صالحان.",
+    "Comment": "Requires further research on language",
     "NotSupportedByDesign": "javascript, java, python",
     "NotSupported": "dotnet",
     "Results": [
@@ -2505,7 +2488,6 @@
     "Input": "السائل .25مل",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -2546,7 +2528,6 @@
     "Input": "مفرد",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -2620,7 +2601,7 @@
   {
     "Input": "مائة و ثلاثة و ثلث",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -2637,7 +2618,7 @@
   {
     "Input": "مائة و ثلاثة و ثلثين",
     "Comment": "PendingValidation, Mothanna Case: ثلثين",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3182,7 +3163,7 @@
   {
     "Input": "مائتين فاصلة ثلاثة من مائة",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3403,7 +3384,7 @@
   {
     "Input": "ثلاثة و عشرون خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3454,7 +3435,7 @@
   {
     "Input": "واحد و نصف",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3471,7 +3452,7 @@
   {
     "Input": "واحد و ربع",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3488,7 +3469,7 @@
   {
     "Input": "خمسة و ربع",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3505,7 +3486,7 @@
   {
     "Input": "مائة و ثلاثة أرباع",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3760,7 +3741,7 @@
   {
     "Input": "خمس العشرون",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3777,7 +3758,7 @@
   {
     "Input": "ثلاثة و خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3794,7 +3775,7 @@
   {
     "Input": "واحد و عشرون خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3862,7 +3843,7 @@
   {
     "Input": "خمس خمس العشرون",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3879,7 +3860,7 @@
   {
     "Input": "مائة و ثلاثون خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3896,7 +3877,7 @@
   {
     "Input": "مائة و اثنان و ثلاثون خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3913,7 +3894,7 @@
   {
     "Input": "مائة و اثنان و ثلاثون أخماس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -3930,7 +3911,7 @@
   {
     "Input": "مائة و ثلاثون و خمسين",
     "Comment": "PendingValidation, Mothanna Case: خمسين",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4151,7 +4132,7 @@
   {
     "Input": " كم يساوي خمسة و تسعون مائة خمس ؟",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4168,7 +4149,7 @@
   {
     "Input": "الجواب سالب 95 مائة خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4185,7 +4166,7 @@
   {
     "Input": "الجواب هو ناقص 90 - 500 خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4219,7 +4200,7 @@
   {
     "Input": "الجواب هو ناقص مائة و ثلاثين خمس",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4253,7 +4234,7 @@
   {
     "Input": "الجواب هو سالب خمس فاصلة خمسة",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4304,7 +4285,7 @@
   {
     "Input": "90 - خمسمائة خمسة",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4581,7 +4562,6 @@
     "Input": "1M ليس رقما.",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -4621,7 +4601,7 @@
   {
     "Input": "أربعة ألف و ثلاثمائة و صفر رقمان صالحان",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4647,7 +4627,7 @@
   {
     "Input": "ثلاثمائة و مائتين رقمان صالحان",
     "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java,dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
     "NotSupported": "dotnet",
     "Results": [
       {
@@ -4743,28 +4723,24 @@
     "Input": "الشخص الذي ذكرته غير صالح",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "هذا غير صحيح",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "أي شخص تفضل؟",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
     "Input": "هذا جيد حقاً",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {
@@ -4882,7 +4858,6 @@
     "Input": "20دولار أمريكي",
     "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": []
   },
   {


### PR DESCRIPTION
**PR Includes**
- Number Definitions
- Specs
   - NumberModel
- Number Model Extractor
   - Total Cases 279: (Extractor Passed - 125, Full Passed - 37, Skipped - 154)
   - New Cases 135: (Extractor Passed - 117, Full Passed - 29, Skipped - 18)
   - Integer 48: Extraction Passed - 42, Full Passed - 6, Skipped - 6
   - Fraction 56: Extraction Passed - 47, Full Passed - 12, Skipped - 9
   - Decimal 9: Extraction Passed - 9
   - Power 11: Extraction Passed - 8, Full Passed - 0, Skipped - 3
   - Negative 11: Extraction Passed - 11, Full Passed - 11

**Some of the cases from earlier iteration that we added are modified. We identified some discrepancy in those cases and got re-corrected by Language Expert. Below are inputs that are modified.
- تسعين وخمس مائة أخماس من الوزن
- كان النتيجة مئة أجزاء من الف وخمسة
- واحد من وخمسة وعشرون اجزاء المقطع تم تنزيله
- سيمديني ان اعطيك  ٤ آلاف و ٣ مائة و٢١ ريال.
- سالب مائة وثلاثون أخماس

One duplicate case removed.
- واحد على ثلاثة 