### PR TITLE
[CN DateTimeV2] Fix the issue where time of day merge was not working in JavaScript (#1882)

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimePeriodConfiguration.ts
@@ -252,13 +252,12 @@ export class ChineseDateTimePeriodExtractor extends BaseDateTimePeriodExtractor 
 
         this.config.singleDateExtractor.extract(source, refDate).forEach(er => {
             let afterStr = source.substr(er.start + er.length);
-            let match = RegExpUtility.getMatches(this.config.timeOfDayRegex, afterStr).pop();
-            if (match) {
+            RegExpUtility.getMatches(this.config.timeOfDayRegex, afterStr).forEach(match => {
                 let middleStr = source.substr(0, match.index);
                 if (StringUtility.isNullOrWhitespace(middleStr) || RegExpUtility.isMatch(this.config.prepositionRegex, middleStr)) {
                     tokens.push(new Token(er.start, er.start + er.length + match.index + match.length));
                 }
-            }
+            });
         });
 
         return tokens;

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -5573,5 +5573,57 @@
         }
       }
     ]
+  },
+  {
+    "Input": "7月25日早间，7月25日早",
+    "Context": {
+      "ReferenceDateTime": "2020-06-11T18:00:00"
+    },
+    "Results": [
+      {
+        "Text": "7月25日早间",
+        "Start": 0,
+        "End": 6,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-07-25TMO",
+              "type": "datetimerange",
+              "start": "2019-07-25 08:00:00",
+              "end": "2019-07-25 12:00:00"
+            },
+            {
+              "timex": "XXXX-07-25TMO",
+              "type": "datetimerange",
+              "start": "2020-07-25 08:00:00",
+              "end": "2020-07-25 12:00:00"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "7月25日早",
+        "Start": 8,
+        "End": 13,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-07-25TMO",
+              "type": "datetimerange",
+              "start": "2019-07-25 08:00:00",
+              "end": "2019-07-25 12:00:00"
+            },
+            {
+              "timex": "XXXX-07-25TMO",
+              "type": "datetimerange",
+              "start": "2020-07-25 08:00:00",
+              "end": "2020-07-25 12:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix issue #1882;
Change to get all match results of timeOfDayRegex in function matchNight of Chinese DateTimePeriodConfiguration in JS;
Add test case to Spec;