### PR TITLE
[.NET] Dutch DateTime DatePeriod support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string LangMarker = @"Dut";
       public const bool CheckBothBeforeAfter = false;
       public static readonly string TillRegex = $@"(?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
-      public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|tot en met|t/m|tot(\s+aan)?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";
       public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de|het)\b";
       public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HalfYearRelativeRegex = $@"(het\s+)?{HalfYearTermRegex}(\s+van|\s*,\s*)?\s+({RelativeRegex}\s+jaar)";
       public static readonly string AllHalfYearRegex = $@"({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})";
       public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b";
-      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)";
+      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)";
       public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
       public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|(?<LatePrefix>laat|later|aan\s+het\s+einde))(\s+(op|van))?(\s+de\s+dag)?\b";
@@ -140,7 +140,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
       public static readonly string WeekDayEnd = $@"(deze\s+)?{WeekDayRegex}\s*,?\s*$";
       public const string WeekDayStart = @"^[\.]";
-      public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maand(en)?|weken|week|dag(en)?)\b";
+      public const string RangeUnitRegex = @"\b(?<unit>ja(ren|ar)|maand(en)?|we(ken|ek)|dag(en)?)\b";
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
       public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
     {
       public const string LangMarker = @"Dut";
       public const bool CheckBothBeforeAfter = false;
-      public static readonly string TillRegex = $@"(?<till>\b(tot|totdat|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
-      public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|tot en met|t/m|tot|tot aan)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string TillRegex = $@"(?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|tot en met|t/m|tot(\s+aan)?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";
-      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de)\b";
+      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de|het)\b";
       public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
       public const string UpcomingPrefixRegex = @"((aankomende?|komende?|aanstaande))";
       public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b";
@@ -36,22 +36,22 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ThisPrefixRegex = @"(dit|deze|huidige?)\b";
       public const string RangePrefixRegex = @"(van|tussen)";
       public const string CenturySuffixRegex = @"(^eeuw|^centennium)\b";
-      public const string ReferencePrefixRegex = @"(dezelfde|hetzelfde|dat|die|overeenkomstige)\b";
-      public const string FutureSuffixRegex = @"\b(in\s+de\s+)?(toekomst|vanaf)\b";
-      public static readonly string DayRegex = $@"(de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)";
+      public const string ReferencePrefixRegex = @"(dezelfde|hetzelfde|dat(zelfde)?|die|overeenkomstige)\b";
+      public const string FutureSuffixRegex = @"\b(in\s+de\s+)?(toekomst|vanaf(\s+nu)?)\b";
+      public const string DayRegex = @"(de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)";
       public static readonly string WrittenDayRegex = $@"(?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}(en|ën))?twintig)|(((één|een)(en|ën))?dertig))";
       public static readonly string WrittenCardinalDayRegex = $@"(?<=((de\s+)|\b))(?<day>(éérste|eerste|tweede|derde|vierde|vijfde|zesde|zevende|achtste|negende|tiende|{WrittenElevenToNineteenRegex}de|({WrittenOneToNineRegex}(en|ën))?twintigste|((één|een)(en|ën))?dertigste))";
-      public const string ImplicitDayRegex = @"(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))";
+      public const string ImplicitDayRegex = @"(de\s*)?(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))\b";
       public const string MonthNumRegex = @"\b(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b";
       public const string WrittenOneToNineRegex = @"(één|een|twee|drie|vier|vijf|zes|zeven|acht|negen)";
       public const string WrittenElevenToNineteenRegex = @"(elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien)";
       public const string WrittenTensRegex = @"(tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)";
       public static readonly string WrittenNumRegex = $@"({WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
       public static readonly string WrittenCenturyFullYearRegex = $@"((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)";
-      public const string WrittenCenturyOrdinalYearRegex = @"((ee|éé)nentwintig|tweeëntwintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig)";
-      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b";
+      public const string WrittenCenturyOrdinalYearRegex = @"((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)";
+      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)";
       public static readonly string LastTwoYearNumRegex = $@"((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})";
-      public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
+      public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})(\s+)?(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
       public const string OclockRegex = @"(?<oclock>uur)";
       public const string SpecialDescRegex = @"(p\b)";
       public static readonly string AmDescRegex = $@"({BaseDateTime.BaseAmDescRegex})";
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
       public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b)))";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
-      public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
+      public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
       public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|jr|decennia|maand(en)?|mnd|week|weken|(?<business>(werk))?dag(en)?|dgn)\b";
       public const string DateTokenPrefix = @"op ";
@@ -76,36 +76,38 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ToTokenRegex = @"\b(voor)$";
       public const string ToHalfTokenRegex = @"\b(over\s+half)$";
       public const string ForHalfTokenRegex = @"\b(voor\s+half)$";
-      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public const string FromTokenRegex = @"(van(af)?)$";
+      public const string BetweenTokenRegex = @"\b(tussen)$";
+      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|december|jan\.?|feb\.?|mar\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar) tot heden|nu|({RelativeRegex}\s+)?(mijn\s+)?(weekend|week|maand|jaar)(?!((\s+van)?\s+\d+|\s+tot\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
+      public static readonly string OneWordPeriodRegex = $@"\b(((((de|het)\s+)?maand(\s+van)?\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b";
-      public static readonly string WeekOfYearRegex = $@"\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b";
+      public static readonly string WeekOfYearRegex = $@"(\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)";
       public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
-      public const string QuarterTermRegex = @"\b(((?<cardinal>eerste|1e|1ste|tweede|2e|2de|derde|3e|3de|vierde|4e|4de)[ -]+kwartaal)|(Q(?<number>[1-4])))\b";
+      public const string QuarterTermRegex = @"\b(((?<cardinal>eerste|1e|1ste|tweede|2e|2de|derde|3e|3de|vierde|4e|4de)[ -]+kwartaal)|(k(?<number>[1-4])))\b";
       public static readonly string QuarterRegex = $@"(het\s+)?{QuarterTermRegex}((\s+van|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+jaar))?";
-      public static readonly string QuarterRegexYearFront = $@"({YearRegex}|{RelativeRegex}\s+jaar)('s)?\s+(de\s+)?{QuarterTermRegex}";
+      public static readonly string QuarterRegexYearFront = $@"({YearRegex}|({RelativeRegex}\s+jaar))('s)?\s+((het|de)\s+)?{QuarterTermRegex}";
       public const string HalfYearTermRegex = @"(?<cardinal>eerste|1e|1ste|tweede|2e|2de)\s+(helft)";
       public static readonly string HalfYearFrontRegex = $@"(?<year>(de\s+){HalfYearTermRegex}(\s+helft van\s+)((1[5-9]|2[0-1]])\d{{2}}))";
       public static readonly string HalfYearBackRegex = $@"(het\s+)?(H(?<number>[1-2])|({HalfYearTermRegex}))(\s+van|\s*,\s*)?\s+({YearRegex})";
       public static readonly string HalfYearRelativeRegex = $@"(het\s+)?{HalfYearTermRegex}(\s+van|\s*,\s*)?\s+({RelativeRegex}\s+jaar)";
       public static readonly string AllHalfYearRegex = $@"({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})";
-      public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>(eerder|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b";
-      public const string MidPrefixRegex = @"\b(?<MidPrefix>mid-?|(midden|halverwege|op\s+de\s+helft)\s+(in|op|van)?)\b";
-      public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|later|aan\s+het\s+einde|eindigend|afsluitend)(\s+(in|op|van)?))\b";
+      public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b";
+      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)";
+      public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
       public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|(?<LatePrefix>laat|later|aan\s+het\s+einde))(\s+(op|van))?(\s+de\s+dag)?\b";
       public const string SeasonDescRegex = @"(?<seas>lente|voorjaar|zomer|herfst|najaar|winter)";
-      public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}\s+)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b";
+      public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}(\s+)?)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b";
       public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
       public const string WeekOfRegex = @"(de\s+)?(week)(\s+van)(\s+de|het)?";
       public const string MonthOfRegex = @"(maand)(\s*)(van)";
-      public const string MonthRegex = @"\b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))";
+      public const string MonthRegex = @"\b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|mrt|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))";
       public static readonly string DateYearRegex = $@"(?<year>{BaseDateTime.FourDigitYearRegex}|{TwoDigitYearRegex})";
       public static readonly string YearSuffix = $@"((,|\s*van)?\s*({DateYearRegex}|{FullTextYearRegex}))";
       public static readonly string OnRegex = $@"(?<=\bop\s+)({DayRegex})\b";
@@ -138,7 +140,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
       public static readonly string WeekDayEnd = $@"(deze\s+)?{WeekDayRegex}\s*,?\s*$";
       public const string WeekDayStart = @"^[\.]";
-      public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maanden|maand|weken|week)\b";
+      public const string RangeUnitRegex = @"\b(?<unit>jaren|jaar|maand(en)?|weken|week|dag(en)?)\b";
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
       public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
@@ -153,7 +155,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimePrefix = $@"(?<prefix>(half|{LessThanOneHour}\s+(over|voor|na)(\s+half)?)|(uur\s+{LessThanOneHour}))";
       public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";
       public static readonly string TimeSuffixFull = $@"(?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})";
-      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex})";
+      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex}(?![%\d]))";
       public const string MidnightRegex = @"(?<midnight>mid\s*(-\s*)?nacht|middernacht|in de nacht|('s|des) nachts)";
       public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?morgen|halverwege de ochtend|het midden van de ochtend)";
       public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)";
@@ -161,7 +163,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
       public static readonly string AtRegex = $@"(((?<=\bom\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
       public static readonly string IshRegex = $@"\b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b";
-      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>uren|uur|u|minuten|minuut|min\.?|mins|secondes|seconden|seconde|secs|sec\.?)\b";
+      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|u(ur)?|minuten|minuut|mins?|seconde[ns]?|secs?)\b)))";
       public const string RestrictedTimeUnitRegex = @"(?<unit>uur|minuut)\b";
       public const string FivesRegex = @"(?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|vijventwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
@@ -186,13 +188,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string SpecificTimeBetweenAnd = $@"(tussen\s+)(?<time1>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))";
       public const string PrepositionRegex = @"(?<prep>^(om|rond|tegen|op)(\s+de)?$)";
       public const string LaterEarlyRegex = @"((?<early>vroege?(\s+|-))|(?<late>(laat|late)(\s+|-)))";
-      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>((((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?)(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b";
-      public static readonly string SpecificTimeOfDayRegex = $@"\b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?)\b";
+      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b";
+      public static readonly string SpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?\b";
       public static readonly string TimeFollowedUnit = $@"^\s*{TimeUnitRegex}";
       public static readonly string TimeNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){TimeUnitRegex}";
       public static readonly string[] BusinessHourSplitStrings = { @"werk", @"uren" };
       public static readonly string[] BusinessHourSplitStrings2 = { @"kantoor", @"uren" };
-      public const string NowRegex = @"\b(?<now>nu(\s+meteen)?|zo snel mogelijk|zo spoedig mogelijk|asap|recent|onlangs|zojuist)\b";
+      public const string NowRegex = @"(?<!vanaf\s+)\b(?<now>nu(\s+meteen)?|zo snel mogelijk|zo spoedig mogelijk|asap|recent|onlangs|zojuist)\b";
       public const string SuffixRegex = @"^\s*(in de\s+)?(vroege\s+|late\s+)?(ochtend|(na)?middag|avond|nacht)\b";
       public const string DateTimeTimeOfDayRegex = @"\b(?<timeOfDay>morgen|ochtend|(na)?middag|avond|nacht)\b";
       public static readonly string DateTimeSpecificTimeOfDayRegex = $@"\b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend|morgen))\b";
@@ -200,16 +202,16 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*$";
       public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?(in\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b";
-      public const string SpecificEndOfRegex = @"((het\s+)?einde? van(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
-      public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde\s+van\s+(de\s+)?dag)\b";
+      public const string SpecificEndOfRegex = @"(((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
+      public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b";
       public const string UnspecificEndOfRangeRegex = @"\b(evj)\b";
       public const string PeriodTimeOfDayRegex = @"\b((in\s+(de)?\s+)?((?<early>vroege(\s+|-))|(?<late>late(\s+|-)))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b";
       public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend))\b";
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b";
-      public const string LessThanRegex = @"\b(minder\s+dan)\b";
+      public const string LessThanRegex = @"\b((binnen\s+)?minder\s+dan)\b";
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier(\s+uur)?)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
-      public const string SuffixAndRegex = @"(?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
+      public const string SuffixAndRegex = @"(?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
       public const string PeriodicRegex = @"\b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b";
       public static readonly string EachUnitRegex = $@"(?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(iedere|elke)\s*$)";
@@ -229,7 +231,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string AMTimeRegex = @"(?<am>('s morgens|'s ochtends)|in\s+de\s+(morgen|ochtend))";
       public const string PMTimeRegex = @"(?<pm>('s middags|'s avonds|'s nachts)|(in\s+de\s+)?(middag|avond|nacht))\b";
       public const string InclusiveModPrepositions = @"(?<include>((in|tegen|tijdens|op)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))";
-      public static readonly string BeforeRegex = $@"(\b{InclusiveModPrepositions}?(voor|vóór|vooraf(gaan)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+op\s+|tegen|tot|totdat|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
+      public static readonly string BeforeRegex = $@"(\b{InclusiveModPrepositions}?(voor|vóór|vooraf(gaan)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+op\s+|tegen|tot(dat)?|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
       public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";
       public const string SinceRegex = @"(\b(sinds|na\s+of\s+gelijk\s+aan|startend\s+(vanaf|op|met)|zo\s+vroeg\s+als|ieder\s+moment\s+vanaf)\b\s*)|(?<!\w|<)(>=)";
       public const string AroundRegex = @"(\b(rond(om)?|ongeveer(\s+om)?)\s*\b)";
@@ -237,7 +239,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string LaterRegex = @"\b(later|vanaf nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b";
       public const string InConnectorRegex = @"\b(in|over)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})";
-      public static readonly string WithinNextPrefixRegex = $@"\b(in(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b";
+      public static readonly string WithinNextPrefixRegex = $@"\b((binnen)(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b";
+      public const string TodayNowRegex = @"\b(vandaag|nu)\b";
       public static readonly string MorningStartEndRegex = $@"(^(('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex}))|((('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(('s|des)\s+middags|in de (na)?middag|{PmDescRegex}))|((('s|des)\s+middags|in de (na)?middag|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(avond|('s|des)?\s+avonds))|((avond|('s|des)?\s+avonds)$)";
@@ -249,7 +252,6 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+(?<duration>week|maand|jaar|decennium|weekend)\b";
       public const string ConnectorRegex = @"^(-|,|voor|t|rond(om)?|@)$";
       public const string FromRegex = @"\b(van)$";
-      public const string BetweenTokenRegex = @"\b(tussen)$";
       public const string FromToRegex = @"\b(van).+(tot)\b.+";
       public const string SingleAmbiguousMonthRegex = @"^(de\s+)?(mei)$";
       public const string SingleAmbiguousTermsRegex = @"^(de\s+)?(dag|week|maand|jaar)$";
@@ -258,7 +260,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))";
       public static readonly string ForTheRegex = $@"\b((((?<=voor\s+)de\s+{FlexibleDayRegex})|((?<=op\s+)de\s+{FlexibleDayRegex}(?<=(ste|de|e))))(?<end>(\s+(tussen|binnen|terug|tegen|aan|uit|mee|bij|vol|uit|aan|op|in|na|af)\s*)?(\s+(ge\w\w\w+|\w\w\w+en)\s*)?(,|\.|!|\?|$)))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b";
-      public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+(?!(de)){DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
+      public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
       public const string RestOfDateTimeRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<unit>dag)\b";
       public const string MealTimeRegex = @"\b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b";
@@ -276,13 +278,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(voor|niet later dan|na)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+op)\s*$";
-      public const string DecadeRegex = @"(?<decade>(de\s+jaren\s+(vijftig|zestig|zeventig|tachtig|negentig))|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e eeuw|(ee|éé)nentwintigste eeuw))";
-      public static readonly string DecadeWithCenturyRegex = $@"(de\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?s)|(({CenturyRegex}(\s+|-)(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(en\s+)?(?<decade>tien|honderd)))";
-      public static readonly string RelativeDecadeRegex = $@"\b((de\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decennia?)\b";
+      public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend))";
+      public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?(')?(?<decade>\d0)(')?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
+      public static readonly string RelativeDecadeRegex = $@"\b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b";
       public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b";
       public const string DateAfterRegex = @"\b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b";
       public static readonly string YearPeriodRegex = $@"((((vanaf|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
-      public static readonly string ComplexDatePeriodRegex = $@"(((vanaf|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
+      public static readonly string ComplexDatePeriodRegex = $@"(((van(af)?|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
       public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
         {
             { @"millennium", @"1000Y" },
@@ -467,6 +469,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"jan", 1 },
             { @"feb", 2 },
             { @"mar", 3 },
+            { @"mrt", 3 },
             { @"apr", 4 },
             { @"jun", 6 },
             { @"jul", 7 },
@@ -480,6 +483,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"jan.", 1 },
             { @"feb.", 2 },
             { @"mar.", 3 },
+            { @"mrt.", 3 },
             { @"apr.", 4 },
             { @"jun.", 6 },
             { @"jul.", 7 },
@@ -589,10 +593,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"zevenenzestig", 67 },
             { @"achtenzestig", 68 },
             { @"negenenzestig", 69 },
-            { @"drieënzeventig", 70 },
+            { @"zeventig", 70 },
             { @"eenenzeventig", 71 },
             { @"tweeënzeventig", 72 },
-            { @"zeventig", 73 },
+            { @"drieënzeventig", 73 },
             { @"vierenzeventig", 74 },
             { @"vijfenzeventig", 75 },
             { @"zesenzeventig", 76 },
@@ -764,13 +768,33 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"tachtiger jaren", 80 },
             { @"jaren 90", 90 },
             { @"jaren negentig", 90 },
-            { @"negentiger jaren", 90 }
+            { @"nul", 0 },
+            { @"tien", 10 },
+            { @"twintig", 20 },
+            { @"twintiger", 20 },
+            { @"dertig", 30 },
+            { @"dertiger", 30 },
+            { @"veertig", 40 },
+            { @"veertiger", 40 },
+            { @"vijftig", 50 },
+            { @"vijftiger", 50 },
+            { @"zestig", 60 },
+            { @"zestiger", 60 },
+            { @"zeventig", 70 },
+            { @"zeventiger", 70 },
+            { @"tachtig", 80 },
+            { @"tachtiger", 80 },
+            { @"negentig", 90 },
+            { @"negentiger", 90 },
+            { @"honderd", 0 }
         };
       public static readonly Dictionary<string, int> SpecialDecadeCases = new Dictionary<string, int>
         {
             { @"21e eeuw", 2000 },
             { @"eenentwintigste eeuw", 2000 },
-            { @"tweeduizend", 2000 }
+            { @"tweeduizend", 2000 },
+            { @"jaren nul", 0 },
+            { @"nul", 0 }
         };
       public const string DefaultLanguageFallback = @"DMY";
       public static readonly IList<string> SuperfluousWordList = new List<string>
@@ -781,7 +805,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             @"say",
             @"like"
         };
-      public static readonly string[] DurationDateRestrictions = {  };
+      public static readonly string[] DurationDateRestrictions = { @"vandaag", @"nu" };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"\bmorning|afternoon|evening|night|day\b", @"\b(good\s+(morning|afternoon|evening|night|day))|(nighty\s+night)\b" },
@@ -859,6 +883,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly IList<string> MonthToDateTerms = new List<string>
         {
             @"maand tot heden",
+            @"maand tot op heden",
             @"vanaf vorig maandeinde"
         };
       public static readonly IList<string> WeekendTerms = new List<string>
@@ -881,6 +906,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly IList<string> YearToDateTerms = new List<string>
         {
             @"jaar tot heden",
+            @"jaar tot op heden",
             @"vanaf vorig jaareinde"
         };
     }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)";
-      public const string FractionHalfRegex = @"(ënhalf|enhalve|ëneenhalf)$";
+      public const string FractionHalfRegex = @"([eë]nhalf|[eë]nhalve|ëneenhal(f|ve))$";
       public static readonly string[] OneHalfTokens = { @"een", @"half" };
       public static readonly string FractionNounRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s+)?)?(({AllIntRegex})(\s+|\s*-\s*|\s*/\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))n?|halven|vierdes|kwart)|{FractionUnitsRegex}))(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+(en\s)?)?(een)(\s+|\s*-\s*|\s*/\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|({FractionUnitsRegex}))|{AllIntRegex}[eë]n(eenhalf|half|halve|helft|kwart))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string InConnectorRegex = @"\b(in)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(the\s+)?year\s*)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(within(\s+the)?(\s+(?<next>{NextPrefixRegex}))?)\b";
+      public const string TodayNowRegex = @"\b(today|now)\b";
       public static readonly string MorningStartEndRegex = $@"(^(morning|{AmDescRegex}))|((morning|{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(afternoon|{PmDescRegex}))|((afternoon|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(evening))|((evening)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string InConnectorRegex = @"\b(dans|en|sur)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(aujourd'hui|maintenant)\b";
       public const string MorningStartEndRegex = @"(^(matin))|((matin)$)";
       public const string AfternoonStartEndRegex = @"(^((d'|l')?apr[eè]s-midi))|(((d'|l')?apr[eè]s-midi)$)";
       public const string EveningStartEndRegex = @"(^(soir[ée]e|soir))|((soir[ée]e|soir)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string InConnectorRegex = @"\b(dans|en|sur)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";
+      public const string TodayNowRegex = @"^[.]";
       public const string MorningStartEndRegex = @"(^(matin))|((matin)$)";
       public const string AfternoonStartEndRegex = @"(^((d'|l')?apr[eè]s-midi))|(((d'|l')?apr[eè]s-midi)$)";
       public const string EveningStartEndRegex = @"(^(soir[ée]e|soir))|((soir[ée]e|soir)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -205,6 +205,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public static readonly string WithinNextPrefixRegex = $@"\b(innerhalb|während(\s+der|de(s|m))?(\s+(?<next>{NextPrefixRegex}))?)\b";
+      public const string TodayNowRegex = @"^[.]";
       public const string MorningStartEndRegex = @"(^(früh|vormittag(s)?)|(morgens?|früh|vormittags?)$)";
       public const string AfternoonStartEndRegex = @"(^(nachmittags?)|(nachmittags?)$)";
       public const string EveningStartEndRegex = @"(^(abends?)|(abends?)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public static readonly string WithinNextPrefixRegex = $@"\b(innerhalb|während(\s+der|de(s|m))?(\s+(?<next>{NextPrefixRegex}))?)\b";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(heute|jetzt)\b";
       public const string MorningStartEndRegex = @"(^(früh|vormittag(s)?)|(morgens?|früh|vormittags?)$)";
       public const string AfternoonStartEndRegex = @"(^(nachmittags?)|(nachmittags?)$)";
       public const string EveningStartEndRegex = @"(^(abends?)|(abends?)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Recognizers.Definitions.Hindi
       public const string InConnectorRegex = @"\b(में|को)";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(the\s+)?year\s*)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(((?<next>{NextPrefixRegex}?के)\s+)?(अंदर|भीतर))";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(आज|अभी)(?![\u0900-\u097f])";
       public static readonly string MorningStartEndRegex = $@"(^(सुबह|{AmDescRegex}))|((सुबह|{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(दोपहर|{PmDescRegex}))|((दोपहर|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(शाम))|((शाम)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Recognizers.Definitions.Hindi
       public const string InConnectorRegex = @"\b(में|को)";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(the\s+)?year\s*)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(((?<next>{NextPrefixRegex}?के)\s+)?(अंदर|भीतर))";
+      public const string TodayNowRegex = @"^[.]";
       public static readonly string MorningStartEndRegex = $@"(^(सुबह|{AmDescRegex}))|((सुबह|{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(दोपहर|{PmDescRegex}))|((दोपहर|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^(शाम))|((शाम)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public const string InConnectorRegex = @"\b(in|tra|fra|a)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}\s*(ann[oi]\s*)?({DateYearRegex}|{FullTextYearRegex}))";
       public static readonly string WithinNextPrefixRegex = $@"\b(entro(\s+(?<next>{NextPrefixRegex}))?)\b";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(oggi|adesso)\b";
       public static readonly string MorningStartEndRegex = $@"(^(((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex}))|((((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^((((di|al)\s+|questo\s+|sto)?pomeriggio)|{PmDescRegex}))|(((((di|il)\s+|questo\s+|sto)?pomeriggio)|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^((di\s+|questa\s+|sta)?sera|serata))|(((di\s+|questa\s+|sta)?sera|serata)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
@@ -232,6 +232,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public const string InConnectorRegex = @"\b(in|tra|fra|a)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}\s*(ann[oi]\s*)?({DateYearRegex}|{FullTextYearRegex}))";
       public static readonly string WithinNextPrefixRegex = $@"\b(entro(\s+(?<next>{NextPrefixRegex}))?)\b";
+      public const string TodayNowRegex = @"^[.]";
       public static readonly string MorningStartEndRegex = $@"(^(((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex}))|((((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex})$)";
       public static readonly string AfternoonStartEndRegex = $@"(^((((di|al)\s+|questo\s+|sto)?pomeriggio)|{PmDescRegex}))|(((((di|il)\s+|questo\s+|sto)?pomeriggio)|{PmDescRegex})$)";
       public const string EveningStartEndRegex = @"(^((di\s+|questa\s+|sta)?sera|serata))|(((di\s+|questa\s+|sta)?sera|serata)$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string InConnectorRegex = @"\b(em)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";
+      public const string TodayNowRegex = @"^[.]";
       public const string CenturySuffixRegex = @"^[.]";
       public const string FromRegex = @"((desde|de)(\s*a(s)?)?)$";
       public const string BetweenRegex = @"(entre\s*([oa](s)?)?)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string InConnectorRegex = @"\b(em)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(hoje|agora)\b";
       public const string CenturySuffixRegex = @"^[.]";
       public const string FromRegex = @"((desde|de)(\s*a(s)?)?)$";
       public const string BetweenRegex = @"(entre\s*([oa](s)?)?)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"\b(dentro\s+de)\b";
+      public const string TodayNowRegex = @"^[.]";
       public const string FromRegex = @"((de(sde)?)(\s*la(s)?)?)$";
       public const string BetweenRegex = @"(entre\s*(la(s)?)?)";
       public const string WeekDayRegex = @"\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"\b(dentro\s+de)\b";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(hoy|ahora)\b";
       public const string FromRegex = @"((de(sde)?)(\s*la(s)?)?)$";
       public const string BetweenRegex = @"(entre\s*(la(s)?)?)";
       public const string WeekDayRegex = @"\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -288,6 +288,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string SinceNumSuffixRegex = @"\b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b";
       public static readonly string SinceYearSuffixRegex = $@"({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)";
       public static readonly string WithinNextPrefixRegex = $@"\b((?<next>{NextPrefixRegex}\s+)?(\d+\s+(saniye|dakika|saat|gün|hafta|ay|yıl)\s+)?içinde)\b";
+      public const string TodayNowRegex = @"^[.]";
       public const string MorningStartEndRegex = @"(^sabahı?$)";
       public const string AfternoonStartEndRegex = @"(^öğle(den\s+sonra)?$)";
       public const string EveningStartEndRegex = @"(^akşamı?$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string SinceNumSuffixRegex = @"\b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b";
       public static readonly string SinceYearSuffixRegex = $@"({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)";
       public static readonly string WithinNextPrefixRegex = $@"\b((?<next>{NextPrefixRegex}\s+)?(\d+\s+(saniye|dakika|saat|gün|hafta|ay|yıl)\s+)?içinde)\b";
-      public const string TodayNowRegex = @"^[.]";
+      public const string TodayNowRegex = @"\b(bugün|şimdi)\b";
       public const string MorningStartEndRegex = @"(^sabahı?$)";
       public const string AfternoonStartEndRegex = @"(^öğle(den\s+sonra)?$)";
       public const string EveningStartEndRegex = @"(^akşamı?$)";

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Dutch.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Dutch.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeExtractor(testSpec);
         }
 
-        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void DatePeriodExtractor(TestModel testSpec)
@@ -42,7 +41,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             ExtractorInitialize(Extractors);
             TestDateTimeExtractor(testSpec);
         }
-        */
 
         [NetCoreTestDataSource]
         [TestMethod]
@@ -60,7 +58,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeExtractor(testSpec);
         }
 
-        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void DateTimePeriodExtractor(TestModel testSpec)
@@ -68,7 +65,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             ExtractorInitialize(Extractors);
             TestDateTimeExtractor(testSpec);
         }
-        */
 
         [NetCoreTestDataSource]
         [TestMethod]
@@ -104,7 +100,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeExtractor(testSpec);
         }
 
-        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void MergedExtractor(TestModel testSpec)
@@ -113,6 +108,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeExtractor(testSpec);
         }
 
+        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void MergedExtractorSkipFromTo(TestModel testSpec)
@@ -140,7 +136,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeParser(testSpec);
         }
 
-        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void DatePeriodParser(TestModel testSpec)
@@ -149,7 +144,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             ParserInitialize(Parsers);
             TestDateTimeParser(testSpec);
         }
-        */
 
         [NetCoreTestDataSource]
         [TestMethod]
@@ -187,6 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeParser(testSpec);
         }
 
+        /*
         [NetCoreTestDataSource]
         [TestMethod]
         public void TimeZoneParser(TestModel testSpec)
@@ -195,6 +190,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             ParserInitialize(Parsers);
             TestDateTimeParser(testSpec);
         }
+        */
 
         [NetCoreTestDataSource]
         [TestMethod]
@@ -205,30 +201,30 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
             TestDateTimeParser(testSpec);
         }
 
-        // [NetCoreTestDataSource]
-        // [TestMethod]
-        // public void SetParser(TestModel testSpec)
-        // {
-        //    ExtractorInitialize(Extractors);
-        //    ParserInitialize(Parsers);
-        //    TestDateTimeParser(testSpec);
-        // }
+        [NetCoreTestDataSource]
+        [TestMethod]
+        public void SetParser(TestModel testSpec)
+        {
+           ExtractorInitialize(Extractors);
+           ParserInitialize(Parsers);
+           TestDateTimeParser(testSpec);
+        }
 
-        // [NetCoreTestDataSource]
-        // [TestMethod]
-        // public void MergedParser(TestModel testSpec)
-        // {
-        //    ExtractorInitialize(Extractors);
-        //    ParserInitialize(Parsers);
-        //    TestDateTimeMergedParser(testSpec);
-        // }
+        [NetCoreTestDataSource]
+        [TestMethod]
+        public void MergedParser(TestModel testSpec)
+        {
+           ExtractorInitialize(Extractors);
+           ParserInitialize(Parsers);
+           TestDateTimeMergedParser(testSpec);
+        }
 
-        // [NetCoreTestDataSource]
-        // [TestMethod]
-        // public void DateTimeModel(TestModel testSpec)
-        // {
-        //    TestDateTime(testSpec);
-        // }
+        [NetCoreTestDataSource]
+        [TestMethod]
+        public void DateTimeModel(TestModel testSpec)
+        {
+           TestDateTime(testSpec);
+        }
 
         // [NetCoreTestDataSource]
         // [TestMethod]

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -168,6 +168,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
+        private static readonly Regex FromTokenRegex =
+            new Regex(DateTimeDefinitions.FromTokenRegex, RegexFlags);
+
+        private static readonly Regex BetweenTokenRegex =
+            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+
         private static readonly Regex[] SimpleCasesRegexes =
         {
             // "3-5 Jan, 2018",
@@ -328,25 +334,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("from"))
+            var fromMatch = FromTokenRegex.Match(text);
+            if (fromMatch.Success)
             {
-                index = text.LastIndexOf("from", StringComparison.Ordinal);
-                return true;
+                index = fromMatch.Index;
             }
 
-            return false;
+            return fromMatch.Success;
         }
 
         public bool GetBetweenTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("between"))
+            var betweenMatch = BetweenTokenRegex.Match(text);
+            if (betweenMatch.Success)
             {
-                index = text.LastIndexOf("between", StringComparison.Ordinal);
-                return true;
+                index = betweenMatch.Index;
             }
 
-            return false;
+            return betweenMatch.Success;
         }
 
         public bool HasConnectorToken(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
+        private IImmutableList<string> lastCardinalTerms = DateTimeDefinitions.LastCardinalTerms.ToImmutableList();
+
         public DutchDateParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
@@ -162,7 +164,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim();
-            return trimmedText.Equals("last");
+            foreach (var s in lastCardinalTerms)
+            {
+                if (trimmedText.Equals(s))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.Dutch;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
@@ -164,15 +165,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim();
-            foreach (var s in lastCardinalTerms)
-            {
-                if (trimmedText.Equals(s))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return lastCardinalTerms.Contains(trimmedText);
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             MoreThanRegex = DutchDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = DutchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = DutchDatePeriodExtractorConfiguration.NowRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -200,6 +201,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public Regex CenturySuffixRegex { get; }
 
         public Regex NowRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             CenturySuffixRegex = EnglishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = EnglishDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -204,6 +205,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             CenturySuffixRegex = FrenchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = FrenchDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -196,6 +197,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             CenturySuffixRegex = GermanDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = GermanDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = GermanDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -186,6 +187,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             CenturySuffixRegex = HindiDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = HindiDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = HindiDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -206,6 +207,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             CenturySuffixRegex = ItalianDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = ItalianDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -203,6 +204,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -588,9 +588,8 @@ namespace Microsoft.Recognizers.Text.DateTime
                     var isLessThanOrWithIn = false;
                     var isMoreThan = false;
 
-                    // @TODO move hardcoded English strings to definition
                     // cases like "within 3 days from yesterday/tomorrow" does not make any sense
-                    if (er.Text.Contains("today") || er.Text.Contains("now"))
+                    if (this.config.TodayNowRegex.IsMatch(er.Text))
                     {
                         MatchWithinNextPrefix(beforeString, isAgo, ref isLessThanOrWithIn, ref isMoreThan);
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDatePeriodParserConfiguration.cs
@@ -105,6 +105,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex SpecialDayRegex { get; }
 
+        Regex TodayNowRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> CardinalMap { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             CenturySuffixRegex = PortugueseDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = PortugueseDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = PortugueseDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -188,6 +189,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             CenturySuffixRegex = SpanishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = SpanishDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -195,6 +196,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex IDatePeriodParserConfiguration.NextPrefixRegex => NextPrefixRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             CenturySuffixRegex = TurkishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = TurkishDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = TurkishDateExtractorConfiguration.SpecialDayRegex;
+            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -204,6 +205,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public Regex NowRegex { get; }
 
         public Regex SpecialDayRegex { get; }
+
+        public Regex TodayNowRegex { get; }
 
         Regex ISimpleDatePeriodParserConfiguration.RelativeRegex => RelativeRegex;
 

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -6,7 +6,7 @@ TillRegex: !nestedRegex
   def: (?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RangeConnectorRegex: !nestedRegex
-  def: (?<and>\b(en|tot en met|t/m|tot(\s+aan)?)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  def: (?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 ArticleRegex: !simpleRegex
   def: \b(de|het|een)\b
@@ -188,7 +188,7 @@ AllHalfYearRegex: !nestedRegex
 EarlyPrefixRegex: !simpleRegex
   def: \b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b
 MidPrefixRegex: !simpleRegex
-  def: \b(?<MidPrefix>(mid(den)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)
+  def: \b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)
 LaterPrefixRegex: !simpleRegex
   def: \b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b
 PrefixPeriodRegex: !nestedRegex
@@ -313,7 +313,7 @@ WeekDayEnd: !nestedRegex
 WeekDayStart: !simpleRegex
   def: ^[\.]
 RangeUnitRegex: !simpleRegex
-  def: \b(?<unit>jaren|jaar|maand(en)?|weken|week|dag(en)?)\b
+  def: \b(?<unit>ja(ren|ar)|maand(en)?|we(ken|ek)|dag(en)?)\b
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b
 MinuteNumRegex: !simpleRegex

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -3,15 +3,15 @@
 LangMarker: Dut
 CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
-  def: (?<till>\b(tot|totdat|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  def: (?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RangeConnectorRegex: !nestedRegex
-  def: (?<and>\b(en|tot en met|t/m|tot|tot aan)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  def: (?<and>\b(en|tot en met|t/m|tot(\s+aan)?)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 ArticleRegex: !simpleRegex
   def: \b(de|het|een)\b
 RelativeRegex: !simpleRegex
-  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de)\b
+  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de|het)\b
 StrictRelativeRegex: !simpleRegex
   def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b
 UpcomingPrefixRegex: !simpleRegex
@@ -33,12 +33,11 @@ RangePrefixRegex: !simpleRegex
 CenturySuffixRegex: !simpleRegex
   def: (^eeuw|^centennium)\b
 ReferencePrefixRegex: !simpleRegex
-  def: (dezelfde|hetzelfde|dat|die|overeenkomstige)\b
+  def: (dezelfde|hetzelfde|dat(zelfde)?|die|overeenkomstige)\b
 FutureSuffixRegex: !simpleRegex
-  def: \b(in\s+de\s+)?(toekomst|vanaf)\b
-DayRegex: !nestedRegex
+  def: \b(in\s+de\s+)?(toekomst|vanaf(\s+nu)?)\b
+DayRegex: !simpleRegex
   def: (de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)
-  references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex ]
 # 1-31 written
 WrittenDayRegex: !nestedRegex
   def: (?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}(en|ën))?twintig)|(((één|een)(en|ën))?dertig))
@@ -47,7 +46,7 @@ WrittenCardinalDayRegex: !nestedRegex
   def: (?<=((de\s+)|\b))(?<day>(éérste|eerste|tweede|derde|vierde|vijfde|zesde|zevende|achtste|negende|tiende|{WrittenElevenToNineteenRegex}de|({WrittenOneToNineRegex}(en|ën))?twintigste|((één|een)(en|ën))?dertigste))
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex ]
 ImplicitDayRegex: !simpleRegex
-  def: (?<day>(3[0-1]|[0-2]?\d)(ste|e|de))
+  def: (de\s*)?(?<day>(3[0-1]|[0-2]?\d)(ste|e|de))\b
 MonthNumRegex: !simpleRegex
   def: \b(?<month>01|02|03|04|05|06|07|08|09|10|11|12|1|2|3|4|5|6|7|8|9)\b
 WrittenOneToNineRegex: !simpleRegex
@@ -63,15 +62,15 @@ WrittenCenturyFullYearRegex: !nestedRegex
   def: ((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)
   references: [ WrittenOneToNineRegex]
 WrittenCenturyOrdinalYearRegex: !simpleRegex
-  def: ((ee|éé)nentwintig|tweeëntwintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig)
+  def: ((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)
 CenturyRegex: !nestedRegex
-  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b
+  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)
   references: [WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex ]
 LastTwoYearNumRegex: !nestedRegex
   def: ((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
 FullTextYearRegex: !nestedRegex
-  def: \b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b
+  def: \b((?<firsttwoyearnum>{CenturyRegex})(\s+)?(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b
   references: [ CenturyRegex, WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex, LastTwoYearNumRegex ]
 OclockRegex: !simpleRegex
   def: (?<oclock>uur)
@@ -105,7 +104,7 @@ RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b
   references: [RelativeRegex]
 WrittenMonthRegex: !simpleRegex
-  def: (((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))
+  def: (((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))
 MonthSuffixRegex: !nestedRegex
   def: (?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
@@ -127,8 +126,12 @@ ToHalfTokenRegex: !simpleRegex
   def: \b(over\s+half)$
 ForHalfTokenRegex: !simpleRegex
   def: \b(voor\s+half)$
+FromTokenRegex: !simpleRegex
+  def: (van(af)?)$
+BetweenTokenRegex: !simpleRegex
+  def: (tussen)$
 SimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
+  def: \b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex ]
 MonthFrontSimpleCasesRegex: !nestedRegex
   def: \b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
@@ -143,7 +146,7 @@ MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b((((de\s+)?maand van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|december|jan\.?|feb\.?|mar\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar) tot heden|nu|({RelativeRegex}\s+)?(mijn\s+)?(weekend|week|maand|jaar)(?!((\s+van)?\s+\d+|\s+tot\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
+  def: \b(((((de|het)\s+)?maand(\s+van)?\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
@@ -152,7 +155,7 @@ WeekOfMonthRegex: !nestedRegex
   def: \b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b
   references: [ MonthSuffixRegex ]
 WeekOfYearRegex: !nestedRegex
-  def: \b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b
+  def: (\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)
   references: [ YearRegex, RelativeRegex ]
 FollowedDateUnit: !nestedRegex
   def: ^\s*{DateUnitRegex}
@@ -161,12 +164,12 @@ NumberCombinedWithDateUnit: !nestedRegex
   def: \b(?<num>\d+(\.\d*)?){DateUnitRegex}
   references: [ DateUnitRegex ]
 QuarterTermRegex: !simpleRegex
-  def: \b(((?<cardinal>eerste|1e|1ste|tweede|2e|2de|derde|3e|3de|vierde|4e|4de)[ -]+kwartaal)|(Q(?<number>[1-4])))\b
+  def: \b(((?<cardinal>eerste|1e|1ste|tweede|2e|2de|derde|3e|3de|vierde|4e|4de)[ -]+kwartaal)|(k(?<number>[1-4])))\b
 QuarterRegex: !nestedRegex
   def: (het\s+)?{QuarterTermRegex}((\s+van|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+jaar))?
   references: [ YearRegex, RelativeRegex, QuarterTermRegex ]
 QuarterRegexYearFront: !nestedRegex
-  def: ({YearRegex}|{RelativeRegex}\s+jaar)('s)?\s+(de\s+)?{QuarterTermRegex}
+  def: ({YearRegex}|({RelativeRegex}\s+jaar))('s)?\s+((het|de)\s+)?{QuarterTermRegex}
   references: [ YearRegex, RelativeRegex, QuarterTermRegex ]
 HalfYearTermRegex: !simpleRegex
   def: (?<cardinal>eerste|1e|1ste|tweede|2e|2de)\s+(helft)
@@ -183,11 +186,11 @@ AllHalfYearRegex: !nestedRegex
   def: ({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})
   references: [ HalfYearFrontRegex, HalfYearBackRegex, HalfYearRelativeRegex ]
 EarlyPrefixRegex: !simpleRegex
-  def: \b(?<EarlyPrefix>(eerder|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b
+  def: \b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b
 MidPrefixRegex: !simpleRegex
-  def: \b(?<MidPrefix>mid-?|(midden|halverwege|op\s+de\s+helft)\s+(in|op|van)?)\b
+  def: \b(?<MidPrefix>(mid(den)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)
 LaterPrefixRegex: !simpleRegex
-  def: \b(?<LatePrefix>(laat|later|aan\s+het\s+einde|eindigend|afsluitend)(\s+(in|op|van)?))\b
+  def: \b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b
 PrefixPeriodRegex: !nestedRegex
   def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
   references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
@@ -196,7 +199,7 @@ PrefixDayRegex: !simpleRegex
 SeasonDescRegex: !simpleRegex
   def: (?<seas>lente|voorjaar|zomer|herfst|najaar|winter)
 SeasonRegex: !nestedRegex
-  def: \b(?<season>({PrefixPeriodRegex}\s+)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b
+  def: \b(?<season>({PrefixPeriodRegex}(\s+)?)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b
   references: [ YearRegex, RelativeRegex, SeasonDescRegex, PrefixPeriodRegex, ArticleRegex ]
 WhichWeekRegex: !simpleRegex
   def: \b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b
@@ -205,7 +208,7 @@ WeekOfRegex: !simpleRegex
 MonthOfRegex: !simpleRegex
   def: (maand)(\s*)(van)
 MonthRegex: !simpleRegex
-  def: \b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))
+  def: \b(?<month>(januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december)\b|(jan|feb|mar|mrt|apr|jun|jul|aug|sept|sep|oct|okt|nov|dec)(?:\.|\b))
 # This is a look-behind assertion. Some cases should extract two digits as year like 11/25/16, where 16 means 2016.
 # The assertion determines if not connected with am/pm or hour separator (:), which should be a time.
 DateYearRegex: !nestedRegex
@@ -310,7 +313,7 @@ WeekDayEnd: !nestedRegex
 WeekDayStart: !simpleRegex
   def: ^[\.]
 RangeUnitRegex: !simpleRegex
-  def: \b(?<unit>jaren|jaar|maanden|maand|weken|week)\b
+  def: \b(?<unit>jaren|jaar|maand(en)?|weken|week|dag(en)?)\b
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b
 MinuteNumRegex: !simpleRegex
@@ -345,7 +348,7 @@ TimeSuffixFull: !nestedRegex
   def: (?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})
   references: [ AmRegex, PmRegexFull, OclockRegex ]
 BasicTime: !nestedRegex
-  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex})
+  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex}(?![%\d]))
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
 MidnightRegex: !simpleRegex
   def: (?<midnight>mid\s*(-\s*)?nacht|middernacht|in de nacht|('s|des) nachts)
@@ -365,7 +368,7 @@ IshRegex: !nestedRegex
   def: \b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b
   references: [ BaseDateTime.HourRegex ]
 TimeUnitRegex: !simpleRegex
-  def: ([^A-Za-z]{1,}|\b)(?<unit>uren|uur|u|minuten|minuut|min\.?|mins|secondes|seconden|seconde|secs|sec\.?)\b
+  def: ([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|u(ur)?|minuten|minuut|mins?|seconde[ns]?|secs?)\b)))
 RestrictedTimeUnitRegex: !simpleRegex
   def: (?<unit>uur|minuut)\b
 FivesRegex: !simpleRegex
@@ -434,10 +437,10 @@ PrepositionRegex: !simpleRegex
 LaterEarlyRegex: !simpleRegex
   def: ((?<early>vroege?(\s+|-))|(?<late>(laat|late)(\s+|-)))
 TimeOfDayRegex: !nestedRegex
-  def: (?<timeOfDay>((((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?)(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b
+  def: (?<timeOfDay>(((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b
   references: [ LaterEarlyRegex, MealTimeRegex ]
 SpecificTimeOfDayRegex: !nestedRegex
-  def: \b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?)\b
+  def: \b(({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?\b
   references: [ TimeOfDayRegex, StrictRelativeRegex ]
 TimeFollowedUnit: !nestedRegex
   def: ^\s*{TimeUnitRegex}
@@ -448,7 +451,7 @@ TimeNumberCombinedWithUnit: !nestedRegex
 BusinessHourSplitStrings: ['werk', 'uren']
 BusinessHourSplitStrings2: ['kantoor', 'uren']
 NowRegex: !simpleRegex
-  def: \b(?<now>nu(\s+meteen)?|zo snel mogelijk|zo spoedig mogelijk|asap|recent|onlangs|zojuist)\b
+  def: (?<!vanaf\s+)\b(?<now>nu(\s+meteen)?|zo snel mogelijk|zo spoedig mogelijk|asap|recent|onlangs|zojuist)\b
 SuffixRegex: !simpleRegex
   def: ^\s*(in de\s+)?(vroege\s+|late\s+)?(ochtend|(na)?middag|avond|nacht)\b
 DateTimeTimeOfDayRegex: !simpleRegex
@@ -469,9 +472,9 @@ SimpleTimeOfTodayBeforeRegex: !nestedRegex
   def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
-  def: ((het\s+)?einde? van(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
+  def: (((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
 UnspecificEndOfRegex: !simpleRegex
-  def: \b(((om|rond|tegen|op)\s+)?het\s+)?(einde\s+van\s+(de\s+)?dag)\b
+  def: \b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b
 UnspecificEndOfRangeRegex: !simpleRegex
   def: \b(evj)\b
 PeriodTimeOfDayRegex: !simpleRegex
@@ -483,14 +486,14 @@ PeriodTimeOfDayWithDateRegex: !nestedRegex
  def: \b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b
  references: [ TimeOfDayRegex ]
 LessThanRegex: !simpleRegex
-  def: \b(minder\s+dan)\b
+  def: \b((binnen\s+)?minder\s+dan)\b
 MoreThanRegex: !simpleRegex
   def: \b(meer\s+dan)\b
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier(\s+uur)?)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
+  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
   references: [ DateUnitRegex ]
 SuffixAndRegex: !simpleRegex
-  def: (?<suffix>\s*(\sen|en een)\s+(?<suffix_num>half|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
+  def: (?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
 PeriodicRegex: !simpleRegex
   def: \b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b
 EachUnitRegex: !nestedRegex
@@ -538,7 +541,7 @@ PMTimeRegex: !simpleRegex
 InclusiveModPrepositions: !simpleRegex
   def: (?<include>((in|tegen|tijdens|op)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))
 BeforeRegex: !nestedRegex
-  def: (\b{InclusiveModPrepositions}?(voor|vóór|vooraf(gaan)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+op\s+|tegen|tot|totdat|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)
+  def: (\b{InclusiveModPrepositions}?(voor|vóór|vooraf(gaan)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+op\s+|tegen|tot(dat)?|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)
   references: [ InclusiveModPrepositions ]
 AfterRegex: !nestedRegex
   def: (\b{InclusiveModPrepositions}?((na|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)
@@ -557,8 +560,10 @@ SinceYearSuffixRegex: !nestedRegex
   def: (^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})
   references: [ SinceRegex, YearSuffix ]
 WithinNextPrefixRegex: !nestedRegex
-  def: \b(in(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b
+  def: \b((binnen)(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex
+  def: \b(vandaag|nu)\b
 # "next" group here is used to judge for illegal cases like "within the next 5 days before today"
 MorningStartEndRegex: !nestedRegex
   def: (^(('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex}))|((('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex})$)
@@ -610,7 +615,7 @@ WeekDayAndDayOfMonthRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b
   references: [WeekDayRegex, FlexibleDayRegex]
 WeekDayAndDayRegex: !nestedRegex
-  def: \b{WeekDayRegex}\s+(?!(de)){DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
+  def: \b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, AmDescRegex, PmDescRegex, OclockRegex]
 RestOfDateRegex: !simpleRegex
   def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b
@@ -654,12 +659,12 @@ TimeBeforeAfterRegex: !nestedRegex
 DateNumberConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>\s+op)\s*$
 DecadeRegex: !simpleRegex
-  def: (?<decade>(de\s+jaren\s+(vijftig|zestig|zeventig|tachtig|negentig))|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e eeuw|(ee|éé)nentwintigste eeuw))
+  def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend))
 DecadeWithCenturyRegex: !nestedRegex
-  def: (de\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?s)|(({CenturyRegex}(\s+|-)(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(en\s+)?(?<decade>tien|honderd)))
+  def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?(')?(?<decade>\d0)(')?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
   references: [ CenturyRegex, DecadeRegex ]
 RelativeDecadeRegex: !nestedRegex
-  def: \b((de\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decennia?)\b
+  def: \b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b
   references: [ RelativeRegex ]
 SuffixAfterRegex: !simpleRegex
   def: \b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b
@@ -669,7 +674,7 @@ YearPeriodRegex: !nestedRegex
   def: ((((vanaf|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 ComplexDatePeriodRegex: !nestedRegex
-  def: (((vanaf|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
+  def: (((van(af)?|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 UnitMap: !dictionary
   types: [ string, string ]
@@ -857,6 +862,7 @@ MonthOfYear: !dictionary
     'jan': 1
     'feb': 2
     'mar': 3
+    'mrt': 3
     'apr': 4
     'jun': 6
     'jul': 7
@@ -870,6 +876,7 @@ MonthOfYear: !dictionary
     'jan.': 1
     'feb.': 2
     'mar.': 3
+    'mrt.': 3
     'apr.': 4
     'jun.': 6
     'jul.': 7
@@ -979,10 +986,10 @@ Numbers: !dictionary
     'zevenenzestig': 67
     'achtenzestig': 68
     'negenenzestig': 69
-    'drieënzeventig': 70
+    'zeventig': 70
     'eenenzeventig': 71
     'tweeënzeventig': 72
-    'zeventig': 73
+    'drieënzeventig': 73
     'vierenzeventig': 74
     'vijfenzeventig': 75
     'zesenzeventig': 76
@@ -1157,7 +1164,25 @@ WrittenDecades: !dictionary
     'tachtiger jaren': 80
     'jaren 90': 90
     'jaren negentig': 90
-    'negentiger jaren': 90
+    'nul': 0
+    'tien': 10
+    'twintig': 20
+    'twintiger': 20
+    'dertig': 30
+    'dertiger': 30
+    'veertig': 40
+    'veertiger': 40
+    'vijftig': 50
+    'vijftiger': 50
+    'zestig': 60
+    'zestiger': 60
+    'zeventig': 70
+    'zeventiger': 70
+    'tachtig': 80
+    'tachtiger': 80
+    'negentig': 90
+    'negentiger': 90
+    'honderd': 0
     #TODO Aanvullen met 19e eeuw etc?
 SpecialDecadeCases: !dictionary
   types: [ string, int ]
@@ -1165,6 +1190,8 @@ SpecialDecadeCases: !dictionary
     '21e eeuw': 2000
     'eenentwintigste eeuw': 2000
     'tweeduizend': 2000
+    'jaren nul': 0
+    'nul': 0
 DefaultLanguageFallback: 'DMY'
 SuperfluousWordList: !list
   types: [ string ]
@@ -1175,7 +1202,7 @@ SuperfluousWordList: !list
     - say
     - like
 # For DurationDateRestrictions, only translate these terms if this particular circumstance applies in the target language. If not, keep it empty.
-DurationDateRestrictions: []
+DurationDateRestrictions: [vandaag, nu]
 # Cases collected from mined data
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
@@ -1257,6 +1284,7 @@ MonthToDateTerms: !list
   types: [ string ]
   entries:
     - maand tot heden
+    - maand tot op heden
     - vanaf vorig maandeinde
 WeekendTerms: !list
   types: [ string ]
@@ -1279,5 +1307,6 @@ YearToDateTerms: !list
   types: [ string ]
   entries:
     - jaar tot heden
+    - jaar tot op heden
     - vanaf vorig jaareinde
 ...

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -82,7 +82,7 @@ FractionNotationRegex: !simpleRegex
 FractionUnitsRegex: !simpleRegex
   def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)
 FractionHalfRegex: !simpleRegex
-  def: (ënhalf|enhalve|ëneenhalf)$
+  def: ([eë]nhalf|[eë]nhalve|ëneenhal(f|ve))$
 OneHalfTokens: [een, half]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}\s+(en\s+)?)?(({AllIntRegex})(\s+|\s*-\s*|\s*/\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))n?|halven|vierdes|kwart)|{FractionUnitsRegex}))(?=\b)

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -561,6 +561,8 @@ SinceYearSuffixRegex: !nestedRegex
 WithinNextPrefixRegex: !nestedRegex
   def: \b(within(\s+the)?(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex  # Added to remove hard coded strings in BaseDatePeriodParser
+  def: \b(today|now)\b
 # "next" group here is used to judge uncommon unsupported cases like "within the next 5 days before today"
 MorningStartEndRegex: !nestedRegex
   def: (^(morning|{AmDescRegex}))|((morning|{AmDescRegex})$)

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -453,6 +453,9 @@ SinceYearSuffixRegex: !simpleRegex
 WithinNextPrefixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 MorningStartEndRegex: !simpleRegex
   def: (^(matin))|((matin)$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -454,8 +454,7 @@ WithinNextPrefixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(aujourd'hui|maintenant)\b
 MorningStartEndRegex: !simpleRegex
   def: (^(matin))|((matin)$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -465,8 +465,7 @@ WithinNextPrefixRegex: !nestedRegex
   def: \b(innerhalb|während(\s+der|de(s|m))?(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(heute|jetzt)\b
 MorningStartEndRegex: !simpleRegex
   def: (^(früh|vormittag(s)?)|(morgens?|früh|vormittags?)$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -464,6 +464,9 @@ SinceYearSuffixRegex: !simpleRegex
 WithinNextPrefixRegex: !nestedRegex
   def: \b(innerhalb|während(\s+der|de(s|m))?(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 MorningStartEndRegex: !simpleRegex
   def: (^(früh|vormittag(s)?)|(morgens?|früh|vormittags?)$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Patterns/Hindi/Hindi-DateTime.yaml
+++ b/Patterns/Hindi/Hindi-DateTime.yaml
@@ -610,8 +610,7 @@ WithinNextPrefixRegex: !nestedRegex
   def: \b(((?<next>{NextPrefixRegex}?के)\s+)?(अंदर|भीतर))
   references: [ NextPrefixRegex ]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(आज|अभी)(?![\u0900-\u097f])
 # "next" group here is used to judge uncommon unsupported cases like "within the next 5 days before today"
 MorningStartEndRegex: !nestedRegex
   def: (^(सुबह|{AmDescRegex}))|((सुबह|{AmDescRegex})$)

--- a/Patterns/Hindi/Hindi-DateTime.yaml
+++ b/Patterns/Hindi/Hindi-DateTime.yaml
@@ -609,6 +609,9 @@ SinceYearSuffixRegex: !nestedRegex
 WithinNextPrefixRegex: !nestedRegex
   def: \b(((?<next>{NextPrefixRegex}?के)\s+)?(अंदर|भीतर))
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 # "next" group here is used to judge uncommon unsupported cases like "within the next 5 days before today"
 MorningStartEndRegex: !nestedRegex
   def: (^(सुबह|{AmDescRegex}))|((सुबह|{AmDescRegex})$)

--- a/Patterns/Italian/Italian-DateTime.yaml
+++ b/Patterns/Italian/Italian-DateTime.yaml
@@ -533,6 +533,9 @@ SinceYearSuffixRegex: !nestedRegex
 WithinNextPrefixRegex: !nestedRegex
   def: \b(entro(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 MorningStartEndRegex: !nestedRegex
   def: (^(((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex}))|((((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex})$)
   references: [ AmDescRegex ]

--- a/Patterns/Italian/Italian-DateTime.yaml
+++ b/Patterns/Italian/Italian-DateTime.yaml
@@ -534,8 +534,7 @@ WithinNextPrefixRegex: !nestedRegex
   def: \b(entro(\s+(?<next>{NextPrefixRegex}))?)\b
   references: [ NextPrefixRegex ]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(oggi|adesso)\b
 MorningStartEndRegex: !nestedRegex
   def: (^(((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex}))|((((di\s+|questa\s+|sta)?mattin[oa]|mattinata)|{AmDescRegex})$)
   references: [ AmDescRegex ]

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -126,8 +126,7 @@ WithinNextPrefixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(hoje|agora)\b
 CenturySuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -125,6 +125,9 @@ SinceYearSuffixRegex: !simpleRegex
 WithinNextPrefixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 CenturySuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -147,8 +147,7 @@ SinceYearSuffixRegex: !simpleRegex
 WithinNextPrefixRegex: !simpleRegex
   def: \b(dentro\s+de)\b
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(hoy|ahora)\b
 FromRegex: !simpleRegex
   def: ((de(sde)?)(\s*la(s)?)?)$
 BetweenRegex: !simpleRegex

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -146,6 +146,9 @@ SinceYearSuffixRegex: !simpleRegex
   def: ^[.]
 WithinNextPrefixRegex: !simpleRegex
   def: \b(dentro\s+de)\b
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 FromRegex: !simpleRegex
   def: ((de(sde)?)(\s*la(s)?)?)$
 BetweenRegex: !simpleRegex

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -672,8 +672,7 @@ WithinNextPrefixRegex: !nestedRegex
   def: \b((?<next>{NextPrefixRegex}\s+)?(\d+\s+(saniye|dakika|saat|gün|hafta|ay|yıl)\s+)?içinde)\b
   references: [ NextPrefixRegex ]
 TodayNowRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: \b(bugün|şimdi)\b
 MorningStartEndRegex: !simpleRegex
   def: (^sabahı?$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -671,6 +671,9 @@ SinceYearSuffixRegex: !nestedRegex
 WithinNextPrefixRegex: !nestedRegex
   def: \b((?<next>{NextPrefixRegex}\s+)?(\d+\s+(saniye|dakika|saat|gün|hafta|ay|yıl)\s+)?içinde)\b
   references: [ NextPrefixRegex ]
+TodayNowRegex: !simpleRegex
+  # TODO: modify below regex according to the counterpart in English
+  def: ^[.]
 MorningStartEndRegex: !simpleRegex
   def: (^sabahı?$)
 AfternoonStartEndRegex: !simpleRegex

--- a/Specs/DateTime/Dutch/DatePeriodExtractor.json
+++ b/Specs/DateTime/Dutch/DatePeriodExtractor.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "Ik ben in jan weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -14,7 +13,6 @@
   },
   {
     "Input": "Ik ben aanstaande jan weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "Ik ben maand jan weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "Ik ben de maand jan weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "Ik miste jan 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "Ik miste jan, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +73,6 @@
   },
   {
     "Input": "Ik ben in feb weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -92,7 +85,6 @@
   },
   {
     "Input": "Ik ben aanstaande feb weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "Ik ben maand feb weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "Ik ben de maand feb weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "Ik miste feb 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +133,6 @@
   },
   {
     "Input": "Ik miste feb, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -157,7 +145,6 @@
   },
   {
     "Input": "Ik ben in mrt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -170,7 +157,6 @@
   },
   {
     "Input": "Ik ben aanstaande mrt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -183,7 +169,6 @@
   },
   {
     "Input": "Ik ben maand mrt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -196,7 +181,6 @@
   },
   {
     "Input": "Ik ben de maand mrt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -209,7 +193,6 @@
   },
   {
     "Input": "Ik miste mrt 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,7 +205,6 @@
   },
   {
     "Input": "Ik miste mrt, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -235,7 +217,6 @@
   },
   {
     "Input": "Ik ben in apr weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,6 @@
   },
   {
     "Input": "Ik ben aanstaande apr weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -261,7 +241,6 @@
   },
   {
     "Input": "Ik ben maand apr weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -274,7 +253,6 @@
   },
   {
     "Input": "Ik ben de maand apr weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -287,7 +265,6 @@
   },
   {
     "Input": "Ik miste apr 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +277,6 @@
   },
   {
     "Input": "Ik miste apr, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -313,7 +289,6 @@
   },
   {
     "Input": "Ik ben in mei weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -326,7 +301,6 @@
   },
   {
     "Input": "Ik ben aanstaande mei weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -339,7 +313,6 @@
   },
   {
     "Input": "Ik ben maand mei weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -352,7 +325,6 @@
   },
   {
     "Input": "Ik ben de maand mei weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -365,7 +337,6 @@
   },
   {
     "Input": "Ik miste mei 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -378,7 +349,6 @@
   },
   {
     "Input": "Ik miste mei, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -391,7 +361,6 @@
   },
   {
     "Input": "Ik ben in jun weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -404,7 +373,6 @@
   },
   {
     "Input": "Ik ben aanstaande jun weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -417,7 +385,6 @@
   },
   {
     "Input": "Ik ben maand jun weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -430,7 +397,6 @@
   },
   {
     "Input": "Ik ben de maand jun weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -443,7 +409,6 @@
   },
   {
     "Input": "Ik miste jun 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -456,7 +421,6 @@
   },
   {
     "Input": "Ik miste jun, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -469,7 +433,6 @@
   },
   {
     "Input": "Ik ben in jul weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -482,7 +445,6 @@
   },
   {
     "Input": "Ik ben aanstaande jul weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -495,7 +457,6 @@
   },
   {
     "Input": "Ik ben maand jul weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -508,7 +469,6 @@
   },
   {
     "Input": "Ik ben de maand jul weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -521,7 +481,6 @@
   },
   {
     "Input": "Ik miste jul 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -534,7 +493,6 @@
   },
   {
     "Input": "Ik miste jul, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -547,7 +505,6 @@
   },
   {
     "Input": "Ik ben in aug weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -560,7 +517,6 @@
   },
   {
     "Input": "Ik ben aanstaande aug weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -573,7 +529,6 @@
   },
   {
     "Input": "Ik ben maand aug weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -586,7 +541,6 @@
   },
   {
     "Input": "Ik ben de maand aug weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -599,7 +553,6 @@
   },
   {
     "Input": "Ik miste aug 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -612,7 +565,6 @@
   },
   {
     "Input": "Ik miste aug, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -625,7 +577,6 @@
   },
   {
     "Input": "Ik ben in sep weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -638,7 +589,6 @@
   },
   {
     "Input": "Ik ben aanstaande sep weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -651,7 +601,6 @@
   },
   {
     "Input": "Ik ben maand sep weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -664,7 +613,6 @@
   },
   {
     "Input": "Ik ben de maand sep weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -677,7 +625,6 @@
   },
   {
     "Input": "Ik miste sep 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -690,7 +637,6 @@
   },
   {
     "Input": "Ik miste sep, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -703,7 +649,6 @@
   },
   {
     "Input": "Ik ben in okt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -716,7 +661,6 @@
   },
   {
     "Input": "Ik ben aanstaande okt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -729,7 +673,6 @@
   },
   {
     "Input": "Ik ben maand okt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -742,7 +685,6 @@
   },
   {
     "Input": "Ik ben de maand okt weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -755,7 +697,6 @@
   },
   {
     "Input": "Ik miste okt 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -768,7 +709,6 @@
   },
   {
     "Input": "Ik miste okt, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -781,7 +721,6 @@
   },
   {
     "Input": "Ik ben nov weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -794,7 +733,6 @@
   },
   {
     "Input": "Ik ben aanstaande nov weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -807,7 +745,6 @@
   },
   {
     "Input": "Ik ben maand nov weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -820,7 +757,6 @@
   },
   {
     "Input": "Ik ben de maand nov weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -833,7 +769,6 @@
   },
   {
     "Input": "Ik miste nov 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -846,7 +781,6 @@
   },
   {
     "Input": "Ik miste nov, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -859,7 +793,6 @@
   },
   {
     "Input": "Ik ben in dec weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -872,7 +805,6 @@
   },
   {
     "Input": "Ik ben aanstaande dec weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -885,7 +817,6 @@
   },
   {
     "Input": "Ik ben maand dec weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -898,7 +829,6 @@
   },
   {
     "Input": "Ik ben de maand dec weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -911,7 +841,6 @@
   },
   {
     "Input": "Ik miste dec 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -924,7 +853,6 @@
   },
   {
     "Input": "Ik miste dec, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -937,7 +865,6 @@
   },
   {
     "Input": "Ik ben in januari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -950,7 +877,6 @@
   },
   {
     "Input": "Ik ben aanstaande januari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -963,7 +889,6 @@
   },
   {
     "Input": "Ik ben maand januari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -976,7 +901,6 @@
   },
   {
     "Input": "Ik ben de maand januari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -989,7 +913,6 @@
   },
   {
     "Input": "Ik miste januari 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1002,7 +925,6 @@
   },
   {
     "Input": "Ik miste januari, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1015,7 +937,6 @@
   },
   {
     "Input": "Ik ben in februari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1028,7 +949,6 @@
   },
   {
     "Input": "Ik ben aanstaande februari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1041,7 +961,6 @@
   },
   {
     "Input": "Ik ben maand februari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1054,7 +973,6 @@
   },
   {
     "Input": "Ik ben de maand februari weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1067,7 +985,6 @@
   },
   {
     "Input": "Ik miste februari 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1080,7 +997,6 @@
   },
   {
     "Input": "Ik miste februari, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1093,7 +1009,6 @@
   },
   {
     "Input": "Ik ben in maart weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1106,7 +1021,6 @@
   },
   {
     "Input": "Ik ben aanstaande maart weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1119,7 +1033,6 @@
   },
   {
     "Input": "Ik ben maand maart weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1132,7 +1045,6 @@
   },
   {
     "Input": "Ik ben de maand maart weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1145,7 +1057,6 @@
   },
   {
     "Input": "Ik miste maart 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1158,7 +1069,6 @@
   },
   {
     "Input": "Ik miste maart, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1171,7 +1081,6 @@
   },
   {
     "Input": "Ik ben in april weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1184,7 +1093,6 @@
   },
   {
     "Input": "Ik ben aanstaande april weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1197,7 +1105,6 @@
   },
   {
     "Input": "Ik ben maand april weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1210,7 +1117,6 @@
   },
   {
     "Input": "Ik ben de maand april weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1223,7 +1129,6 @@
   },
   {
     "Input": "Ik miste april 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1236,7 +1141,6 @@
   },
   {
     "Input": "Ik miste april, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1249,7 +1153,6 @@
   },
   {
     "Input": "Ik ben in juni weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1262,7 +1165,6 @@
   },
   {
     "Input": "Ik ben aanstaande juni weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1275,7 +1177,6 @@
   },
   {
     "Input": "Ik ben maand juni weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1288,7 +1189,6 @@
   },
   {
     "Input": "Ik ben de maand juni weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1301,7 +1201,6 @@
   },
   {
     "Input": "Ik miste juni 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1314,7 +1213,6 @@
   },
   {
     "Input": "Ik miste juni, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1327,7 +1225,6 @@
   },
   {
     "Input": "Ik ben in juli weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1340,7 +1237,6 @@
   },
   {
     "Input": "Ik ben aanstaande juli weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1353,7 +1249,6 @@
   },
   {
     "Input": "Ik ben maand juli weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1366,7 +1261,6 @@
   },
   {
     "Input": "Ik ben de maand juli weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1379,7 +1273,6 @@
   },
   {
     "Input": "Ik miste juli 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1392,7 +1285,6 @@
   },
   {
     "Input": "Ik miste juli, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1405,7 +1297,6 @@
   },
   {
     "Input": "Ik ben in augustus weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1418,7 +1309,6 @@
   },
   {
     "Input": "Ik ben aanstaande augustus weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1431,7 +1321,6 @@
   },
   {
     "Input": "Ik ben maand augustus weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1444,7 +1333,6 @@
   },
   {
     "Input": "Ik ben de maand augustus weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1457,7 +1345,6 @@
   },
   {
     "Input": "Ik miste augustus 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1470,7 +1357,6 @@
   },
   {
     "Input": "Ik miste augustus, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1483,7 +1369,6 @@
   },
   {
     "Input": "Ik ben in september weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1496,7 +1381,6 @@
   },
   {
     "Input": "Ik ben aanstaande september weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1509,7 +1393,6 @@
   },
   {
     "Input": "Ik ben maand september weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1522,7 +1405,6 @@
   },
   {
     "Input": "Ik ben de maand september weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1535,7 +1417,6 @@
   },
   {
     "Input": "Ik miste september 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1548,7 +1429,6 @@
   },
   {
     "Input": "Ik miste september, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1561,7 +1441,6 @@
   },
   {
     "Input": "Ik ben in oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1574,7 +1453,6 @@
   },
   {
     "Input": "Ik ben aanstaande oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1587,7 +1465,6 @@
   },
   {
     "Input": "Ik ben maand oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1600,7 +1477,6 @@
   },
   {
     "Input": "Ik ben de maand oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1613,7 +1489,6 @@
   },
   {
     "Input": "Ik miste oktober 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1626,7 +1501,6 @@
   },
   {
     "Input": "Ik miste oktober, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1639,7 +1513,6 @@
   },
   {
     "Input": "Ik ben november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1652,7 +1525,6 @@
   },
   {
     "Input": "Ik ben aanstaande november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1665,7 +1537,6 @@
   },
   {
     "Input": "Ik ben maand november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1678,7 +1549,6 @@
   },
   {
     "Input": "Ik ben de maand november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1691,7 +1561,6 @@
   },
   {
     "Input": "Ik miste november 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1704,7 +1573,6 @@
   },
   {
     "Input": "Ik miste november, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1717,7 +1585,6 @@
   },
   {
     "Input": "Ik ben in december weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1730,7 +1597,6 @@
   },
   {
     "Input": "Ik ben aanstaande december weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1743,7 +1609,6 @@
   },
   {
     "Input": "Ik ben maand december weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1756,7 +1621,6 @@
   },
   {
     "Input": "Ik ben de maand december weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1769,7 +1633,6 @@
   },
   {
     "Input": "Ik miste december 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1782,7 +1645,6 @@
   },
   {
     "Input": "Ik miste december, 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1795,7 +1657,6 @@
   },
   {
     "Input": "Agenda voor de maand september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1808,20 +1669,18 @@
   },
   {
     "Input": "Ik ben deze maand van 4 tot 22 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "deze maand van 4 tot 22 ",
+        "Text": "deze maand van 4 tot 22",
         "Type": "daterange",
         "Start": 7,
-        "Length": 24
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben volgende maand van 4 tot 23 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1834,7 +1693,6 @@
   },
   {
     "Input": "Ik ben weg van 3 tot 12 sep hahaha",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1847,33 +1705,30 @@
   },
   {
     "Input": "Ik ben weg van 4 tot 23 volgende maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4 tot 23 volgende maand",
+        "Text": "van 4 tot 23 volgende maand",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 23
+        "Start": 11,
+        "Length": 27
       }
     ]
   },
   {
     "Input": "Ik ben weg van 4 tot 22 deze maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4 tot 22 deze maand",
+        "Text": "van 4 tot 22 deze maand",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 19
+        "Start": 11,
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben weg tussen 4 en 22 deze maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1886,7 +1741,6 @@
   },
   {
     "Input": "Ik ben weg tussen 3 en 12 van sep hahaha",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1899,7 +1753,6 @@
   },
   {
     "Input": "Ik ben weg tussen 4e september tot en met 8e september ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1912,46 +1765,42 @@
   },
   {
     "Input": "Ik ben weg tussen 15e november tot en met 19e ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 15e november tot en met 19e ",
+        "Text": "tussen 15e november tot en met 19e",
         "Type": "daterange",
         "Start": 11,
-        "Length": 35
+        "Length": 34
       }
     ]
   },
   {
     "Input": "Ik ben weg tussen 15e november tot en met de 19e ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 15e november tot en met de 19e ",
+        "Text": "tussen 15e november tot en met de 19e",
         "Type": "daterange",
         "Start": 11,
-        "Length": 38
+        "Length": 37
       }
     ]
   },
   {
     "Input": "Ik ben weg tussen de 15e november tot en met 19e ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen de 15e november tot en met 19e ",
+        "Text": "tussen de 15e november tot en met 19e",
         "Type": "daterange",
         "Start": 11,
-        "Length": 38
+        "Length": 37
       }
     ]
   },
   {
     "Input": "Ik ben weg van 4 tot 22 januari, 2017",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1964,7 +1813,6 @@
   },
   {
     "Input": "Ik ben weg tussen 4-22 januari, 2017",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1977,7 +1825,6 @@
   },
   {
     "Input": "Ik ben weg op deze week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1990,20 +1837,18 @@
   },
   {
     "Input": "Ik ben weg de komende week ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de komende week ",
+        "Text": "komende week",
         "Type": "daterange",
-        "Start": 11,
-        "Length": 16
+        "Start": 14,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "Ik ben weg in september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2016,7 +1861,6 @@
   },
   {
     "Input": "Ik ben weg afgelopen september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2029,7 +1873,6 @@
   },
   {
     "Input": "Ik ben volgende juni weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2042,7 +1885,6 @@
   },
   {
     "Input": "Ik ben juni 2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2055,7 +1897,6 @@
   },
   {
     "Input": "Ik ben juni volgend jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2068,7 +1909,6 @@
   },
   {
     "Input": "Ik ben dit weekend weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2081,33 +1921,30 @@
   },
   {
     "Input": "Ik ben de derde week van deze maand weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de derde week van deze maand ",
+        "Text": "de derde week van deze maand",
         "Type": "daterange",
         "Start": 7,
-        "Length": 29
+        "Length": 28
       }
     ]
   },
   {
     "Input": "Ik ben de laatste week van juli weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de laatste week van juli ",
+        "Text": "de laatste week van juli",
         "Type": "daterange",
         "Start": 7,
-        "Length": 25
+        "Length": 24
       }
     ]
   },
   {
     "Input": "Plan kamperen in voor vrijdag tot en met zondag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2120,7 +1957,6 @@
   },
   {
     "Input": "Ik ben de volgende 3 dagen weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2133,7 +1969,6 @@
   },
   {
     "Input": "Ik ben de volgende 3 maanden weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2146,44 +1981,45 @@
   },
   {
     "Input": "Ik ben over 3 jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Ik ben over 3 weken weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Ik ben over 3 maanden weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Ik ben de afgelopen 3 weken weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " afgelopen 3 weken",
+        "Text": "afgelopen 3 weken",
         "Type": "daterange",
-        "Start": 9,
-        "Length": 18
+        "Start": 10,
+        "Length": 17
       }
     ]
   },
   {
     "Input": "Ik ben de afgelopen 3 jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+    {
+        "Text": "afgelopen 3 jaar",
+        "Type": "daterange",
+        "Start": 10,
+        "Length": 16
+      }
+    ]
   },
   {
     "Input": "Ik ben afgelopen jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2196,7 +2032,6 @@
   },
   {
     "Input": "Ik ben vorige maand weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2209,7 +2044,6 @@
   },
   {
     "Input": "Ik ben vorige 3 weken weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2222,7 +2056,6 @@
   },
   {
     "Input": "afgelopen paar weken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2235,7 +2068,6 @@
   },
   {
     "Input": "afgelopen paar dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2248,7 +2080,6 @@
   },
   {
     "Input": "Ik ben 2 okt. tot 22 oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2261,7 +2092,6 @@
   },
   {
     "Input": "Ik ben 12 januari, 2016 tot 22-02-2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2274,20 +2104,18 @@
   },
   {
     "Input": "Ik ben 1e jan tot woens 22 jan weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1e jan tot woens 22 jan ",
+        "Text": "1e jan tot woens 22 jan",
         "Type": "daterange",
         "Start": 7,
-        "Length": 24
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben vandaag tot morgen weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2300,7 +2128,6 @@
   },
   {
     "Input": "Ik ben vandaag tot 22 oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2313,7 +2140,6 @@
   },
   {
     "Input": "Ik ben 2 okt. tot overmorgen weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2326,7 +2152,6 @@
   },
   {
     "Input": "Ik ben vandaag tot volgende zondag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2339,7 +2164,6 @@
   },
   {
     "Input": "Ik ben deze vrijdag tot volgende zondag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2352,7 +2176,6 @@
   },
   {
     "Input": "Ik ben van 2 okt. tot 22 oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2365,7 +2188,6 @@
   },
   {
     "Input": "Ik ben van 12-08-2015 tot 22 oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2378,7 +2200,6 @@
   },
   {
     "Input": "Ik ben van vrijdag de 2e tot dinsdag de 6e weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2391,7 +2212,6 @@
   },
   {
     "Input": "Ik ben van vandaag tot morgen weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2404,7 +2224,6 @@
   },
   {
     "Input": "Ik ben van deze vrijdag tot volgende zondag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2417,7 +2236,6 @@
   },
   {
     "Input": "Ik ben tussen 2 okt. en 22 oktober weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2430,7 +2248,6 @@
   },
   {
     "Input": "Ik ben 19-20 november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2443,7 +2260,6 @@
   },
   {
     "Input": "Ik ben 19 tot 20 november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2456,7 +2272,6 @@
   },
   {
     "Input": "Ik ben november tussen 19 en 20 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2469,7 +2284,6 @@
   },
   {
     "Input": "Ik ben het derde kwartaal van 2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2482,7 +2296,6 @@
   },
   {
     "Input": "Ik ben het derde kwartaal dit jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2495,7 +2308,6 @@
   },
   {
     "Input": "Ik ben 2016 het derde kwartaal weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2508,7 +2320,6 @@
   },
   {
     "Input": "Ik ben tijdens K1 terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2521,7 +2332,6 @@
   },
   {
     "Input": "Ik ben dit K3 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2534,7 +2344,6 @@
   },
   {
     "Input": "Ik ben 2015.3 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2547,7 +2356,6 @@
   },
   {
     "Input": "Ik ben 2015-3 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2560,7 +2368,6 @@
   },
   {
     "Input": "Ik ben 2015/3 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2573,7 +2380,6 @@
   },
   {
     "Input": "Ik ben 3/2015 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2586,7 +2392,6 @@
   },
   {
     "Input": "Ik ben de derde week van 2027 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2599,7 +2404,6 @@
   },
   {
     "Input": "Ik ben volgend jaar de derde week weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2612,7 +2416,6 @@
   },
   {
     "Input": "Ik vertrek deze zomer",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2625,7 +2428,6 @@
   },
   {
     "Input": "Ik vertrek volgende lente",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2638,7 +2440,6 @@
   },
   {
     "Input": "Ik vertrek de zomer",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2651,7 +2452,6 @@
   },
   {
     "Input": "Ik vertrek zomer",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2664,7 +2464,6 @@
   },
   {
     "Input": "Ik vertrek zomer 2016",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2677,7 +2476,6 @@
   },
   {
     "Input": "Ik vertrek zomer van 2016",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2690,7 +2488,6 @@
   },
   {
     "Input": "vakanties aankomende maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2703,7 +2500,6 @@
   },
   {
     "Input": "vakantie volgende maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2716,7 +2512,6 @@
   },
   {
     "Input": "Wat heb ik de week van 30e november",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2729,7 +2524,6 @@
   },
   {
     "Input": "de week van 15e september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2742,7 +2536,6 @@
   },
   {
     "Input": "week van 15e september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2755,7 +2548,6 @@
   },
   {
     "Input": "maand van 15e september",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2768,7 +2560,6 @@
   },
   {
     "Input": "Ik vertrek tijdens het weekend",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2781,7 +2572,6 @@
   },
   {
     "Input": "Ik vertrek de rest van de week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2794,7 +2584,6 @@
   },
   {
     "Input": "Ik vertrek de rest van mijn week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2807,7 +2596,6 @@
   },
   {
     "Input": "Ik vertrek rest van week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2820,7 +2608,6 @@
   },
   {
     "Input": "Ik vertrek rest van de week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2833,7 +2620,6 @@
   },
   {
     "Input": "Ik vertrek rest van deze week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2846,7 +2632,6 @@
   },
   {
     "Input": "Ik vertrek rest van huidige week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2859,7 +2644,6 @@
   },
   {
     "Input": "Ik vertrek rest van de maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2872,7 +2656,6 @@
   },
   {
     "Input": "Ik vertrek rest van het jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2885,7 +2668,6 @@
   },
   {
     "Input": "Zoek een tijd om elkaar later deze maand te ontmoeten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2898,7 +2680,6 @@
   },
   {
     "Input": "Zoek een tijd om elkaar later deze week te ontmoeten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2911,7 +2692,6 @@
   },
   {
     "Input": "Zoek een tijd om elkaar eind volgende week te ontmoeten",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2924,7 +2704,6 @@
   },
   {
     "Input": "Zoek een tijd om elkaar eind volgend jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2937,7 +2716,6 @@
   },
   {
     "Input": "We hebben eind vorige week afgesproken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2950,7 +2728,6 @@
   },
   {
     "Input": "Zoek een tijd voor ons om af te spreken begin deze maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2963,7 +2740,6 @@
   },
   {
     "Input": "Zoek een tijd voor ons om af te spreken begin deze week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2976,7 +2752,6 @@
   },
   {
     "Input": "Zoek een tijd voor ons om af te spreken begin volgende week",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2989,7 +2764,6 @@
   },
   {
     "Input": "Zoek een tijd voor ons om af te spreken begin volgend jaar",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3002,7 +2776,6 @@
   },
   {
     "Input": "Cortana, regel alsjeblieft een meeting van 25 minuten met antonio volgende week tussen woensdag en vrijdag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3015,7 +2788,6 @@
   },
   {
     "Input": "Ik ben jaar 247 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3028,7 +2800,6 @@
   },
   {
     "Input": "In de jaren 1970",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3041,7 +2812,6 @@
   },
   {
     "Input": "In de jaren 2000 werd hij geboren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3054,7 +2824,6 @@
   },
   {
     "Input": "In de jaren '70",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3067,7 +2836,6 @@
   },
   {
     "Input": "In de jaren '40",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3080,7 +2848,6 @@
   },
   {
     "Input": "In de jaren zeventig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3093,7 +2860,6 @@
   },
   {
     "Input": "In de jaren negentienzeventig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3106,7 +2872,6 @@
   },
   {
     "Input": "In de jaren tweeduizend tien",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3119,7 +2884,6 @@
   },
   {
     "Input": "In de jaren tweeduizend",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3132,7 +2896,6 @@
   },
   {
     "Input": "In de jaren nul",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3145,7 +2908,6 @@
   },
   {
     "Input": "Ik ben van 2 tot 7 feb, tweeduizend achttien weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3158,7 +2920,6 @@
   },
   {
     "Input": "Ik ben tussen 2 tot 7 feb tweeduizend achttien weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3171,7 +2932,6 @@
   },
   {
     "Input": "Ik ben feb tussen 2-7 tweeduizend achttien weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3184,7 +2944,6 @@
   },
   {
     "Input": "Het gebeurde in juni van negentiennegenennegentig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3197,7 +2956,6 @@
   },
   {
     "Input": "In negentienachtentwintig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3210,7 +2968,6 @@
   },
   {
     "Input": "Ik ben de eerste week van tweeduizend zevenentwintig weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3223,7 +2980,6 @@
   },
   {
     "Input": "Ik ben het eerste kwartaal van tweeduizend twintig weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3236,7 +2992,6 @@
   },
   {
     "Input": "In de lente van negentienachtenzeventig",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3249,20 +3004,18 @@
   },
   {
     "Input": "Jaar tweehonderdzevenenzestig,",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tweehonderdzevenenzestig",
+        "Text": "Jaar tweehonderdzevenenzestig",
         "Type": "daterange",
-        "Start": 5,
-        "Length": 24
+        "Start": 0,
+        "Length": 29
       }
     ]
   },
   {
     "Input": "Ik ben de week na de volgende weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3275,7 +3028,6 @@
   },
   {
     "Input": "Het gebeurde in de afgelopen 2 decennia",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3288,7 +3040,6 @@
   },
   {
     "Input": "Het gebeurde in de laatste twee decennia",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3301,7 +3052,6 @@
   },
   {
     "Input": "Het gebeurde in het volgende decennium",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3314,7 +3064,6 @@
   },
   {
     "Input": "Het zal 4 weken in de toekomst gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3327,20 +3076,18 @@
   },
   {
     "Input": "Het zal 2 dagen vanaf nu gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 dagen vanaf nu ",
+        "Text": "2 dagen vanaf nu",
         "Type": "daterange",
         "Start": 8,
-        "Length": 17
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Cortana kan een tijd begin volgende week voor ons vinden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3353,20 +3100,18 @@
   },
   {
     "Input": "Natuurlijk, laten we eind van volgende week Skypen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " eind van volgende week",
+        "Text": "eind van volgende week",
         "Type": "daterange",
-        "Start": 20,
-        "Length": 23
+        "Start": 21,
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Cortana kan half maart een ontmoeting voor ons regelen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3379,7 +3124,6 @@
   },
   {
     "Input": "en anders tegen midzomer?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3392,7 +3136,6 @@
   },
   {
     "Input": "Ik kan begin van volgende week een tijd voor ons vastleggen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3405,7 +3148,6 @@
   },
   {
     "Input": "Ik ben 11-2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3418,7 +3160,6 @@
   },
   {
     "Input": "Ik ben 11/2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3431,7 +3172,6 @@
   },
   {
     "Input": "Ik ben 2016/11 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3444,7 +3184,6 @@
   },
   {
     "Input": "Ik ben 2016-11 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3457,7 +3196,6 @@
   },
   {
     "Input": "Ik ben 2016 november weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3470,7 +3208,6 @@
   },
   {
     "Input": "Ik ben november, 2016 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3483,7 +3220,6 @@
   },
   {
     "Input": "Ik ben 2016, nov weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3496,33 +3232,30 @@
   },
   {
     "Input": "Ik ben tussen de 1e januari en de 5e april weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1e januari en de 5e april ",
+        "Text": "tussen de 1e januari en de 5e april",
         "Type": "daterange",
-        "Start": 17,
-        "Length": 26
+        "Start": 7,
+        "Length": 35
       }
     ]
   },
   {
     "Input": "Ik ben tussen de 1e januari 2015 en de 5e feb 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1e januari 2015 en de 5e feb 2018",
+        "Text": "tussen de 1e januari 2015 en de 5e feb 2018",
         "Type": "daterange",
-        "Start": 17,
-        "Length": 33
+        "Start": 7,
+        "Length": 43
       }
     ]
   },
   {
     "Input": "Ik ben tussen de 1e januari 2015 en feb 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3535,20 +3268,18 @@
   },
   {
     "Input": "Ik ben tussen 2015 en feb 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2015 en feb 2018",
+        "Text": "tussen 2015 en feb 2018",
         "Type": "daterange",
-        "Start": 14,
-        "Length": 16
+        "Start": 7,
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben van 1 feb tot maart 2019 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3561,20 +3292,18 @@
   },
   {
     "Input": "Ik ben tussen 1 feb en maart 2019 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 1 feb en maart 2019 ",
+        "Text": "tussen 1 feb en maart 2019",
         "Type": "daterange",
         "Start": 7,
-        "Length": 27
+        "Length": 26
       }
     ]
   },
   {
     "Input": "Ik ben tussen juni 2015 en mei 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3587,7 +3316,6 @@
   },
   {
     "Input": "Ik ben tussen mei 2015 en 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3600,7 +3328,6 @@
   },
   {
     "Input": "Ik ben tussen mei 2015 en juni 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3613,7 +3340,6 @@
   },
   {
     "Input": "Ik ben tussen 2015 en de 5e van januari 2018 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3626,7 +3352,6 @@
   },
   {
     "Input": "Ik ben van 2015 tot 5 mei 2017 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3639,7 +3364,6 @@
   },
   {
     "Input": "Ik ben van laatste maandag april tot 2019 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3652,7 +3376,6 @@
   },
   {
     "Input": "Ik ben van week 31 tot week 35 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3665,20 +3388,18 @@
   },
   {
     "Input": "Ik ben tussen week 31 en week 35 weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen week 31 en week 35 ",
+        "Text": "tussen week 31 en week 35",
         "Type": "daterange",
         "Start": 7,
-        "Length": 26
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik zal hier blijven van vandaag tot tweeënhalve dag later",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3691,7 +3412,6 @@
   },
   {
     "Input": "Wat is mijn bonus van april 2017?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3704,7 +3424,6 @@
   },
   {
     "Input": "Ik was daar niet in dezelfde maand dat het gebeurd",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3717,7 +3436,6 @@
   },
   {
     "Input": "Ik was daar niet in dezelfde week dat het gebeurd",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3730,7 +3448,6 @@
   },
   {
     "Input": "Ik was er niet dat jaar.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3743,7 +3460,6 @@
   },
   {
     "Input": "Ik heb al mijn werk al meer dan 2 weken voor vandaag afgerond",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3756,7 +3472,6 @@
   },
   {
     "Input": "Ik kom binnen 2 weken vanaf vandaag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3769,13 +3484,18 @@
   },
   {
     "Input": "Ik kom binnen minder dan 2 weken vanaf vandaag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": []
+    "Results": [
+    {
+        "Text": "binnen minder dan 2 weken vanaf vandaag",
+        "Type": "daterange",
+        "Start": 7,
+        "Length": 39
+      }
+    ]
   },
   {
     "Input": "Deze taak zou meer dan 2 dagen voor gisteren moeten zijn gedaan",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3788,7 +3508,6 @@
   },
   {
     "Input": "Deze taak zal minder dan 3 dagen na morgen afgerond zijn",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3801,7 +3520,6 @@
   },
   {
     "Input": "Ik miste okt. 2001",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3814,7 +3532,6 @@
   },
   {
     "Input": "verkoop waarvan de datum dit decennium is",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3827,7 +3544,6 @@
   },
   {
     "Input": "Ik ben het derde kwartaal weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3840,39 +3556,35 @@
   },
   {
     "Input": "Ik ben het derde kwartaal van volgend jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "derde kwartaal van volgend jaar ",
+        "Text": "het derde kwartaal van volgend jaar",
         "Type": "daterange",
-        "Start": 11,
-        "Length": 32
+        "Start": 7,
+        "Length": 35
       }
     ]
   },
   {
     "Input": "Ik ben het vierde kwartaal van volgend jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vierde kwartaal van volgend jaar ",
+        "Text": "het vierde kwartaal van volgend jaar",
         "Type": "daterange",
-        "Start": 11,
-        "Length": 33
+        "Start": 7,
+        "Length": 36
       }
     ]
   },
   {
     "Input": "Zet alsjeblieft $2000 om naar Britse ponden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Het aandeel van deze bank is 20% lager in het jaar tot op heden",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3885,7 +3597,6 @@
   },
   {
     "Input": "van 1-10 tot 7-11",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {

--- a/Specs/DateTime/Dutch/DatePeriodParser.json
+++ b/Specs/DateTime/Dutch/DatePeriodParser.json
@@ -1,12 +1,25 @@
 [
   {
     "Input": "Ik ben deze maand van 4 tot 22 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze maand van 4 tot 22",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-04,2016-11-22,P18D)",
+          "FutureResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-22"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -14,38 +27,77 @@
   },
   {
     "Input": "Ik ben volgende maand van 4-23 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende maand van 4-23 ",
+        "Text": "volgende maand van 4-23",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-12-04,2016-12-23,P19D)",
+          "FutureResolution": {
+            "startDate": "2016-12-04",
+            "endDate": "2016-12-23"
+          },
+          "PastResolution": {
+            "startDate": "2016-12-04",
+            "endDate": "2016-12-23"
+          }
+        },
         "Start": 7,
-        "Length": 24
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben van 3 tot 12 van sept weg hahaha",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 3 tot 12 van sept ",
+        "Text": "van 3 tot 12 van sept",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-09-03,XXXX-09-12,P9D)",
+          "FutureResolution": {
+            "startDate": "2017-09-03",
+            "endDate": "2017-09-12"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-03",
+            "endDate": "2016-09-12"
+          }
+        },
         "Start": 7,
-        "Length": 22
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik ben van vrijdag de 11e tot dinsdag de 15e weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van vrijdag de 11e tot dinsdag de 15e",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-11,2016-11-15,P4D)",
+          "FutureResolution": {
+            "startDate": "2016-11-11",
+            "endDate": "2016-11-15"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-11",
+            "endDate": "2016-11-15"
+          }
+        },
         "Start": 7,
         "Length": 37
       }
@@ -53,12 +105,25 @@
   },
   {
     "Input": "Ik ben volgende maand 4 tot 23 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende maand 4 tot 23",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-12-04,2016-12-23,P19D)",
+          "FutureResolution": {
+            "startDate": "2016-12-04",
+            "endDate": "2016-12-23"
+          },
+          "PastResolution": {
+            "startDate": "2016-12-04",
+            "endDate": "2016-12-23"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -66,25 +131,51 @@
   },
   {
     "Input": "Ik ben deze maand 4 tot 23 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "deze maand 4 tot 23 ",
+        "Text": "deze maand 4 tot 23",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-04,2016-11-23,P19D)",
+          "FutureResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-23"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-23"
+          }
+        },
         "Start": 7,
-        "Length": 20
+        "Length": 19
       }
     ]
   },
   {
     "Input": "Ik ben deze maand tussen 4 en 22 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze maand tussen 4 en 22",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-04,2016-11-22,P18D)",
+          "FutureResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-22"
+          }
+        },
         "Start": 7,
         "Length": 25
       }
@@ -92,12 +183,25 @@
   },
   {
     "Input": "Ik ben tussen 3 en 12 van sept weg hahaha",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 12 van sept",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-09-03,XXXX-09-12,P9D)",
+          "FutureResolution": {
+            "startDate": "2017-09-03",
+            "endDate": "2017-09-12"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-03",
+            "endDate": "2016-09-12"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -105,12 +209,25 @@
   },
   {
     "Input": "Ik ben van 4 tot 22 januari 1995 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 4 tot 22 januari 1995",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(1995-01-04,1995-01-22,P18D)",
+          "FutureResolution": {
+            "startDate": "1995-01-04",
+            "endDate": "1995-01-22"
+          },
+          "PastResolution": {
+            "startDate": "1995-01-04",
+            "endDate": "1995-01-22"
+          }
+        },
         "Start": 7,
         "Length": 25
       }
@@ -118,12 +235,25 @@
   },
   {
     "Input": "Ik ben tussen 4-22 januari 1995 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 4-22 januari 1995",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(1995-01-04,1995-01-22,P18D)",
+          "FutureResolution": {
+            "startDate": "1995-01-04",
+            "endDate": "1995-01-22"
+          },
+          "PastResolution": {
+            "startDate": "1995-01-04",
+            "endDate": "1995-01-22"
+          }
+        },
         "Start": 7,
         "Length": 24
       }
@@ -131,25 +261,51 @@
   },
   {
     "Input": "Ik ben tussen de 4e van september tot en met de 8e van september weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de 4e van september tot en met de 8e van september",
+        "Text": "tussen de 4e van september tot en met de 8e van september",
         "Type": "daterange",
-        "Start": 14,
-        "Length": 50
+        "Value": {
+          "Timex": "(XXXX-09-04,XXXX-09-08,P4D)",
+          "FutureResolution": {
+            "startDate": "2017-09-04",
+            "endDate": "2017-09-08"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-04",
+            "endDate": "2016-09-08"
+          }
+        },
+        "Start": 7,
+        "Length": 57
       }
     ]
   },
   {
     "Input": "Ik ben op deze week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 10,
         "Length": 9
       }
@@ -157,12 +313,25 @@
   },
   {
     "Input": "Ik ben op de komende week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W46",
+          "FutureResolution": {
+            "startDate": "2016-11-14",
+            "endDate": "2016-11-21"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-14",
+            "endDate": "2016-11-21"
+          }
+        },
         "Start": 13,
         "Length": 12
       }
@@ -170,12 +339,25 @@
   },
   {
     "Input": "Ik ben op de huidige week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "huidige week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 13,
         "Length": 12
       }
@@ -183,12 +365,25 @@
   },
   {
     "Input": "Ik ben februari weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "februari",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-02",
+          "FutureResolution": {
+            "startDate": "2017-02-01",
+            "endDate": "2017-03-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-02-01",
+            "endDate": "2016-03-01"
+          }
+        },
         "Start": 7,
         "Length": 8
       }
@@ -196,12 +391,25 @@
   },
   {
     "Input": "Ik ben deze september weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze september",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-09",
+          "FutureResolution": {
+            "startDate": "2016-09-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 7,
         "Length": 14
       }
@@ -209,12 +417,25 @@
   },
   {
     "Input": "Ik ben afgelopen september weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen september",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-09",
+          "FutureResolution": {
+            "startDate": "2015-09-01",
+            "endDate": "2015-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-09-01",
+            "endDate": "2015-10-01"
+          }
+        },
         "Start": 7,
         "Length": 19
       }
@@ -222,12 +443,25 @@
   },
   {
     "Input": "Ik ben volgende juni weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende juni",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-06",
+          "FutureResolution": {
+            "startDate": "2017-06-01",
+            "endDate": "2017-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-06-01",
+            "endDate": "2017-07-01"
+          }
+        },
         "Start": 7,
         "Length": 13
       }
@@ -235,25 +469,51 @@
   },
   {
     "Input": "Ik ben de derde week van deze maand weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de derde week van deze maand ",
+        "Text": "de derde week van deze maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11-W03",
+          "FutureResolution": {
+            "startDate": "2016-11-14",
+            "endDate": "2016-11-21"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-14",
+            "endDate": "2016-11-21"
+          }
+        },
         "Start": 7,
-        "Length": 29
+        "Length": 28
       }
     ]
   },
   {
     "Input": "Ik ben de laatste week van juli weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de laatste week van juli",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-07-W05",
+          "FutureResolution": {
+            "startDate": "2017-07-24",
+            "endDate": "2017-07-31"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-25",
+            "endDate": "2016-08-01"
+          }
+        },
         "Start": 7,
         "Length": 24
       }
@@ -261,12 +521,25 @@
   },
   {
     "Input": "week van september de 16e",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "week van september de 16e",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-09-16",
+          "FutureResolution": {
+            "startDate": "2017-09-11",
+            "endDate": "2017-09-18"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-12",
+            "endDate": "2016-09-19"
+          }
+        },
         "Start": 0,
         "Length": 25
       }
@@ -274,12 +547,25 @@
   },
   {
     "Input": "maand van september de 16e",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maand van september de 16e",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-09-16",
+          "FutureResolution": {
+            "startDate": "2017-09-01",
+            "endDate": "2017-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-09-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 0,
         "Length": 26
       }
@@ -287,12 +573,25 @@
   },
   {
     "Input": "Ik ben 2015.3 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015.3",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-03",
+          "FutureResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          }
+        },
         "Start": 7,
         "Length": 6
       }
@@ -300,12 +599,25 @@
   },
   {
     "Input": "Ik ben 2015-3 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015-3",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-03",
+          "FutureResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          }
+        },
         "Start": 7,
         "Length": 6
       }
@@ -313,12 +625,25 @@
   },
   {
     "Input": "Ik ben 3-2015 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3-2015",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-03",
+          "FutureResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-03-01",
+            "endDate": "2015-04-01"
+          }
+        },
         "Start": 7,
         "Length": 6
       }
@@ -326,18 +651,33 @@
   },
   {
     "Input": "plan een meeting over twee weken in",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "komende 2 dagen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende 2 dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-08,2016-11-10,P2D)",
+          "FutureResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-10"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-10"
+          }
+        },
         "Start": 0,
         "Length": 15
       }
@@ -345,25 +685,77 @@
   },
   {
     "Input": "afgelopen paar dagen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen paar dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-05,2016-11-07,P2D)",
+          "FutureResolution": {
+            "startDate": "2016-11-05",
+            "endDate": "2016-11-07"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-05",
+            "endDate": "2016-11-07"
+          }
+        },
         "Start": 0,
         "Length": 20
       }
     ]
   },
+   {
+    "Input": "afgelopen enkele dagen",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "afgelopen enkele dagen",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-04,2016-11-07,P3D)",
+          "FutureResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-07"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-04",
+            "endDate": "2016-11-07"
+          }
+        },
+        "Start": 0,
+        "Length": 22
+      }
+    ]
+  },
   {
     "Input": "de week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 0,
         "Length": 7
       }
@@ -371,12 +763,25 @@
   },
   {
     "Input": "deze week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2026-01-01T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2026-W01",
+          "FutureResolution": {
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
+          },
+          "PastResolution": {
+            "startDate": "2025-12-29",
+            "endDate": "2026-01-05"
+          }
+        },
         "Start": 0,
         "Length": 9
       }
@@ -384,12 +789,25 @@
   },
   {
     "Input": "mijn week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "mijn week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 0,
         "Length": 9
       }
@@ -397,12 +815,25 @@
   },
   {
     "Input": "het weekend",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het weekend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 0,
         "Length": 11
       }
@@ -410,12 +841,25 @@
   },
   {
     "Input": "dit weekend",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dit weekend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 0,
         "Length": 11
       }
@@ -423,12 +867,25 @@
   },
   {
     "Input": "mijn weekend",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "mijn weekend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 0,
         "Length": 12
       }
@@ -436,51 +893,103 @@
   },
   {
     "Input": "Ik ben 2 okt. tot 22 oktober weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 2 okt. tot 22 oktober",
+        "Text": "2 okt. tot 22 oktober",
         "Type": "daterange",
-        "Start": 6,
-        "Length": 22
+        "Value": {
+          "Timex": "(XXXX-10-02,XXXX-10-22,P20D)",
+          "FutureResolution": {
+            "startDate": "2017-10-02",
+            "endDate": "2017-10-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-10-02",
+            "endDate": "2016-10-22"
+          }
+        },
+        "Start": 7,
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik ben 12 januari 2016 - 22-01-2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12 januari 2016 - 22-01-2016 ",
+        "Text": "12 januari 2016 - 22-01-2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-01-12,2016-01-22,P10D)",
+          "FutureResolution": {
+            "startDate": "2016-01-12",
+            "endDate": "2016-01-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-01-12",
+            "endDate": "2016-01-22"
+          }
+        },
         "Start": 7,
-        "Length": 29
+        "Length": 28
       }
     ]
   },
   {
     "Input": "Ik ben de 1e van jan tot woens, de 22e jan weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de 1e van jan tot woens, de 22e jan ",
+        "Text": "de 1e van jan tot woens, de 22e jan",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-01-01,XXXX-01-22,P21D)",
+          "FutureResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2017-01-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-01-01",
+            "endDate": "2016-01-22"
+          }
+        },
         "Start": 7,
-        "Length": 36
+        "Length": 35
       }
     ]
   },
   {
     "Input": "Ik ben vandaag tot morgen weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vandaag tot morgen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-08,P1D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-08"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-08"
+          }
+        },
         "Start": 7,
         "Length": 18
       }
@@ -488,25 +997,51 @@
   },
   {
     "Input": "Ik ben van 2 okt. tot 22 oktober weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 2 okt. tot 22 oktober ",
+        "Text": "van 2 okt. tot 22 oktober",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-10-02,XXXX-10-22,P20D)",
+          "FutureResolution": {
+            "startDate": "2017-10-02",
+            "endDate": "2017-10-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-10-02",
+            "endDate": "2016-10-22"
+          }
+        },
         "Start": 7,
-        "Length": 26
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik ben tussen 2 okt. en 22 oktober weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 2 okt. en 22 oktober",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-10-02,XXXX-10-22,P20D)",
+          "FutureResolution": {
+            "startDate": "2017-10-02",
+            "endDate": "2017-10-22"
+          },
+          "PastResolution": {
+            "startDate": "2016-10-02",
+            "endDate": "2016-10-22"
+          }
+        },
         "Start": 7,
         "Length": 27
       }
@@ -514,25 +1049,51 @@
   },
   {
     "Input": "Ik ben 19-20 november weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "19-20 november ",
+        "Text": "19-20 november",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-11-19,XXXX-11-20,P1D)",
+          "FutureResolution": {
+            "startDate": "2016-11-19",
+            "endDate": "2016-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2015-11-19",
+            "endDate": "2015-11-20"
+          }
+        },
         "Start": 7,
-        "Length": 15
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik ben 19 tot 20 november weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "19 tot 20 november",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-11-19,XXXX-11-20,P1D)",
+          "FutureResolution": {
+            "startDate": "2016-11-19",
+            "endDate": "2016-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2015-11-19",
+            "endDate": "2015-11-20"
+          }
+        },
         "Start": 7,
         "Length": 18
       }
@@ -540,12 +1101,25 @@
   },
   {
     "Input": "Ik ben tussen 19 en 20 november weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 19 en 20 november",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-11-19,XXXX-11-20,P1D)",
+          "FutureResolution": {
+            "startDate": "2016-11-19",
+            "endDate": "2016-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2015-11-19",
+            "endDate": "2015-11-20"
+          }
+        },
         "Start": 7,
         "Length": 24
       }
@@ -553,25 +1127,51 @@
   },
   {
     "Input": "Ik ben rest van de week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "rest van de week ",
+        "Text": "rest van de week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-13,P6D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          }
+        },
         "Start": 7,
-        "Length": 17
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Ik ben rest van week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-13,P6D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          }
+        },
         "Start": 7,
         "Length": 13
       }
@@ -579,12 +1179,25 @@
   },
   {
     "Input": "Ik ben rest deze week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-13,P6D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          }
+        },
         "Start": 7,
         "Length": 14
       }
@@ -592,25 +1205,51 @@
   },
   {
     "Input": "Ik ben rest van mijn week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "rest van mijn week ",
+        "Text": "rest van mijn week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-13,P6D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          }
+        },
         "Start": 7,
-        "Length": 19
+        "Length": 18
       }
     ]
   },
   {
     "Input": "Ik ben rest van huidige week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van huidige week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-13,P6D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-13"
+          }
+        },
         "Start": 7,
         "Length": 21
       }
@@ -618,51 +1257,103 @@
   },
   {
     "Input": "Ik ben rest van de maand weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "rest van de maand ",
+        "Text": "rest van de maand",
         "Type": "daterange",
-        "Start": 7,
-        "Length": 18
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben rest van het jaar weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "rest van het jaar",
-        "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-07,2016-11-30,P24D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-30"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-11-30"
+          }
+        },
         "Start": 7,
         "Length": 17
       }
     ]
   },
   {
-    "Input": "Ik ben op weekend weg",
-    "NotSupported": "dotnet",
+    "Input": "Ik ben rest van het jaar weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "weekend",
+        "Text": "rest van het jaar",
         "Type": "daterange",
-        "Start": 10,
-        "Length": 7
+        "Value": {
+          "Timex": "(2016-11-07,2016-12-31,P55D)",
+          "FutureResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-12-31"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-07",
+            "endDate": "2016-12-31"
+          }
+        },
+        "Start": 7,
+        "Length": 17
       }
     ]
   },
   {
-    "Input": "Ik ben op dit weekend weg",
-    "NotSupported": "dotnet",
+    "Input": "Ik ben dit weekend weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dit weekend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben op dit weekend weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dit weekend",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W45-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 10,
         "Length": 11
       }
@@ -670,12 +1361,25 @@
   },
   {
     "Input": "Ik ben juni 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "juni 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-06",
+          "FutureResolution": {
+            "startDate": "2016-06-01",
+            "endDate": "2016-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-06-01",
+            "endDate": "2016-07-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -683,12 +1387,25 @@
   },
   {
     "Input": "Ik ben volgend jaar juni weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgend jaar juni",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-06",
+          "FutureResolution": {
+            "startDate": "2017-06-01",
+            "endDate": "2017-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-06-01",
+            "endDate": "2017-07-01"
+          }
+        },
         "Start": 7,
         "Length": 17
       }
@@ -696,25 +1413,51 @@
   },
   {
     "Input": "Ik ben volgend jaar weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgend jaar ",
+        "Text": "volgend jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017",
+          "FutureResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 7,
-        "Length": 13
+        "Length": 12
       }
     ]
   },
   {
     "Input": "Ik ben komende 3 dagen weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende 3 dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-08,2016-11-11,P3D)",
+          "FutureResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-11"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-11"
+          }
+        },
         "Start": 7,
         "Length": 15
       }
@@ -722,12 +1465,25 @@
   },
   {
     "Input": "Ik ben komende 3 maanden weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende 3 maanden",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-08,2017-02-08,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2017-02-08"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2017-02-08"
+          }
+        },
         "Start": 7,
         "Length": 17
       }
@@ -735,31 +1491,59 @@
   },
   {
     "Input": "Ik ben over 3 jaar weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "Results": []
   },
   {
     "Input": "de eerste week van okt",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de eerste week van okt",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-10-W01",
+          "FutureResolution": {
+            "startDate": "2017-10-02",
+            "endDate": "2017-10-09"
+          },
+          "PastResolution": {
+            "startDate": "2016-10-03",
+            "endDate": "2016-10-10"
+          }
+        },
         "Start": 0,
         "Length": 22
       }
     ]
   },
   {
-    "Input": "Ik ben de derde week van 2017 weg",
-    "NotSupported": "dotnet",
+    "Input": "Ik ben de derde week van 2027 weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de derde week van 2017",
+        "Text": "de derde week van 2027",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2027-W03",
+          "FutureResolution": {
+            "startDate": "2027-01-18",
+            "endDate": "2027-01-25"
+          },
+          "PastResolution": {
+            "startDate": "2027-01-18",
+            "endDate": "2027-01-25"
+          }
+        },
         "Start": 7,
         "Length": 22
       }
@@ -767,12 +1551,25 @@
   },
   {
     "Input": "Ik ben volgend jaar de derde week weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgend jaar de derde week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W03",
+          "FutureResolution": {
+            "startDate": "2017-01-16",
+            "endDate": "2017-01-23"
+          },
+          "PastResolution": {
+            "startDate": "2017-01-16",
+            "endDate": "2017-01-23"
+          }
+        },
         "Start": 7,
         "Length": 26
       }
@@ -780,12 +1577,25 @@
   },
   {
     "Input": "Ik ben het derde kwartaal van 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het derde kwartaal van 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 7,
         "Length": 27
       }
@@ -793,12 +1603,25 @@
   },
   {
     "Input": "Ik ben dit jaar het derde kwartaal weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dit jaar het derde kwartaal",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 7,
         "Length": 27
       }
@@ -806,38 +1629,77 @@
   },
   {
     "Input": "Ik ben 2016 het derde kwartaal weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2016 het derde kwartaal ",
+        "Text": "2016 het derde kwartaal",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 7,
-        "Length": 24
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben weg tijdens K3 dit jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tijdens K3 dit jaar",
+        "Text": "K3 dit jaar",
         "Type": "daterange",
-        "Start": 11,
-        "Length": 19
+        "Value": {
+          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
+        "Start": 19,
+        "Length": 11
       }
     ]
   },
   {
     "Input": "Ik ben 2016 K3 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016 K3",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-07-01,2016-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -845,12 +1707,25 @@
   },
   {
     "Input": "Ik ben tijdens K3 terug",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "K3",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-07-01,XXXX-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2017-07-01",
+            "endDate": "2017-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2016-10-01"
+          }
+        },
         "Start": 15,
         "Length": 2
       }
@@ -858,12 +1733,25 @@
   },
   {
     "Input": "Ik ben tijdens K2 terug",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "K2",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-04-01,XXXX-07-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2017-04-01",
+            "endDate": "2017-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-04-01",
+            "endDate": "2016-07-01"
+          }
+        },
         "Start": 15,
         "Length": 2
       }
@@ -871,12 +1759,25 @@
   },
   {
     "Input": "Ik ben K1 2016 terug",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "K1 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-01-01,2016-04-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-01-01",
+            "endDate": "2016-04-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-01-01",
+            "endDate": "2016-04-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -884,25 +1785,45 @@
   },
   {
     "Input": "Ik ben tijdens K4 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "K4 2016 ",
+        "Text": "K4 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-10-01,2017-01-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2016-10-01",
+            "endDate": "2017-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-10-01",
+            "endDate": "2017-01-01"
+          }
+        },
         "Start": 15,
-        "Length": 8
+        "Length": 7
       }
     ]
   },
   {
     "Input": "Ik vertrek deze zomer",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze zomer",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-SU",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 10
       }
@@ -910,12 +1831,19 @@
   },
   {
     "Input": "Ik vertrek volgende lente",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende lente",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-SP",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 14
       }
@@ -923,12 +1851,19 @@
   },
   {
     "Input": "Ik vertrek de zomer",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de zomer",
         "Type": "daterange",
+        "Value": {
+          "Timex": "SU",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 8
       }
@@ -936,12 +1871,19 @@
   },
   {
     "Input": "Ik vertrek zomer",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zomer",
         "Type": "daterange",
+        "Value": {
+          "Timex": "SU",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 5
       }
@@ -949,12 +1891,19 @@
   },
   {
     "Input": "Ik vertrek zomer 2016",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zomer 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-SU",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 10
       }
@@ -962,12 +1911,19 @@
   },
   {
     "Input": "Ik vertrek zomer van 2016",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zomer van 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-SU",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 11,
         "Length": 14
       }
@@ -975,12 +1931,25 @@
   },
   {
     "Input": "vakanties aankomende maand ",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "aankomende maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-12",
+          "FutureResolution": {
+            "startDate": "2016-12-01",
+            "endDate": "2017-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-12-01",
+            "endDate": "2017-01-01"
+          }
+        },
         "Start": 10,
         "Length": 16
       }
@@ -988,12 +1957,25 @@
   },
   {
     "Input": "vakanties volgende maand ",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-12",
+          "FutureResolution": {
+            "startDate": "2016-12-01",
+            "endDate": "2017-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-12-01",
+            "endDate": "2017-01-01"
+          }
+        },
         "Start": 10,
         "Length": 14
       }
@@ -1001,12 +1983,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten eind deze maand",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind deze maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-11",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-11-16",
+            "endDate": "2017-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-16",
+            "endDate": "2017-12-01"
+          }
+        },
         "Start": 53,
         "Length": 15
       }
@@ -1014,12 +2010,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten eind deze week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W45",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-11-09",
+            "endDate": "2017-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-09",
+            "endDate": "2017-11-13"
+          }
+        },
         "Start": 53,
         "Length": 14
       }
@@ -1027,12 +2037,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten eind dit jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind dit jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-07-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-07-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 53,
         "Length": 13
       }
@@ -1040,12 +2064,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten begin volgend jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "begin volgend jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2018-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2018-07-01"
+          }
+        },
         "Start": 53,
         "Length": 18
       }
@@ -1053,12 +2091,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten begin volgende week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "begin volgende week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          }
+        },
         "Start": 53,
         "Length": 19
       }
@@ -1066,12 +2118,26 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip om elkaar te ontmoeten begin volgende maand",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "begin volgende maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-12",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2017-12-01",
+            "endDate": "2017-12-16"
+          },
+          "PastResolution": {
+            "startDate": "2017-12-01",
+            "endDate": "2017-12-16"
+          }
+        },
         "Start": 53,
         "Length": 20
       }
@@ -1079,12 +2145,26 @@
   },
   {
     "Input": "We hadden een ontmoeting eind vorig jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind vorig jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2017-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-07-01",
+            "endDate": "2017-01-01"
+          }
+        },
         "Start": 25,
         "Length": 15
       }
@@ -1092,12 +2172,26 @@
   },
   {
     "Input": "We hadden een ontmoeting eind vorige week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind vorige week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W44",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-11-02",
+            "endDate": "2017-11-06"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-02",
+            "endDate": "2017-11-06"
+          }
+        },
         "Start": 25,
         "Length": 16
       }
@@ -1105,12 +2199,26 @@
   },
   {
     "Input": "We hadden een ontmoeting eind vorige maand",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind vorige maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-10",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-10-16",
+            "endDate": "2017-11-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-10-16",
+            "endDate": "2017-11-01"
+          }
+        },
         "Start": 25,
         "Length": 17
       }
@@ -1118,12 +2226,25 @@
   },
   {
     "Input": "Cortana, regel alsjeblieft een meeting van 25 minuten met antonio volgende week tussen woensdag en vrijdag",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-14T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende week tussen woensdag en vrijdag",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-22,2017-11-24,P2D)",
+          "FutureResolution": {
+            "startDate": "2017-11-22",
+            "endDate": "2017-11-24"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-22",
+            "endDate": "2017-11-24"
+          }
+        },
         "Start": 66,
         "Length": 40
       }
@@ -1131,12 +2252,25 @@
   },
   {
     "Input": "We hadden een ontmoeting deze week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-17T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46",
+          "FutureResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-20"
+          }
+        },
         "Start": 25,
         "Length": 9
       }
@@ -1144,25 +2278,51 @@
   },
   {
     "Input": "We hadden een ontmoeting de eerste week van dit jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-17T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eerste week van dit jaar",
+        "Text": "de eerste week van dit jaar",
         "Type": "daterange",
-        "Start": 28,
-        "Length": 24
+        "Value": {
+          "Timex": "2017-W01",
+          "FutureResolution": {
+            "startDate": "2017-01-02",
+            "endDate": "2017-01-09"
+          },
+          "PastResolution": {
+            "startDate": "2017-01-02",
+            "endDate": "2017-01-09"
+          }
+        },
+        "Start": 25,
+        "Length": 27
       }
     ]
   },
   {
     "Input": "eerste week van 2015",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-20T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eerste week van 2015",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-W01",
+          "FutureResolution": {
+            "startDate": "2014-12-29",
+            "endDate": "2015-01-05"
+          },
+          "PastResolution": {
+            "startDate": "2014-12-29",
+            "endDate": "2015-01-05"
+          }
+        },
         "Start": 0,
         "Length": 20
       }
@@ -1170,12 +2330,25 @@
   },
   {
     "Input": "tweede week van 2015",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-20T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tweede week van 2015",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-W02",
+          "FutureResolution": {
+            "startDate": "2015-01-05",
+            "endDate": "2015-01-12"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-05",
+            "endDate": "2015-01-12"
+          }
+        },
         "Start": 0,
         "Length": 20
       }
@@ -1183,12 +2356,25 @@
   },
   {
     "Input": "laatste week van 2015",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-20T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste week van 2015",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2015-W53",
+          "FutureResolution": {
+            "startDate": "2015-12-28",
+            "endDate": "2016-01-04"
+          },
+          "PastResolution": {
+            "startDate": "2015-12-28",
+            "endDate": "2016-01-04"
+          }
+        },
         "Start": 0,
         "Length": 21
       }
@@ -1196,12 +2382,25 @@
   },
   {
     "Input": "Ik ben jaar 247 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-12-18T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "jaar 247",
         "Type": "daterange",
+        "Value": {
+          "Timex": "0247",
+          "FutureResolution": {
+            "startDate": "0247-01-01",
+            "endDate": "0248-01-01"
+          },
+          "PastResolution": {
+            "startDate": "0247-01-01",
+            "endDate": "0248-01-01"
+          }
+        },
         "Start": 7,
         "Length": 8
       }
@@ -1209,12 +2408,25 @@
   },
   {
     "Input": "In de jaren 1970",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren 1970",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(1970-01-01,1980-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          }
+        },
         "Start": 3,
         "Length": 13
       }
@@ -1222,12 +2434,25 @@
   },
   {
     "Input": "In de jaren 2000 werd hij geboren",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren 2000",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2000-01-01,2010-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2010-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2010-01-01"
+          }
+        },
         "Start": 3,
         "Length": 13
       }
@@ -1235,12 +2460,25 @@
   },
   {
     "Input": "In de jaren '70",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren '70",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XX70-01-01,XX80-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2070-01-01",
+            "endDate": "2080-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          }
+        },
         "Start": 3,
         "Length": 12
       }
@@ -1248,12 +2486,25 @@
   },
   {
     "Input": "In jaren '70",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "jaren '70",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XX70-01-01,XX80-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2070-01-01",
+            "endDate": "2080-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          }
+        },
         "Start": 3,
         "Length": 9
       }
@@ -1261,12 +2512,25 @@
   },
   {
     "Input": "In de jaren '40",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren '40",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XX40-01-01,XX50-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2040-01-01",
+            "endDate": "2050-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1940-01-01",
+            "endDate": "1950-01-01"
+          }
+        },
         "Start": 3,
         "Length": 12
       }
@@ -1274,38 +2538,77 @@
   },
   {
     "Input": "In de jaren zeventig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren zeventig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XX70-01-01,XX80-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2070-01-01",
+            "endDate": "2080-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          }
+        },
         "Start": 3,
         "Length": 17
       }
     ]
   },
   {
-    "Input": "In de jaren negentien zeventien",
-    "NotSupported": "dotnet",
+    "Input": "In de jaren negentien zeventig",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de jaren negentienzeventien",
+        "Text": "de jaren negentien zeventig",
         "Type": "daterange",
-        "Start": -1,
+        "Value": {
+          "Timex": "(1970-01-01,1980-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1970-01-01",
+            "endDate": "1980-01-01"
+          }
+        },
+        "Start": 3,
         "Length": 27
       }
     ]
   },
   {
     "Input": "In de jaren tweeduizend tien",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren tweeduizend tien",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2010-01-01,2020-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2010-01-01",
+            "endDate": "2020-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2010-01-01",
+            "endDate": "2020-01-01"
+          }
+        },
         "Start": 3,
         "Length": 25
       }
@@ -1313,12 +2616,25 @@
   },
   {
     "Input": "In de jaren tweeduizend",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren tweeduizend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2000-01-01,2010-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2010-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2010-01-01"
+          }
+        },
         "Start": 3,
         "Length": 20
       }
@@ -1326,12 +2642,25 @@
   },
   {
     "Input": "In de jaren nul",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de jaren nul",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XX0-01-01,XX10-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2100-01-01",
+            "endDate": "2110-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2010-01-01"
+          }
+        },
         "Start": 3,
         "Length": 12
       }
@@ -1339,12 +2668,25 @@
   },
   {
     "Input": "Ik ben van 2 tot 7 feb, tweeduizend achttien weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 2 tot 7 feb, tweeduizend achttien",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-02-02,2018-02-07,P5D)",
+          "FutureResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          },
+          "PastResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          }
+        },
         "Start": 7,
         "Length": 37
       }
@@ -1352,12 +2694,25 @@
   },
   {
     "Input": "Ik ben tussen 2 en 7 feb tweeduizend achttien weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 2 en 7 feb tweeduizend achttien",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-02-02,2018-02-07,P5D)",
+          "FutureResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          },
+          "PastResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          }
+        },
         "Start": 7,
         "Length": 38
       }
@@ -1365,25 +2720,51 @@
   },
   {
     "Input": "Ik ben in feb tussen 2-7 tweeduizend achttien weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "feb tussen 2-7 tweeduizend achttien",
+        "Text": "in feb tussen 2-7 tweeduizend achttien",
         "Type": "daterange",
-        "Start": 10,
-        "Length": 35
+        "Value": {
+          "Timex": "(2018-02-02,2018-02-07,P5D)",
+          "FutureResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          },
+          "PastResolution": {
+            "startDate": "2018-02-02",
+            "endDate": "2018-02-07"
+          }
+        },
+        "Start": 7,
+        "Length": 38
       }
     ]
   },
   {
     "Input": "Het gebeurde in juni negentiennegenennegentig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "juni negentiennegenennegentig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "1999-06",
+          "FutureResolution": {
+            "startDate": "1999-06-01",
+            "endDate": "1999-07-01"
+          },
+          "PastResolution": {
+            "startDate": "1999-06-01",
+            "endDate": "1999-07-01"
+          }
+        },
         "Start": 16,
         "Length": 29
       }
@@ -1391,12 +2772,25 @@
   },
   {
     "Input": "In negentienachtentwintig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "negentienachtentwintig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "1928",
+          "FutureResolution": {
+            "startDate": "1928-01-01",
+            "endDate": "1929-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1928-01-01",
+            "endDate": "1929-01-01"
+          }
+        },
         "Start": 3,
         "Length": 22
       }
@@ -1404,12 +2798,25 @@
   },
   {
     "Input": "In zeventienhonderdnegenentachtig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zeventienhonderdnegenentachtig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "1789",
+          "FutureResolution": {
+            "startDate": "1789-01-01",
+            "endDate": "1790-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1789-01-01",
+            "endDate": "1790-01-01"
+          }
+        },
         "Start": 3,
         "Length": 30
       }
@@ -1417,38 +2824,71 @@
   },
   {
     "Input": "Ik ben de derde week van tweeduizend zevenentwintig weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de derde week van tweeduizend zevenentwintig ",
+        "Text": "de derde week van tweeduizend zevenentwintig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2027-W03",
+          "FutureResolution": {
+            "startDate": "2027-01-18",
+            "endDate": "2027-01-25"
+          },
+          "PastResolution": {
+            "startDate": "2027-01-18",
+            "endDate": "2027-01-25"
+          }
+        },
         "Start": 7,
-        "Length": 45
+        "Length": 44
       }
     ]
   },
   {
     "Input": "Ik ben het derde kwartaal van tweeduizend twintig weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het derde kwartaal van tweeduizend twintig weg",
+        "Text": "het derde kwartaal van tweeduizend twintig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2020-07-01,2020-10-01,P3M)",
+          "FutureResolution": {
+            "startDate": "2020-07-01",
+            "endDate": "2020-10-01"
+          },
+          "PastResolution": {
+            "startDate": "2020-07-01",
+            "endDate": "2020-10-01"
+          }
+        },
         "Start": 7,
-        "Length": 46
+        "Length": 42
       }
     ]
   },
   {
     "Input": "In de lente van negentienachtenzeventig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de lente van negentienachtenzeventig",
         "Type": "daterange",
+        "Value": {
+          "Timex": "1978-SP",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 3,
         "Length": 36
       }
@@ -1456,25 +2896,51 @@
   },
   {
     "Input": "Jaar tweehonderdzevenenzestig",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tweehonderdzevenenzestig",
+        "Text": "jaar tweehonderdzevenenzestig",
         "Type": "daterange",
-        "Start": 5,
-        "Length": 24
+        "Value": {
+          "Timex": "0267",
+          "FutureResolution": {
+            "startDate": "0267-01-01",
+            "endDate": "0268-01-01"
+          },
+          "PastResolution": {
+            "startDate": "0267-01-01",
+            "endDate": "0268-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 29
       }
     ]
   },
   {
     "Input": "Ik ben de week na de volgende weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de week na de volgende",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W47",
+          "FutureResolution": {
+            "startDate": "2016-11-21",
+            "endDate": "2016-11-28"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-21",
+            "endDate": "2016-11-28"
+          }
+        },
         "Start": 7,
         "Length": 22
       }
@@ -1482,12 +2948,25 @@
   },
   {
     "Input": "Ik ben de maand na de volgende weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de maand na de volgende",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-01",
+          "FutureResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2017-02-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2017-02-01"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -1495,12 +2974,25 @@
   },
   {
     "Input": "Ik ben het jaar na het volgende weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het jaar na het volgende",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018",
+          "FutureResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2019-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2019-01-01"
+          }
+        },
         "Start": 7,
         "Length": 24
       }
@@ -1508,12 +3000,25 @@
   },
   {
     "Input": "Ik ben het weekend na het volgende weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het weekend na het volgende",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W47-WE",
+          "FutureResolution": {
+            "startDate": "2016-11-26",
+            "endDate": "2016-11-28"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-26",
+            "endDate": "2016-11-28"
+          }
+        },
         "Start": 7,
         "Length": 27
       }
@@ -1521,12 +3026,25 @@
   },
   {
     "Input": "Het bereik is 2014-2018",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2014-2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2014-01-01,2018-01-01,P4Y)",
+          "FutureResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 14,
         "Length": 9
       }
@@ -1534,12 +3052,25 @@
   },
   {
     "Input": "Het bereik is tussen 2014-2018",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 2014-2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2014-01-01,2018-01-01,P4Y)",
+          "FutureResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 14,
         "Length": 16
       }
@@ -1547,12 +3078,25 @@
   },
   {
     "Input": "Het bereik is van 2014 tot 2018",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 2014 tot 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2014-01-01,2018-01-01,P4Y)",
+          "FutureResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 14,
         "Length": 17
       }
@@ -1560,25 +3104,51 @@
   },
   {
     "Input": "Het bereik is in 2014 tot en met 2018",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " in 2014 tot en met 2018",
+        "Text": "in 2014 tot en met 2018",
         "Type": "daterange",
-        "Start": 13,
-        "Length": 24
+        "Value": {
+          "Timex": "(2014-01-01,2018-01-01,P4Y)",
+          "FutureResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2014-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
+        "Start": 14,
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Het bereik is van tweeduizend tot tweeduizend veertien",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van tweeduizend tot tweeduizend veertien",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2000-01-01,2014-01-01,P14Y)",
+          "FutureResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2014-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2014-01-01"
+          }
+        },
         "Start": 14,
         "Length": 40
       }
@@ -1586,12 +3156,25 @@
   },
   {
     "Input": "Het gebeurde in de afgelopen 2 decennia",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de afgelopen 2 decennia",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(1990-01-01,2010-01-01,P20Y)",
+          "FutureResolution": {
+            "startDate": "1990-01-01",
+            "endDate": "2010-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1990-01-01",
+            "endDate": "2010-01-01"
+          }
+        },
         "Start": 16,
         "Length": 23
       }
@@ -1599,12 +3182,25 @@
   },
   {
     "Input": "Het gebeurde in de laatste 2 decennia",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de laatste 2 decennia",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(1990-01-01,2010-01-01,P20Y)",
+          "FutureResolution": {
+            "startDate": "1990-01-01",
+            "endDate": "2010-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1990-01-01",
+            "endDate": "2010-01-01"
+          }
+        },
         "Start": 16,
         "Length": 21
       }
@@ -1612,12 +3208,25 @@
   },
   {
     "Input": "Het gebeurde in het volgende decennium",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "het volgende decennium",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2020-01-01,2030-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2020-01-01",
+            "endDate": "2030-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2020-01-01",
+            "endDate": "2030-01-01"
+          }
+        },
         "Start": 16,
         "Length": 22
       }
@@ -1625,12 +3234,25 @@
   },
   {
     "Input": "Het gebeurde in de volgende 3 decennia",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de volgende 3 decennia",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2020-01-01,2050-01-01,P30Y)",
+          "FutureResolution": {
+            "startDate": "2020-01-01",
+            "endDate": "2050-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2020-01-01",
+            "endDate": "2050-01-01"
+          }
+        },
         "Start": 16,
         "Length": 22
       }
@@ -1638,25 +3260,51 @@
   },
   {
     "Input": "Het zal 4 weken in de toekomst gebeuren",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4 weken in de toekomst ",
+        "Text": "4 weken in de toekomst",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-08,2016-12-06,P4W)",
+          "FutureResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-12-06"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-12-06"
+          }
+        },
         "Start": 8,
-        "Length": 23
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Het zal 2 dagen vanaf nu gebeuren",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 dagen vanaf nu",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2016-11-08,2016-11-10,P2D)",
+          "FutureResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-10"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-08",
+            "endDate": "2016-11-10"
+          }
+        },
         "Start": 8,
         "Length": 16
       }
@@ -1664,12 +3312,26 @@
   },
   {
     "Input": "Cortana kan een tijdstip voor ons vinden begin van volgende week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "begin van volgende week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          }
+        },
         "Start": 41,
         "Length": 23
       }
@@ -1677,12 +3339,26 @@
   },
   {
     "Input": "Natuurlijk, laten we eind van volgende week Skypen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eind van volgende week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46",
+          "Mod": "end",
+          "FutureResolution": {
+            "startDate": "2017-11-16",
+            "endDate": "2017-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-16",
+            "endDate": "2017-11-20"
+          }
+        },
         "Start": 21,
         "Length": 22
       }
@@ -1690,12 +3366,26 @@
   },
   {
     "Input": "Ik kan een tijdstip voor ons vastleggen begin van volgende week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "begin van volgende week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W46",
+          "Mod": "start",
+          "FutureResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-16"
+          }
+        },
         "Start": 40,
         "Length": 23
       }
@@ -1703,12 +3393,20 @@
   },
   {
     "Input": "is midzomer wat?",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "midzomer",
         "Type": "daterange",
+        "Value": {
+          "Timex": "SU",
+          "Mod": "mid",
+          "FutureResolution": {},
+          "PastResolution": {}
+        },
         "Start": 3,
         "Length": 8
       }
@@ -1716,12 +3414,25 @@
   },
   {
     "Input": "Ik zal binnen 5 dagen terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2017-11-13,P5D)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2017-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2017-11-13"
+          }
+        },
         "Start": 7,
         "Length": 14
       }
@@ -1729,12 +3440,25 @@
   },
   {
     "Input": "Ik zal binnen 10 maanden terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 10 maanden",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2018-09-08,P10M)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-09-08"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-09-08"
+          }
+        },
         "Start": 7,
         "Length": 17
       }
@@ -1742,12 +3466,25 @@
   },
   {
     "Input": "Ik zal binnen 3 jaar terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 3 jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2020-11-08,P3Y)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2020-11-08"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2020-11-08"
+          }
+        },
         "Start": 7,
         "Length": 13
       }
@@ -1755,12 +3492,25 @@
   },
   {
     "Input": "Ik zal binnen 5 jaar 1 maand en 12 dagen terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 jaar 1 maand en 12 dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2022-12-20,P5Y1M12D)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2022-12-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2022-12-20"
+          }
+        },
         "Start": 7,
         "Length": 33
       }
@@ -1768,25 +3518,51 @@
   },
   {
     "Input": "Ik zal binnen de volgende 3 jaar terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "binnen de volgende 3 jaar ",
+        "Text": "binnen de volgende 3 jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2020-11-08,P3Y)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2020-11-08"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2020-11-08"
+          }
+        },
         "Start": 7,
-        "Length": 26
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik zal binnen de aankomende 5 jaar 1 maand en 12 dagen terug zijn",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen de aankomende 5 jaar 1 maand en 12 dagen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2017-11-08,2022-12-20,P5Y1M12D)",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2022-12-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2022-12-20"
+          }
+        },
         "Start": 7,
         "Length": 47
       }
@@ -1794,11 +3570,24 @@
   },
   {
     "Input": "Ik wil een kamer van 02 tot 07 april",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-04-02T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 02 tot 07 april",
+        "Value": {
+          "Timex": "(XXXX-04-02,XXXX-04-07,P5D)",
+          "FutureResolution": {
+            "startDate": "2018-04-02",
+            "endDate": "2018-04-07"
+          },
+          "PastResolution": {
+            "startDate": "2017-04-02",
+            "endDate": "2017-04-07"
+          }
+        },
         "Type": "daterange",
         "Start": 17,
         "Length": 19
@@ -1807,18 +3596,30 @@
   },
   {
     "Input": "leg een meeting vast in aantal weken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Ik ben 2016 juni weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016 juni",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-06",
+          "FutureResolution": {
+            "startDate": "2016-06-01",
+            "endDate": "2016-07-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-06-01",
+            "endDate": "2016-07-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -1826,12 +3627,25 @@
   },
   {
     "Input": "Ik ben 2016, nov weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016, nov",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -1839,12 +3653,25 @@
   },
   {
     "Input": "Ik ben november, 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "november, 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 14
       }
@@ -1852,25 +3679,51 @@
   },
   {
     "Input": "Ik ben november 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "11/1/2016 12:00:00 AM",
+        "Text": "november 2016",
         "Type": "daterange",
-        "Start": -1,
-        "Length": 21
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
+        "Start": 7,
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik ben 2016-11 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016-11",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -1878,12 +3731,25 @@
   },
   {
     "Input": "Ik ben 2016 - 11 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016 - 11",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -1891,12 +3757,25 @@
   },
   {
     "Input": "Ik ben 2016/11 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016/11",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -1904,11 +3783,24 @@
   },
   {
     "Input": "Ik ben 2016 / 11 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016 / 11",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Type": "daterange",
         "Start": 7,
         "Length": 9
@@ -1917,12 +3809,25 @@
   },
   {
     "Input": "Ik ben 11-2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11-2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -1930,12 +3835,25 @@
   },
   {
     "Input": "Ik ben 11 - 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11 - 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -1943,12 +3861,25 @@
   },
   {
     "Input": "Ik ben 11/2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11/2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 7
       }
@@ -1956,12 +3887,25 @@
   },
   {
     "Input": "Ik ben 11 / 2016 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11 / 2016",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2016-11",
+          "FutureResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-01",
+            "endDate": "2016-12-01"
+          }
+        },
         "Start": 7,
         "Length": 9
       }
@@ -1969,12 +3913,25 @@
   },
   {
     "Input": "Ik ben tussen 1 januari en 5 april weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 januari en 5 april",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "FutureResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2017-04-05"
+          },
+          "PastResolution": {
+            "startDate": "2016-01-01",
+            "endDate": "2016-04-05"
+          }
+        },
         "Start": 7,
         "Length": 27
       }
@@ -1982,12 +3939,25 @@
   },
   {
     "Input": "Ik ben tussen 1 januari 2015 en 5 februari 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 januari 2015 en 5 februari 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-01-01,2018-02-05,P1131D)",
+          "FutureResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-05"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-05"
+          }
+        },
         "Start": 7,
         "Length": 40
       }
@@ -1995,12 +3965,25 @@
   },
   {
     "Input": "Ik ben tussen 1 januari 2015 en feb 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 januari 2015 en feb 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-01-01,2018-02-01,P1127D)",
+          "FutureResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-01"
+          }
+        },
         "Start": 7,
         "Length": 33
       }
@@ -2008,38 +3991,77 @@
   },
   {
     "Input": "Ik ben tussen 2015 en feb 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 2015 en feb 2018 ",
+        "Text": "tussen 2015 en feb 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-01-01,2018-02-01,P37M)",
+          "FutureResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-02-01"
+          }
+        },
+        "Start": 7,
+        "Length": 23
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 1 feb tot maart 2019 weg",
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 1 feb tot maart 2019",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "(2019-02-01,2019-03-01,P28D)",
+          "FutureResolution": {
+            "startDate": "2019-02-01",
+            "endDate": "2019-03-01"
+          },
+          "PastResolution": {
+            "startDate": "2019-02-01",
+            "endDate": "2019-03-01"
+          }
+        },
         "Start": 7,
         "Length": 24
       }
     ]
   },
   {
-    "Input": "Ik ben van 1 feb tot maart 2019 weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 1 feb tot maart 2019 ",
-        "Type": "daterange",
-        "Start": 7,
-        "Length": 25
-      }
-    ]
-  },
-  {
     "Input": "Ik ben tussen 1 feb en maart 2019 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 feb en maart 2019",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2019-02-01,2019-03-01,P28D)",
+          "FutureResolution": {
+            "startDate": "2019-02-01",
+            "endDate": "2019-03-01"
+          },
+          "PastResolution": {
+            "startDate": "2019-02-01",
+            "endDate": "2019-03-01"
+          }
+        },
         "Start": 7,
         "Length": 26
       }
@@ -2047,12 +4069,25 @@
   },
   {
     "Input": "Ik ben tussen juni 2015 en mei 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen juni 2015 en mei 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-06-01,2018-05-01,P35M)",
+          "FutureResolution": {
+            "startDate": "2015-06-01",
+            "endDate": "2018-05-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-06-01",
+            "endDate": "2018-05-01"
+          }
+        },
         "Start": 7,
         "Length": 28
       }
@@ -2060,12 +4095,25 @@
   },
   {
     "Input": "Ik ben tussen mei 2015 en 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen mei 2015 en 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-05-01,2018-01-01,P32M)",
+          "FutureResolution": {
+            "startDate": "2015-05-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-05-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -2073,12 +4121,25 @@
   },
   {
     "Input": "Ik ben tussen mei 2015 en juni 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen mei 2015 en juni 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-05-01,2018-06-01,P37M)",
+          "FutureResolution": {
+            "startDate": "2015-05-01",
+            "endDate": "2018-06-01"
+          },
+          "PastResolution": {
+            "startDate": "2015-05-01",
+            "endDate": "2018-06-01"
+          }
+        },
         "Start": 7,
         "Length": 28
       }
@@ -2086,12 +4147,25 @@
   },
   {
     "Input": "Ik ben tussen 2015 en 5 januari 2018 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 2015 en 5 januari 2018",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2015-01-01,2018-01-05,P1100D)",
+          "FutureResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-01-05"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2018-01-05"
+          }
+        },
         "Start": 7,
         "Length": 29
       }
@@ -2099,25 +4173,51 @@
   },
   {
     "Input": "Ik ben van 2015 tot 5 mei 2017 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " van 2015 tot 5 mei 2017",
+        "Text": "van 2015 tot 5 mei 2017",
         "Type": "daterange",
-        "Start": 6,
-        "Length": 24
+        "Value": {
+          "Timex": "(2015-01-01,2017-05-05,P855D)",
+          "FutureResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2017-05-05"
+          },
+          "PastResolution": {
+            "startDate": "2015-01-01",
+            "endDate": "2017-05-05"
+          }
+        },
+        "Start": 7,
+        "Length": 23
       }
     ]
   },
   {
     "Input": "Ik ben van de laatste maandag in april tot 2019 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-04T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van de laatste maandag in april tot 2019",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-04-30,2019-01-01,P246D)",
+          "FutureResolution": {
+            "startDate": "2018-04-30",
+            "endDate": "2019-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2018-04-30",
+            "endDate": "2019-01-01"
+          }
+        },
         "Start": 7,
         "Length": 40
       }
@@ -2125,12 +4225,25 @@
   },
   {
     "Input": "Ik ben van week 31 tot week 35 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-04T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van week 31 tot week 35",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-07-30,2018-08-27,P4W)",
+          "FutureResolution": {
+            "startDate": "2018-07-30",
+            "endDate": "2018-08-27"
+          },
+          "PastResolution": {
+            "startDate": "2018-07-30",
+            "endDate": "2018-08-27"
+          }
+        },
         "Start": 7,
         "Length": 23
       }
@@ -2138,12 +4251,25 @@
   },
   {
     "Input": "Ik ben tussen week 31 en week 35 weg",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-04T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen week 31 en week 35",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-07-30,2018-08-27,P4W)",
+          "FutureResolution": {
+            "startDate": "2018-07-30",
+            "endDate": "2018-08-27"
+          },
+          "PastResolution": {
+            "startDate": "2018-07-30",
+            "endDate": "2018-08-27"
+          }
+        },
         "Start": 7,
         "Length": 25
       }
@@ -2151,12 +4277,25 @@
   },
   {
     "Input": "Ik blijf hier van vandaag tot tweeënhalve dag later",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-04T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van vandaag tot tweeënhalve dag later",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-05-04,2018-05-06,P2.5D)",
+          "FutureResolution": {
+            "startDate": "2018-05-04",
+            "endDate": "2018-05-06"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-04",
+            "endDate": "2018-05-06"
+          }
+        },
         "Start": 14,
         "Length": 37
       }
@@ -2164,12 +4303,26 @@
   },
   {
     "Input": "Ik was er niet dezelfde week dat het gebeurde",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-17T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dezelfde week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-WXX",
+          "Mod": "ref_undef",
+          "FutureResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-20"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-13",
+            "endDate": "2017-11-20"
+          }
+        },
         "Start": 15,
         "Length": 13
       }
@@ -2177,12 +4330,26 @@
   },
   {
     "Input": "Ik was er niet dezelfde maand dat het gebeurde",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dezelfde maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-XX",
+          "Mod": "ref_undef",
+          "FutureResolution": {
+            "startDate": "2017-11-01",
+            "endDate": "2017-12-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-01",
+            "endDate": "2017-12-01"
+          }
+        },
         "Start": 15,
         "Length": 14
       }
@@ -2190,12 +4357,26 @@
   },
   {
     "Input": "Ik was er dat weekend niet",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2016-11-11T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dat weekend",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX-WXX-WE",
+          "Mod": "ref_undef",
+          "FutureResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-12",
+            "endDate": "2016-11-14"
+          }
+        },
         "Start": 10,
         "Length": 11
       }
@@ -2203,12 +4384,26 @@
   },
   {
     "Input": "Ik was er niet datzelfde jaar dat het gebeurde",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "datzelfde jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "XXXX",
+          "Mod": "ref_undef",
+          "FutureResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-01-01",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 15,
         "Length": 14
       }
@@ -2216,12 +4411,25 @@
   },
   {
     "Input": "We hadden een tijdstip om elkaar te ontmoeten kunnen vastleggen eerder in de week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eerder in de week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018-W22",
+          "FutureResolution": {
+            "startDate": "2018-05-28",
+            "endDate": "2018-05-31"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-28",
+            "endDate": "2018-05-31"
+          }
+        },
         "Start": 64,
         "Length": 17
       }
@@ -2229,12 +4437,25 @@
   },
   {
     "Input": "We hadden een tijdstip om elkaar te ontmoeten kunnen vastleggen eerder deze maand.",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-13T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eerder deze maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018-05",
+          "FutureResolution": {
+            "startDate": "2018-05-01",
+            "endDate": "2018-05-13"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-01",
+            "endDate": "2018-05-13"
+          }
+        },
         "Start": 64,
         "Length": 17
       }
@@ -2242,12 +4463,25 @@
   },
   {
     "Input": "We hadden een tijdstip om elkaar te ontmoeten kunnen vastleggen eerder dit jaar.",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-28T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "eerder dit jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018",
+          "FutureResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2018-05-28"
+          },
+          "PastResolution": {
+            "startDate": "2018-01-01",
+            "endDate": "2018-05-28"
+          }
+        },
         "Start": 64,
         "Length": 15
       }
@@ -2255,12 +4489,25 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip voor ons om elkaar te ontmoeten later deze week",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-10T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "later deze week",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017-W45",
+          "FutureResolution": {
+            "startDate": "2017-11-10",
+            "endDate": "2017-11-13"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-10",
+            "endDate": "2017-11-13"
+          }
+        },
         "Start": 62,
         "Length": 15
       }
@@ -2268,12 +4515,25 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip voor ons om elkaar te ontmoeten later deze maand",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-28T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "later deze maand",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018-05",
+          "FutureResolution": {
+            "startDate": "2018-05-28",
+            "endDate": "2018-06-01"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-28",
+            "endDate": "2018-06-01"
+          }
+        },
         "Start": 62,
         "Length": 16
       }
@@ -2281,12 +4541,25 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip voor ons om elkaar te ontmoeten later dit jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "later dit jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 62,
         "Length": 14
       }
@@ -2294,12 +4567,25 @@
   },
   {
     "Input": "Zoek alsjeblieft een tijdstip voor ons om elkaar te ontmoeten later in het jaar",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "later in het jaar",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2017",
+          "FutureResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2017-11-08",
+            "endDate": "2018-01-01"
+          }
+        },
         "Start": 62,
         "Length": 17
       }
@@ -2307,12 +4593,24 @@
   },
   {
     "Input": "De taak zal meer dan 2 weken na vandaag beginnen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "meer dan 2 weken na vandaag",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018-06-12",
+          "Mod": "after",
+          "FutureResolution": {
+            "startDate": "2018-06-12"
+          },
+          "PastResolution": {
+            "startDate": "2018-06-12"
+          }
+        },
         "Start": 12,
         "Length": 27
       }
@@ -2320,12 +4618,25 @@
   },
   {
     "Input": "Ik zal over minder dan 2 weken vanaf vandaag terugkomen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "minder dan 2 weken vanaf vandaag",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-05-29,2018-06-12,P2W)",
+          "FutureResolution": {
+            "startDate": "2018-05-29",
+            "endDate": "2018-06-12"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-29",
+            "endDate": "2018-06-12"
+          }
+        },
         "Start": 12,
         "Length": 32
       }
@@ -2333,38 +4644,75 @@
   },
   {
     "Input": "Binnen 2 weken vanaf vandaag zal ik terug zijn gekomen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 2 weken vanaf vandaag",
         "Type": "daterange",
-        "Start": -1,
+        "Value": {
+          "Timex": "(2018-05-29,2018-06-12,P2W)",
+          "FutureResolution": {
+            "startDate": "2018-05-29",
+            "endDate": "2018-06-12"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-29",
+            "endDate": "2018-06-12"
+          }
+        },
+        "Start": 0,
         "Length": 28
       }
     ]
   },
   {
     "Input": "Ik heb al mijn werk al afgerond meer dan 2 weken voor vandaag",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "meer dan weken voor vandaag",
+        "Text": "meer dan 2 weken voor vandaag",
         "Type": "daterange",
-        "Start": -1,
-        "Length": 27
+        "Value": {
+          "Timex": "2018-05-15",
+          "Mod": "before",
+          "FutureResolution": {
+            "endDate": "2018-05-15"
+          },
+          "PastResolution": {
+            "endDate": "2018-05-15"
+          }
+        },
+        "Start": 32,
+        "Length": 29
       }
     ]
   },
   {
     "Input": "Deze taak zou afgerond moeten zijn geweest meer dan 2 dagen voor gisteren",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "meer dan 2 dagen voor gisteren",
         "Type": "daterange",
+        "Value": {
+          "Timex": "2018-05-26",
+          "Mod": "before",
+          "FutureResolution": {
+            "endDate": "2018-05-26"
+          },
+          "PastResolution": {
+            "endDate": "2018-05-26"
+          }
+        },
         "Start": 43,
         "Length": 30
       }
@@ -2372,12 +4720,25 @@
   },
   {
     "Input": "Deze taak zal afgerond zijn minder dan 3 dagen na morgen",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "minder dan 3 dagen na morgen",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2018-05-30,2018-06-02,P3D)",
+          "FutureResolution": {
+            "startDate": "2018-05-30",
+            "endDate": "2018-06-02"
+          },
+          "PastResolution": {
+            "startDate": "2018-05-30",
+            "endDate": "2018-06-02"
+          }
+        },
         "Start": 28,
         "Length": 28
       }
@@ -2385,38 +4746,77 @@
   },
   {
     "Input": "Het gebeurt in de 15e eeuw",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de 15e eeuw",
+        "Text": "15e eeuw",
         "Type": "daterange",
-        "Start": 15,
-        "Length": 11
+        "Value": {
+          "Timex": "(1400-01-01,1500-01-01,P100Y)",
+          "FutureResolution": {
+            "startDate": "1400-01-01",
+            "endDate": "1500-01-01"
+          },
+          "PastResolution": {
+            "startDate": "1400-01-01",
+            "endDate": "1500-01-01"
+          }
+        },
+        "Start": 18,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Toon me de gegevens in de 21e eeuw",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de 21e eeuw",
+        "Text": "21e eeuw",
         "Type": "daterange",
-        "Start": 23,
-        "Length": 11
+        "Value": {
+          "Timex": "(2000-01-01,2100-01-01,P100Y)",
+          "FutureResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2100-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2000-01-01",
+            "endDate": "2100-01-01"
+          }
+        },
+        "Start": 26,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "verkoop waarvan de datum dit decennium is",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-08-31T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dit decennium",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(2010-01-01,2020-01-01,P10Y)",
+          "FutureResolution": {
+            "startDate": "2010-01-01",
+            "endDate": "2020-01-01"
+          },
+          "PastResolution": {
+            "startDate": "2010-01-01",
+            "endDate": "2020-01-01"
+          }
+        },
         "Start": 25,
         "Length": 13
       }
@@ -2424,12 +4824,25 @@
   },
   {
     "Input": "van 1-10 tot 7-11",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 1-10 tot 7-11",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-10-01,XXXX-11-07,P37D)",
+          "FutureResolution": {
+            "startDate": "2018-10-01",
+            "endDate": "2018-11-07"
+          },
+          "PastResolution": {
+            "startDate": "2018-10-01",
+            "endDate": "2018-11-07"
+          }
+        },
         "Start": 0,
         "Length": 17
       }
@@ -2437,12 +4850,25 @@
   },
   {
     "Input": "van 25-10 tot 25-01",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 25-10 tot 25-01",
         "Type": "daterange",
+        "Value": {
+          "Timex": "(XXXX-10-25,XXXX-01-25,P92D)",
+          "FutureResolution": {
+            "startDate": "2018-10-25",
+            "endDate": "2019-01-25"
+          },
+          "PastResolution": {
+            "startDate": "2017-10-25",
+            "endDate": "2018-01-25"
+          }
+        },
         "Start": 0,
         "Length": 19
       }

--- a/Specs/DateTime/Dutch/MergedParser.json
+++ b/Specs/DateTime/Dutch/MergedParser.json
@@ -1073,33 +1073,6 @@
     ]
   },
   {
-    "Input": "leg een meeting voorafgaand aan 14.00 vast",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "voorafgaand aan 14.00 ",
-        "Type": "datetimeV2.timerange",
-        "Value": {
-          "values": [
-            {
-              "timex": "T14",
-              "Mod": "before",
-              "type": "timerange",
-              "end": "14:00:00",
-              "sourceEntity": "datetimepoint"
-            }
-          ]
-        },
-        "Start": 16,
-        "Length": 22
-      }
-    ]
-  },
-  {
     "Input": "Ik zal de afspraak van tien uur 's ochtends naar twintig verzetten!",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -2157,32 +2130,6 @@
     ]
   },
   {
-    "Input": "Ik zal 11 - 2016 weg zijn",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11 - 2016 ",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 10
-      }
-    ]
-  },
-  {
     "Input": "Ik zal 11- 2016 weg zijn",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -2257,32 +2204,6 @@
         },
         "Start": 7,
         "Length": 7
-      }
-    ]
-  },
-  {
-    "Input": "Ik zal 11 / 2016 weg zijn ",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11 / 2016",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 9
       }
     ]
   },
@@ -2339,32 +2260,6 @@
     ]
   },
   {
-    "Input": "Ik zal 11-2016 weg zijn",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11-2016",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 7
-      }
-    ]
-  },
-  {
     "Input": "Ik zal 11 - 2016 weg zijn",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -2387,84 +2282,6 @@
         },
         "Start": 7,
         "Length": 10
-      }
-    ]
-  },
-  {
-    "Input": "Ik zal 11- 2016 weg zijn",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11- 2016",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 8
-      }
-    ]
-  },
-  {
-    "Input": "Ik zal 11 -2016 weg zijn",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11 -2016",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 8
-      }
-    ]
-  },
-  {
-    "Input": "Ik zal 11/2016 weg zijn",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "11/2016",
-        "Type": "datetimeV2.daterange",
-        "Value": {
-          "values": [
-            {
-              "timex": "2016-11",
-              "type": "daterange",
-              "start": "2016-11-01",
-              "end": "2016-12-01"
-            }
-          ]
-        },
-        "Start": 7,
-        "Length": 7
       }
     ]
   },

--- a/Specs/DateTime/Dutch/MergedParser.json
+++ b/Specs/DateTime/Dutch/MergedParser.json
@@ -1,0 +1,5533 @@
+[
+  {
+    "Input": "VOEG LUNCH TOE OM 12.30 OP VRIJ",
+    "Comment": "Disable this for now because of new features in .NET",
+    "NotSupported": "javascript, Java, python",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "12.30 OP VRIJ",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-5T12:30",
+              "type": "datetime",
+              "value": "2016-11-04 12:30:00"
+            },
+            {
+              "timex": "XXXX-WXX-5T12:30",
+              "type": "datetime",
+              "value": "2016-11-11 12:30:00"
+            }
+          ]
+        },
+        "Start": 18,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Wat heb ik de week van 30 november?",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "de week van 30 november",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-11-30",
+              "type": "daterange",
+              "start": "2015-11-30",
+              "end": "2015-12-07"
+            },
+            {
+              "timex": "XXXX-11-30",
+              "type": "daterange",
+              "start": "2016-11-28",
+              "end": "2016-12-05"
+            }
+          ]
+        },
+        "Start": 11,
+        "Length": 23
+      }
+    ]
+  },
+  {
+    "Input": "Voor vier maandag om 12.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "maandag om 12.00",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-1T12",
+              "type": "datetime",
+              "value": "2016-10-31 12:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-1T12",
+              "type": "datetime",
+              "value": "2016-11-07 12:00:00"
+            }
+          ]
+        },
+        "Start": 10,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Voeg 649 toe vanavond middernacht",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanavond middernacht",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T12",
+              "type": "datetime",
+              "value": "2016-11-07 12:00:00"
+            }
+          ]
+        },
+        "Start": 13,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik wil voor 3 mensen bij een pizzatent reserveren in seattle voor vanavond rond 20.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanavond rond 20.00",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T20",
+              "type": "datetime",
+              "value": "2016-11-07 20:00:00"
+            }
+          ]
+        },
+        "Start": 66,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Pasen",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Pasen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2016-03-27"
+            },
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2017-04-16"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Pasen 2019",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Pasen 2019",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2019-04-21",
+              "type": "date",
+              "value": "2019-04-21"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "overmorgen",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "overmorgen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "type": "date",
+              "value": "2016-11-09"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "overmorgen om 8.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "overmorgen om 8.00",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09T08",
+              "type": "datetime",
+              "value": "2016-11-09 08:00:00"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "op vrijdag in de middag",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag in de middag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-5TAF",
+              "type": "datetimerange",
+              "start": "2016-11-04 12:00:00",
+              "end": "2016-11-04 16:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-5TAF",
+              "type": "datetimerange",
+              "start": "2016-11-11 12:00:00",
+              "end": "2016-11-11 16:00:00"
+            }
+          ]
+        },
+        "Start": 3,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "op vrijdag voor 3 's middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag voor 3 's middags",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-5T15",
+              "type": "datetime",
+              "value": "2016-11-04 15:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-5T15",
+              "type": "datetime",
+              "value": "2016-11-11 15:00:00"
+            }
+          ]
+        },
+        "Start": 3,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Maak afspraak voor morgenochtend om 9 uur",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgenochtend om 9 uur",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-08T09",
+              "type": "datetime",
+              "value": "2016-11-08 09:00:00"
+            }
+          ]
+        },
+        "Start": 19,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Zet de bruiloft van make cable in mijn agena voor woensdag de eenendertigste",
+    "Context": {
+      "ReferenceDateTime": "2017-09-15T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "woensdag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-3",
+              "type": "date",
+              "value": "2017-09-13"
+            },
+            {
+              "timex": "XXXX-WXX-3",
+              "type": "date",
+              "value": "2017-09-20"
+            }
+          ]
+        },
+        "Start": 50,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Zet de bruiloft van make cable in mijn agena voor dinsdag de eenendertigste",
+    "Context": {
+      "ReferenceDateTime": "2017-10-15T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag de eenendertigste",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2017-10-31",
+              "type": "date",
+              "value": "2017-10-31"
+            }
+          ]
+        },
+        "Start": 50,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Leg een meeting over 8 minuten vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 8 minuten",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T00:08:00",
+              "type": "datetime",
+              "value": "2016-11-07 00:08:00"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Leg een meeting over 10 uur vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 10 uur",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T10:00:00",
+              "type": "datetime",
+              "value": "2016-11-07 10:00:00"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Leg een meeting over 10 dagen vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 10 dagen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-17",
+              "type": "date",
+              "value": "2016-11-17"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Leg een meeting over 3 weken vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 3 weken",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-28",
+              "type": "date",
+              "value": "2016-11-28"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Leg een meeting over 3 maanden vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 3 maanden",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2017-02-07",
+              "type": "date",
+              "value": "2017-02-07"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben over 3 jaar weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 3 jaar",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2019-11-07",
+              "type": "date",
+              "value": "2019-11-07"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "na 20.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 20.00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T20",
+              "Mod": "after",
+              "type": "timerange",
+              "start": "20:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "voor 20.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor 20.00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T20",
+              "Mod": "before",
+              "type": "timerange",
+              "end": "20:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "sinds 20.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "sinds 20.00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T20",
+              "Mod": "since",
+              "type": "timerange",
+              "start": "20:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "30-2-2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "30-2-2016",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "2015-1-32",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2015-1",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2015-01",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2015-02-01"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "2017-13-12",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "voeg yoga toe aan persoonlijke agenda op maandag en woensdag om 15.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "maandag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "date",
+              "value": "2016-10-31"
+            },
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "date",
+              "value": "2016-11-07"
+            }
+          ]
+        },
+        "Start": 41,
+        "Length": 7
+      },
+      {
+        "Text": "wednesday at 3pm",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-3T15",
+              "type": "datetime",
+              "value": "2016-11-02 15:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-3T15",
+              "type": "datetime",
+              "value": "2016-11-09 15:00:00"
+            }
+          ]
+        },
+        "Start": 44,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "leg een meeting vast iedere week om 8.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "8.00",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T08",
+              "type": "time",
+              "value": "08:00:00"
+            }
+          ]
+        },
+        "Start": 36,
+        "Length": 4
+      },
+      {
+        "Text": "every week",
+        "Type": "datetimeV2.set",
+        "Value": {
+          "values": [
+            {
+              "timex": "P1W",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 27,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "leg vast tweede zaterdag elke maand ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tweede zaterdag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-12",
+              "type": "date",
+              "value": "2016-11-12"
+            }
+          ]
+        },
+        "Start": 9,
+        "Length": 15
+      },
+      {
+        "Text": "each month",
+        "Type": "datetimeV2.set",
+        "Value": {
+          "values": [
+            {
+              "timex": "P1M",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 28,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Eerste Paasdag",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Eerste Paasdag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2016-03-27"
+            },
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2017-04-16"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Tweede Paasdag 2017",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Tweede Paasdag 2017",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2017-04-17",
+              "type": "date",
+              "value": "2017-04-17"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Blok 1 uur af op mijn agenda morgenochtend",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1 uur",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "PT1H",
+              "type": "duration",
+              "value": "3600"
+            }
+          ]
+        },
+        "Start": 5,
+        "Length": 5
+      },
+      {
+        "Text": "tomorrow morning",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-08TMO",
+              "type": "datetimerange",
+              "start": "2016-11-08 08:00:00",
+              "end": "2016-11-08 12:00:00"
+            }
+          ]
+        },
+        "Start": 28,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Wijzig de meeting van 22 juli in Bellevue naar 22 augustus",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "22 juli",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-07-22",
+              "type": "date",
+              "value": "2016-07-22"
+            },
+            {
+              "timex": "XXXX-07-22",
+              "type": "date",
+              "value": "2017-07-22"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 7
+      },
+      {
+        "Text": "August 22nd",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-08-22",
+              "type": "date",
+              "value": "2016-08-22"
+            },
+            {
+              "timex": "XXXX-08-22",
+              "type": "date",
+              "value": "2017-08-22"
+            }
+          ]
+        },
+        "Start": 40,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "op vrijdag voor 3 in Bellevue in de middag",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-5",
+              "type": "date",
+              "value": "2016-11-04"
+            },
+            {
+              "timex": "XXXX-WXX-5",
+              "type": "date",
+              "value": "2016-11-11"
+            }
+          ]
+        },
+        "Start": 3,
+        "Length": 7
+      },
+      {
+        "Text": "in the afternoon",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "TAF",
+              "type": "timerange",
+              "start": "12:00:00",
+              "end": "16:00:00"
+            }
+          ]
+        },
+        "Start": 28,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "pik Jordans medicijnen op bij de costco apotheek op havana ergens voor aankomende dinsdag om 12.00",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor aankomende dinsdag om 12.00",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-15T12:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2016-11-15 12:00:00",
+              "sourceEntity": "datetimepoint"
+            },
+            {
+              "timex": "2016-11-15T00:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2016-11-15 00:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 66,
+        "Length": 32
+      }
+    ]
+  },
+  {
+    "Input": "leg een meeting voorafgaand aan 14.00 vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voorafgaand aan 14.00 ",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T14",
+              "Mod": "before",
+              "type": "timerange",
+              "end": "14:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "leg een meeting voorafgaand aan 14.00 vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voorafgaand aan 14.00 ",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T14",
+              "Mod": "before",
+              "type": "timerange",
+              "end": "14:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal de afspraak van tien uur 's ochtends naar twintig verzetten!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tien uur 's ochtends",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T10",
+              "type": "time",
+              "value": "10:00:00"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 20
+      },
+      {
+        "Text": "twenty",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T20",
+              "type": "time",
+              "value": "20:00:00"
+            }
+          ]
+        },
+        "Start": 38,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal de afspraak van tien uur 's ochtends naar 20.00 verzetten!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tien uur 's ochtends",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T10",
+              "type": "time",
+              "value": "10:00:00"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 20
+      },
+      {
+        "Text": "20",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T20",
+              "type": "time",
+              "value": "20:00:00"
+            }
+          ]
+        },
+        "Start": 38,
+        "Length": 2
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal de afspraak van tien uur 's ochtends naar negen verzetten!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tien uur 's ochtends",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T10",
+              "type": "time",
+              "value": "10:00:00"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 20
+      },
+      {
+        "Text": "nine",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T09",
+              "type": "time",
+              "value": "09:00:00"
+            },
+            {
+              "timex": "T21",
+              "type": "time",
+              "value": "21:00:00"
+            }
+          ]
+        },
+        "Start": 38,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal de afspraak van tien uur 's ochtends naar 26 verzetten!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tien uur 's ochtends",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T10",
+              "type": "time",
+              "value": "10:00:00"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal de afspraak van tien uur 's ochtends naar zesentwintig verzetten!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tien uur 's ochtends",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T10",
+              "type": "time",
+              "value": "10:00:00"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben over 5 minuten terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 5 minuten",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T00:05:00",
+              "type": "datetime",
+              "value": "2016-11-07 00:05:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "over 5 minuten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 5 minuten",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T00:05:00",
+              "type": "datetime",
+              "value": "2016-11-07 00:05:00"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Leg ergens tijdens de ochtend vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "ochtend",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "TMO",
+              "type": "timerange",
+              "start": "08:00:00",
+              "end": "12:00:00"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-08",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-11-08",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal voor morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-08",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-11-08",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal niet later dan morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "niet later dan morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-08",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-11-08",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "geef me alle beschikbare plekken met data na of gelijk aan 1-1-2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na of gelijk aan 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 42,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal later dan 1-1-2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "later dan 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal na 1-1-2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal eerder dan 1-1-2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Het zal beginnend vanaf 1-1-2016 sluiten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "beginnend vanaf 1-1-2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "eindigend met 1-1-2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eindigend met 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 0,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal eerder dan 2020 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 2020",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2020",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2020-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Het bereik is tot 2012",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tot 2012",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2012",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2012-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Het bereik is 2012 of erna",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2012 of erna",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2012",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2012-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 5 dagen terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 5 dagen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2017-11-13,P5D)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2017-11-13"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 10 maanden terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 10 maanden",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2018-09-08,P10M)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2018-09-08"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 3 jaar terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 3 jaar",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2020-11-08,P3Y)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2020-11-08"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 5 jaar 1 maand 12 dagen terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 5 jaar 1 maand 12 dagen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2022-12-20,P5Y1M12D)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2022-12-20"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 30
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 15 seconden terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 15 seconden",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T16:12:15,PT15S)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 16:12:15"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 5 minuten terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 5 minuten",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T16:17:00,PT5M)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 16:17:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 5 uren terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 5 uren",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 21:12:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen 1 dag en 5 uren terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 1 dag en 5 uren",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-08 21:12:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zou binnen 2 dagen 1 uur 5 minuten 30 seconden af moeten zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 2 dagen 1 uur 5 minuten 30 seconden",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-09 17:17:30"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 42
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen de komende 1 dag en 5 uren terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende 1 dag en 5 uren",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-08 21:12:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 33
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zou binnen de komende 2 dagen 1 uur 5 minuten 30 seconden af moeten zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende 2 dagen 1 uur 5 minuten 30 seconden",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-09 17:17:30"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 53
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen de komende 15 seconden terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende 15 seconden",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T16:12:15,PT15S)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 16:12:15"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen de komende 10 maanden terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende 10 maanden ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2018-09-08,P10M)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2018-09-08"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 2016, nov weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2016, nov",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 2016 , nov weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2016 , nov",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal november , 2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "november , 2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 2016 november weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2016 november",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11-2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 - 2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 - 2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11- 2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11- 2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 -2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 -2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11/2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11/2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 / 2016 weg zijn ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 / 2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11/ 2016 weg zijn ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11/ 2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 /2016 weg zijn ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 /2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11-2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 - 2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 - 2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11- 2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11- 2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 -2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 -2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11/2016 weg zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11/2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 11 / 2016 weg zijn ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "11 / 2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "type": "daterange",
+              "start": "2016-11-01",
+              "end": "2016-12-01"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal later dan of op 1-1-2016 arriveren",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "later dan of op 1-1-2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal later dan 1-1-2016 arriveren",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "later dan 1-1-2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal op 1-1-2016 arriveren",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1-1-2016 ",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "type": "date",
+              "value": "2016-01-01"
+            }
+          ]
+        },
+        "Start": 11,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal voor of op 1-1-2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor of op 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "until",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal voor 1-1-2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor 1-1-2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal op of eerder dan 1-1-2016 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op of eerder dan 1-1-2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "until",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal op 1-1-2016 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1-1-2016",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "type": "date",
+              "value": "2016-01-01"
+            }
+          ]
+        },
+        "Start": 17,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal eerder dan 1-1-2016 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal voor of in feb 2018 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor of in feb 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-02",
+              "Mod": "until",
+              "type": "daterange",
+              "end": "2018-03-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal voor feb 2018 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor feb 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-02",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2018-02-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal in feb 2018 af zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "feb 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-02",
+              "type": "daterange",
+              "start": "2018-02-01",
+              "end": "2018-03-01"
+            }
+          ]
+        },
+        "Start": 17,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt niet later dan of in 2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "later dan of in 2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 13,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt niet later dan 2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "later dan 2016 ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2017-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 13,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt niet in 2016 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "end": "2017-01-01"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt kantoor niet op of na 18.30 vandaag verlaten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op of na 18.30 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T18:30",
+              "Mod": "since",
+              "type": "datetimerange",
+              "start": "2016-11-07 18:30:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt kantoor niet na 18.30 vandaag verlaten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 18.30 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T18:30",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2016-11-07 18:30:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt kantoor niet om 18.30 vandaag verlaten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "18.30 vandaag ",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T18:30",
+              "type": "datetime",
+              "value": "2016-11-07 18:30:00"
+            }
+          ]
+        },
+        "Start": 19,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Je moet op of voor overmorgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op of voor overmorgen ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "Mod": "until",
+              "type": "daterange",
+              "end": "2016-11-09",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Je moet overmorgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "overmorgen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "type": "date",
+              "value": "2016-11-09"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Je moet voor overmorgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor overmorgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-11-09",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Je moet op of eerder dan 15.00 15-5-2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op of eerder dan 15.00 15-5-2018",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-15T15",
+              "Mod": "until",
+              "type": "datetimerange",
+              "end": "2018-05-15 15:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 32
+      }
+    ]
+  },
+  {
+    "Input": "Je moet eerder dan 15.00 15-5-2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 15.00 15-5-2018 ",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-15T15",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-05-15 15:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "Je moet op 15.00 15-5-2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15.00 15-5-2018 ",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-15T15",
+              "type": "datetime",
+              "value": "2018-05-15 15:00:00"
+            }
+          ]
+        },
+        "Start": 11,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ben je twee dagen na vandaag beschikbaar?",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "twee dagen na vandaag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-02",
+              "type": "date",
+              "value": "2018-06-02"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "Ben je drie weken na morgen beschikbaar?",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "drie weken na morgen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-22",
+              "type": "date",
+              "value": "2018-06-22"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Waar was je twee dagen voor gisteren?",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "twee dagen voor gisteren",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-28",
+              "type": "date",
+              "value": "2018-05-28"
+            }
+          ]
+        },
+        "Start": 12,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "laat me verkoop zien voor 2010 of na 2018",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor 2010",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2010",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2010-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 9
+      },
+      {
+        "Text": "after 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 29,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "laat me verkoop zien na 2010 en voor 2018 of voor 2000 maar niet 1998",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2010",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2010",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2011-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 7
+      },
+      {
+        "Text": "before 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2018-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 29,
+        "Length": 11
+      },
+      {
+        "Text": "before 2000",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2000",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2000-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 44,
+        "Length": 11
+      },
+      {
+        "Text": "1998",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "1998",
+              "type": "daterange",
+              "start": "1998-01-01",
+              "end": "1999-01-01"
+            }
+          ]
+        },
+        "Start": 64,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "laat me gegevens zien meer dan 4 dagen en minder dan 1 week",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 4 dagen",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "P4D",
+              "Mod": "more",
+              "type": "duration",
+              "value": "345600"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 16
+      },
+      {
+        "Text": "less than 1 week",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "P1W",
+              "Mod": "less",
+              "type": "duration",
+              "value": "604800"
+            }
+          ]
+        },
+        "Start": 37,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "laat me gegevens zien meer dan 1 uur en 30 minuten",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 1 uur en 30 minuten",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "PT1H30M",
+              "Mod": "more",
+              "type": "duration",
+              "value": "5400"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 28
+      }
+    ]
+  },
+  {
+    "Input": "Ik heb meer dan 2 weken voor vandaag al mijn werk al afgerond ",
+    "Context": {
+      "ReferenceDateTime": "2018-06-12T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 2 weken voor vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-29",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2018-05-29"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "Ik heb meer dan 2 weken voor vandaag al mijn werk al afgerond ",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 2 weken voor vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-15",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2018-05-15"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 29
+      }
+    ]
+  },
+  {
+    "Input": "deze taak zou al meer dan 2 dagen voor gisteren afgerond moeten zijn geweest",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 2 dagen voor gisteren ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-26",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2018-05-26"
+            }
+          ]
+        },
+        "Start": 17,
+        "Length": 31
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal minder dan 3 dagen na morgen af zijn",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "minder dan 3 dagen na morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2018-05-30,2018-06-02,P3D)",
+              "type": "daterange",
+              "start": "2018-05-30",
+              "end": "2018-06-02"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 28
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal meer dan 2 weken na vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "meer dan 2 weken na vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-12",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-06-12"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "Laten we over 3 minuten vanaf nu beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 minuten vanaf nu",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-29T00:03:00",
+              "type": "datetime",
+              "value": "2018-05-29 00:03:00"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Laten we over 3 minuten vanaf vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 minuten",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "PT3M",
+              "type": "duration",
+              "value": "180"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 9
+      },
+      {
+        "Text": "from today",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-29",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "start": "2018-05-29"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen 2 weken na vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen 2 weken na vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2018-05-29,2018-06-12,P2W)",
+              "type": "daterange",
+              "start": "2018-05-29",
+              "end": "2018-06-12"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen de komende 2 weken na vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende 2 weken na vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2018-05-29,2018-06-12,P2W)",
+              "type": "daterange",
+              "start": "2018-05-29",
+              "end": "2018-06-12"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 36
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen de komende 2 weken voor vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 weken voor vandaag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-08",
+              "type": "date",
+              "value": "2018-06-08"
+            }
+          ]
+        },
+        "Start": 32,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen de komende 2 weken na morgen beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 weken na morgen ",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-07",
+              "type": "date",
+              "value": "2018-07-07"
+            }
+          ]
+        },
+        "Start": 32,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen 2 weken voor gisteren beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 weken voor gisteren ",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-07",
+              "type": "date",
+              "value": "2018-06-07"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "laat me verkoop zien van 2010 - 2020 en niet 2015",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 2010 - 2020",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2010-01-01,2020-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2010-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 15
+      },
+      {
+        "Text": "2015",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        },
+        "Start": 39,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na 2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na feb 2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na feb 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na feb vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na feb",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
+            },
+            {
+              "timex": "XXXX-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2019-03-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "Het zal 1-1-2015 na 2:00 gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1-1-2015 na 2:00",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2015-01-01T02:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2015-01-01 02:00:00"
+            },
+            {
+              "timex": "2015-01-01T14:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2015-01-01 14:00:00"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Het zal vandaag voor 16.00  gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vandaag voor 16.00",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-22T16",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-06-22 16:00:00"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Het zal volgende week woensdag later dan 10 uur 's ochtends gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende week woensdag later dan 10 uur 's ochtends ",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-04T10",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2018-07-04 10:00:00"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 52
+      }
+    ]
+  },
+  {
+    "Input": "Het gebeurde op vorige week dinsdag om 2 uur 's middags",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vorige week dinsdag om 2 uur 's middags",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-19T14",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-06-19 14:00:00"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 39
+      }
+    ]
+  },
+  {
+    "Input": "Laten we op 1 feb niet later dan 6:00 gaan",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1 feb niet later dan 6:00",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-02-01T06:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-02-01 06:00:00"
+            },
+            {
+              "timex": "XXXX-02-01T06:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2019-02-01 06:00:00"
+            },
+            {
+              "timex": "XXXX-02-01T18:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-02-01 18:00:00"
+            },
+            {
+              "timex": "XXXX-02-01T18:00",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2019-02-01 18:00:00"
+            }
+          ]
+        },
+        "Start": 12,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Het gebeurde op volgende week na 2:00",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende week",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W27",
+              "type": "daterange",
+              "start": "2018-07-02",
+              "end": "2018-07-09"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 13
+      },
+      {
+        "Text": "after 2:00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T02:00",
+              "Mod": "after",
+              "type": "timerange",
+              "start": "02:00:00",
+              "sourceEntity": "datetimepoint"
+            },
+            {
+              "timex": "T14:00",
+              "Mod": "after",
+              "type": "timerange",
+              "start": "14:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 25,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in 2007 en 2009",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2007",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2007",
+              "type": "daterange",
+              "start": "2007-01-01",
+              "end": "2008-01-01"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 4
+      },
+      {
+        "Text": "2009",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2009",
+              "type": "daterange",
+              "start": "2009-01-01",
+              "end": "2010-01-01"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien tussen 2007 en 2009",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tussen 2007 en 2009",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2007-01-01,2009-01-01,P2Y)",
+              "type": "daterange",
+              "start": "2007-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        },
+        "Start": 18,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in het jaar 2008",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "jaar 2008",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2008",
+              "type": "daterange",
+              "start": "2008-01-01",
+              "end": "2009-01-01"
+            }
+          ]
+        },
+        "Start": 25,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in het jaar",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "het jaar",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "type": "daterange",
+              "start": "2018-01-01",
+              "end": "2019-01-01"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in de week",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "de week",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W27",
+              "type": "daterange",
+              "start": "2018-07-02",
+              "end": "2018-07-09"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in de week na de volgende",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "de week na de volgende",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W29",
+              "type": "daterange",
+              "start": "2018-07-16",
+              "end": "2018-07-23"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in de week 31",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "week 31",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W31",
+              "type": "daterange",
+              "start": "2018-07-30",
+              "end": "2018-08-06"
+            }
+          ]
+        },
+        "Start": 24,
+        "Length": 7
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 3 uur vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 3 uur",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-05T03:00:00",
+              "type": "datetime",
+              "value": "2018-07-05 03:00:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 weken vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 2 weken",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-19",
+              "type": "date",
+              "value": "2018-07-19"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 dagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 2 dagen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-07",
+              "type": "date",
+              "value": "2018-07-07"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 maanden vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 2 maanden",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-09-05",
+              "type": "date",
+              "value": "2018-09-05"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 jaar vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over 2 jaar",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2020-07-05",
+              "type": "date",
+              "value": "2020-07-05"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 dagen vanaf vandaag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 dagen vanaf vandaag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-07",
+              "type": "date",
+              "value": "2018-07-07"
+            }
+          ]
+        },
+        "Start": 12,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "Zal je > 18.00 vandaag vertrekken?",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "> 18.00 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-08-10T18",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2018-08-10 18:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "Zal je >= 18.00 vandaag vertrekken?",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": ">= 18.00 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-08-10T18",
+              "Mod": "since",
+              "type": "datetimerange",
+              "start": "2018-08-10 18:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Zal je <18.00 vandaag arriveren?",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "<18.00 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-08-10T18",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-08-10 18:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Zal je <=18.00 vandaag arriveren?",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "<=18.00 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-08-10T18",
+              "Mod": "until",
+              "type": "datetimerange",
+              "end": "2018-08-10 18:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 15
+      }
+    ]
+  },
+  {
+    "Input": "<div>18.00</div>",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "18.00",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T18",
+              "type": "time",
+              "value": "18:00:00"
+            }
+          ]
+        },
+        "Start": 5,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "De tijd is <>18.00",
+    "Context": {
+      "ReferenceDateTime": "2018-08-10T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "18.00",
+        "Type": "datetimeV2.time",
+        "Value": {
+          "values": [
+            {
+              "timex": "T18",
+              "type": "time",
+              "value": "18:00:00"
+            }
+          ]
+        },
+        "Start": 13,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal na 2016 en voor 2018, of voor 2019 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2016",
+        "Start": 8,
+        "Length": 7,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 29,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 45,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Paaszondag",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Paaszondag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2016-03-27"
+            },
+            {
+              "timex": "XXXX-03-27",
+              "type": "date",
+              "value": "2017-04-16"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Maak een afspraak voor Paasmaandag 2017",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "Paasmaandag 2017",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2017-04-17",
+              "type": "date",
+              "value": "2017-04-17"
+            }
+          ]
+        },
+        "Start": 23,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "leg een meeting eerder dan 14:00 vast",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 14:00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T14",
+              "Mod": "before",
+              "type": "timerange",
+              "end": "14:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "geef me alle beschikbare plekken met data na of op 1-1-2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na of op 1-1-2016",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-01-01",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 42,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen de komende dag en 5 uren terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen de komende dag en 5 uren",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-08 21:12:00"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 31
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal binnen komende 10 maanden terug zijn",
+    "Context": {
+      "ReferenceDateTime": "2017-11-08T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "binnen komende 10 maanden ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2017-11-08,2018-09-08,P10M)",
+              "type": "daterange",
+              "start": "2017-11-08",
+              "end": "2018-09-08"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt kantoor na 18.30 vandaag verlaten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 18.30 vandaag",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T18:30",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2016-11-07 18:30:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Je kunt kantoor om 18.30 vandaag verlaten",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "18.30 vandaag ",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-07T18:30",
+              "type": "datetime",
+              "value": "2016-11-07 18:30:00"
+            }
+          ]
+        },
+        "Start": 19,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Je moet op of voor de dag na morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op of voor de dag na morgen ",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "Mod": "until",
+              "type": "daterange",
+              "end": "2016-11-09",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 28
+      }
+    ]
+  },
+  {
+    "Input": "Je moet de dag na morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "de dag na morgen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "type": "date",
+              "value": "2016-11-09"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Je moet voor de dag na morgen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voor de dag na morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016-11-09",
+              "Mod": "before",
+              "type": "daterange",
+              "end": "2016-11-09",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal eerder dan 3 dagen na morgen af zijn",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eerder dan 3 dagen na morgen",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "(2018-05-30,2018-06-02,P3D)",
+              "type": "daterange",
+              "start": "2018-05-30",
+              "end": "2018-06-02"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 28
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal ruim 2 weken na vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "ruim 2 weken na vandaag",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-12",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-06-12"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 23
+      }
+    ]
+  },
+  {
+    "Input": "Laten we over 3 minuten sinds nu beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 minuten sinds nu",
+        "Type": "datetimeV2.datetime",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-29T00:03:00",
+              "type": "datetime",
+              "value": "2018-05-29 00:03:00"
+            }
+          ]
+        },
+        "Start": 14,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Laten we over 3 minuten sinds vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 minutes",
+        "Type": "datetimeV2.duration",
+        "Value": {
+          "values": [
+            {
+              "timex": "PT3M",
+              "type": "duration",
+              "value": "180"
+            }
+          ]
+        },
+        "Start": 12,
+        "Length": 9
+      },
+      {
+        "Text": "from today",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-05-29",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "start": "2018-05-29"
+            }
+          ]
+        },
+        "Start": 22,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Deze taak zal binnen 2 weken eerder dan gisteren beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 weken eerder dan gisteren ",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-06-07",
+              "type": "date",
+              "value": "2018-06-07"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 28
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na afloop van 2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na afloop van 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na afloop van feb 2018 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na afloop van feb 2018",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Misschien kunnen we na afloop van feb vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na afloop van feb",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "XXXX-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
+            },
+            {
+              "timex": "XXXX-02",
+              "Mod": "after",
+              "type": "daterange",
+              "start": "2019-03-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        },
+        "Start": 20,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Het zal 1-1-2015 later dan 2:00 gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-06-22T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "1-1-2015 later dan 2:00",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2015-01-01T02:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2015-01-01 02:00:00"
+            },
+            {
+              "timex": "2015-01-01T14:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2015-01-01 14:00:00"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 23
+      }
+    ]
+  },
+  {
+    "Input": "Het zal volgende week woensdag na 10 uur 's ochtends gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende week woensdag na 10 uur 's ochtends ",
+        "Type": "datetimeV2.datetimerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-04T10",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2018-07-04 10:00:00"
+            }
+          ]
+        },
+        "Start": 8,
+        "Length": 45
+      }
+    ]
+  },
+  {
+    "Input": "Het gebeurde op komende week na 2:00",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "komende week",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W27",
+              "type": "daterange",
+              "start": "2018-07-02",
+              "end": "2018-07-09"
+            }
+          ]
+        },
+        "Start": 16,
+        "Length": 12
+      },
+      {
+        "Text": "after 2:00",
+        "Type": "datetimeV2.timerange",
+        "Value": {
+          "values": [
+            {
+              "timex": "T02:00",
+              "Mod": "after",
+              "type": "timerange",
+              "start": "02:00:00",
+              "sourceEntity": "datetimepoint"
+            },
+            {
+              "timex": "T14:00",
+              "Mod": "after",
+              "type": "timerange",
+              "start": "14:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        },
+        "Start": 25,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Laat verkoop zien in de week na afloop van de volgende",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "de week na afloop van de volgende",
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-W29",
+              "type": "daterange",
+              "start": "2018-07-16",
+              "end": "2018-07-23"
+            }
+          ]
+        },
+        "Start": 21,
+        "Length": 33
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal na 2 weken vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2 weken",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-19",
+              "type": "date",
+              "value": "2018-07-19"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal na 2 dagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2 dagen",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-07",
+              "type": "date",
+              "value": "2018-07-07"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal na 2 maanden vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2 maanden",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-09-05",
+              "type": "date",
+              "value": "2018-09-05"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal na 2 jaar vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na 2 jaar",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2020-07-05",
+              "type": "date",
+              "value": "2020-07-05"
+            }
+          ]
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal over 2 dagen sedert vandaag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2018-07-05T00:00:00"
+    },
+    "NotSupported": "javascript",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 dagen sedert vandaag",
+        "Type": "datetimeV2.date",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018-07-07",
+              "type": "date",
+              "value": "2018-07-07"
+            }
+          ]
+        },
+        "Start": 12,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Hij zal na afloop van 2016 en voor 2018, of voor 2019 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2015-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "na afloop van 2016",
+        "Start": 8,
+        "Length": 18,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "after",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2018",
+        "Start": 29,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2018",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "before 2019",
+        "Start": 45,
+        "Length": 11,
+        "Type": "datetimeV2.daterange",
+        "Value": {
+          "values": [
+            {
+              "timex": "2019",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/Specs/DateTime/Dutch/SetParser.json
+++ b/Specs/DateTime/Dutch/SetParser.json
@@ -1,0 +1,1152 @@
+[
+  {
+    "Input": "Ik zal wekelijks vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2744475+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "wekelijks",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1W",
+          "FutureResolution": {
+            "set": "Set: P1W"
+          },
+          "PastResolution": {
+            "set": "Set: P1W"
+          }
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal tweewekelijks vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2754476+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tweewekelijks",
+        "Type": "set",
+        "Value": {
+          "Timex": "P2W",
+          "FutureResolution": {
+            "set": "Set: P2W"
+          },
+          "PastResolution": {
+            "set": "Set: P2W"
+          }
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal dagelijks vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2779449+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dagelijks",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1D",
+          "FutureResolution": {
+            "set": "Set: P1D"
+          },
+          "PastResolution": {
+            "set": "Set: P1D"
+          }
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2794445+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1D",
+          "FutureResolution": {
+            "set": "Set: P1D"
+          },
+          "PastResolution": {
+            "set": "Set: P1D"
+          }
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke maand vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2829445+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke maand",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1M",
+          "FutureResolution": {
+            "set": "Set: P1M"
+          },
+          "PastResolution": {
+            "set": "Set: P1M"
+          }
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal jaarlijks vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2844439+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "jaarlijks",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1Y",
+          "FutureResolution": {
+            "set": "Set: P1Y"
+          },
+          "PastResolution": {
+            "set": "Set: P1Y"
+          }
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke twee dagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2909444+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke twee dagen ",
+        "Type": "set",
+        "Value": {
+          "Timex": "P2D",
+          "FutureResolution": {
+            "set": "Set: P2D"
+          },
+          "PastResolution": {
+            "set": "Set: P2D"
+          }
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke 3 weken vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2959472+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke 3 weken",
+        "Type": "set",
+        "Value": {
+          "Timex": "P3W",
+          "FutureResolution": {
+            "set": "Set: P3W"
+          },
+          "PastResolution": {
+            "set": "Set: P3W"
+          }
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 15.00 elke dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2989494+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15.00 elke dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "T15",
+          "FutureResolution": {
+            "set": "Set: T15"
+          },
+          "PastResolution": {
+            "set": "Set: T15"
+          }
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 15.00 iedere dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3039501+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15.00 iedere dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "T15",
+          "FutureResolution": {
+            "set": "Set: T15"
+          },
+          "PastResolution": {
+            "set": "Set: T15"
+          }
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke 15/4 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3109498+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke 15/4",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-04-15",
+          "FutureResolution": {
+            "set": "Set: XXXX-04-15"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-04-15"
+          }
+        },
+        "Start": 7,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere maandag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3259514+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere maandag",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-1",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-1"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-1"
+          }
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke maandag 16.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3379507+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke maandag 16.00",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-1T16",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-1T16"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-1T16"
+          }
+        },
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere ochtend vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3429518+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere ochtend",
+        "Type": "set",
+        "Value": {
+          "Timex": "TMO",
+          "FutureResolution": {
+            "set": "Set: TMO"
+          },
+          "PastResolution": {
+            "set": "Set: TMO"
+          }
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere ochtend om 9.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3609535+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere ochtend om 9.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T09",
+          "FutureResolution": {
+            "set": "Set: T09"
+          },
+          "PastResolution": {
+            "set": "Set: T09"
+          }
+        },
+        "Start": 7,
+        "Length": 23
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere middag  om 16.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3730732+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere middag  om 16.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T16",
+          "FutureResolution": {
+            "set": "Set: T16"
+          },
+          "PastResolution": {
+            "set": "Set: T16"
+          }
+        },
+        "Start": 7,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere avond om 21.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3840706+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere avond om 21.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T21",
+          "FutureResolution": {
+            "set": "Set: T21"
+          },
+          "PastResolution": {
+            "set": "Set: T21"
+          }
+        },
+        "Start": 7,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere avond om 21.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3930718+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere avond om 21.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T21",
+          "FutureResolution": {
+            "set": "Set: T21"
+          },
+          "PastResolution": {
+            "set": "Set: T21"
+          }
+        },
+        "Start": 7,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal ochtenden om 9.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4065719+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "ochtenden om 9.00",
+        "Type": "set",
+        "Value": {
+          "Timex": "T09",
+          "FutureResolution": {
+            "set": "Set: T09"
+          },
+          "PastResolution": {
+            "set": "Set: T09"
+          }
+        },
+        "Start": 7,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal op ochtenden om 9.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4170727+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op ochtenden om 9.00",
+        "Type": "set",
+        "Value": {
+          "Timex": "T09",
+          "FutureResolution": {
+            "set": "Set: T09"
+          },
+          "PastResolution": {
+            "set": "Set: T09"
+          }
+        },
+        "Start": 7,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal om 9.00 iedere zondag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4295727+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": " 9.00 iedere zondag ",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7T09",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          }
+        },
+        "Start": 9,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal om 9.00 op zondagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.438575+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "9.00 op zondagen ",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7T09",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          }
+        },
+        "Start": 10,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal zondagen 9.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4505726+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "zondagen 9.00",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7T09",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          }
+        },
+        "Start": 7,
+        "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal op maandagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4570731+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op maandagen",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-1",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-1"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-1"
+          }
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal op zondagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4635727+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op zondagen",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7"
+          }
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal zondagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4710739+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "zondagen",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7"
+          }
+        },
+        "Start": 7,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga eenmaal per jaar op vakantie",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eenmaal per jaar",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1Y",
+          "FutureResolution": {
+            "set": "Set: P1Y"
+          },
+          "PastResolution": {
+            "set": "Set: P1Y"
+          }
+        },
+        "Start": 6,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Laten we eenmaal per week afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "eenmaal per week",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1W",
+          "FutureResolution": {
+            "set": "Set: P1W"
+          },
+          "PastResolution": {
+            "set": "Set: P1W"
+          }
+        },
+        "Start": 9,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Laten we vrijdag om de week afspreken",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag om de week",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-5",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-5"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-5"
+          }
+        },
+        "Start": 9,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Laten we een driemaandelijkse meeting instellen",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "driemaandelijkse",
+        "Type": "set",
+        "Value": {
+          "Timex": "P3M",
+          "FutureResolution": {
+            "set": "Set: P3M"
+          },
+          "PastResolution": {
+            "set": "Set: P3M"
+          }
+        },
+        "Start": 13,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2794445+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1D",
+          "FutureResolution": {
+            "set": "Set: P1D"
+          },
+          "PastResolution": {
+            "set": "Set: P1D"
+          }
+        },
+        "Start": 7,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere maand vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2829445+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere maand",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1M",
+          "FutureResolution": {
+            "set": "Set: P1M"
+          },
+          "PastResolution": {
+            "set": "Set: P1M"
+          }
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere twee dagen vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2909444+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere twee dagen ",
+        "Type": "set",
+        "Value": {
+          "Timex": "P2D",
+          "FutureResolution": {
+            "set": "Set: P2D"
+          },
+          "PastResolution": {
+            "set": "Set: P2D"
+          }
+        },
+        "Start": 7,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 15.00 iedere dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.2989494+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15.00 iedere dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "T15",
+          "FutureResolution": {
+            "set": "Set: T15"
+          },
+          "PastResolution": {
+            "set": "Set: T15"
+          }
+        },
+        "Start": 7,
+        "Length": 16
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal 15.00 elke dag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3039501+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15.00 elke dag",
+        "Type": "set",
+        "Value": {
+          "Timex": "T15",
+          "FutureResolution": {
+            "set": "Set: T15"
+          },
+          "PastResolution": {
+            "set": "Set: T15"
+          }
+        },
+        "Start": 7,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere 15/4 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3109498+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere 15/4",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-04-15",
+          "FutureResolution": {
+            "set": "Set: XXXX-04-15"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-04-15"
+          }
+        },
+        "Start": 7,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke maandag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3259514+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke maandag",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-1",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-1"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-1"
+          }
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal iedere maandag 16.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3379507+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "iedere maandag 16.00",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-1T16",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-1T16"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-1T16"
+          }
+        },
+        "Start": 7,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke ochtend vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3429518+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke ochtend",
+        "Type": "set",
+        "Value": {
+          "Timex": "TMO",
+          "FutureResolution": {
+            "set": "Set: TMO"
+          },
+          "PastResolution": {
+            "set": "Set: TMO"
+          }
+        },
+        "Start": 7,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke ochtend om 9.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3609535+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke ochtend om 9.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T09",
+          "FutureResolution": {
+            "set": "Set: T09"
+          },
+          "PastResolution": {
+            "set": "Set: T09"
+          }
+        },
+        "Start": 7,
+        "Length": 21
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke middag  om 16.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3730732+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke middag  om 16.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T16",
+          "FutureResolution": {
+            "set": "Set: T16"
+          },
+          "PastResolution": {
+            "set": "Set: T16"
+          }
+        },
+        "Start": 7,
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke avond om 21.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3840706+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke avond om 21.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T21",
+          "FutureResolution": {
+            "set": "Set: T21"
+          },
+          "PastResolution": {
+            "set": "Set: T21"
+          }
+        },
+        "Start": 7,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke avond om 21.00 vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.3930718+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke avond om 21.00 ",
+        "Type": "set",
+        "Value": {
+          "Timex": "T21",
+          "FutureResolution": {
+            "set": "Set: T21"
+          },
+          "PastResolution": {
+            "set": "Set: T21"
+          }
+        },
+        "Start": 7,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal om 9.00 elke zondag vertrekken",
+    "Context": {
+      "ReferenceDateTime": "2017-09-27T12:25:54.4295727+03:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": " 9.00 elke zondag ",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-7T09",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-7T09"
+          }
+        },
+        "Start": 9,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Laten we vrijdag om de andere week afspreken",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag om de andere week",
+        "Type": "set",
+        "Value": {
+          "Timex": "XXXX-WXX-5",
+          "FutureResolution": {
+            "set": "Set: XXXX-WXX-5"
+          },
+          "PastResolution": {
+            "set": "Set: XXXX-WXX-5"
+          }
+        },
+        "Start": 9,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "Laten we een kwartaal meeting instellen",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": " kwartaal",
+        "Type": "set",
+        "Value": {
+          "Timex": "P3M",
+          "FutureResolution": {
+            "set": "Set: P3M"
+          },
+          "PastResolution": {
+            "set": "Set: P3M"
+          }
+        },
+        "Start": 12,
+        "Length": 9
+      }
+    ]
+  }
+]


### PR DESCRIPTION
All test cases pass.

Two cases were updated because the original translation did not make sense:
- "Ik ben op weekend weg" -> "Ik ben dit weekend weg" (I'll be out on weekend)
- "In de jaren negentien zeventien" -> "In de jaren negentien zeventig" (In the nineteen seventies)
(but if @iMicknl thinks they should be kept, they can be reintroduced)

Hard coded strings ("today" and "now") in BaseDatePeriodParser have been moved to regex in yaml files, because they were needed in Dutch.

in DateTimeModel: 159 pass, 192 fail.

Added missing specs for MergedParser and SetParser