### PR TITLE
[EN Number] Fix wrong fraction extraction (#840)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)";
-      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|in|out\s+of)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
+      public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";
       public static readonly string AllFloatRegex = $@"{AllIntRegex}(\s+point){AllPointRegex}";

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Recognizers.Text.Number.English
 
             RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
+            NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(config));
+
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Cardinal
@@ -74,6 +76,8 @@ namespace Microsoft.Recognizers.Text.Number.English
 
             AmbiguityFiltersDict = ambiguityBuilder.ToImmutable();
         }
+
+        public override BaseNumberParser NumberParser { get; }
 
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -95,7 +95,7 @@ FractionNounWithArticleRegex: !nestedRegex
   def: (?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]
 FractionPrepositionRegex: !nestedRegex
-  def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|in|out\s+of)\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)
+  def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)
   references: [ AllIntRegex, BaseNumbers.CommonCurrencySymbol ]
 FractionPrepositionWithinPercentModeRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2734,5 +2734,109 @@
         "End": 15
       }
     ]
+  },
+  {
+    "Input": "The result is 8 in 5",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "8",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "8"
+        },
+        "Start": 14,
+        "End": 14
+      },
+      {
+        "Text": "5",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "5"
+        },
+        "Start": 19,
+        "End": 19
+      }
+    ]
+  },
+  {
+    "Input": "there are 12 out of 10",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "12"
+        },
+        "Start": 10,
+        "End": 11
+      },
+      {
+        "Text": "10",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "10"
+        },
+        "Start": 20,
+        "End": 21
+      }
+    ]
+  },
+  {
+    "Input": "I see five out of three pieces",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "five",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "5"
+        },
+        "Start": 6,
+        "End": 9
+      },
+      {
+        "Text": "three",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "3"
+        },
+        "Start": 18,
+        "End": 22
+      }
+    ]
+  },
+  {
+    "Input": "I count 12 in six boxes",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "12"
+        },
+        "Start": 8,
+        "End": 9
+      },
+      {
+        "Text": "six",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "6"
+        },
+        "Start": 14,
+        "End": 16
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/NumberRangeModel.json
+++ b/Specs/Number/English/NumberRangeModel.json
@@ -1009,12 +1009,12 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "equals to 20000 in 1998",
+        "Text": "equals to 20000",
         "Start": 14,
-        "End": 36,
+        "End": 28,
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "[10.01001001001,10.01001001001]"
+          "value": "[20000,20000]"
         }
       }
     ]
@@ -1029,12 +1029,12 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "from 200 to 3000000 in 2008",
+        "Text": "from 200 to 3000000",
         "Start": 14,
-        "End": 40,
+        "End": 32,
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "[200,1494.02390438247)"
+          "value": "[200,3000000)"
         }
       }
     ]


### PR DESCRIPTION
Fix to issue #840 

Added relevant test cases to NumberModel.

2 test cases needed to be updated in NumberRangeModel:
- "The number is equals to 20000 in 1998"
- "The number is from 200 to 3000000 in 2008"