### PR TITLE
[CN Currency] Fix incorrect number extraction cases (#568)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -79,6 +79,27 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             {
                 var numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
 
+                // Checking if there are conflicting interpretations between currency unit as prefix and suffix for each number.
+                // For example, in Chinese, "$20，300美圆" should be broken into two entities instead of treating 20,300 as one number: "$20" and "300美圆".
+                if (numbers.Count() > 0 && CheckExtractorType(Constants.SYS_UNIT_CURRENCY) && prefixMatches.Count() > 0 && suffixMatches.Count() > 0)
+                {
+
+                    foreach (var number in numbers)
+                    {
+                        int start = (int)number.Start, length = (int)number.Length;
+                        var numberPrefix = prefixMatches.Any(o => o.Start + o.Length == number.Start);
+                        var numberSuffix = suffixMatches.Any(o => o.Start == number.Start + number.Length);
+
+                        if (numberPrefix != false && numberSuffix != false && number.Text.Contains(","))
+                        {
+                            int commaIndex = (int)number.Start + number.Text.IndexOf(",");
+                            source = source.Substring(0, commaIndex) + " " + source.Substring(commaIndex + 1);
+                        }
+                    }
+
+                    numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
+                }
+
                 // Special case for cases where number multipliers clash with unit
                 var ambiguousMultiplierRegex = this.config.AmbiguousUnitNumberMultiplierRegex;
                 if (ambiguousMultiplierRegex != null)

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Models/AbstractNumberWithUnitModel.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
                         foreach (var extractionResult in extractionResults)
                         {
-                            if (extractionResult.Start == result.Start && extractionResult.End == result.End)
+                            if (result.Start <= extractionResult.Start && result.End >= extractionResult.End)
                             {
                                 shouldAdd = false;
                             }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/extractors/NumberWithUnitExtractor.java
@@ -2,6 +2,7 @@ package com.microsoft.recognizers.text.numberwithunit.extractors;
 
 import com.microsoft.recognizers.text.ExtractResult;
 import com.microsoft.recognizers.text.IExtractor;
+import com.microsoft.recognizers.text.numberwithunit.Constants;
 import com.microsoft.recognizers.text.numberwithunit.models.PrefixUnitResult;
 import com.microsoft.recognizers.text.numberwithunit.resources.BaseUnits;
 import com.microsoft.recognizers.text.numberwithunit.utilities.StringComparer;
@@ -81,6 +82,51 @@ public class NumberWithUnitExtractor implements IExtractor {
         Arrays.fill(matched, false);
         List<ExtractResult> numbers = this.config.getUnitNumExtractor().extract(source);
         int sourceLen = source.length();
+
+        List<Matcher> prefixMatch = new ArrayList<Matcher>();
+        List<Matcher> suffixMatch = new ArrayList<Matcher>();
+
+        for (Pattern regex : prefixRegexes) {
+            Matcher match = regex.matcher(source);
+            if (match.find()) {
+                prefixMatch.add(match);
+            }
+        }
+
+        for (Pattern regex : suffixRegexes) {
+            Matcher match = regex.matcher(source);
+            if (match.find()) {
+                suffixMatch.add(match);
+            }
+        }
+
+        if (numbers.size() > 0  && this.config.getExtractType() == Constants.SYS_UNIT_CURRENCY && prefixMatch.size() > 0 && suffixMatch.size() > 0) {
+
+            for (ExtractResult number : numbers) {
+                int start = number.getStart();
+                int length = number.getLength();
+                Boolean numberPrefix = false;
+                Boolean numberSuffix = false;
+
+                for (Matcher match : prefixMatch) {
+                    if (match.end() == start) {
+                        numberPrefix = true;
+                    }
+                }
+
+                for (Matcher match : suffixMatch) {
+                    if (start + length == match.start()) {
+                        numberSuffix = true;
+                    }
+                }
+
+                if (numberPrefix && numberSuffix && number.getText().contains(",")) {
+                    int commaIndex = start + number.getText().indexOf(",");
+                    source = source.substring(0, commaIndex) + " " + source.substring(commaIndex + 1);
+                }
+            }
+            numbers = this.config.getUnitNumExtractor().extract(source);
+        }
 
         /* Special case for cases where number multipliers clash with unit */
         Pattern ambiguousMultiplierRegex = this.config.getAmbiguousUnitNumberMultiplierRegex();

--- a/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
+++ b/JavaScript/packages/recognizers-number-with-unit/src/numberWithUnit/extractors.ts
@@ -73,6 +73,43 @@ export class NumberWithUnitExtractor implements IExtractor {
         let result = new Array<ExtractResult>();
         let sourceLen = source.length;
 
+        if (numbers.length > 0 && this.config.extractType == Constants.SYS_UNIT_CURRENCY) {
+            numbers.forEach(extNumber => {
+                let start = extNumber.start;
+                let length = extNumber.length;
+                let numberPrefix = false;
+                let numberSuffix = false;
+                this.prefixRegexes.forEach(regex => {
+                    let collection = RegExpUtility.getMatches(regex, source).filter(m => m.length);
+                    if (collection.length === 0) {
+                        return;
+                    }
+                    collection.forEach(match => {
+                        if (match.index + match.length == start) {
+                            numberPrefix = true;
+                        }
+                    });
+                });
+                this.suffixRegexes.forEach(regex => {
+                    let collection = RegExpUtility.getMatches(regex, source).filter(m => m.length);
+                    if (collection.length === 0) {
+                        return;
+                    }
+                    collection.forEach(match => {
+                        if (start + length == match.index) {
+                            numberSuffix = true;
+                        }
+                    });
+                });
+                if (numberPrefix && numberSuffix && extNumber.text.indexOf(",") != -1) {
+                    let commaIndex = start + extNumber.text.indexOf(",");
+                    source = source.substring(0, commaIndex) + " " + source.substring(commaIndex + 1)
+                }
+
+            })
+            numbers = this.config.unitNumExtractor.extract(source);
+        }
+
         /* Special case for cases where number multipliers clash with unit */
         let ambiguousMultiplierRegex = this.config.ambiguousUnitNumberMultiplierRegex;
         if (ambiguousMultiplierRegex !== null) {

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
@@ -173,6 +173,19 @@ class NumberWithUnitExtractor(Extractor):
 
             numbers: List[ExtractResult] = sorted(self.config.unit_num_extractor.extract(source), key=lambda o: o.start)
 
+            if len(numbers) > 0 and self.config.extract_type is Constants.SYS_UNIT_CURRENCY and len(prefix_match) > 0 and len(suffix_match) > 0:
+
+                for number in numbers:
+                    start = number.start
+                    length = number.length
+                    number_prefix = [(mr.start + mr.length) == start for mr in prefix_match]
+                    number_suffix = [mr.start == (start + length) for mr in suffix_match]
+                    if True in number_prefix and True in number_suffix and "," in number.text:
+                        comma_index = number.start + number.text.index(",")
+                        source = source[:comma_index] + " " + source[comma_index + 1:]
+
+                numbers: List[ExtractResult] = sorted(self.config.unit_num_extractor.extract(source), key=lambda o: o.start)
+
             # Special case for cases where number multipliers clash with unit
             ambiguous_multiplier_regex = self.config.ambiguous_unit_number_multiplier_regex
             if ambiguous_multiplier_regex is not None:

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/models.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/models.py
@@ -50,8 +50,7 @@ class AbstractNumberWithUnitModel(Model):
                     model_result.resolution = self.get_resolution(
                         parse_result.value)
 
-                    b_add = not [x for x in extraction_results if x.start ==
-                                 model_result.start and x.end == model_result.end]
+                    b_add = not [x for x in extraction_results if (model_result.start <= x.start and model_result.end >= x.end)]
 
                     if b_add:
                         extraction_results.append(model_result)

--- a/Specs/NumberWithUnit/Chinese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Chinese/CurrencyModel.json
@@ -518,5 +518,42 @@
     "Input": "标准普尔指数下降",
     "NotSupported": "javascript, java, python",
     "Results": []
+  },
+  {
+    "Input": "在下面的价格中选一个，$20，300美圆, ￥300, ok?",
+    "Results": [
+      {
+        "Text": "$20",
+        "Start": 11,
+        "End": 13,
+        "TypeName": "currency",
+        "Resolution": {
+          "unit": "Dollar",
+          "value": "20"
+        }
+      },
+      {
+        "Text": "300美圆",
+        "Start": 15,
+        "End": 19,
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "unit": "United States dollar",
+          "value": "300"
+        }
+      },
+      {
+        "Text": "￥300",
+        "Start": 22,
+        "End": 25,
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "CNY",
+          "unit": "Chinese yuan",
+          "value": "300"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix the issue #568
Add codes for detecting conflicts to extract function of NumberWithUnitExtractor for all platforms
Add codes for solving conflicts when merging results to AbstractNumberWithUnitModel for .NET and Python
To improve the performance, add a length check for PrefixMatch and SuffixMatch in the if statement so that it will only check the cases that have prefix and suffix at the same time.  
Add test case to Specs