### PR TITLE
[.NET] Dutch DateTime DateTimePeriod

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -23,21 +23,23 @@ namespace Microsoft.Recognizers.Definitions.Dutch
     {
       public const string LangMarker = @"Dut";
       public const bool CheckBothBeforeAfter = false;
-      public static readonly string TillRegex = $@"(?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string TillRegex = $@"(?<till>\b(tot(dat)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";
-      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de|het)\b";
+      public const string ApostrofRegex = @"(’|‘|'|ʼ)";
+      public static readonly string ApostrofsRegex = $@"({ApostrofRegex}\s*s)";
+      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b";
       public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
-      public const string UpcomingPrefixRegex = @"((aankomende?|komende?|aanstaande))";
-      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b";
-      public const string AfterNextSuffixRegex = @"\b(na\s+((de|het)\s+)?volgende?)\b";
+      public const string UpcomingPrefixRegex = @"((aankomende?|komende?|aanstaande?))";
+      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|aanstaande?|over|{UpcomingPrefixRegex})\b";
+      public const string AfterNextSuffixRegex = @"\b((na\s+((de|het)\s+)?volgende?)|over)\b";
       public const string PastPrefixRegex = @"((deze\s+)?verleden)\b";
-      public static readonly string PreviousPrefixRegex = $@"(voorgaand[e]|vorige?|afgelopen|verleden|laatste|{PastPrefixRegex})\b";
+      public static readonly string PreviousPrefixRegex = $@"(voorgaand[e]|vorige?|afgelopen|verleden|laatste|terug|{PastPrefixRegex})\b";
       public const string ThisPrefixRegex = @"(dit|deze|huidige?)\b";
-      public const string RangePrefixRegex = @"(van|tussen)";
+      public const string RangePrefixRegex = @"(?<desc>van|tussen)";
       public const string CenturySuffixRegex = @"(^eeuw|^centennium)\b";
       public const string ReferencePrefixRegex = @"(dezelfde|hetzelfde|dat(zelfde)?|die|overeenkomstige)\b";
-      public const string FutureSuffixRegex = @"\b(in\s+de\s+)?(toekomst|vanaf(\s+nu)?)\b";
+      public const string FutureSuffixRegex = @"\b(((in\s+de\s+)?toekomst)|vanaf(\s+nu)?|over|na)\b";
       public const string DayRegex = @"(de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)";
       public static readonly string WrittenDayRegex = $@"(?<day>({WrittenOneToNineRegex})|({WrittenElevenToNineteenRegex})|(({WrittenOneToNineRegex}(en|ën))?twintig)|(((één|een)(en|ën))?dertig))";
       public static readonly string WrittenCardinalDayRegex = $@"(?<=((de\s+)|\b))(?<day>(éérste|eerste|tweede|derde|vierde|vijfde|zesde|zevende|achtste|negende|tiende|{WrittenElevenToNineteenRegex}de|({WrittenOneToNineRegex}(en|ën))?twintigste|((één|een)(en|ën))?dertigste))";
@@ -49,7 +51,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string WrittenNumRegex = $@"({WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
       public static readonly string WrittenCenturyFullYearRegex = $@"((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)";
       public const string WrittenCenturyOrdinalYearRegex = @"((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)";
-      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)";
+      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b";
       public static readonly string LastTwoYearNumRegex = $@"((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})(\s+)?(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
       public const string OclockRegex = @"(?<oclock>uur)";
@@ -60,7 +62,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string DescRegex = $@"((({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
       public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
-      public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
+      public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
       public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b)))";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
@@ -82,8 +84,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b(((((de|het)\s+)?maand(\s+van)?\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
+      public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
+      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b";
       public static readonly string WeekOfYearRegex = $@"(\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)";
@@ -91,17 +93,17 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
       public const string QuarterTermRegex = @"\b(((?<cardinal>eerste|1e|1ste|tweede|2e|2de|derde|3e|3de|vierde|4e|4de)[ -]+kwartaal)|(k(?<number>[1-4])))\b";
       public static readonly string QuarterRegex = $@"(het\s+)?{QuarterTermRegex}((\s+van|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+jaar))?";
-      public static readonly string QuarterRegexYearFront = $@"({YearRegex}|({RelativeRegex}\s+jaar))('s)?\s+((het|de)\s+)?{QuarterTermRegex}";
+      public static readonly string QuarterRegexYearFront = $@"({YearRegex}|({RelativeRegex}\s+jaar))({ApostrofsRegex})?\s+((het|de)\s+)?{QuarterTermRegex}";
       public const string HalfYearTermRegex = @"(?<cardinal>eerste|1e|1ste|tweede|2e|2de)\s+(helft)";
       public static readonly string HalfYearFrontRegex = $@"(?<year>(de\s+){HalfYearTermRegex}(\s+helft van\s+)((1[5-9]|2[0-1]])\d{{2}}))";
       public static readonly string HalfYearBackRegex = $@"(het\s+)?(H(?<number>[1-2])|({HalfYearTermRegex}))(\s+van|\s*,\s*)?\s+({YearRegex})";
       public static readonly string HalfYearRelativeRegex = $@"(het\s+)?{HalfYearTermRegex}(\s+van|\s*,\s*)?\s+({RelativeRegex}\s+jaar)";
       public static readonly string AllHalfYearRegex = $@"({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})";
-      public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b";
-      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)";
-      public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b";
+      public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)(\s+(in|op|van)(\s+de)?)?)\b";
+      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)\b";
+      public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
-      public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|(?<LatePrefix>laat|later|aan\s+het\s+einde))(\s+(op|van))?(\s+de\s+dag)?\b";
+      public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later|aan\s+het\s+einde?(\s+van(\s+de)?)?))(\s+(in|op|van))?(\s+de\s+dag)?\b";
       public const string SeasonDescRegex = @"(?<seas>lente|voorjaar|zomer|herfst|najaar|winter)";
       public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}(\s+)?)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b";
       public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
@@ -123,7 +125,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(vanaf\s+nu|later))\b";
       public static readonly string SpecialDate = $@"(?=\b(op\s+)(de\s+)?){DayRegex}\b";
-      public const string DatePreposition = @"\b(op)";
+      public const string DatePreposition = @"\b(op(\s+de)?)";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*,\s*){DateYearRegex}";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";
       public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*)?(de\s+)?)?({DayRegex}(\s*dag|\.)?)((\s+|\s*[,-]\s*|\s+van\s+)?{MonthRegex})((\.)?(\s+|\s*,\s*|\s+in\s+)?{DateYearRegex})?\b";
@@ -144,25 +146,28 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
       public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
-      public const string PmRegex = @"(?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
-      public const string PmRegexFull = @"(?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
-      public const string AmRegex = @"(?<am>(((’|‘|'|ʼ)\s*s|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))";
+      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))";
+      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
+      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))";
       public const string LunchRegex = @"\b(lunchtijd)\b";
-      public const string NightRegex = @"\b((((’|‘|')\s*s|des)\s+)?nachts|(midder)?nacht)\b";
+      public static readonly string NightRegex = $@"\b((({ApostrofsRegex}|des)\s+)?nachts|(midder)?nacht)\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
       public static readonly string LessThanOneHour = $@"(?<lth>((een\s+)?((drie\s+)?kwart(ier)?|half(uur)?))|{BaseDateTime.DeltaMinuteRegex}(\s+(minuten|mins|min\.?))?|({DeltaMinuteNumRegex}(\s+(minuten|mins|min\.?))?))";
       public static readonly string WrittenTimeRegex = $@"(?<writtentime>({HourNumRegex}\s+{MinuteNumRegex}|(?<prefix>half)\s+({HourNumRegex})(\s+uur)?))";
       public static readonly string TimePrefix = $@"(?<prefix>(half|{LessThanOneHour}\s+(over|voor|na)(\s+half)?)|(uur\s+{LessThanOneHour}))";
       public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";
       public static readonly string TimeSuffixFull = $@"(?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})";
-      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex}(?![%\d]))";
-      public const string MidnightRegex = @"(?<midnight>mid\s*(-\s*)?nacht|middernacht|in de nacht|('s|des) nachts)";
-      public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?morgen|halverwege de ochtend|het midden van de ochtend)";
+      public static readonly string HourDTRegEx = $@"({BaseDateTime.HourRegex})";
+      public static readonly string MinuteDTRegEx = $@"({BaseDateTime.MinuteRegex})";
+      public static readonly string SecondDTRegEx = $@"({BaseDateTime.SecondRegex})";
+      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx})";
+      public static readonly string MidnightRegex = $@"(?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)";
+      public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?(morgen|ochtend)|halverwege de ochtend|het midden van de ochtend)";
       public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)";
-      public const string MiddayRegex = @"(?<midday>(((rond\s+)?(het|de)|(’|‘|')\s*s)\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)";
+      public static readonly string MiddayRegex = $@"(?<midday>(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)";
       public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
       public static readonly string AtRegex = $@"(((?<=\bom\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
-      public static readonly string IshRegex = $@"\b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b";
+      public static readonly string IshRegex = $@"\b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*{ApostrofRegex}\s*)?en|middagloos)\b";
       public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|u(ur)?|minuten|minuut|mins?|seconde[ns]?|secs?)\b)))";
       public const string RestrictedTimeUnitRegex = @"(?<unit>uur|minuut)\b";
       public const string FivesRegex = @"(?<tens>(vijf|tien|vijftien|twintig|vijfentwintig|vijventwintig|dertig|vijfendertig|veertig|vijfenveertig|vijftig|vijfenvijftig))\b";
@@ -181,15 +186,21 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s+{FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?";
       public static readonly string TimeRegex11 = $@"\b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%)))";
+      public static readonly string TimeRegex12 = $@"({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))";
       public static readonly string FirstTimeRegexInTimeRange = $@"\b{TimeRegexWithDotConnector}(\s*{DescRegex})?";
-      public static readonly string PureNumFromTo = $@"({RangePrefixRegex}\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
-      public static readonly string PureNumBetweenAnd = $@"(tussen\s+)({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?\s*{RangeConnectorRegex}\s*({HourRegex}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
-      public static readonly string SpecificTimeFromTo = $@"({RangePrefixRegex}\s+)?(?<time1>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{TillRegex}\s*(?<time2>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))";
-      public static readonly string SpecificTimeBetweenAnd = $@"(tussen\s+)(?<time1>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))";
-      public const string PrepositionRegex = @"(?<prep>^(om|rond|tegen|op)(\s+de)?$)";
-      public const string LaterEarlyRegex = @"((?<early>vroege?(\s+|-))|(?<late>(laat|late)(\s+|-)))";
-      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b";
-      public static readonly string SpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?\b";
+      public static readonly string PureNumFromToPrefixExcluded = $@"({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
+      public static readonly string PureNumFromToPrefix = $@"({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
+      public static readonly string PureNumFromToWithDateBefore = $@"({RangePrefixRegex}\s+)({HourDTRegEx})(\s+(vandaag|morgen)\s+)?(\s*{RangeConnectorRegex}\s*)({HourDTRegEx})";
+      public static readonly string PureNumFromToWithDateAfter = $@"({RangePrefixRegex}\s+)({HourDTRegEx})(\s*{RangeConnectorRegex}\s*)({HourDTRegEx}(\s+(vandaag|morgen))?)";
+      public static readonly string PureNumFromTo = $@"({PureNumFromToPrefix}|{PureNumFromToPrefixExcluded})";
+      public static readonly string TimeDateFromTo = $@"({PureNumFromToWithDateAfter}|{PureNumFromToWithDateBefore})";
+      public static readonly string PureNumBetweenAnd = $@"(tussen\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
+      public static readonly string SpecificTimeFromTo = $@"({RangePrefixRegex}\s+)?(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{TillRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))";
+      public static readonly string SpecificTimeBetweenAnd = $@"(tussen\s+)(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?(\s+{TimeSuffix})?))";
+      public const string PrepositionRegex = @"(?<prep>^(om|rond|tegen|op|van|deze)(\s+de)?$)";
+      public const string EarlyLateRegex = @"(((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)";
+      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b";
+      public static readonly string SpecificTimeOfDayRegex = $@"\b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|avond|nacht)))s?\b";
       public static readonly string TimeFollowedUnit = $@"^\s*{TimeUnitRegex}";
       public static readonly string TimeNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){TimeUnitRegex}";
       public static readonly string[] BusinessHourSplitStrings = { @"werk", @"uren" };
@@ -198,16 +209,16 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string SuffixRegex = @"^\s*(in de\s+)?(vroege\s+|late\s+)?(ochtend|(na)?middag|avond|nacht)\b";
       public const string DateTimeTimeOfDayRegex = @"\b(?<timeOfDay>morgen|ochtend|(na)?middag|avond|nacht)\b";
       public static readonly string DateTimeSpecificTimeOfDayRegex = $@"\b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend|morgen))\b";
-      public static readonly string TimeOfTodayAfterRegex = $@"^\s*(,\s*)?(in\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
-      public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*$";
-      public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?(in\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
-      public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b";
-      public const string SpecificEndOfRegex = @"(((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
+      public static readonly string TimeOfTodayAfterRegex = $@"^\s*(,\s*)?((in\s+de)|(op\s+de))?{DateTimeSpecificTimeOfDayRegex}";
+      public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$";
+      public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
+      public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b";
+      public const string SpecificEndOfRegex = @"((aan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
       public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b";
       public const string UnspecificEndOfRangeRegex = @"\b(evj)\b";
-      public const string PeriodTimeOfDayRegex = @"\b((in\s+(de)?\s+)?((?<early>vroege(\s+|-))|(?<late>late(\s+|-)))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b";
-      public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend))\b";
-      public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b";
+      public static readonly string PeriodTimeOfDayRegex = $@"\b((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b";
+      public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b";
+      public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b";
       public const string LessThanRegex = @"\b((binnen\s+)?minder\s+dan)\b";
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
@@ -216,10 +227,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string EachUnitRegex = $@"(?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(iedere|elke)\s*$)";
       public const string SetEachRegex = @"\b(?<each>(iedere|elke)\s*)";
-      public const string SetLastRegex = @"(?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorig|verleden|vorige|laatste)";
+      public const string SetLastRegex = @"(?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorige?|verleden|laatste)";
       public const string EachDayRegex = @"^\s*(elke)\s*dag\b";
       public static readonly string DurationFollowedUnit = $@"^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
-      public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}";
+      public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}";
       public static readonly string AnUnitRegex = $@"\b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}";
       public const string DuringRegex = @"\b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b";
       public const string AllRegex = @"\b(?<all>((de|het|een)(\s+))?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
@@ -228,41 +239,41 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HolidayRegex1 = $@"\b(?<holiday>(goede\s+vrijdag|pasen|kerst|kerstavond|kerstmis|thanksgiving|halloween|nieuwjaar|bevrijdingsdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b";
       public static readonly string HolidayRegex2 = $@"\b(?<holiday>(nationale dodenherdenking|nationale herdenking|dodenherdenking|dag van de leraar|dag van de arbeid|martin luther kingdag|mlkdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b";
       public static readonly string HolidayRegex3 = $@"\b(?<holiday>(yuandan|valentijnsdag|valentijn|oude?jaarsavond|nieuwjaarsdag|eerste paasdag|tweede paasdag|prinsjesdag|koningsdag|koninginnedag|bevrijdingsdag|hemelvaartsdag|eerste kerstdag|1e kerstdag|tweede kerstdag|2e kerstdag|vaderdag|moederdag|meisjesdag|amerikaanse onafhankelijkheidsdag|onafhankelijkheidsdag|nederlandse veteranendag|veteranendag|boomplantdag|boomfeestdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b";
-      public const string AMTimeRegex = @"(?<am>('s morgens|'s ochtends)|in\s+de\s+(morgen|ochtend))";
-      public const string PMTimeRegex = @"(?<pm>('s middags|'s avonds|'s nachts)|(in\s+de\s+)?(middag|avond|nacht))\b";
+      public static readonly string AMTimeRegex = $@"(?<am>{ApostrofsRegex}\s*(morgens|ochtends)|in\s+de\s+(morgen|ochtend))";
+      public static readonly string PMTimeRegex = $@"(?<pm>{ApostrofsRegex}\s*(middags|avonds|nachts)|(in\s+de\s+)?(deze\s+)?((na)?middag|avond|nacht))\b";
       public const string InclusiveModPrepositions = @"(?<include>((in|tegen|tijdens|op)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))";
       public static readonly string BeforeRegex = $@"(\b{InclusiveModPrepositions}?(voor|vóór|vooraf(gaan)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+op\s+|tegen|tot(dat)?|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
       public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";
       public const string SinceRegex = @"(\b(sinds|na\s+of\s+gelijk\s+aan|startend\s+(vanaf|op|met)|zo\s+vroeg\s+als|ieder\s+moment\s+vanaf)\b\s*)|(?<!\w|<)(>=)";
       public const string AroundRegex = @"(\b(rond(om)?|ongeveer(\s+om)?)\s*\b)";
       public const string AgoRegex = @"\b(geleden|voor\s+(?<day>gisteren|vandaag))\b";
-      public const string LaterRegex = @"\b(later|vanaf nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b";
-      public const string InConnectorRegex = @"\b(in|over)\b";
+      public const string LaterRegex = @"\b(later|vanaf\s+nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b";
+      public const string InConnectorRegex = @"\b(in|over)(\s+de)?\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b((binnen)(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b";
       public const string TodayNowRegex = @"\b(vandaag|nu)\b";
-      public static readonly string MorningStartEndRegex = $@"(^(('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex}))|((('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex})$)";
-      public static readonly string AfternoonStartEndRegex = $@"(^(('s|des)\s+middags|in de (na)?middag|{PmDescRegex}))|((('s|des)\s+middags|in de (na)?middag|{PmDescRegex})$)";
-      public const string EveningStartEndRegex = @"(^(avond|('s|des)?\s+avonds))|((avond|('s|des)?\s+avonds)$)";
-      public const string NightStartEndRegex = @"(^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)";
+      public static readonly string MorningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+(morgens|ochtends)|in\s+de\s+(na)?(morgen|ochtend)|deze\s+(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+(morgen|ochtend)|{AmDescRegex}|(morgen|ochtend)))|((({ApostrofsRegex}|des)\s+(morgens|ochtends)|deze\s+(morgen|ochtend)|in\s+de\s+(na)?(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|(morgen|ochtend)\s+aan\s+het\s+einde?|{AmDescRegex}|(morgen|ochtend))$)";
+      public static readonly string AfternoonStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+middags|in\s+de\s+(na)?middag|deze\s+middag|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+middag|{PmDescRegex}))|((({ApostrofsRegex}|des)?\s+middags|in\s+de\s+(na)?middag|deze\s+middag|middag\s+in\s+het\s+begin|middag\s+aan\s+het\s+einde?|{PmDescRegex}|middag)$)";
+      public static readonly string EveningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{{PmDescRegex}}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{{PmDescRegex}}|avond)$)";
+      public static readonly string NightStartEndRegex = $@"(^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)";
       public const string InexactNumberRegex = @"\b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+({DurationUnitRegex})";
       public static readonly string RelativeTimeUnitRegex = $@"((({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({TimeUnitRegex}))|((de|het|mijn))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string RelativeDurationUnitRegex = $@"(((?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+(?<duration>week|maand|jaar|decennium|weekend)\b";
       public const string ConnectorRegex = @"^(-|,|voor|t|rond(om)?|@)$";
-      public const string FromRegex = @"\b(van)$";
-      public const string FromToRegex = @"\b(van).+(tot)\b.+";
+      public const string FromRegex = @"\b(vanaf|van)$";
+      public const string FromToRegex = @"\b(van(af)?).+(tot)\b.+";
       public const string SingleAmbiguousMonthRegex = @"^(de\s+)?(mei)$";
       public const string SingleAmbiguousTermsRegex = @"^(de\s+)?(dag|week|maand|jaar)$";
       public const string UnspecificDatePeriodRegex = @"^(week|weekend|maand|jaar)$";
-      public const string PrepositionSuffixRegex = @"\b(op|in|om|rond(om)?|van|tot)$";
+      public const string PrepositionSuffixRegex = @"\b((op|in)(\s+de)?|om|rond(om)?|van|tot)$";
       public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))";
       public static readonly string ForTheRegex = $@"\b((((?<=voor\s+)de\s+{FlexibleDayRegex})|((?<=op\s+)de\s+{FlexibleDayRegex}(?<=(ste|de|e))))(?<end>(\s+(tussen|binnen|terug|tegen|aan|uit|mee|bij|vol|uit|aan|op|in|na|af)\s*)?(\s+(ge\w\w\w+|\w\w\w+en)\s*)?(,|\.|!|\?|$)))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
-      public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
-      public const string RestOfDateTimeRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<unit>dag)\b";
+      public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
+      public const string RestOfDateTimeRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<unit>vandaag|dag)\b";
       public const string MealTimeRegex = @"\b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b";
       public const string AmbiguousRangeModifierPrefix = @"^[.]";
       public static readonly string NumberEndingPattern = $@"^(\s+(?<meeting>vergadering|afspraak|conferentie|telefoontje|skype-gesprek)\s+om\s+(?<newTime>{PeriodHourNumRegex}|{HourRegex})((\.)?$|(\.,|,|!|\?)))";
@@ -278,13 +289,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(voor|niet later dan|na)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+op)\s*$";
-      public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend))";
-      public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?(')?(?<decade>\d0)(')?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
+      public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e\s+eeuw|(ee|éé)nentwintigste\s+eeuw))";
+      public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
       public static readonly string RelativeDecadeRegex = $@"\b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b";
       public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b";
       public const string DateAfterRegex = @"\b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b";
       public static readonly string YearPeriodRegex = $@"((((vanaf|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
-      public static readonly string ComplexDatePeriodRegex = $@"(((van(af)?|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
+      public static readonly string ComplexDatePeriodRegex = $@"(((van(af)?|tijdens|gedurende|in(\s+de)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
       public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
         {
             { @"millennium", @"1000Y" },
@@ -302,6 +313,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"week", @"W" },
             { @"dagen", @"D" },
             { @"dag", @"D" },
+            { @"vandaag", @"D" },
             { @"dgn", @"D" },
             { @"uren", @"H" },
             { @"uur", @"H" },
@@ -334,6 +346,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"week", 604800 },
             { @"dagen", 86400 },
             { @"dag", 86400 },
+            { @"vandaag", 86400 },
             { @"dgn", 86400 },
             { @"werkdagen", 86400 },
             { @"werkdag", 86400 },
@@ -821,7 +834,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         };
       public static readonly IList<string> AfternoonTermList = new List<string>
         {
-            @"middag"
+            @"middag",
+            @"namiddag",
+            @"voormiddag"
         };
       public static readonly IList<string> EveningTermList = new List<string>
         {
@@ -840,21 +855,28 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly IList<string> SameDayTerms = new List<string>
         {
             @"vandaag",
+            @"huidige dag",
+            @"huidige datum",
+            @"actuele datum",
+            @"actuele dag",
             @"deze morgen",
-            @"vanmorgen"
+            @"actuele morgen"
         };
       public static readonly IList<string> PlusOneDayTerms = new List<string>
         {
             @"morgen",
             @"dag na",
             @"volgende dag",
-            @"morgenochtend"
+            @"morgenochtend",
+            @"morgenavond"
         };
       public static readonly IList<string> MinusOneDayTerms = new List<string>
         {
             @"gisteren",
             @"dag voor",
-            @"vorige dag"
+            @"vorige dag",
+            @"gisterenochtend",
+            @"gisterenavond"
         };
       public static readonly IList<string> PlusTwoDayTerms = new List<string>
         {
@@ -869,7 +891,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             @"deze",
             @"volgend",
             @"volgende",
-            @"dit"
+            @"dit",
+            @"die"
         };
       public static readonly IList<string> LastCardinalTerms = new List<string>
         {
@@ -878,7 +901,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         };
       public static readonly IList<string> MonthTerms = new List<string>
         {
-            @"maand"
+            @"maand",
+            @"maanden"
         };
       public static readonly IList<string> MonthToDateTerms = new List<string>
         {
@@ -888,7 +912,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         };
       public static readonly IList<string> WeekendTerms = new List<string>
         {
-            @"weekend"
+            @"weekend",
+            @"weekenden"
         };
       public static readonly IList<string> WeekTerms = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ToTokenRegex = @"\b(voor)$";
       public const string ToHalfTokenRegex = @"\b(over\s+half)$";
       public const string ForHalfTokenRegex = @"\b(voor\s+half)$";
-      public const string FromTokenRegex = @"(van(af)?)$";
+      public const string FromRegex = @"\b(van(af)?)$";
       public const string BetweenTokenRegex = @"\b(tussen)$";
       public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
@@ -262,7 +262,6 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string RelativeDurationUnitRegex = $@"(((?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+(?<duration>week|maand|jaar|decennium|weekend)\b";
       public const string ConnectorRegex = @"^(-|,|voor|t|rond(om)?|@)$";
-      public const string FromRegex = @"\b(vanaf|van)$";
       public const string FromToRegex = @"\b(van(af)?).+(tot)\b.+";
       public const string SingleAmbiguousMonthRegex = @"^(de\s+)?(mei)$";
       public const string SingleAmbiguousTermsRegex = @"^(de\s+)?(dag|week|maand|jaar)$";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -23,15 +23,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
     {
       public const string LangMarker = @"Dut";
       public const bool CheckBothBeforeAfter = false;
-      public static readonly string TillRegex = $@"(?<till>\b(tot(dat)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string TillRegex = $@"(?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string ArticleRegex = @"\b(de|het|een)\b";
       public const string ApostrofRegex = @"(’|‘|'|ʼ)";
       public static readonly string ApostrofsRegex = $@"({ApostrofRegex}\s*s)";
       public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b";
       public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
-      public const string UpcomingPrefixRegex = @"((aankomende?|komende?|aanstaande?))";
-      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|aanstaande?|over|{UpcomingPrefixRegex})\b";
+      public const string UpcomingPrefixRegex = @"(aankomende?|komende?|aanstaande?)";
+      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|aanstaande?|{UpcomingPrefixRegex})\b";
       public const string AfterNextSuffixRegex = @"\b((na\s+((de|het)\s+)?volgende?)|over)\b";
       public const string PastPrefixRegex = @"((deze\s+)?verleden)\b";
       public static readonly string PreviousPrefixRegex = $@"(voorgaand[e]|vorige?|afgelopen|verleden|laatste|terug|{PastPrefixRegex})\b";
@@ -51,10 +51,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string WrittenNumRegex = $@"({WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
       public static readonly string WrittenCenturyFullYearRegex = $@"((twee)\s*duizend(\s+en)?(\s*{WrittenOneToNineRegex}\s*honderd)?)";
       public const string WrittenCenturyOrdinalYearRegex = @"((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)";
-      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b";
+      public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)";
       public static readonly string LastTwoYearNumRegex = $@"((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})";
-      public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})(\s+)?(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
-      public const string OclockRegex = @"(?<oclock>uur)";
+      public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
+      public const string OclockRegex = @"(?<oclock>u(ur)?)\b";
       public const string SpecialDescRegex = @"(p\b)";
       public static readonly string AmDescRegex = $@"({BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
       public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
-      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b)))";
+      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
@@ -85,7 +85,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
+      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b";
       public static readonly string WeekOfYearRegex = $@"(\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)";
@@ -100,7 +100,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HalfYearRelativeRegex = $@"(het\s+)?{HalfYearTermRegex}(\s+van|\s*,\s*)?\s+({RelativeRegex}\s+jaar)";
       public static readonly string AllHalfYearRegex = $@"({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})";
       public const string EarlyPrefixRegex = @"\b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)(\s+(in|op|van)(\s+de)?)?)\b";
-      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)\b";
+      public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)";
       public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
       public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later|aan\s+het\s+einde?(\s+van(\s+de)?)?))(\s+(in|op|van))?(\s+de\s+dag)?\b";
@@ -118,7 +118,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string ThisRegex = $@"\b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
       public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
       public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b";
-      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|(morgen|(?<weekday>zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag))(ochtend|(na)?middag|avond|nacht))\b";
+      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)";
       public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
       public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+))?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)s\b";
@@ -147,8 +147,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
       public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))";
-      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))";
-      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))";
+      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))";
+      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^ochtend))";
       public const string LunchRegex = @"\b(lunchtijd)\b";
       public static readonly string NightRegex = $@"\b((({ApostrofsRegex}|des)\s+)?nachts|(midder)?nacht)\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HourDTRegEx = $@"({BaseDateTime.HourRegex})";
       public static readonly string MinuteDTRegEx = $@"({BaseDateTime.MinuteRegex})";
       public static readonly string SecondDTRegEx = $@"({BaseDateTime.SecondRegex})";
-      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx})";
+      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))";
       public static readonly string MidnightRegex = $@"(?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)";
       public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?(morgen|ochtend)|halverwege de ochtend|het midden van de ochtend)";
       public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)";
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeRegex4 = $@"\b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
       public static readonly string TimeRegex5 = $@"\b({TimePrefix}\s+{BasicTime}|{BasicTime}\s+{TimePrefix})((\s*({DescRegex}|{TimeSuffix}))|\b)";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+{BasicTime})((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex8 = $@".^";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s+{FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?";
@@ -213,12 +213,12 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$";
       public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b";
-      public const string SpecificEndOfRegex = @"((aan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
+      public const string SpecificEndOfRegex = @"((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
       public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b";
       public const string UnspecificEndOfRangeRegex = @"\b(evj)\b";
-      public static readonly string PeriodTimeOfDayRegex = $@"\b((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b";
+      public static readonly string PeriodTimeOfDayRegex = $@"((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|(eer)?gisteren|morgen)?(?<timeOfDay>ochtend|(na)?middag|avond|nacht))\b";
       public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b";
-      public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b(({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b";
+      public static readonly string PeriodTimeOfDayWithDateRegex = $@"(({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b";
       public const string LessThanRegex = @"\b((binnen\s+)?minder\s+dan)\b";
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
@@ -289,7 +289,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(voor|niet later dan|na)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+op)\s*$";
-      public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e\s+eeuw|(ee|éé)nentwintigste\s+eeuw))";
+      public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|(ee|éé)nentwintigste\s+eeuw))";
       public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
       public static readonly string RelativeDecadeRegex = $@"\b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b";
       public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter)(?!\s+dan))\b";
@@ -860,7 +860,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             @"actuele datum",
             @"actuele dag",
             @"deze morgen",
-            @"actuele morgen"
+            @"actuele morgen",
+            @"vanmorgen"
         };
       public static readonly IList<string> PlusOneDayTerms = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromTokenRegex =
-            new Regex(DateTimeDefinitions.FromTokenRegex, RegexFlags);
+            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex BetweenTokenRegex =
             new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -74,9 +74,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex[] SimpleCases =
-{
+        {
             DutchTimePeriodExtractorConfiguration.PureNumFromTo,
+            DutchTimePeriodExtractorConfiguration.TimeDateFromTo,
             DutchTimePeriodExtractorConfiguration.PureNumBetweenAnd,
+            DutchTimePeriodExtractorConfiguration.SpecificTimeFromTo,
         };
 
         public DutchDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
@@ -174,9 +176,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("from"))
+            if (text.EndsWith("vanaf"))
             {
-                index = text.LastIndexOf("from", StringComparison.Ordinal);
+                index = text.LastIndexOf("vanaf", StringComparison.Ordinal);
+                return true;
+            }
+            else if (text.EndsWith("van"))
+            {
+                index = text.LastIndexOf("van", StringComparison.Ordinal);
                 return true;
             }
 
@@ -186,9 +193,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool GetBetweenTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("between"))
+            if (text.EndsWith("tussen"))
             {
-                index = text.LastIndexOf("between", StringComparison.Ordinal);
+                index = text.LastIndexOf("tussen", StringComparison.Ordinal);
                 return true;
             }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -73,6 +73,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private static readonly Regex TimeFollowedUnit =
             new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
+        private static readonly Regex FromTokenRegex =
+            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+
+        private static readonly Regex BetweenTokenRegex =
+            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+
+        private static readonly Regex RangeConnectorRegex =
+            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+
         private static readonly Regex[] SimpleCases =
         {
             DutchTimePeriodExtractorConfiguration.PureNumFromTo,
@@ -176,37 +185,30 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("vanaf"))
+            var fromMatch = FromTokenRegex.Match(text);
+            if (fromMatch.Success)
             {
-                index = text.LastIndexOf("vanaf", StringComparison.Ordinal);
-                return true;
-            }
-            else if (text.EndsWith("van"))
-            {
-                index = text.LastIndexOf("van", StringComparison.Ordinal);
-                return true;
+                index = fromMatch.Index;
             }
 
-            return false;
+            return fromMatch.Success;
         }
 
         public bool GetBetweenTokenIndex(string text, out int index)
         {
             index = -1;
-            if (text.EndsWith("tussen"))
+            var betweenMatch = BetweenTokenRegex.Match(text);
+            if (betweenMatch.Success)
             {
-                index = text.LastIndexOf("tussen", StringComparison.Ordinal);
-                return true;
+                index = betweenMatch.Index;
             }
 
-            return false;
+            return betweenMatch.Success;
         }
 
         public bool HasConnectorToken(string text)
         {
-            var rangeConnetorRegex = new Regex(DateTimeDefinitions.RangeConnectorRegex);
-
-            return rangeConnetorRegex.IsExactMatch(text, trim: true);
+            return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -119,6 +119,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             // 3.30pm, "am/pm" suffix is required here
             new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
+            // 16 from "16 vandaag"
+            new Regex(DateTimeDefinitions.TimeRegex12, RegexFlags),
+
             // 340pm
             ConnectNumRegex,
         };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -153,10 +153,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        // This method is used to disambiguate extractions containing 'morgen' (that can mean both 'tomorrow' and 'morning').
+        // It discards isolated occurrences of 'morgen', keeping as valid extractions only those cases
+        // where it is part of a bigger match (e.g. 'diensdag morgen')
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs)
         {
             {
-                var morgenStr = "morgen";
+                var morgenStr = DateTimeDefinitions.MorningTermList[0];
                 List<ExtractResult> timePeriodErsResult = new List<ExtractResult>();
                 foreach (var timePeriodEr in timePeriodErs)
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -152,5 +152,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        {
+            {
+                var morgenStr = "morgen";
+                List<ExtractResult> timePeriodErsResult = new List<ExtractResult>();
+                foreach (var timePeriodEr in timePeriodErs)
+                {
+                    if (!timePeriodEr.Text.Equals(morgenStr))
+                    {
+                        timePeriodErsResult.Add(timePeriodEr);
+                    }
+                }
+
+                return timePeriodErsResult;
+            }
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex PureNumFromTo =
             new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
+        public static readonly Regex TimeDateFromTo =
+            new Regex(DateTimeDefinitions.TimeDateFromTo, RegexFlags);
+
         public static readonly Regex PureNumBetweenAnd =
             new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -178,14 +178,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public int GetSwiftPrefix(string text)
         {
-            var trimmedText = text.Trim().ToLowerInvariant();
+            var trimmedText = text.Trim();
 
             var swift = 0;
-            if (trimmedText.StartsWith("volgende"))
+            if (FutureRegex.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (trimmedText.StartsWith("vorige") || trimmedText.StartsWith("laatste"))
+            else if (PreviousPrefixRegex.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         Regex ITimePeriodExtractorConfiguration.GeneralEndingRegex => GeneralEndingRegex;
 
+        // @TODO move hardcoded strings to YAML file
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
@@ -140,6 +141,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             return text.Equals("and");
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -139,5 +139,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             return text.Equals("and");
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Filter ambiguous extractions e.g. 'morgen' in German and Dutch
-            timePeriodErs = this.config.FilterAmbiguousCases(text, timePeriodErs);
+            timePeriodErs = this.config.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
 
             return timePeriodErs;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimePeriodExtractor.cs
@@ -80,12 +80,38 @@ namespace Microsoft.Recognizers.Text.DateTime
         // It should also be solvable through the config but we do not want to introduce changes to the interface and configs for all other languages.
         private List<ExtractResult> GermanMorgenWorkaround(string text, List<ExtractResult> timePeriodErs)
         {
-            if (text.Equals("morgen"))
-            {
-                timePeriodErs.Clear();
-            }
+            var culture = this.config.Culture;
+            var isGerman = culture == Culture.German;
+            var isDutch = culture == Culture.Dutch;
+            var morgenStr = "morgen";
 
-            return timePeriodErs;
+            List<ExtractResult> timePeriodErsResult = new List<ExtractResult>();
+
+            if (isGerman)
+            {
+                if (text.Equals(morgenStr))
+                {
+                    timePeriodErs.Clear();
+                }
+
+                return timePeriodErs;
+            }
+            else if (isDutch)
+            {
+                foreach (var timePeriodEr in timePeriodErs)
+                {
+                    if (!timePeriodEr.Text.Equals(morgenStr))
+                    {
+                        timePeriodErsResult.Add(timePeriodEr);
+                    }
+                }
+
+                return timePeriodErsResult;
+            }
+            else
+            {
+                return timePeriodErs;
+            }
         }
 
         // Cases like "from 3 to 5am" or "between 3:30 and 5" are extracted here

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
@@ -30,5 +30,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         bool IsConnectorToken(string text);
 
         bool GetBetweenTokenIndex(string text, out int index);
+
+        List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimePeriodExtractorConfiguration.cs
@@ -31,6 +31,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         bool GetBetweenTokenIndex(string text, out int index);
 
-        List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs);
+        List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -147,6 +147,6 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             return ConnectorAndRegex.IsMatch(text);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -146,5 +146,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         {
             return ConnectorAndRegex.IsMatch(text);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         Regex ITimePeriodExtractorConfiguration.GeneralEndingRegex => GeneralEndingRegex;
 
+        // @TODO move hardcoded strings to YAML file
         public bool GetFromTokenIndex(string text, out int index)
         {
             index = -1;
@@ -128,7 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         // When trying to do this on the string "morgen" it will be extracted as a time period ("morning") by the TimePeriodExtractor, and not as "tomorrow".
         // Filtering out the string "morgen" from the TimePeriodExtractor will fix the problem as only in the case where "morgen" is NOT a time period the string "morgen" will be passed to this extractor.
         // It should also be solvable through the config but we do not want to introduce changes to the interface and configs for all other languages.
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs)
         {
             if (text.Equals("morgen"))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -122,5 +122,20 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             return text.Equals("und");
         }
+
+        // For German there is a problem with cases like "Morgen Abend" which is parsed as "Morning Evening" as "Morgen" can mean both "tomorrow" and "morning".
+        // When the extractor extracts "Abend" in this example it will take the string before that to look for a relative shift to another day like "yesterday", "tomorrow" etc.
+        // When trying to do this on the string "morgen" it will be extracted as a time period ("morning") by the TimePeriodExtractor, and not as "tomorrow".
+        // Filtering out the string "morgen" from the TimePeriodExtractor will fix the problem as only in the case where "morgen" is NOT a time period the string "morgen" will be passed to this extractor.
+        // It should also be solvable through the config but we do not want to introduce changes to the interface and configs for all other languages.
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        {
+            if (text.Equals("morgen"))
+            {
+                timePeriodErs.Clear();
+            }
+
+            return timePeriodErs;
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
@@ -137,5 +137,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         {
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
@@ -138,6 +138,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
@@ -157,6 +157,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             return ConnectorAndRegex.IsMatch(text) || FullTillRegex.IsExactMatch(text, false);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
@@ -156,5 +156,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             return ConnectorAndRegex.IsMatch(text) || FullTillRegex.IsExactMatch(text, false);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
@@ -129,6 +129,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             return RangeConnectorRegex.IsExactMatch(text, true);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
@@ -128,5 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             return RangeConnectorRegex.IsExactMatch(text, true);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -128,5 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             return RangeConnectorRegex.IsExactMatch(text, true);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -129,6 +129,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             return RangeConnectorRegex.IsExactMatch(text, true);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
@@ -153,5 +153,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         {
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
+
+        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
@@ -154,6 +154,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             return RangeConnectorRegex.IsExactMatch(text, trim: true);
         }
 
-        public List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.FilterAmbiguousCases(text, timePeriodErs);
+        public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -161,6 +162,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             }
 
             return spanTimex.ToString();
+        }
+
+        // used to filter ambiguous extractions e.g. 'morgen' in German and Dutch
+        public static List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        {
+            return timePeriodErs;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         }
 
         // used to filter ambiguous extractions e.g. 'morgen' in German and Dutch
-        public static List<ExtractResult> FilterAmbiguousCases(string text, List<ExtractResult> timePeriodErs)
+        public static List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs)
         {
             return timePeriodErs;
         }

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -3,39 +3,44 @@
 LangMarker: Dut
 CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
-  def: (?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  def: (?<till>\b(tot(dat)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RangeConnectorRegex: !nestedRegex
   def: (?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 ArticleRegex: !simpleRegex
   def: \b(de|het|een)\b
+ApostrofRegex: !simpleRegex
+  def: (’|‘|'|ʼ)
+ApostrofsRegex: !nestedRegex
+  def: ({ApostrofRegex}\s*s)
+  references: [ ApostrofRegex ]
 RelativeRegex: !simpleRegex
-  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|de|het)\b
+  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b
 StrictRelativeRegex: !simpleRegex
   def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b
 UpcomingPrefixRegex: !simpleRegex
-  def: ((aankomende?|komende?|aanstaande))
+  def: ((aankomende?|komende?|aanstaande?))
 NextPrefixRegex: !nestedRegex
-  def: \b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b
+  def: \b(volgende?|eerstvolgende|aanstaande?|over|{UpcomingPrefixRegex})\b
   references: [ UpcomingPrefixRegex ]
 AfterNextSuffixRegex: !simpleRegex
-  def: \b(na\s+((de|het)\s+)?volgende?)\b
+  def: \b((na\s+((de|het)\s+)?volgende?)|over)\b
 PastPrefixRegex: !simpleRegex
   def: ((deze\s+)?verleden)\b
 PreviousPrefixRegex: !nestedRegex
-  def: (voorgaand[e]|vorige?|afgelopen|verleden|laatste|{PastPrefixRegex})\b
+  def: (voorgaand[e]|vorige?|afgelopen|verleden|laatste|terug|{PastPrefixRegex})\b
   references: [ PastPrefixRegex ]
 ThisPrefixRegex: !simpleRegex
   def: (dit|deze|huidige?)\b
 RangePrefixRegex: !simpleRegex
-  def: (van|tussen)
+  def: (?<desc>van|tussen)
 CenturySuffixRegex: !simpleRegex
   def: (^eeuw|^centennium)\b
 ReferencePrefixRegex: !simpleRegex
   def: (dezelfde|hetzelfde|dat(zelfde)?|die|overeenkomstige)\b
 FutureSuffixRegex: !simpleRegex
-  def: \b(in\s+de\s+)?(toekomst|vanaf(\s+nu)?)\b
+  def: \b(((in\s+de\s+)?toekomst)|vanaf(\s+nu)?|over|na)\b
 DayRegex: !simpleRegex
   def: (de\s*)?(?<!(\d+:?|\$)\s*)(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(?=\b|t)
 # 1-31 written
@@ -64,7 +69,7 @@ WrittenCenturyFullYearRegex: !nestedRegex
 WrittenCenturyOrdinalYearRegex: !simpleRegex
   def: ((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)
 CenturyRegex: !nestedRegex
-  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)
+  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b
   references: [WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex ]
 LastTwoYearNumRegex: !nestedRegex
   def: ((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})
@@ -97,7 +102,7 @@ YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
 WeekDayRegex: !simpleRegex
-  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)
+  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)
 SingleWeekDayRegex: !simpleRegex
   def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b)))
 RelativeMonthRegex: !nestedRegex
@@ -143,10 +148,10 @@ BetweenRegex: !nestedRegex
   def: \b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, RangeConnectorRegex , MonthSuffixRegex, YearRegex ]
 MonthWithYear: !nestedRegex
-  def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b
+  def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((de|het)\s+)?maand(\s+van)?\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
+  def: \b((((de\s+)?maand\s+van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
@@ -169,8 +174,8 @@ QuarterRegex: !nestedRegex
   def: (het\s+)?{QuarterTermRegex}((\s+van|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+jaar))?
   references: [ YearRegex, RelativeRegex, QuarterTermRegex ]
 QuarterRegexYearFront: !nestedRegex
-  def: ({YearRegex}|({RelativeRegex}\s+jaar))('s)?\s+((het|de)\s+)?{QuarterTermRegex}
-  references: [ YearRegex, RelativeRegex, QuarterTermRegex ]
+  def: ({YearRegex}|({RelativeRegex}\s+jaar))({ApostrofsRegex})?\s+((het|de)\s+)?{QuarterTermRegex}
+  references: [ YearRegex, RelativeRegex, QuarterTermRegex, ApostrofsRegex ]
 HalfYearTermRegex: !simpleRegex
   def: (?<cardinal>eerste|1e|1ste|tweede|2e|2de)\s+(helft)
 HalfYearFrontRegex: !nestedRegex
@@ -186,16 +191,16 @@ AllHalfYearRegex: !nestedRegex
   def: ({HalfYearFrontRegex})|({HalfYearBackRegex})|({HalfYearRelativeRegex})
   references: [ HalfYearFrontRegex, HalfYearBackRegex, HalfYearRelativeRegex ]
 EarlyPrefixRegex: !simpleRegex
-  def: \b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)\s+(in|op|van)?)\b
+  def: \b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)(\s+(in|op|van)(\s+de)?)?)\b
 MidPrefixRegex: !simpleRegex
-  def: \b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+)?((in|op|van)\b)?)
+  def: \b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)\b
 LaterPrefixRegex: !simpleRegex
-  def: \b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde|eind(igend)?|afsluitend)(\s+(in|op|van)?))\b
+  def: \b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b
 PrefixPeriodRegex: !nestedRegex
   def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
   references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
 PrefixDayRegex: !simpleRegex
-  def: \b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|(?<LatePrefix>laat|later|aan\s+het\s+einde))(\s+(op|van))?(\s+de\s+dag)?\b
+  def: \b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later|aan\s+het\s+einde?(\s+van(\s+de)?)?))(\s+(in|op|van))?(\s+de\s+dag)?\b
 SeasonDescRegex: !simpleRegex
   def: (?<seas>lente|voorjaar|zomer|herfst|najaar|winter)
 SeasonRegex: !nestedRegex
@@ -255,7 +260,7 @@ SpecialDate: !nestedRegex
   def: (?=\b(op\s+)(de\s+)?){DayRegex}\b
   references: [ DayRegex ]
 DatePreposition: !simpleRegex
-  def: \b(op)
+  def: \b(op(\s+de)?)
 DateExtractorYearTermRegex: !nestedRegex
   def: (\s+|\s*,\s*){DateYearRegex}
   references: [ DateYearRegex ]
@@ -320,16 +325,20 @@ MinuteNumRegex: !simpleRegex
   def: (?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)
 DeltaMinuteNumRegex: !simpleRegex
   def: (?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
-PmRegex: !simpleRegex
-  def: (?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))
-PmRegexFull: !simpleRegex
-  def: (?<pm>(((’|‘|'|ʼ)\s*s|des)\s+(middags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))
-AmRegex: !simpleRegex
-  def: (?<am>(((’|‘|'|ʼ)\s*s|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))
+PmRegex: !nestedRegex
+  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))
+  references: [ ApostrofsRegex ]
+PmRegexFull: !nestedRegex
+  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))
+  references: [ ApostrofsRegex ]
+AmRegex: !nestedRegex
+  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))
+  references: [ ApostrofsRegex ]
 LunchRegex: !simpleRegex
   def: \b(lunchtijd)\b
-NightRegex: !simpleRegex
-  def: \b((((’|‘|')\s*s|des)\s+)?nachts|(midder)?nacht)\b
+NightRegex: !nestedRegex
+  def: \b((({ApostrofsRegex}|des)\s+)?nachts|(midder)?nacht)\b
+  references: [ ApostrofsRegex ]
 CommonDatePrefixRegex: !simpleRegex
   def: ^[\.]
 LessThanOneHour: !nestedRegex
@@ -347,17 +356,28 @@ TimeSuffix: !nestedRegex
 TimeSuffixFull: !nestedRegex
   def: (?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})
   references: [ AmRegex, PmRegexFull, OclockRegex ]
+HourDTRegEx: !nestedRegex
+  def: ({BaseDateTime.HourRegex})
+  references: [ BaseDateTime.HourRegex ]
+MinuteDTRegEx: !nestedRegex
+  def: ({BaseDateTime.MinuteRegex})
+  references: [ BaseDateTime.MinuteRegex]
+SecondDTRegEx: !nestedRegex
+  def: ({BaseDateTime.SecondRegex})
+  references: [ BaseDateTime.SecondRegex, BaseUnits.SecondRegex]
 BasicTime: !nestedRegex
-  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|((?<prefix>half)\s+)?{BaseDateTime.HourRegex}(?![%\d]))
-  references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
-MidnightRegex: !simpleRegex
-  def: (?<midnight>mid\s*(-\s*)?nacht|middernacht|in de nacht|('s|des) nachts)
+  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx})
+  references: [ WrittenTimeRegex, HourNumRegex, HourDTRegEx, MinuteDTRegEx, SecondDTRegEx ]
+MidnightRegex: !nestedRegex
+  def: (?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)
+  references: [ ApostrofsRegex ]
 MidmorningRegex: !simpleRegex
-  def: (?<midmorning>mid\s*(-\s*)?morgen|halverwege de ochtend|het midden van de ochtend)
+  def: (?<midmorning>mid\s*(-\s*)?(morgen|ochtend)|halverwege de ochtend|het midden van de ochtend)
 MidafternoonRegex: !simpleRegex
   def: (?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)
-MiddayRegex: !simpleRegex
-  def: (?<midday>(((rond\s+)?(het|de)|(’|‘|')\s*s)\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)
+MiddayRegex: !nestedRegex
+  def: (?<midday>(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)
+  references: [ ApostrofsRegex ]
 MidTimeRegex: !nestedRegex
   def: (?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))
   references: [ MidnightRegex, MidmorningRegex, MidafternoonRegex, MiddayRegex ]
@@ -365,8 +385,8 @@ AtRegex: !nestedRegex
   def: (((?<=\bom\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, MidTimeRegex ]
 IshRegex: !nestedRegex
-  def: \b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*(’|‘|')\s*)?en|middagloos)\b
-  references: [ BaseDateTime.HourRegex ]
+  def: \b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*{ApostrofRegex}\s*)?en|middagloos)\b
+  references: [ BaseDateTime.HourRegex, ApostrofRegex ]
 TimeUnitRegex: !simpleRegex
   def: ([^A-Za-z]{1,}|\b)(?<unit>((min\.|sec\.)|((uren|u(ur)?|minuten|minuut|mins?|seconde[ns]?|secs?)\b)))
 RestrictedTimeUnitRegex: !simpleRegex
@@ -417,30 +437,48 @@ TimeRegex10: !nestedRegex
 TimeRegex11: !nestedRegex
   def: \b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%)))
   references: [ TimeTokenPrefix, TimeRegexWithDotConnector, DescRegex, TimeSuffix ]
+TimeRegex12: !nestedRegex
+  def: ({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))
+  references: [ BaseDateTime.HourRegex ]
 FirstTimeRegexInTimeRange: !nestedRegex
   def: \b{TimeRegexWithDotConnector}(\s*{DescRegex})?
   references: [ TimeRegexWithDotConnector, DescRegex ]
+PureNumFromToPrefixExcluded: !nestedRegex
+  def: ({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
+  references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, TillRegex, PmRegex, AmRegex ]
+PureNumFromToPrefix: !nestedRegex
+  def: ({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
+  references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, RangeConnectorRegex, PmRegex, AmRegex, RangePrefixRegex ]
+PureNumFromToWithDateBefore: !nestedRegex
+  def: ({RangePrefixRegex}\s+)({HourDTRegEx})(\s+(vandaag|morgen)\s+)?(\s*{RangeConnectorRegex}\s*)({HourDTRegEx})
+  references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, RangeConnectorRegex, PmRegex, AmRegex, RangePrefixRegex ]
+PureNumFromToWithDateAfter: !nestedRegex
+  def: ({RangePrefixRegex}\s+)({HourDTRegEx})(\s*{RangeConnectorRegex}\s*)({HourDTRegEx}(\s+(vandaag|morgen))?)
+  references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, RangeConnectorRegex, PmRegex, AmRegex, RangePrefixRegex ]
 PureNumFromTo: !nestedRegex
-  def: ({RangePrefixRegex}\s+)?({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourRegex}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
-  references: [ HourRegex, PeriodHourNumRegex, DescRegex, TillRegex, PmRegex, AmRegex, RangePrefixRegex ]
+  def: ({PureNumFromToPrefix}|{PureNumFromToPrefixExcluded})
+  references: [ PureNumFromToPrefix, PureNumFromToPrefixExcluded, PureNumFromToWithDateAfter, PureNumFromToWithDateBefore,  ]
+TimeDateFromTo: !nestedRegex
+  def: ({PureNumFromToWithDateAfter}|{PureNumFromToWithDateBefore})
+  references: [ PureNumFromToPrefix, PureNumFromToPrefixExcluded, PureNumFromToWithDateAfter, PureNumFromToWithDateBefore,  ]
 PureNumBetweenAnd: !nestedRegex
-  def: (tussen\s+)({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?\s*{RangeConnectorRegex}\s*({HourRegex}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
-  references: [ HourRegex, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex, RangeConnectorRegex ]
+  def: (tussen\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
+  references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex, RangeConnectorRegex ]
 SpecificTimeFromTo: !nestedRegex
-  def: ({RangePrefixRegex}\s+)?(?<time1>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{TillRegex}\s*(?<time2>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))
-  references: [ TimeRegex2, TillRegex, HourRegex, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex, RangePrefixRegex ]
+  def: ({RangePrefixRegex}\s+)?(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{TillRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))
+  references: [ TimeRegex2, TillRegex, HourDTRegEx, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex, RangePrefixRegex ]
 SpecificTimeBetweenAnd: !nestedRegex
-  def: (tussen\s+)(?<time1>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourRegex}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))
-  references: [ TimeRegex2, RangeConnectorRegex, HourRegex, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex ]
+  def: (tussen\s+)(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?(\s+{TimeSuffix})?))
+  references: [ TimeRegex2, RangeConnectorRegex, HourDTRegEx, PeriodHourNumRegex, DescRegex, PmRegex, AmRegex, TimeSuffix ]
 PrepositionRegex: !simpleRegex
-  def: (?<prep>^(om|rond|tegen|op)(\s+de)?$)
-LaterEarlyRegex: !simpleRegex
-  def: ((?<early>vroege?(\s+|-))|(?<late>(laat|late)(\s+|-)))
+  def: (?<prep>^(om|rond|tegen|op|van|deze)(\s+de)?$)
+EarlyLateRegex: !simpleRegex
+  def: (((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)
 TimeOfDayRegex: !nestedRegex
-  def: (?<timeOfDay>(((in\s+(de)?\s+)?{LaterEarlyRegex}?(in\s+(de)?\s+)?(morgen|ochtend(en)?|middag|nacht|avond(en)?))|{MealTimeRegex})s?|((((’|‘|'|ʼ)\s*s\s+)?)(morgen|ochtend|middag|avond|nacht)s?(\s+((?<early>vroeg)|(?<late>laat)))?)|(tijdens\s+(de\s+)?)?(kantoor|werk)uren)\b
-  references: [ LaterEarlyRegex, MealTimeRegex ]
+  def: (?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b
+  references: [ EarlyLateRegex, MealTimeRegex, ApostrofsRegex ]
 SpecificTimeOfDayRegex: !nestedRegex
-  def: \b(({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(nacht|avond))s?\b
+  def: \b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|avond|nacht)))s?\b
   references: [ TimeOfDayRegex, StrictRelativeRegex ]
 TimeFollowedUnit: !nestedRegex
   def: ^\s*{TimeUnitRegex}
@@ -460,30 +498,31 @@ DateTimeSpecificTimeOfDayRegex: !nestedRegex
   def: \b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend|morgen))\b
   references: [ DateTimeTimeOfDayRegex, RelativeRegex ]
 TimeOfTodayAfterRegex: !nestedRegex
-  def: ^\s*(,\s*)?(in\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}
+  def: ^\s*(,\s*)?((in\s+de)|(op\s+de))?{DateTimeSpecificTimeOfDayRegex}
   references: [ DateTimeSpecificTimeOfDayRegex ]
 TimeOfTodayBeforeRegex: !nestedRegex
-  def: '{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*$'
+  def: '{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$'
   references: [ DateTimeSpecificTimeOfDayRegex ]
 SimpleTimeOfTodayAfterRegex: !nestedRegex
-  def: ({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?(in\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}
+  def: ({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}
   references: [ HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, DateTimeSpecificTimeOfDayRegex, OclockRegex ]
 SimpleTimeOfTodayBeforeRegex: !nestedRegex
-  def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b'
+  def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
-  def: (((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
+  def: ((aan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
 UnspecificEndOfRegex: !simpleRegex
   def: \b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b
 UnspecificEndOfRangeRegex: !simpleRegex
   def: \b(evj)\b
-PeriodTimeOfDayRegex: !simpleRegex
-  def: \b((in\s+(de)?\s+)?((?<early>vroege(\s+|-))|(?<late>late(\s+|-)))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b
+PeriodTimeOfDayRegex: !nestedRegex
+  def: \b((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b
+  references: [ EarlyLateRegex ]
 PeriodSpecificTimeOfDayRegex: !nestedRegex
-  def: \b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend))\b
+  def: \b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b
   references: [ PeriodTimeOfDayRegex, StrictRelativeRegex ]
 PeriodTimeOfDayWithDateRegex: !nestedRegex
- def: \b(({TimeOfDayRegex}(\s+(om|rond|tegen|op))?))\b
+ def: \b(({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b
  references: [ TimeOfDayRegex ]
 LessThanRegex: !simpleRegex
   def: \b((binnen\s+)?minder\s+dan)\b
@@ -504,14 +543,14 @@ EachPrefixRegex: !simpleRegex
 SetEachRegex: !simpleRegex
   def: \b(?<each>(iedere|elke)\s*)
 SetLastRegex: !simpleRegex
-  def: (?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorig|verleden|vorige|laatste)
+  def: (?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorige?|verleden|laatste)
 EachDayRegex: !simpleRegex
   def: ^\s*(elke)\s*dag\b
 DurationFollowedUnit: !nestedRegex
   def: ^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})
   references: [ SuffixAndRegex, DurationUnitRegex ]
 NumberCombinedWithDurationUnit: !nestedRegex
-  def: \b(?<num>\d+(\.\d*)?)(-)?{DurationUnitRegex}
+  def: \b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 AnUnitRegex: !nestedRegex
   def: \b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}
@@ -534,10 +573,12 @@ HolidayRegex2: !nestedRegex
 HolidayRegex3: !nestedRegex # -dag suffix
   def: \b(?<holiday>(yuandan|valentijnsdag|valentijn|oude?jaarsavond|nieuwjaarsdag|eerste paasdag|tweede paasdag|prinsjesdag|koningsdag|koninginnedag|bevrijdingsdag|hemelvaartsdag|eerste kerstdag|1e kerstdag|tweede kerstdag|2e kerstdag|vaderdag|moederdag|meisjesdag|amerikaanse onafhankelijkheidsdag|onafhankelijkheidsdag|nederlandse veteranendag|veteranendag|boomplantdag|boomfeestdag))(\s+(van\s+|in\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?\b
   references: [ YearRegex, RelativeRegex ]
-AMTimeRegex: !simpleRegex
-  def: (?<am>('s morgens|'s ochtends)|in\s+de\s+(morgen|ochtend))
-PMTimeRegex: !simpleRegex
-  def: (?<pm>('s middags|'s avonds|'s nachts)|(in\s+de\s+)?(middag|avond|nacht))\b
+AMTimeRegex: !nestedRegex
+  def: (?<am>{ApostrofsRegex}\s*(morgens|ochtends)|in\s+de\s+(morgen|ochtend))
+  references: [ ApostrofsRegex ]
+PMTimeRegex: !nestedRegex
+  def: (?<pm>{ApostrofsRegex}\s*(middags|avonds|nachts)|(in\s+de\s+)?(deze\s+)?((na)?middag|avond|nacht))\b
+  references: [ ApostrofsRegex ]
 InclusiveModPrepositions: !simpleRegex
   def: (?<include>((in|tegen|tijdens|op)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))
 BeforeRegex: !nestedRegex
@@ -553,9 +594,9 @@ AroundRegex: !simpleRegex
 AgoRegex: !simpleRegex
   def: \b(geleden|voor\s+(?<day>gisteren|vandaag))\b
 LaterRegex: !simpleRegex
-  def: \b(later|vanaf nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b
+  def: \b(later|vanaf\s+nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b
 InConnectorRegex: !simpleRegex
-  def: \b(in|over)\b
+  def: \b(in|over)(\s+de)?\b
 SinceYearSuffixRegex: !nestedRegex
   def: (^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})
   references: [ SinceRegex, YearSuffix ]
@@ -566,15 +607,17 @@ TodayNowRegex: !simpleRegex
   def: \b(vandaag|nu)\b
 # "next" group here is used to judge for illegal cases like "within the next 5 days before today"
 MorningStartEndRegex: !nestedRegex
-  def: (^(('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex}))|((('s|des)\s+morgens|in de morgen|('s|des)\s+ochtends|in de ochtend{AmDescRegex})$)
-  references: [ AmDescRegex ]
+  def: (^(({ApostrofsRegex}|des)\s+(morgens|ochtends)|in\s+de\s+(na)?(morgen|ochtend)|deze\s+(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+(morgen|ochtend)|{AmDescRegex}|(morgen|ochtend)))|((({ApostrofsRegex}|des)\s+(morgens|ochtends)|deze\s+(morgen|ochtend)|in\s+de\s+(na)?(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|(morgen|ochtend)\s+aan\s+het\s+einde?|{AmDescRegex}|(morgen|ochtend))$)
+  references: [ ApostrofsRegex, AmDescRegex ]
 AfternoonStartEndRegex: !nestedRegex
-  def: (^(('s|des)\s+middags|in de (na)?middag|{PmDescRegex}))|((('s|des)\s+middags|in de (na)?middag|{PmDescRegex})$)
-  references: [ PmDescRegex ]
-EveningStartEndRegex: !simpleRegex
-  def: (^(avond|('s|des)?\s+avonds))|((avond|('s|des)?\s+avonds)$)
-NightStartEndRegex: !simpleRegex
-  def: (^(gedurende de nacht|vannacht|nacht|('s|des)?\s+nachts))|((gedurende de nacht|vannacht|('s|des)?\s+nachts|nacht)$)
+  def: (^(({ApostrofsRegex}|des)\s+middags|in\s+de\s+(na)?middag|deze\s+middag|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+middag|{PmDescRegex}))|((({ApostrofsRegex}|des)?\s+middags|in\s+de\s+(na)?middag|deze\s+middag|middag\s+in\s+het\s+begin|middag\s+aan\s+het\s+einde?|{PmDescRegex}|middag)$)
+  references: [ ApostrofsRegex, PmDescRegex ]
+EveningStartEndRegex: !nestedRegex
+  def: (^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{PmDescRegex}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{PmDescRegex}|avond)$)
+  references: [ ApostrofsRegex ]
+NightStartEndRegex: !nestedRegex
+  def: (^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)
+  references: [ ApostrofsRegex ]
 InexactNumberRegex: !simpleRegex
   def: \b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b
 InexactNumberUnitRegex: !nestedRegex
@@ -592,11 +635,11 @@ ReferenceDatePeriodRegex: !nestedRegex
 ConnectorRegex: !simpleRegex
   def: ^(-|,|voor|t|rond(om)?|@)$
 FromRegex: !simpleRegex
-  def: \b(van)$
+  def: \b(vanaf|van)$
 BetweenTokenRegex: !simpleRegex
   def: \b(tussen)$
 FromToRegex: !simpleRegex
-  def: \b(van).+(tot)\b.+
+  def: \b(van(af)?).+(tot)\b.+
 SingleAmbiguousMonthRegex: !simpleRegex
   def: ^(de\s+)?(mei)$
 # Filter ambiguous single word datetime extractions in CalendarMode or when adding the modifier
@@ -605,7 +648,7 @@ SingleAmbiguousTermsRegex: !simpleRegex
 UnspecificDatePeriodRegex: !simpleRegex
   def: ^(week|weekend|maand|jaar)$
 PrepositionSuffixRegex: !simpleRegex
-  def: \b(op|in|om|rond(om)?|van|tot)$
+  def: \b((op|in)(\s+de)?|om|rond(om)?|van|tot)$
 FlexibleDayRegex: !simpleRegex
   def: (?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))
 ForTheRegex: !nestedRegex
@@ -618,9 +661,9 @@ WeekDayAndDayRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, AmDescRegex, PmDescRegex, OclockRegex]
 RestOfDateRegex: !simpleRegex
-  def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b
+  def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b
 RestOfDateTimeRegex: !simpleRegex
-  def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|huidige)\s+)?(?<unit>dag)\b
+  def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<unit>vandaag|dag)\b
 MealTimeRegex: !simpleRegex
   def: \b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b
 AmbiguousRangeModifierPrefix: !simpleRegex
@@ -659,10 +702,10 @@ TimeBeforeAfterRegex: !nestedRegex
 DateNumberConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>\s+op)\s*$
 DecadeRegex: !simpleRegex
-  def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend))
+  def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e\s+eeuw|(ee|éé)nentwintigste\s+eeuw))
 DecadeWithCenturyRegex: !nestedRegex
-  def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?(')?(?<decade>\d0)(')?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
-  references: [ CenturyRegex, DecadeRegex ]
+  def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
+  references: [ CenturyRegex, DecadeRegex, ApostrofRegex ]
 RelativeDecadeRegex: !nestedRegex
   def: \b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b
   references: [ RelativeRegex ]
@@ -674,7 +717,7 @@ YearPeriodRegex: !nestedRegex
   def: ((((vanaf|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 ComplexDatePeriodRegex: !nestedRegex
-  def: (((van(af)?|tijdens|gedurende|in)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
+  def: (((van(af)?|tijdens|gedurende|in(\s+de)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 UnitMap: !dictionary
   types: [ string, string ]
@@ -694,6 +737,7 @@ UnitMap: !dictionary
     week: W
     dagen: D
     dag: D
+    vandaag: D
     dgn: D
     uren: H
     uur: H
@@ -726,6 +770,7 @@ UnitValueMap: !dictionary
     week: 604800
     dagen: 86400
     dag: 86400
+    vandaag: 86400
     dgn: 86400
     werkdagen: 86400
     werkdag: 86400
@@ -1222,6 +1267,8 @@ AfternoonTermList: !list
   types: [ string ]
   entries:
     - middag
+    - namiddag
+    - voormiddag
 EveningTermList: !list
   types: [ string ]
   entries:
@@ -1240,8 +1287,12 @@ SameDayTerms: !list
   types: [ string ]
   entries:
     - vandaag
+    - huidige dag
+    - huidige datum
+    - actuele datum
+    - actuele dag
     - deze morgen
-    - vanmorgen
+    - actuele morgen
 PlusOneDayTerms: !list
   types: [ string ]
   entries:
@@ -1249,12 +1300,15 @@ PlusOneDayTerms: !list
     - dag na
     - volgende dag
     - morgenochtend
+    - morgenavond
 MinusOneDayTerms: !list
   types: [ string ]
   entries:
     - gisteren
     - dag voor
     - vorige dag
+    - gisterenochtend
+    - gisterenavond
 PlusTwoDayTerms: !list
   types: [ string ]
   entries:
@@ -1271,6 +1325,7 @@ FutureTerms: !list
     - volgend
     - volgende
     - dit
+    - die
 LastCardinalTerms: !list
   types: [ string ]
   entries:
@@ -1280,6 +1335,7 @@ MonthTerms: !list
   types: [ string ]
   entries:
     - maand
+    - maanden
 MonthToDateTerms: !list
   types: [ string ]
   entries:
@@ -1290,6 +1346,7 @@ WeekendTerms: !list
   types: [ string ]
   entries:
     - weekend
+    - weekenden
 WeekTerms: !list
   types: [ string ]
   entries:

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -131,10 +131,10 @@ ToHalfTokenRegex: !simpleRegex
   def: \b(over\s+half)$
 ForHalfTokenRegex: !simpleRegex
   def: \b(voor\s+half)$
-FromTokenRegex: !simpleRegex
-  def: (van(af)?)$
+FromRegex: !simpleRegex
+  def: \b(van(af)?)$
 BetweenTokenRegex: !simpleRegex
-  def: (tussen)$
+  def: \b(tussen)$
 SimpleCasesRegex: !nestedRegex
   def: \b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex ]
@@ -634,10 +634,6 @@ ReferenceDatePeriodRegex: !nestedRegex
   references: [ReferencePrefixRegex]
 ConnectorRegex: !simpleRegex
   def: ^(-|,|voor|t|rond(om)?|@)$
-FromRegex: !simpleRegex
-  def: \b(vanaf|van)$
-BetweenTokenRegex: !simpleRegex
-  def: \b(tussen)$
 FromToRegex: !simpleRegex
   def: \b(van(af)?).+(tot)\b.+
 SingleAmbiguousMonthRegex: !simpleRegex

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -3,7 +3,7 @@
 LangMarker: Dut
 CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
-  def: (?<till>\b(tot(dat)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
+  def: (?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RangeConnectorRegex: !nestedRegex
   def: (?<and>\b(en|t/m|tot(\s+(aan|en\s+met))?)\b|{BaseDateTime.RangeConnectorSymbolRegex})
@@ -20,9 +20,9 @@ RelativeRegex: !simpleRegex
 StrictRelativeRegex: !simpleRegex
   def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b
 UpcomingPrefixRegex: !simpleRegex
-  def: ((aankomende?|komende?|aanstaande?))
+  def: (aankomende?|komende?|aanstaande?)
 NextPrefixRegex: !nestedRegex
-  def: \b(volgende?|eerstvolgende|aanstaande?|over|{UpcomingPrefixRegex})\b
+  def: \b(volgende?|eerstvolgende|aanstaande?|{UpcomingPrefixRegex})\b
   references: [ UpcomingPrefixRegex ]
 AfterNextSuffixRegex: !simpleRegex
   def: \b((na\s+((de|het)\s+)?volgende?)|over)\b
@@ -69,16 +69,16 @@ WrittenCenturyFullYearRegex: !nestedRegex
 WrittenCenturyOrdinalYearRegex: !simpleRegex
   def: ((ee|éé)nentwintig|tweeëntwintig|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|een|twee|drie|vier|vijf|zes|zeven|acht|negen)
 CenturyRegex: !nestedRegex
-  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)\b
+  def: \b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*honderd)?(\s+en)?)
   references: [WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex ]
 LastTwoYearNumRegex: !nestedRegex
   def: ((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
 FullTextYearRegex: !nestedRegex
-  def: \b((?<firsttwoyearnum>{CenturyRegex})(\s+)?(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b
+  def: \b((?<firsttwoyearnum>{CenturyRegex})\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b
   references: [ CenturyRegex, WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex, LastTwoYearNumRegex ]
 OclockRegex: !simpleRegex
-  def: (?<oclock>uur)
+  def: (?<oclock>u(ur)?)\b
 SpecialDescRegex: !simpleRegex
   def: (p\b)
 AmDescRegex: !nestedRegex
@@ -104,7 +104,7 @@ YearRegex: !nestedRegex
 WeekDayRegex: !simpleRegex
   def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)
 SingleWeekDayRegex: !simpleRegex
-  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b)))
+  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b
   references: [RelativeRegex]
@@ -151,7 +151,7 @@ MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b((((de\s+)?maand\s+van\s+)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
+  def: \b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|nu|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
@@ -193,7 +193,7 @@ AllHalfYearRegex: !nestedRegex
 EarlyPrefixRegex: !simpleRegex
   def: \b(?<EarlyPrefix>((?<RelEarly>eerder)|vroeg(er)?|begin(nend)?|start(end)?)(\s+(in|op|van)(\s+de)?)?)\b
 MidPrefixRegex: !simpleRegex
-  def: \b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)\b
+  def: \b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)
 LaterPrefixRegex: !simpleRegex
   def: \b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b
 PrefixPeriodRegex: !nestedRegex
@@ -240,7 +240,7 @@ NextDateRegex: !nestedRegex
   def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b
   references: [ NextPrefixRegex, WeekDayRegex ]
 SpecialDayRegex: !nestedRegex
-  def: \b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|(morgen|(?<weekday>zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag))(ochtend|(na)?middag|avond|nacht))\b
+  def: \b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
   def: \b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
@@ -329,10 +329,10 @@ PmRegex: !nestedRegex
   def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))
   references: [ ApostrofsRegex ]
 PmRegexFull: !nestedRegex
-  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)))
+  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))
   references: [ ApostrofsRegex ]
 AmRegex: !nestedRegex
-  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))))
+  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^ochtend))
   references: [ ApostrofsRegex ]
 LunchRegex: !simpleRegex
   def: \b(lunchtijd)\b
@@ -366,7 +366,7 @@ SecondDTRegEx: !nestedRegex
   def: ({BaseDateTime.SecondRegex})
   references: [ BaseDateTime.SecondRegex, BaseUnits.SecondRegex]
 BasicTime: !nestedRegex
-  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx})
+  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))
   references: [ WrittenTimeRegex, HourNumRegex, HourDTRegEx, MinuteDTRegEx, SecondDTRegEx ]
 MidnightRegex: !nestedRegex
   def: (?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)
@@ -423,8 +423,8 @@ TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
 TimeRegex7: !nestedRegex
-  def: ({TimeSuffixFull}\s+{BasicTime})((\s*{DescRegex})|\b)
-  references: [ TimeSuffixFull, BasicTime, DescRegex ]
+  def: ({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)
+  references: [ TimeSuffixFull, BasicTime, DescRegex, WrittenTimeRegex, TimePrefix ]
 TimeRegex8: !nestedRegex
   def: .^
   references: [ TimeSuffixFull, BasicTime, DescRegex ]
@@ -510,19 +510,19 @@ SimpleTimeOfTodayBeforeRegex: !nestedRegex
   def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*({HourNumRegex}|{BaseDateTime.HourRegex})\b'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
-  def: ((aan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
+  def: ((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
 UnspecificEndOfRegex: !simpleRegex
   def: \b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b
 UnspecificEndOfRangeRegex: !simpleRegex
   def: \b(evj)\b
 PeriodTimeOfDayRegex: !nestedRegex
-  def: \b((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(?<timeOfDay>ochtend|(na)?middag|nacht|avond))\b
+  def: ((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|(eer)?gisteren|morgen)?(?<timeOfDay>ochtend|(na)?middag|avond|nacht))\b
   references: [ EarlyLateRegex ]
 PeriodSpecificTimeOfDayRegex: !nestedRegex
   def: \b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b
   references: [ PeriodTimeOfDayRegex, StrictRelativeRegex ]
 PeriodTimeOfDayWithDateRegex: !nestedRegex
- def: \b(({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b
+ def: (({TimeOfDayRegex}(\s+(om|rond|tegen|op(\s+de)?))?))\b
  references: [ TimeOfDayRegex ]
 LessThanRegex: !simpleRegex
   def: \b((binnen\s+)?minder\s+dan)\b
@@ -702,7 +702,7 @@ TimeBeforeAfterRegex: !nestedRegex
 DateNumberConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>\s+op)\s*$
 DecadeRegex: !simpleRegex
-  def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|21e\s+eeuw|(ee|éé)nentwintigste\s+eeuw))
+  def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|(ee|éé)nentwintigste\s+eeuw))
 DecadeWithCenturyRegex: !nestedRegex
   def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
   references: [ CenturyRegex, DecadeRegex, ApostrofRegex ]
@@ -1293,6 +1293,7 @@ SameDayTerms: !list
     - actuele dag
     - deze morgen
     - actuele morgen
+    - vanmorgen
 PlusOneDayTerms: !list
   types: [ string ]
   entries:

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -9740,5 +9740,265 @@
         }
       }
     ]
+  },
+  {
+    "Input": "ik ben vandaag weg tussen vijf en zeven",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vandaag weg tussen vijf en zeven",
+        "Start": 7,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T05,2016-11-07T07,PT2H)",
+              "type": "daterange",
+              "start": "2016-11-07 05:00:00",
+              "end": "2016-11-07 07:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "ik ben op 1 januari weg van 5 tot 6",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op 1 januari weg van 5 tot 6",
+        "Start": 7,
+        "End": 34,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
+              "type": "daterange",
+              "start": "2017-01-01 05:00:00",
+              "end": "2017-01-01 06:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Morgen ben ik weg tussen 3 en 4 uur ’s middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tussen 3 en 4 uur ’s middags",
+        "Start": 18,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
+              "type": "daterange",
+              "start": "2016-11-08 15:00:00",
+              "end": "2016-11-08 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Morgen ben ik weg tussen 3 en 4 uur ’s middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tussen 3 en 4 uur ’s middags",
+        "Start": 18,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
+              "type": "daterange",
+              "start": "2016-11-08 15:00:00",
+              "end": "2016-11-08 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Morgen ben ik weg van half acht tot 4 uur ‘s middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+     "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van half acht tot 4 uur ‘s middags",
+        "Start": 18,
+        "End": 51,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
+              "type": "daterange",
+              "start": "2016-11-08 07:30:00",
+              "end": "2016-11-08 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Vandaag ben ik tussen 4 en 5 uur in de middag weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "tussen 4 en 5 uur in de middag",
+        "Start": 15,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16,2016-11-07T17,PT1H)",
+              "type": "daterange",
+              "start": "2016-11-07 16:00:00",
+              "end": "2016-11-07 17:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga deze middag terugI'll go back this afternoon",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "deze middag",
+        "Start": 6,
+        "End": 16,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-07TAF",
+              "type": "daterange",
+              "start": "2016-11-07 12:00:00",
+              "end": "2016-11-07 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "ik ga een minuut terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "een minuut terug",
+        "Start": 6,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:11:00,2016-11-07T16:12:00,PT1M)",
+              "type": "daterange",
+              "start": "2016-11-07 16:11:00",
+              "end": "2016-11-07 16:12:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga over een uur terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "over een uur",
+        "Start": 6,
+        "End": 17,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
+              "type": "daterange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 17:12:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Het zal over 2 uur in de toekomst gebeuren ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2 uur in de toekomst",
+        "Start": 13,
+        "End": 32,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
+              "type": "daterange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 18:12:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -9820,32 +9820,6 @@
     ]
   },
   {
-    "Input": "Morgen ben ik weg tussen 3 en 4 uur ’s middags",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "NotSupported": "dotNet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "tussen 3 en 4 uur ’s middags",
-        "Start": 18,
-        "End": 45,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
-              "type": "daterange",
-              "start": "2016-11-08 15:00:00",
-              "end": "2016-11-08 16:00:00"
-            }
-          ]
-        }
-      }
-    ]
-  },
-  {
     "Input": "Morgen ben ik weg van half acht tot 4 uur ‘s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"

--- a/Specs/DateTime/Dutch/DateTimeParser.json
+++ b/Specs/DateTime/Dutch/DateTimeParser.json
@@ -1232,7 +1232,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het eind van de dag",
+        "Text": "aan het eind van de dag",
         "Type": "datetime",
         "Value": {
           "Timex": "2018-11-21T23:59:59",
@@ -1243,8 +1243,8 @@
             "dateTime": "2018-11-21 23:59:59"
           }
         },
-        "Start": 65,
-        "Length": 19
+        "Start": 61,
+        "Length": 23
       }
     ]
   }

--- a/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
@@ -768,18 +768,6 @@
     ]
   },
   {
-    "Input": "Kan je 23-09-2015 13:30 tot 4 voor ons vastleggen",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "23-09-2015 13:30 tot 4",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 22
-      }
-    ]
-  },
-  {
     "Input": "Ik ga dinsdagmorgen terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [

--- a/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
@@ -756,6 +756,18 @@
     ]
   },
   {
+    "Input": "Kan je 23-09-2015 13:00 tot 4 voor ons vastleggen",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "23-09-2015 13:00 tot 4",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 22
+      }
+    ]
+  },
+  {
     "Input": "Kan je 23-09-2015 13:30 tot 4 voor ons vastleggen",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [

--- a/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodExtractor.json
@@ -1,63 +1,22 @@
 [
   {
     "Input": "Ik ben vijf tot zeven vandaag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vijf tot zeven vandaag",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 19
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Ik ben morgen vijf tot zeven weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen vijf tot zeven",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 25
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 5 tot 6 volgende zondag weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 5 tot 6 volgende zondag",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 23
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 5 tot 18:00 volgende zondag weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 5 tot 18:00 volgende zondag",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 25
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 16:00 tot 17:00 vandaag weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 16:00 tot 17:00 vandaag",
         "Type": "datetimerange",
         "Start": 7,
         "Length": 21
@@ -65,12 +24,95 @@
     ]
   },
   {
-    "Input": "Ik ben van 16:00 vandaag tot 17:00 morgen weg",
-    "NotSupported": "dotnet",
+    "Input": "Ik ben van 5 tot 6 volgende zondag weg",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 16:00 vandaag tot 17:00 morgen ",
+        "Text": "van 5 tot 6 volgende zondag",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 5 tot 18:00 volgende zondag weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 5 tot 18:00 volgende zondag",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 31
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 16:00 tot 17:00 vandaag weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 16:00 tot 17:00 vandaag",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 27
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 16:00 vandaag tot 17:00 morgen weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 16:00 vandaag tot 17:00 morgen",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 34
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 16:00 tot 17:00 morgen weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 16:00 tot 17:00 morgen",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 16:00 tot 17:00 van 6-6-2017 weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 16:00 tot 17:00 van 6-6-2017",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 32
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 16:00 tot 17:00 5 mei, 2018 weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 16:00 tot 17:00 5 mei, 2018",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 31
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben van 4:00 tot 17:00 5 mei, 2018 weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 4:00 tot 17:00 5 mei, 2018",
         "Type": "datetimerange",
         "Start": 7,
         "Length": 30
@@ -78,77 +120,11 @@
     ]
   },
   {
-    "Input": "Ik ben van 16:00 tot 17:00 morgen weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 16:00 tot 17:00 morgen",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 27
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 16:00 tot 17:00 van 6-6-2017 weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 16:00 tot 17:00 van 6-6-2017",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 27
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 16:00 tot 17:00 5 mei, 2018 weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 16:00 tot 17:00 5 mei, 2018 ",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 27
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 4:00 tot 17:00 5 mei, 2018 weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 4:00 tot 17:00 5 mei, 2018 ",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 28
-      }
-    ]
-  },
-  {
     "Input": "Ik ben van 16:00 op 1 jan, 2016 tot 17:00 vandaag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 16:00 op 1 jan, 2016 tot 17:00 vandaag",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 36
-      }
-    ]
-  },
-  {
-    "Input": "Ik ben van 14:00, 21-2-2016 tot 3:32, 23-04-2016 weg",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
         "Type": "datetimerange",
         "Start": 7,
         "Length": 42
@@ -156,60 +132,67 @@
     ]
   },
   {
+    "Input": "Ik ben van 14:00, 21-2-2016 tot 3:32, 23-04-2016 weg",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 41
+      }
+    ]
+  },
+  {
     "Input": "Ik ben van vandaag om 4 uur tot volgende woens om 5 uur weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van vandaag om 4 uur tot volgende woens om 5 uur",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 33
+        "Length": 48
       }
     ]
   },
   {
     "Input": "Ik ben tussen 16:00 en 17:00 vandaag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 16:00 en 17:00 vandaag",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 25
+        "Length": 29
       }
     ]
   },
   {
     "Input": "Ik ben tussen 16:00 op 1 jan, 2016 en 17:00 vandaag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 16:00 op 1 jan, 2016 en 17:00 vandaag ",
+        "Text": "tussen 16:00 op 1 jan, 2016 en 17:00 vandaag",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 40
+        "Length": 44
       }
     ]
   },
   {
     "Input": "Ik ga vanavond terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 7
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Ik ga deze nacht terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,20 +205,18 @@
   },
   {
     "Input": "Ik ga deze avond terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze avond",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 12
+        "Length": 10
       }
     ]
   },
   {
     "Input": "Ik ga deze ochtend terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,180 +229,82 @@
   },
   {
     "Input": "Ik ga deze middag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze middag",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 14
+        "Length": 11
       }
     ]
   },
   {
     "Input": "Ik ga volgende nacht terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende nacht",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 10
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik ga gisterenavond terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "gisterenavond",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 10
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik ga morgenavond terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgenavond",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 14
+        "Length": 11
       }
     ]
   },
   {
     "Input": "Ik ga volgende maandagmiddag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende maandagmiddag",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 21
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Ik ga de nacht van de 5e mei terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de nacht van de 5e mei",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 13
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Ik ga laatste 3 minuut terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste 3 minuut",
-        "Type": "datetimerange",
-        "Start": 6,
-        "Length": 13
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga afgelopen 3 minuut terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "afgelopen 3 minuut",
-        "Type": "datetimerange",
-        "Start": 6,
-        "Length": 13
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga voorgaande 3 minuut terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "voorgaande 3 minuut",
-        "Type": "datetimerange",
-        "Start": 6,
-        "Length": 17
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga voorgaande 3 minuten terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "voorgaande 3 minuten",
-        "Type": "datetimerange",
-        "Start": 6,
-        "Length": 14
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga de volgende 5 uur terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "volgende 5 uur",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 10
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga de laatste minuut terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "laatste minuut",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 11
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga volgend uur terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "volgend uur",
-        "Type": "datetimerange",
-        "Start": 6,
-        "Length": 9
-      }
-    ]
-  },
-  {
-    "Input": "Ik ga laatste paar minuten terug",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "laatste paar minuten",
         "Type": "datetimerange",
         "Start": 6,
         "Length": 16
@@ -429,12 +312,35 @@
     ]
   },
   {
-    "Input": "Ik ga laatste aantal minuten terug",
-    "NotSupported": "dotnet",
+    "Input": "Ik ga afgelopen 3 minuut terug",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "laatste aantal minuten",
+        "Text": "afgelopen 3 minuut",
+        "Type": "datetimerange",
+        "Start": 6,
+        "Length": 18
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga voorgaande 3 minuut terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voorgaande 3 minuut",
+        "Type": "datetimerange",
+        "Start": 6,
+        "Length": 19
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga voorgaande 3 minuten terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "voorgaande 3 minuten",
         "Type": "datetimerange",
         "Start": 6,
         "Length": 20
@@ -442,129 +348,119 @@
     ]
   },
   {
+    "Input": "Ik ga de volgende 5 uur terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende 5 uur",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga de laatste minuut terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "laatste minuut",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 14
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga volgend uur terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgend uur",
+        "Type": "datetimerange",
+        "Start": 6,
+        "Length": 11
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga laatste paar minuten terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "laatste paar minuten",
+        "Type": "datetimerange",
+        "Start": 6,
+        "Length": 20
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga laatste aantal minuten terug",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "laatste aantal minuten",
+        "Type": "datetimerange",
+        "Start": 6,
+        "Length": 22
+      }
+    ]
+  },
+  {
     "Input": "Ik ga dinsdag in de ochtend terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de ochtend",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 22
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik ga dinsdag in de middag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de middag",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 24
+        "Length": 20
       }
     ]
   },
   {
     "Input": "Ik ga dinsdag in de avond terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de avond",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 22
+        "Length": 19
       }
     ]
   },
   {
     "Input": "laten we dinsdag vroeg in de ochtend afspreken ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de ochtend",
         "Type": "datetimerange",
         "Start": 9,
-        "Length": 28
+        "Length": 27
       }
     ]
   },
   {
     "Input": "laten we dinsdag laat in de ochtend afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de ochtend",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 27
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdag vroeg in de middag afspreken",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdag vroeg in de middag",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 30
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdag laat in de middag afspreken",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdag laat in de middag",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 29
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdag vroeg in de avond afspreken",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdag vroeg in de avond",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 28
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdag laat in de avond afspreken",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdag laat in de avond",
-        "Type": "datetimerange",
-        "Start": 9,
-        "Length": 27
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdag vroeg in de nacht afspreken",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdag vroeg in de nacht",
         "Type": "datetimerange",
         "Start": 9,
         "Length": 26
@@ -572,12 +468,23 @@
     ]
   },
   {
-    "Input": "laten we dinsdag laat in de nacht afspreken",
-    "NotSupported": "dotnet",
+    "Input": "laten we dinsdag vroeg in de middag afspreken",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "dinsdag laat in de nacht",
+        "Text": "dinsdag vroeg in de middag",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 26
+      }
+    ]
+  },
+  {
+    "Input": "laten we dinsdag laat in de middag afspreken",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag laat in de middag",
         "Type": "datetimerange",
         "Start": 9,
         "Length": 25
@@ -585,138 +492,175 @@
     ]
   },
   {
-    "Input": "laten we op dinsdag vroeg in de ochtend afspreken ",
-    "NotSupported": "dotnet",
+    "Input": "laten we dinsdag vroeg in de avond afspreken",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag vroeg in de ochtend",
+        "Text": "dinsdag vroeg in de avond",
         "Type": "datetimerange",
         "Start": 9,
-        "Length": 31
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "laten we dinsdag laat in de avond afspreken",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag laat in de avond",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "laten we dinsdag vroeg in de nacht afspreken",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag vroeg in de nacht",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 25
+      }
+    ]
+  },
+  {
+    "Input": "laten we dinsdag laat in de nacht afspreken",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag laat in de nacht",
+        "Type": "datetimerange",
+        "Start": 9,
+        "Length": 24
+      }
+    ]
+  },
+  {
+    "Input": "laten we op dinsdag vroeg in de ochtend afspreken ",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dinsdag vroeg in de ochtend",
+        "Type": "datetimerange",
+        "Start": 12,
+        "Length": 27
       }
     ]
   },
   {
     "Input": "laten we op dinsdag laat in de ochtend afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag laat in de ochtend",
+        "Text": "dinsdag laat in de ochtend",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 30
+        "Start": 12,
+        "Length": 26
       }
     ]
   },
   {
     "Input": "laten we op dinsdag vroeg in de middag afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag vroeg in de middag",
+        "Text": "dinsdag vroeg in de middag",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 33
+        "Start": 12,
+        "Length": 26
       }
     ]
   },
   {
     "Input": "laten we op dinsdag laat in de middag afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag laat in de middag",
+        "Text": "dinsdag laat in de middag",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 32
+        "Start": 12,
+        "Length": 25
       }
     ]
   },
   {
     "Input": "laten we op dinsdag vroeg in de avond afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag vroeg in de avond",
+        "Text": "dinsdag vroeg in de avond",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 31
+        "Start": 12,
+        "Length": 25
       }
     ]
   },
   {
     "Input": "laten we op dinsdag laat in de avond afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag laat in de avond",
+        "Text": "dinsdag laat in de avond",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 30
+        "Start": 12,
+        "Length": 24
       }
     ]
   },
   {
     "Input": "laten we op dinsdag vroeg in de nacht afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag vroeg in de nacht",
+        "Text": "dinsdag vroeg in de nacht",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 29
+        "Start": 12,
+        "Length": 25
       }
     ]
   },
   {
     "Input": "laten we op dinsdag laat in de nacht afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op dinsdag laat in de nacht",
+        "Text": "dinsdag laat in de nacht",
         "Type": "datetimerange",
-        "Start": 9,
-        "Length": 28
+        "Start": 12,
+        "Length": 24
       }
     ]
   },
   {
     "Input": "laten we op dinsdag vroeg in de morgen afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de morgen",
         "Type": "datetimerange",
         "Start": 12,
-        "Length": 21
+        "Length": 26
       }
     ]
   },
   {
     "Input": "laten we op dinsdag laat in de morgen afspreken",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de morgen",
         "Type": "datetimerange",
         "Start": 12,
-        "Length": 20
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Ik ben rest van de dag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -729,193 +673,178 @@
   },
   {
     "Input": "Ik ben rest van deze dag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van deze dag",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 16
+        "Length": 17
       }
     ]
   },
   {
     "Input": "Ik ben rest van huidige dag weg",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "rest van huidige dag weg",
+        "Text": "rest van huidige dag",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 19
+        "Length": 20
       }
     ]
   },
   {
     "Input": "Cortana, plan alsjeblieft een skype voor zakelijk gesprek met Wayne, op vrijdag tussen 13:00 en 16:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vrijdag tussen 13:00 en 16:00",
         "Type": "datetimerange",
         "Start": 72,
-        "Length": 27
+        "Length": 29
       }
     ]
   },
   {
     "Input": "Kan je ons morgen tussen 8:00 en 12:00  inplannen?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 8:00 en 12:00",
         "Type": "datetimerange",
         "Start": 11,
-        "Length": 28
+        "Length": 27
       }
     ]
   },
   {
     "Input": "Kan je ons de 9e dec tussen 8:00 en 14:00 inplannen?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de 9e dec tussen 8:00 en 14:00",
         "Type": "datetimerange",
         "Start": 11,
-        "Length": 27
+        "Length": 30
       }
     ]
   },
   {
     "Input": "Hoi Cortana- leg alsjeblieft een skypegesprek met Jennifer vast. Het is een meeting van 30 minuten op deze vrijdag, in de middag ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze vrijdag, in de middag",
         "Type": "datetimerange",
         "Start": 102,
-        "Length": 29
+        "Length": 26
       }
     ]
   },
   {
     "Input": "Hoi Cortana- leg alsjeblieft een skypegesprek met Jennifer vast. Het is een meeting van 30 minuten in de middag, deze vrijdag ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "in de middag, deze vrijdag ",
+        "Text": "in de middag, deze vrijdag",
         "Type": "datetimerange",
         "Start": 99,
-        "Length": 29
-      }
-    ]
-  },
-  {
-    "Input": "Kan je 23-09-2015 13:00 tot 4 voor ons vastleggen",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "23-09-2015 13:00 tot 4 ",
-        "Type": "datetimerange",
-        "Start": 7,
-        "Length": 21
+        "Length": 26
       }
     ]
   },
   {
     "Input": "Kan je 23-09-2015 13:30 tot 4 voor ons vastleggen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "23-09-2015 13:30 tot 4 ",
+        "Text": "23-09-2015 13:30 tot 4",
         "Type": "datetimerange",
         "Start": 7,
-        "Length": 24
+        "Length": 22
+      }
+    ]
+  },
+  {
+    "Input": "Kan je 23-09-2015 13:30 tot 4 voor ons vastleggen",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "23-09-2015 13:30 tot 4",
+        "Type": "datetimerange",
+        "Start": 7,
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Ik ga dinsdagmorgen terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagmorgen",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 10
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Ik ga dinsdagmiddag terug",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagmiddag",
         "Type": "datetimerange",
         "Start": 6,
-        "Length": 10
+        "Length": 13
       }
     ]
   },
   {
     "Input": "Het zal 2 uur in de toekomst gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 uur in de toekomst",
         "Type": "datetimerange",
         "Start": 8,
-        "Length": 21
+        "Length": 20
       }
     ]
   },
   {
     "Input": "Het zal tussen 10 en 11:30 op 1-1-2015 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "tussen 10 en 11:30 op 1-1-2015 ",
+        "Text": "tussen 10 en 11:30 op 1-1-2015",
         "Type": "datetimerange",
         "Start": 8,
-        "Length": 32
+        "Length": 30
       }
     ]
   },
   {
     "Input": "Het zal 1-1-2015 tussen 10 en 11:30 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1-1-2015 tussen 10 en 11:30 ",
+        "Text": "1-1-2015 tussen 10 en 11:30",
         "Type": "datetimerange",
         "Start": 8,
-        "Length": 29
+        "Length": 27
       }
     ]
   },
   {
     "Input": "Het zal van 10:30 tot 3 op 1-1-2015 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 10:30 tot 3 op 1-1-2015 ",
+        "Text": "van 10:30 tot 3 op 1-1-2015",
         "Type": "datetimerange",
         "Start": 8,
         "Length": 27
@@ -924,20 +853,18 @@
   },
   {
     "Input": "Het zal tussen 3 en 5 op 1-1-2015 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1-1-2015",
         "Type": "datetimerange",
         "Start": 8,
-        "Length": 27
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Het zal van 3:30 tot 5:55 op 1-1-2015 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -950,24 +877,10 @@
   },
   {
     "Input": "Het zal 1-1-2015 na 2:00 gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1-1-2015 na 2:00",
-        "Type": "datetimerange",
-        "Start": 8,
-        "Length": 19
-      }
-    ]
-  },
-  {
-    "Input": "Het zal vandaag voor 16:00 gebeuren",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "vandaag voor 16:00 ",
         "Type": "datetimerange",
         "Start": 8,
         "Length": 16
@@ -975,21 +888,31 @@
     ]
   },
   {
+    "Input": "Het zal vandaag voor 16:00 gebeuren",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vandaag voor 16:00",
+        "Type": "datetimerange",
+        "Start": 8,
+        "Length": 18
+      }
+    ]
+  },
+  {
     "Input": "Het zal volgende woensdag later dan 10 uur 's morgens gebeuren",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende woensdag later dan 10 uur 's morgens",
         "Type": "datetimerange",
         "Start": 8,
-        "Length": 43
+        "Length": 45
       }
     ]
   },
   {
     "Input": "Het gebeurde op afgelopen dinsdag tegen 2 in de middag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1002,20 +925,18 @@
   },
   {
     "Input": "Laten we op 1 feb niet later dan 6:00 gaan",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 feb niet later dan 6:00",
         "Type": "datetimerange",
         "Start": 12,
-        "Length": 26
+        "Length": 25
       }
     ]
   },
   {
     "Input": "Het gebeurde op volgende week na 2:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   }

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -4,7 +4,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "the word 'weg' is not part of our entities and does not fit in between them",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vandaag tussen vijf en zeven",
@@ -23,14 +23,14 @@
         "Start": 11,
         "Length": 28
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben weg van 5 tot 6 op 22/4/2016",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22/4/2016",
@@ -49,14 +49,14 @@
         "Start": 11,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben weg van 5 tot 6 op 22 april",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22 april",
@@ -75,14 +75,14 @@
         "Start": 11,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben weg van 5 tot 6 ‘s middags op 22 april",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 ‘s middags op 22 april",
@@ -101,15 +101,14 @@
         "Start": 11,
         "Length": 34
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben weg op 1 januari van 5 tot 6",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "the word 'weg' is not part of our entities and does not fit in between them",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 januari van 5 tot 6",
@@ -128,15 +127,14 @@
         "Start": 14,
         "Length": 21
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben weg morgen tussen 15 en 16 uur ’s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 15 en 16 uur ’s middags",
@@ -155,42 +153,14 @@
         "Start": 11,
         "Length": 37
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
-  },
-  {
-    "Input": "Ik ben weg morgen tussen 15 en 16 uur",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "Comment": "Added this test case for debugging purposes",
-    "Results": [
-      {
-        "Text": "morgen tussen 15 en 16 uur",
-        "Type": "datetimerange",
-        "Value": {
-          "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
-          "FutureResolution": {
-            "startDateTime": "2016-11-08 15:00:00",
-            "endDateTime": "2016-11-08 16:00:00"
-          },
-          "PastResolution": {
-            "startDateTime": "2016-11-08 15:00:00",
-            "endDateTime": "2016-11-08 16:00:00"
-          }
-        },
-        "Start": 11,
-        "Length": 26
-      }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben weg morgen tussen 15 en 16 uur ‘s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 15 en 16 uur ‘s middags",
@@ -209,15 +179,40 @@
         "Start": 11,
         "Length": 37
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben weg morgen tussen 15 en 16 uur",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgen tussen 15 en 16 uur",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          }
+        },
+        "Start": 11,
+        "Length": 26
+      }
+    ]
   },
   {
     "Input": "Ik ben weg van morgen half acht tot 16 uur ‘s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van morgen half acht tot 16 uur ‘s middags",
@@ -236,15 +231,40 @@
         "Start": 11,
         "Length": 42
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben weg vanaf 4 uur vandaag tot morgen 5 uur ’s middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanaf 4 uur vandaag tot morgen 5 uur ’s middags",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-07T04,2016-11-08T17,PT37H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-07 04:00:00",
+            "endDateTime": "2016-11-08 17:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-07 04:00:00",
+            "endDateTime": "2016-11-08 17:00:00"
+          }
+        },
+        "Start": 11,
+        "Length": 47
+      }
+    ]
   },
   {
     "Input": "Ik ben weg vanaf 16 uur vandaag tot morgen 17 uur ’s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanaf 16 uur vandaag tot morgen 17 uur ’s middags",
@@ -263,15 +283,40 @@
         "Start": 11,
         "Length": 49
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben weg van 2016-2-21 vanaf 14:00 tot 2016-04-23 15:32",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanaf 14:00 tot 2016-04-23 15:32",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-04-23T14:00,2016-04-23T15:32,PT1H32M)",
+          "FutureResolution": {
+            "startDateTime": "2016-04-23 14:00:00",
+            "endDateTime": "2016-04-23 15:32:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-04-23 14:00:00",
+            "endDateTime": "2016-04-23 15:32:00"
+          }
+        },
+        "Start": 25,
+        "Length": 32
+      }
+    ]
   },
   {
     "Input": "Ik ben weg van 2016-2-21 14:00 tot 2016-04-23 03:32",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Removed 'vanaf' and make it consistent with the English test case",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 2016-2-21 14:00 tot 2016-04-23 03:32",
@@ -290,15 +335,14 @@
         "Start": 11,
         "Length": 40
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben vandaag tussen 16 en 17 uur in de middag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vandaag tussen 16 en 17 uur in de middag",
@@ -317,15 +361,40 @@
         "Start": 7,
         "Length": 40
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben niet beschikbaar tussen 1 januari 2016 vanaf 4 uur tot vandaag 5 uur in de middag",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanaf 4 uur tot vandaag 5 uur in de middag",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-07T04,2016-11-07T17,PT13H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-07 04:00:00",
+            "endDateTime": "2016-11-07 17:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-07 04:00:00",
+            "endDateTime": "2016-11-07 17:00:00"
+          }
+        },
+        "Start": 46,
+        "Length": 42
+      }
+    ]
   },
   {
     "Input": "Ik ben niet beschikbaar tussen 1 januari 2016 16 uur tot vandaag 17 uur in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 januari 2016 16 uur tot vandaag 17 uur in de middag",
@@ -344,14 +413,14 @@
         "Start": 24,
         "Length": 60
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga vanavond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
@@ -370,14 +439,14 @@
         "Start": 6,
         "Length": 8
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben vanavond beschikbaar",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
@@ -396,14 +465,14 @@
         "Start": 7,
         "Length": 8
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze avond terug ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze avond",
@@ -422,14 +491,14 @@
         "Start": 6,
         "Length": 10
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga vanavond terug ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
@@ -448,14 +517,14 @@
         "Start": 6,
         "Length": 8
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze ochtend terug ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze ochtend",
@@ -474,15 +543,14 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The English text was not removed",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze middag",
@@ -501,14 +569,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga morgenavond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgenavond",
@@ -527,14 +595,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga de laatste avond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste avond",
@@ -553,14 +621,14 @@
         "Start": 9,
         "Length": 13
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga morgenavond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgenavond",
@@ -579,14 +647,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga morgennacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgennacht",
@@ -605,14 +673,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga aankomende maandagmiddag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "aankomende maandagmiddag",
@@ -631,14 +699,14 @@
         "Start": 6,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de laatste 3 minuten terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste 3 minuten",
@@ -657,14 +725,14 @@
         "Start": 9,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga 3 minuten terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3 minuten terug",
@@ -683,14 +751,14 @@
         "Start": 6,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga drie minuten terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "drie minuten terug",
@@ -709,14 +777,14 @@
         "Start": 6,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga binnen 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 uur",
@@ -735,15 +803,14 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga terug in de laatste minuut",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The translation into Dutch was not correct, considering the meaning behind it",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste minuut",
@@ -762,17 +829,17 @@
         "Start": 18,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
-    "Input": "Ik ga over een uur terug",
+    "Input": "Ik ga terug in het volgende uur",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "over een uur",
+        "Text": "volgende uur",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
@@ -785,17 +852,17 @@
             "endDateTime": "2016-11-07 17:12:00"
           }
         },
-        "Start": 6,
+        "Start": 19,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga binnen een paar uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen een paar uur",
@@ -814,14 +881,14 @@
         "Start": 6,
         "Length": 19
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga dinsdagochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend",
@@ -840,14 +907,14 @@
         "Start": 6,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kan je aankomende dinsdagochtend een tijdstip voor ons vinden?",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "aankomende dinsdagochtend",
@@ -866,14 +933,14 @@
         "Start": 7,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Organizeer een vergadering van 30 minuten op dinsdagochtend alsjeblieft. ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend",
@@ -892,14 +959,14 @@
         "Start": 45,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga dinsdagmiddag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagmiddag",
@@ -918,14 +985,14 @@
         "Start": 6,
         "Length": 13
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga dinsdagavond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond",
@@ -944,14 +1011,14 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Laten we dinsdagochtend vroeg afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend vroeg",
@@ -971,15 +1038,42 @@
         "Start": 9,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "laten we vroeg op de dinsdagochtend afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Parsing cannot be done on both sides of the day/date, and time(-related) entities ('vroeg' (early), 'ochtend' (morning)) need to be placed together",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vroeg op de dinsdagochtend",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TMO",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 08:00:00",
+            "endDateTime": "2016-11-08 10:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 08:00:00",
+            "endDateTime": "2016-11-01 10:00:00"
+          }
+        },
+        "Start": 9,
+        "Length": 26
+      }
+    ]
   },
   {
     "Input": "laten we op de dinsdagochtend vroeg afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('vroeg', 'ochtend') need to be placed together",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend vroeg",
@@ -999,14 +1093,14 @@
         "Start": 15,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we dinsdag laat in de ochtend afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de ochtend",
@@ -1026,15 +1120,42 @@
         "Start": 9,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "laten we in het begin van dinsdagmiddag afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Parsing cannot be done on both sides of the day/date, and time(-related) entities ('in het begin', 'middag') need to be placed together",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "begin van dinsdagmiddag",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TAF",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 12:00:00",
+            "endDateTime": "2016-11-08 14:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 12:00:00",
+            "endDateTime": "2016-11-01 14:00:00"
+          }
+        },
+        "Start": 16,
+        "Length": 23
+      }
+    ]
   },
   {
     "Input": "laten we dinsdagmiddag in het begin afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('in het begin', 'middag') need to be placed together",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagmiddag in het begin",
@@ -1054,14 +1175,14 @@
         "Start": 9,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we op dinsdag later in de middag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag later in de middag",
@@ -1081,14 +1202,14 @@
         "Start": 12,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we dinsdag vroeg in de avond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de avond",
@@ -1108,15 +1229,14 @@
         "Start": 9,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we dinsdag in het begin van de avond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The word 'dinsdag' belongs to our entities",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in het begin van de avond",
@@ -1136,14 +1256,14 @@
         "Start": 9,
         "Length": 33
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond laat",
@@ -1163,14 +1283,14 @@
         "Start": 9,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Laten we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond laat",
@@ -1190,14 +1310,14 @@
         "Start": 9,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we dinsdagavond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond",
@@ -1216,14 +1336,14 @@
         "Start": 9,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "zullen we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond laat",
@@ -1243,14 +1363,14 @@
         "Start": 10,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "zullen we dinsdag vroeg in de ochtend afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de ochtend",
@@ -1270,15 +1390,42 @@
         "Start": 10,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "laten we aan het einde van dinsdagochtend afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'ochtend') need to be placed together",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "einde van dinsdagochtend",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TMO",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 10:00:00",
+            "endDateTime": "2016-11-08 12:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 10:00:00",
+            "endDateTime": "2016-11-01 12:00:00"
+          }
+        },
+        "Start": 17,
+        "Length": 24
+      }
+    ]
   },
   {
     "Input": "laten we dinsdagochtend aan het einde afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'ochtend') need to be placed together",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend aan het einde",
@@ -1298,15 +1445,42 @@
         "Start": 9,
         "Length": 28
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "zullen we aan het einde van dinsdagmiddag afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'middag') need to be placed together",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "het einde van dinsdagmiddag",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TAF",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 14:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 14:00:00",
+            "endDateTime": "2016-11-01 16:00:00"
+          }
+        },
+        "Start": 14,
+        "Length": 27
+      }
+    ]
   },
   {
     "Input": "zullen we dinsdagmiddag aan het einde afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'middag') need to be placed together",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagmiddag aan het einde",
@@ -1326,14 +1500,14 @@
         "Start": 10,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Zullen we op dinsdag aan het einde van de middag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag aan het einde van de middag",
@@ -1353,14 +1527,14 @@
         "Start": 13,
         "Length": 35
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we op dinsdag in de avond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de avond",
@@ -1379,14 +1553,14 @@
         "Start": 12,
         "Length": 19
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "zullen we dinsdag in de avond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de avond",
@@ -1405,15 +1579,42 @@
         "Start": 10,
         "Length": 19
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "laten we laat op dinsdagavond afspreken",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Parsing cannot be done on both sides of the day/date, and time(-related) entities ('laat', 'avond') need to be placed together",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "laat op dinsdagavond",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TNI",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 22:00:00",
+            "endDateTime": "2016-11-08 23:59:59"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 22:00:00",
+            "endDateTime": "2016-11-01 23:59:59"
+          }
+        },
+        "Start": 9,
+        "Length": 20
+      }
+    ]
   },
   {
     "Input": "laten we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('laat', 'avond') need to be placed together",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagavond laat",
@@ -1433,14 +1634,14 @@
         "Start": 9,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we de rest van de dag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van de dag",
@@ -1459,14 +1660,14 @@
         "Start": 12,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we de rest van deze dag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van deze dag",
@@ -1485,14 +1686,14 @@
         "Start": 12,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we de rest van mijn dag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van mijn dag",
@@ -1511,14 +1712,14 @@
         "Start": 12,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we rest van vandaag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van vandaag",
@@ -1537,15 +1738,14 @@
         "Start": 9,
         "Length": 16
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we de rest van vandaag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Other test cases where 'rest' is used, 'de' is not extracted so it is also removed from this test case",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van vandaag",
@@ -1564,14 +1764,14 @@
         "Start": 12,
         "Length": 16
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben afwezig van 2016-02-21 14:00 uur tot 2016-02-23 03:32",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 2016-02-21 14:00 uur tot 2016-02-23 03:32",
@@ -1590,15 +1790,40 @@
         "Start": 15,
         "Length": 45
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 1 en 4 uur ‘s middags.",
+    "Context": {
+      "ReferenceDateTime": "2017-11-09T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdag tussen 1 en 4 uur ‘s middags",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-WXX-5T01,XXXX-WXX-5T04,PT3H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-10 01:00:00",
+            "endDateTime": "2017-11-10 04:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-03 01:00:00",
+            "endDateTime": "2017-11-03 04:00:00"
+          }
+        },
+        "Start": 58,
+        "Length": 36
+      }
+    ]
   },
   {
     "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 13 en 16 uur ‘s middags.",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vrijdag tussen 13 en 16 uur ‘s middags",
@@ -1617,15 +1842,14 @@
         "Start": 58,
         "Length": 38
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 13 en 16 uur.",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "Comment": "Added this test case for debugging purposes",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vrijdag tussen 13 en 16 uur",
@@ -1644,15 +1868,40 @@
         "Start": 58,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Kan je ons morgen tussen 8 uur ‘s ochtends en 2 uur ’s middags inplannen?",
+    "Context": {
+      "ReferenceDateTime": "2017-11-09T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgen tussen 8 uur ‘s ochtends en 2 uur ’s middags",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2017-11-10T08,2017-11-10T14,PT6H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-10 08:00:00",
+            "endDateTime": "2017-11-10 14:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-10 08:00:00",
+            "endDateTime": "2017-11-10 14:00:00"
+          }
+        },
+        "Start": 11,
+        "Length": 51
+      }
+    ]
   },
   {
     "Input": "Kan je ons morgen tussen 8 uur ‘s ochtends en 14 uur ’s middags inplannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so double digit hours are used for the afternoon and evening",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 8 uur ‘s ochtends en 14 uur ’s middags",
@@ -1671,15 +1920,40 @@
         "Start": 11,
         "Length": 52
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Kan je ons op 9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags in plannen?",
+    "Context": {
+      "ReferenceDateTime": "2017-11-09T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-12-09T08,XXXX-12-09T14,PT6H)",
+          "FutureResolution": {
+            "startDateTime": "2017-12-09 08:00:00",
+            "endDateTime": "2017-12-09 14:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-12-09 08:00:00",
+            "endDateTime": "2016-12-09 14:00:00"
+          }
+        },
+        "Start": 14,
+        "Length": 55
+      }
+    ]
   },
   {
     "Input": "Kan je ons op 9 december tussen 8 uur ‘s ochtends en 14 uur ‘s middags in plannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9 december tussen 8 uur ‘s ochtends en 14 uur ‘s middags",
@@ -1698,15 +1972,42 @@
         "Start": 14,
         "Length": 56
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Hi Cortana, plan een skype meeting in met Jennifer. Ik heb een afspraak van 30 minuten op vrijdagmiddag aanstaande nodig. ",
+    "Context": {
+      "ReferenceDateTime": "2017-11-13T16:12:00"
+    },
+    "Comment": "Words that are related to each other, such as 'aanstaande' and 'vrijdag', may not be seperated by other words from a different entity such as 'middag'",
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdagmiddag aanstaande",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2017-11-17TAF",
+          "FutureResolution": {
+            "startDateTime": "2017-11-17 12:00:00",
+            "endDateTime": "2017-11-17 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-17 12:00:00",
+            "endDateTime": "2017-11-17 16:00:00"
+          }
+        },
+        "Start": 90,
+        "Length": 24
+      }
+    ]
   },
   {
     "Input": "Hi Cortana, plan een skype meeting in met Jennifer. Ik heb een afspraak van 30 minuten op aanstaande vrijdagmiddag nodig. ",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
-    "Comment": "Words that are related to each other, such as 'aanstaande' and 'vrijdag', may not be seperated by other words from a different entity such as 'middag''",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "aanstaande vrijdagmiddag",
@@ -1725,14 +2026,14 @@
         "Start": 90,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Hi Coratna – plan aub een skype meeting met Jennifer in. Ik heb een afspraak van 30 minuten op deze vrijdagmiddag nodig.",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze vrijdagmiddag",
@@ -1751,14 +2052,14 @@
         "Start": 95,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Hi Cortana- maak een skype meeting met Jennifer aan. Ik wil volgende vrijdagmiddag een afspraak van 30 minuten!",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende vrijdagmiddag",
@@ -1777,14 +2078,14 @@
         "Start": 60,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": " Hi Cortana- maak een skype meeting met Jennifer aan. Ik wil een afspraak van 30 minuten op afgelopen vrijdagmiddag! ",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen vrijdagmiddag",
@@ -1803,15 +2104,40 @@
         "Start": 92,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdagmiddag tussen 1 en 4. ",
+    "Context": {
+      "ReferenceDateTime": "2017-11-14T19:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vrijdagmiddag tussen 1 en 4",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-WXX-5T1,XXXX-WXX-5T4,PT3H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-17 01:00:00",
+            "endDateTime": "2017-11-17 04:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-10 01:00:00",
+            "endDateTime": "2017-11-10 04:00:00"
+          }
+        },
+        "Start": 63,
+        "Length": 27
+      }
+    ]
   },
   {
     "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdagmiddag tussen 13 en 16. ",
     "Context": {
       "ReferenceDateTime": "2017-11-14T19:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vrijdagmiddag tussen 13 en 16",
@@ -1830,15 +2156,14 @@
         "Start": 63,
         "Length": 29
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdag tussen 13 en 16. ",
     "Context": {
       "ReferenceDateTime": "2017-11-14T19:12:00"
     },
-    "Comment": "Added this test case for debugging purposes",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vrijdag tussen 13 en 16",
@@ -1857,15 +2182,14 @@
         "Start": 63,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we 5 februari in de ochtend afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Corrected the translation into Dutch, 'in ochtend afspreken' does not make sense",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5 februari in de ochtend",
@@ -1884,14 +2208,14 @@
         "Start": 9,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga dinsdagochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdagochtend",
@@ -1910,14 +2234,14 @@
         "Start": 6,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ga dinsdag in de middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de middag",
@@ -1936,18 +2260,17 @@
         "Start": 6,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
-    "Input": "Het zal over 2 uur in de toekomst gebeuren ",
+    "Input": "Het zal binnen 2 uur in de toekomst gebeuren",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The word 'over' already means 'after'",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "over 2 uur",
+        "Text": "binnen 2 uur",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
@@ -1961,16 +2284,16 @@
           }
         },
         "Start": 8,
-        "Length": 10
+        "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben terug binnen 15 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 15 seconden",
@@ -1989,14 +2312,14 @@
         "Start": 13,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen 5 minuten terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 minuten",
@@ -2015,14 +2338,14 @@
         "Start": 7,
         "Length": 16
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben binnen 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 uur",
@@ -2041,14 +2364,14 @@
         "Start": 7,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben binnen een dag en 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen een dag en 5 uur",
@@ -2067,15 +2390,14 @@
         "Start": 7,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak is af binnen 2 dagen, 1 uur, 5 minuten en 30 seconden ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The Timex value from the English test case is used",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 2 dagen, 1 uur, 5 minuten en 30 seconden",
@@ -2094,15 +2416,14 @@
         "Start": 16,
         "Length": 47
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak is compleet binnen 2 dagen, 1 uur, 5 minuten en 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The Timex value from the English test case is used",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 2 dagen, 1 uur, 5 minuten en 30 seconden",
@@ -2121,15 +2442,14 @@
         "Start": 22,
         "Length": 47
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak is klaar binnen aankomende 2 dagen, 1 uur, 5 minuten en 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The Timex value from the English test case is used",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen aankomende 2 dagen, 1 uur, 5 minuten en 30 seconden",
@@ -2148,14 +2468,14 @@
         "Start": 19,
         "Length": 58
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 uur",
@@ -2174,14 +2494,14 @@
         "Start": 7,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "ik ben maandag tussen 8 en 9 terug",
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag tussen 8 en 9",
@@ -2200,14 +2520,14 @@
         "Start": 7,
         "Length": 21
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Cortana kan je een tijd voor ons vinden op maandag 11-4 ",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 11-4",
@@ -2226,14 +2546,14 @@
         "Start": 43,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal op 1/1/2015 tussen 10 en 11:30 plaatsvinden",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1/1/2015 tussen 10 en 11:30",
@@ -2252,14 +2572,14 @@
         "Start": 11,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal gebeuren op 1/1/2015 tussen 10 en 11:30",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1/1/2015 tussen 10 en 11:30",
@@ -2278,15 +2598,40 @@
         "Start": 20,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Het zal gebeuren van 10:30 tot 3 op 1/1/2015",
+    "Context": {
+      "ReferenceDateTime": "2018-05-16T08:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 10:30 tot 3 op 1/1/2015",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2015-01-01T10:30,2015-01-01T15,PT4H30M)",
+          "FutureResolution": {
+            "startDateTime": "2015-01-01 10:30:00",
+            "endDateTime": "2015-01-01 15:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2015-01-01 10:30:00",
+            "endDateTime": "2015-01-01 15:00:00"
+          }
+        },
+        "Start": 17,
+        "Length": 27
+      }
+    ]
   },
   {
     "Input": "Het zal gebeuren van 10:30 tot 15 op 1/1/2015",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 10:30 tot 15 op 1/1/2015",
@@ -2305,14 +2650,14 @@
         "Start": 17,
         "Length": 28
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "het zal tussen 3 en 5 op 1/1/2015 gebeuren.",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1/1/2015",
@@ -2331,14 +2676,14 @@
         "Start": 8,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het is op 1/1/2015 van 3:30 tot 5:55",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1/1/2015 van 3:30 tot 5:55",
@@ -2357,14 +2702,14 @@
         "Start": 10,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben vandaag vijf tot zeven weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vandaag vijf tot zeven",
@@ -2383,14 +2728,14 @@
         "Start": 7,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben van 5 tot 6 op 22-4-2016 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22-4-2016",
@@ -2409,14 +2754,14 @@
         "Start": 7,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben van 5 tot 6 op 22 april weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22 april",
@@ -2435,15 +2780,40 @@
         "Start": 7,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik van van 5 tot 18:00 op 22 april weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van 5 tot 18:00 op 22 april",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-04-22T05,XXXX-04-22T18:00,PT13H)",
+          "FutureResolution": {
+            "startDateTime": "2017-04-22 05:00:00",
+            "endDateTime": "2017-04-22 18:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-04-22 05:00:00",
+            "endDateTime": "2016-04-22 18:00:00"
+          }
+        },
+        "Start": 7,
+        "Length": 27
+      }
+    ]
   },
   {
     "Input": "Ik ga van 17 tot 18:00 op 22 april weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Correction to the translation, and am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 17 tot 18:00 op 22 april",
@@ -2462,14 +2832,14 @@
         "Start": 6,
         "Length": 28
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben van 5 tot 6 op de 1e van jan weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op de 1e van jan",
@@ -2488,14 +2858,40 @@
         "Start": 7,
         "Length": 28
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben morgen van 15:00 tot 16:00 weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgen van 15:00 tot 16:00",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-08T15:00,2016-11-08T16:00,PT1H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          }
+        },
+        "Start": 7,
+        "Length": 26
+      }
+    ]
   },
   {
     "Input": "Ik ben morgen van 15 tot 16 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen van 15 tot 16",
@@ -2514,14 +2910,14 @@
         "Start": 7,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben 3:00 tot 4:00 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3:00 tot 4:00 morgen",
@@ -2540,14 +2936,40 @@
         "Start": 7,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ben half acht tot 16:00 morgen weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "half acht tot 16:00 morgen",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-08T07:30,2016-11-08T16:00,PT8H30M)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 07:30:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-08 07:30:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          }
+        },
+        "Start": 7,
+        "Length": 26
+      }
+    ]
   },
   {
     "Input": "Ik ben half acht tot 16 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "half acht tot 16 morgen",
@@ -2566,41 +2988,14 @@
         "Start": 7,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
-  },
-  {
-    "Input": "Ik ben van 16 vandaag tot 17 morgen weg",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "Comment": "Added this test case for debugging purposes",
-    "Results": [
-      {
-        "Text": "van 16 vandaag tot 17 morgen",
-        "Type": "datetimerange",
-        "Value": {
-          "Timex": "(2016-11-07T16,2016-11-08T17,PT25H)",
-          "FutureResolution": {
-            "startDateTime": "2016-11-07 16:00:00",
-            "endDateTime": "2016-11-08 17:00:00"
-          },
-          "PastResolution": {
-            "startDateTime": "2016-11-07 16:00:00",
-            "endDateTime": "2016-11-08 17:00:00"
-          }
-        },
-        "Start": 7,
-        "Length": 28
-      }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben van 16:00 vandaag tot 17:00 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 16:00 vandaag tot 17:00 morgen",
@@ -2619,14 +3014,14 @@
         "Start": 7,
         "Length": 34
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben van 14:00, 21-2-2016 tot 3:32, 23-04-2016 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
@@ -2645,14 +3040,14 @@
         "Start": 7,
         "Length": 41
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben tussen 16:00 en 17:00 vandaag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 16:00 en 17:00 vandaag",
@@ -2671,14 +3066,14 @@
         "Start": 7,
         "Length": 29
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben tussen 16:00 op 1 jan, 2016 en 17:00 vandaag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 16:00 op 1 jan, 2016 en 17:00 vandaag",
@@ -2697,15 +3092,14 @@
         "Start": 7,
         "Length": 44
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
-    "Input": "Ik ga vanavond voor 20 terug",
+    "Input": "Ik ga vanavond voor 8 terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
@@ -2724,14 +3118,40 @@
         "Start": 6,
         "Length": 8
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
+  },
+  {
+    "Input": "Ik ga vanavond voor 20 terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vanavond",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2016-11-07TEV",
+          "FutureResolution": {
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
+          }
+        },
+        "Start": 6,
+        "Length": 8
+      }
+    ]
   },
   {
     "Input": "Ik ga deze nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze nacht",
@@ -2750,14 +3170,14 @@
         "Start": 6,
         "Length": 10
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze avond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze avond",
@@ -2776,14 +3196,14 @@
         "Start": 6,
         "Length": 10
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze ochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze ochtend",
@@ -2802,14 +3222,14 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga deze middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze middag",
@@ -2828,14 +3248,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de volgende nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende nacht",
@@ -2854,15 +3274,14 @@
         "Start": 9,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga afgelopen nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The word 'afgelopen' means last. See the next added test case, where 'vorige' is used, which means previous",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen nacht",
@@ -2881,15 +3300,14 @@
         "Start": 6,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga vorige nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Added this test case for debugging purposes",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vorige nacht",
@@ -2908,14 +3326,14 @@
         "Start": 6,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga morgennacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgennacht",
@@ -2934,14 +3352,14 @@
         "Start": 6,
         "Length": 11
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga volgende maandagmiddag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende maandagmiddag",
@@ -2960,14 +3378,14 @@
         "Start": 6,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga afgelopen 3 min terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen 3 min",
@@ -2986,14 +3404,14 @@
         "Start": 6,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga de volgende 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende 5 uren",
@@ -3012,14 +3430,14 @@
         "Start": 9,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga laatste minuut terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste minuut",
@@ -3038,14 +3456,14 @@
         "Start": 6,
         "Length": 14
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga komend uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komend uur",
@@ -3064,14 +3482,14 @@
         "Start": 6,
         "Length": 10
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga komende paar uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende paar uur",
@@ -3090,14 +3508,14 @@
         "Start": 6,
         "Length": 16
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga dinsdag in de ochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de ochtend",
@@ -3116,14 +3534,14 @@
         "Start": 6,
         "Length": 21
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kunt u ons alstublieft helpen een tijdstip te vinden in de ochtend van deze dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "in de ochtend van deze dinsdag",
@@ -3142,14 +3560,14 @@
         "Start": 53,
         "Length": 30
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Organiseer alsjeblieft een meeting van 30 minuten op dinsdag, in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag, in de ochtend",
@@ -3168,14 +3586,14 @@
         "Start": 53,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga dinsdag in de middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de middag",
@@ -3194,14 +3612,14 @@
         "Start": 6,
         "Length": 20
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ga dinsdag in de avond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de avond",
@@ -3220,14 +3638,14 @@
         "Start": 6,
         "Length": 19
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken vroeg in de ochtend dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de ochtend dinsdag",
@@ -3247,14 +3665,14 @@
         "Start": 19,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken vroeg in de ochtend op dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de ochtend op dinsdag",
@@ -3274,14 +3692,14 @@
         "Start": 19,
         "Length": 30
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken laat in de ochtend dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de ochtend dinsdag",
@@ -3301,14 +3719,14 @@
         "Start": 19,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken vroeg in de middag dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de middag dinsdag",
@@ -3328,14 +3746,14 @@
         "Start": 19,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken laat in de middag dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de middag dinsdag",
@@ -3355,14 +3773,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken vroeg in de avond dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de avond dinsdag",
@@ -3382,14 +3800,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken laat in de avond dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de avond dinsdag",
@@ -3409,14 +3827,14 @@
         "Start": 19,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken vroeg in de nacht dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de nacht dinsdag",
@@ -3436,14 +3854,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken laat in de nacht dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de nacht dinsdag",
@@ -3463,14 +3881,14 @@
         "Start": 19,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de ochtend",
@@ -3490,14 +3908,14 @@
         "Start": 19,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag laat in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de ochtend",
@@ -3517,14 +3935,14 @@
         "Start": 19,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de middag",
@@ -3544,14 +3962,14 @@
         "Start": 19,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag laat in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de middag",
@@ -3571,14 +3989,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de avond",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de avond",
@@ -3598,14 +4016,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag laat in de avond",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de avond",
@@ -3625,14 +4043,14 @@
         "Start": 19,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de nacht",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de nacht",
@@ -3652,14 +4070,14 @@
         "Start": 19,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken dinsdag laat in de nacht",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de nacht",
@@ -3679,15 +4097,14 @@
         "Start": 19,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we de rest van de huidige dag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "Other test cases where 'rest' is used, 'de' is not extracted so it is also removed from this test case",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "rest van de huidige dag",
@@ -3706,14 +4123,14 @@
         "Start": 12,
         "Length": 23
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben weg van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
@@ -3732,14 +4149,14 @@
         "Start": 11,
         "Length": 41
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken in de late nacht op dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "in de late nacht op dinsdag",
@@ -3759,14 +4176,14 @@
         "Start": 19,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kan je ons morgen tussen 8:00 en 14:00 inplannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 8:00 en 14:00",
@@ -3785,14 +4202,14 @@
         "Start": 11,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Kan je ons 9 dec tussen 8:00 en 14:00 inplannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9 dec tussen 8:00 en 14:00",
@@ -3811,14 +4228,14 @@
         "Start": 11,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Hoi Cortana, plan alsjeblieft een Skypegesprek met Jennifer. Ik heb een meeting van 30 min nodig op deze vrijdag, in de middag.",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze vrijdag, in de middag",
@@ -3837,14 +4254,14 @@
         "Start": 100,
         "Length": 26
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "laten we afspreken op 5 feb 's ochtends",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5 feb 's ochtends",
@@ -3863,14 +4280,14 @@
         "Start": 22,
         "Length": 17
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal 2 uren in de toekomst gebeuren",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 uren in de toekomst",
@@ -3889,15 +4306,14 @@
         "Start": 8,
         "Length": 21
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen 15 seconden terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The word 'binnen' (within) is part of the entity and part of the meaning",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 15 seconden",
@@ -3916,14 +4332,14 @@
         "Start": 7,
         "Length": 18
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 uren",
@@ -3942,14 +4358,14 @@
         "Start": 7,
         "Length": 13
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen 1 dag en 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 1 dag en 5 uren",
@@ -3968,14 +4384,14 @@
         "Start": 7,
         "Length": 22
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak zou af zijn binnen 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 2 dagen, 1 uur, 5 minuten, 30 seconden",
@@ -3994,14 +4410,14 @@
         "Start": 22,
         "Length": 45
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak zou af zijn binnen volgende 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen volgende 2 dagen, 1 uur, 5 minuten, 30 seconden",
@@ -4020,15 +4436,14 @@
         "Start": 22,
         "Length": 54
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Deze taak zou af zijn binnen aankomende 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "Comment": "The word 'binnen' (within) is part of the entity and part of the meaning",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen aankomende 2 dagen, 1 uur, 5 minuten, 30 seconden",
@@ -4047,14 +4462,14 @@
         "Start": 22,
         "Length": 56
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben binnen de volgende 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen de volgende 5 uur",
@@ -4073,14 +4488,14 @@
         "Start": 7,
         "Length": 24
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Ik ben maandag 8 tot 9 terug",
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 8 tot 9",
@@ -4099,14 +4514,14 @@
         "Start": 7,
         "Length": 15
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 12-4",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 12-4",
@@ -4125,14 +4540,14 @@
         "Start": 46,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 11-4",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 11-4",
@@ -4151,14 +4566,14 @@
         "Start": 46,
         "Length": 12
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal tussen 10 en 11:30 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 10 en 11:30 op 1-1-2015",
@@ -4177,14 +4592,14 @@
         "Start": 8,
         "Length": 30
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal 1-1-2015 tussen 10 en 11:30 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1-1-2015 tussen 10 en 11:30",
@@ -4203,14 +4618,14 @@
         "Start": 8,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal van 10:30 tot 3 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 10:30 tot 3 op 1-1-2015",
@@ -4229,14 +4644,14 @@
         "Start": 8,
         "Length": 27
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal tussen 3 en 5 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1-1-2015",
@@ -4255,15 +4670,14 @@
         "Start": 8,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal tussen 3 en 5 op 1/1/2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "Comment": "Added this test case for debugging purposes",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1/1/2015",
@@ -4282,14 +4696,14 @@
         "Start": 8,
         "Length": 25
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   },
   {
     "Input": "Het zal van 3:30 tot 5:55 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 3:30 tot 5:55 op 1-1-2015",
@@ -4308,7 +4722,6 @@
         "Start": 8,
         "Length": 29
       }
-    ],
-    "NotSupportedByDesign": "javascript,python,java"
+    ]
   }
 ]

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -3207,14 +3207,14 @@
         "Text": "afgelopen nacht",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-07TNI",
+          "Timex": "2016-11-06TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           }
         },
         "Start": 6,

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -546,32 +546,6 @@
     ]
   },
   {
-    "Input": "Ik ga deze middag terug",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "deze middag",
-        "Type": "datetimerange",
-        "Value": {
-          "Timex": "2016-11-07TAF",
-          "FutureResolution": {
-            "startDateTime": "2016-11-07 12:00:00",
-            "endDateTime": "2016-11-07 16:00:00"
-          },
-          "PastResolution": {
-            "startDateTime": "2016-11-07 12:00:00",
-            "endDateTime": "2016-11-07 16:00:00"
-          }
-        },
-        "Start": 6,
-        "Length": 11
-      }
-    ]
-  },
-  {
     "Input": "Ik ga morgenavond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
@@ -1286,33 +1260,6 @@
     ]
   },
   {
-    "Input": "Laten we dinsdagavond laat afspreken",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdagavond laat",
-        "Type": "datetimerange",
-        "Value": {
-          "Timex": "XXXX-WXX-2TEV",
-          "Mod": "end",
-          "FutureResolution": {
-            "startDateTime": "2016-11-08 18:00:00",
-            "endDateTime": "2016-11-08 20:00:00"
-          },
-          "PastResolution": {
-            "startDateTime": "2016-11-01 18:00:00",
-            "endDateTime": "2016-11-01 20:00:00"
-          }
-        },
-        "Start": 9,
-        "Length": 17
-      }
-    ]
-  },
-  {
     "Input": "laten we dinsdagavond afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
@@ -1606,33 +1553,6 @@
         },
         "Start": 9,
         "Length": 20
-      }
-    ]
-  },
-  {
-    "Input": "laten we dinsdagavond laat afspreken",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T16:12:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dinsdagavond laat",
-        "Type": "datetimerange",
-        "Value": {
-          "Timex": "XXXX-WXX-2TEV",
-          "Mod": "end",
-          "FutureResolution": {
-            "startDateTime": "2016-11-08 18:00:00",
-            "endDateTime": "2016-11-08 20:00:00"
-          },
-          "PastResolution": {
-            "startDateTime": "2016-11-01 18:00:00",
-            "endDateTime": "2016-11-01 20:00:00"
-          }
-        },
-        "Start": 9,
-        "Length": 17
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -1,12 +1,13 @@
 [
   {
-    "Input": "ik ben vandaag weg tussen vijf en zeven",
+    "Input": "ik ben weg vandaag tussen vijf en zeven",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "the word 'weg' is not part of our entities and does not fit in between them",
     "Results": [
       {
-        "Text": "vandaag weg tussen vijf en zeven",
+        "Text": "vandaag tussen vijf en zeven",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T05,2016-11-07T07,PT2H)",
@@ -19,11 +20,10 @@
             "endDateTime": "2016-11-07 07:00:00"
           }
         },
-        "Start": 7,
-        "Length": 32
+        "Start": 11,
+        "Length": 28
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -50,7 +50,6 @@
         "Length": 24
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -77,7 +76,6 @@
         "Length": 23
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -104,17 +102,17 @@
         "Length": 34
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "ik ben op 1 januari weg van 5 tot 6",
+    "Input": "ik ben weg op 1 januari van 5 tot 6",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "the word 'weg' is not part of our entities and does not fit in between them",
     "Results": [
       {
-        "Text": "op 1 januari weg van 5 tot 6",
+        "Text": "1 januari van 5 tot 6",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
@@ -127,21 +125,21 @@
             "endDateTime": "2016-01-01 06:00:00"
           }
         },
-        "Start": 7,
-        "Length": 28
+        "Start": 14,
+        "Length": 21
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Morgen ben ik weg tussen 3 en 4 uur ’s middags",
+    "Input": "Ik ben weg morgen tussen 15 en 16 uur ’s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "tussen 3 en 4 uur ’s middags",
+        "Text": "morgen tussen 15 en 16 uur ’s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
@@ -154,49 +152,75 @@
             "endDateTime": "2016-11-08 16:00:00"
           }
         },
-        "Start": 18,
-        "Length": 28
+        "Start": 11,
+        "Length": 37
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Morgen ben ik weg tussen 3 en 4 uur ‘s middags",
+    "Input": "Ik ben weg morgen tussen 15 en 16 uur",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Added this test case for debugging purposes",
     "Results": [
       {
-        "Text": "tussen 3 en 4 uur ‘s middags",
+        "Text": "morgen tussen 15 en 16 uur",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-08T03:00,2016-11-08T04:00,PT1H)",
+          "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 03:00:00",
-            "endDateTime": "2016-11-08 04:00:00"
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-08 03:00:00",
-            "endDateTime": "2016-11-08 04:00:00"
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
           }
         },
-        "Start": 18,
-        "Length": 28
+        "Start": 11,
+        "Length": 26
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Morgen ben ik weg van half acht tot 4 uur ‘s middags",
+    "Input": "Ik ben weg morgen tussen 15 en 16 uur ‘s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "van half acht tot 4 uur ‘s middags",
+        "Text": "morgen tussen 15 en 16 uur ‘s middags",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-08 15:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
+          }
+        },
+        "Start": 11,
+        "Length": 37
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Ik ben weg van morgen half acht tot 16 uur ‘s middags",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
+    "Results": [
+      {
+        "Text": "van morgen half acht tot 16 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
@@ -209,20 +233,21 @@
             "endDateTime": "2016-11-08 16:00:00"
           }
         },
-        "Start": 18,
-        "Length": 34
+        "Start": 11,
+        "Length": 42
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg vanaf 4 uur vandaag tot morgen 5 uur ’s middags",
+    "Input": "Ik ben weg vanaf 16 uur vandaag tot morgen 17 uur ’s middags",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "vanaf 4 uur vandaag tot morgen 5 uur ’s middags",
+        "Text": "vanaf 16 uur vandaag tot morgen 17 uur ’s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16,2016-11-08T17,PT25H)",
@@ -236,20 +261,20 @@
           }
         },
         "Start": 11,
-        "Length": 47
+        "Length": 49
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben weg van 2016-2-21 vanaf 14:00 tot 2016-04-23 15:32",
+    "Input": "Ik ben weg van 2016-2-21 14:00 tot 2016-04-23 03:32",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Removed 'vanaf' and make it consistent with the English test case",
     "Results": [
       {
-        "Text": "van 2016-2-21 vanaf 14:00 tot 2016-04-23 15:32",
+        "Text": "van 2016-2-21 14:00 tot 2016-04-23 03:32",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
@@ -263,20 +288,20 @@
           }
         },
         "Start": 11,
-        "Length": 46
+        "Length": 40
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Vandaag ben ik tussen 4 en 5 uur in de middag weg",
+    "Input": "Ik ben vandaag tussen 16 en 17 uur in de middag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "tussen 4 en 5 uur in de middag",
+        "Text": "vandaag tussen 16 en 17 uur in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16,2016-11-07T17,PT1H)",
@@ -289,21 +314,21 @@
             "endDateTime": "2016-11-07 17:00:00"
           }
         },
-        "Start": 15,
-        "Length": 30
+        "Start": 7,
+        "Length": 40
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben niet beschikbaar tussen 1 januari 2016 vanaf 4 uur tot vandaag 5 uur in de middag",
+    "Input": "Ik ben niet beschikbaar tussen 1 januari 2016 16 uur tot vandaag 17 uur in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "tussen 1 januari 2016 vanaf 4 uur tot vandaag 5 uur in de middag",
+        "Text": "tussen 1 januari 2016 16 uur tot vandaag 17 uur in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-01-01T16,2016-11-07T17,PT7465H)",
@@ -317,10 +342,9 @@
           }
         },
         "Start": 24,
-        "Length": 64
+        "Length": 60
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -333,21 +357,20 @@
         "Text": "vanavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-07TNI",
+          "Timex": "2016-11-07TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           }
         },
         "Start": 6,
         "Length": 8
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -360,21 +383,20 @@
         "Text": "vanavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-07TNI",
+          "Timex": "2016-11-07TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           }
         },
         "Start": 7,
         "Length": 8
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -387,21 +409,20 @@
         "Text": "deze avond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-07TNI",
+          "Timex": "2016-11-07TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           }
         },
         "Start": 6,
         "Length": 10
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -428,7 +449,6 @@
         "Length": 8
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -455,14 +475,14 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ga deze middag terugI'll go back this afternoon",
+    "Input": "Ik ga deze middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "The English text was not removed",
     "Results": [
       {
         "Text": "deze middag",
@@ -482,7 +502,6 @@
         "Length": 11
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -495,21 +514,20 @@
         "Text": "morgenavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-08TNI",
+          "Timex": "2016-11-08TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           }
         },
         "Start": 6,
         "Length": 11
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -522,21 +540,20 @@
         "Text": "laatste avond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-06TNI",
+          "Timex": "2016-11-06TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-06 20:00:00",
-            "endDateTime": "2016-11-06 23:59:59"
+            "startDateTime": "2016-11-06 16:00:00",
+            "endDateTime": "2016-11-06 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-06 20:00:00",
-            "endDateTime": "2016-11-06 23:59:59"
+            "startDateTime": "2016-11-06 16:00:00",
+            "endDateTime": "2016-11-06 20:00:00"
           }
         },
         "Start": 9,
         "Length": 13
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -549,21 +566,20 @@
         "Text": "morgenavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-08TNI",
+          "Timex": "2016-11-08TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           }
         },
         "Start": 6,
         "Length": 11
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -578,19 +594,18 @@
         "Value": {
           "Timex": "2016-11-08TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 00:00:00",
-            "endDateTime": "2016-11-08 06:00:00"
+            "startDateTime": "2016-11-08 20:00:00",
+            "endDateTime": "2016-11-08 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-08 00:00:00",
-            "endDateTime": "2016-11-08 06:00:00"
+            "startDateTime": "2016-11-08 20:00:00",
+            "endDateTime": "2016-11-08 23:59:59"
           }
         },
         "Start": 6,
         "Length": 11
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -617,7 +632,6 @@
         "Length": 24
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -644,7 +658,6 @@
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -671,7 +684,6 @@
         "Length": 15
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -698,7 +710,6 @@
         "Length": 18
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -725,17 +736,17 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "ik ga een minuut terug",
+    "Input": "ik ga terug in de laatste minuut",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "The translation into Dutch was not correct, considering the meaning behind it",
     "Results": [
       {
-        "Text": "een minuut terug",
+        "Text": "laatste minuut",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:11:00,2016-11-07T16:12:00,PT1M)",
@@ -748,11 +759,10 @@
             "endDateTime": "2016-11-07 16:12:00"
           }
         },
-        "Start": 6,
-        "Length": 16
+        "Start": 18,
+        "Length": 14
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -779,7 +789,6 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -792,21 +801,20 @@
         "Text": "binnen een paar uur",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16:12:00,2016-11-07T19:12:00,PT3H)",
+          "Timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:12:00",
-            "endDateTime": "2016-11-07 19:12:00"
+            "endDateTime": "2016-11-07 18:12:00"
           },
           "PastResolution": {
             "startDateTime": "2016-11-07 16:12:00",
-            "endDateTime": "2016-11-07 19:12:00"
+            "endDateTime": "2016-11-07 18:12:00"
           }
         },
         "Start": 6,
         "Length": 19
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -833,7 +841,6 @@
         "Length": 14
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -860,7 +867,6 @@
         "Length": 25
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -887,7 +893,6 @@
         "Length": 14
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -914,7 +919,6 @@
         "Length": 13
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -941,7 +945,6 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -955,6 +958,7 @@
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -968,20 +972,21 @@
         "Length": 20
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "laten we vroeg op de dinsdagochtend afspreken",
+    "Input": "laten we op de dinsdagochtend vroeg afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('vroeg', 'ochtend') need to be placed together",
     "Results": [
       {
-        "Text": "vroeg op de dinsdagochtend",
+        "Text": "dinsdagochtend vroeg",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -991,11 +996,10 @@
             "endDateTime": "2016-11-01 10:00:00"
           }
         },
-        "Start": 9,
-        "Length": 26
+        "Start": 15,
+        "Length": 20
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1009,6 +1013,7 @@
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 10:00:00",
             "endDateTime": "2016-11-08 12:00:00"
@@ -1022,20 +1027,21 @@
         "Length": 26
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "laten we in het begin van dinsdagmiddag afspreken",
+    "Input": "laten we dinsdagmiddag in het begin afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('in het begin', 'middag') need to be placed together",
     "Results": [
       {
-        "Text": "begin van dinsdagmiddag",
+        "Text": "dinsdagmiddag in het begin",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 12:00:00",
             "endDateTime": "2016-11-08 14:00:00"
@@ -1045,11 +1051,10 @@
             "endDateTime": "2016-11-01 14:00:00"
           }
         },
-        "Start": 16,
-        "Length": 23
+        "Start": 9,
+        "Length": 26
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1063,6 +1068,7 @@
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 14:00:00",
             "endDateTime": "2016-11-08 16:00:00"
@@ -1076,7 +1082,6 @@
         "Length": 26
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1090,6 +1095,7 @@
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 16:00:00",
             "endDateTime": "2016-11-08 18:00:00"
@@ -1103,7 +1109,6 @@
         "Length": 25
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1111,26 +1116,27 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "The word 'dinsdag' belongs to our entities",
     "Results": [
       {
-        "Text": "begin van de avond",
+        "Text": "dinsdag in het begin van de avond",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "start",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 18:00:00",
-            "endDateTime": "2016-11-08 20:00:00"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 18:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 18:00:00",
-            "endDateTime": "2016-11-01 20:00:00"
+            "startDateTime": "2016-11-01 16:00:00",
+            "endDateTime": "2016-11-01 18:00:00"
           }
         },
-        "Start": 24,
-        "Length": 18
+        "Start": 9,
+        "Length": 33
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1143,21 +1149,21 @@
         "Text": "dinsdagavond laat",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 22:00:00"
+            "startDateTime": "2016-11-08 18:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 20:00:00",
-            "endDateTime": "2016-11-01 22:00:00"
+            "startDateTime": "2016-11-01 18:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 9,
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1170,21 +1176,21 @@
         "Text": "dinsdagavond laat",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 22:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 18:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 22:00:00",
-            "endDateTime": "2016-11-01 23:59:59"
+            "startDateTime": "2016-11-01 18:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 9,
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1197,21 +1203,20 @@
         "Text": "dinsdagavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 22:00:00"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 20:00:00",
-            "endDateTime": "2016-11-01 22:00:00"
+            "startDateTime": "2016-11-01 16:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 9,
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1224,21 +1229,21 @@
         "Text": "dinsdagavond laat",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 22:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 18:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 22:00:00",
-            "endDateTime": "2016-11-01 23:59:59"
+            "startDateTime": "2016-11-01 18:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 10,
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1252,6 +1257,7 @@
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -1265,20 +1271,21 @@
         "Length": 27
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "laten we aan het einde van dinsdagochtend afspreken",
+    "Input": "laten we dinsdagochtend aan het einde afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'ochtend') need to be placed together",
     "Results": [
       {
-        "Text": "einde van dinsdagochtend",
+        "Text": "dinsdagochtend aan het einde",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 10:00:00",
             "endDateTime": "2016-11-08 12:00:00"
@@ -1288,24 +1295,25 @@
             "endDateTime": "2016-11-01 12:00:00"
           }
         },
-        "Start": 17,
-        "Length": 24
+        "Start": 9,
+        "Length": 28
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "zullen we aan het einde van dinsdagmiddag afspreken",
+    "Input": "zullen we dinsdagmiddag aan het einde afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('aan het einde', 'middag') need to be placed together",
     "Results": [
       {
-        "Text": "het einde van dinsdagmiddag",
+        "Text": "dinsdagmiddag aan het einde",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 14:00:00",
             "endDateTime": "2016-11-08 16:00:00"
@@ -1315,11 +1323,10 @@
             "endDateTime": "2016-11-01 16:00:00"
           }
         },
-        "Start": 14,
+        "Start": 10,
         "Length": 27
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1332,21 +1339,21 @@
         "Text": "dinsdag aan het einde van de middag",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TEV",
+          "Timex": "XXXX-WXX-2TAF",
+          "Mod": "end",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 16:00:00",
-            "endDateTime": "2016-11-08 18:00:00"
+            "startDateTime": "2016-11-08 14:00:00",
+            "endDateTime": "2016-11-08 16:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 16:00:00",
-            "endDateTime": "2016-11-01 18:00:00"
+            "startDateTime": "2016-11-01 14:00:00",
+            "endDateTime": "2016-11-01 16:00:00"
           }
         },
         "Start": 13,
         "Length": 35
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1361,11 +1368,11 @@
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 18:00:00",
+            "startDateTime": "2016-11-08 16:00:00",
             "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 18:00:00",
+            "startDateTime": "2016-11-01 16:00:00",
             "endDateTime": "2016-11-01 20:00:00"
           }
         },
@@ -1373,7 +1380,6 @@
         "Length": 19
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1386,48 +1392,48 @@
         "Text": "dinsdag in de avond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 20:00:00",
-            "endDateTime": "2016-11-08 22:00:00"
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 20:00:00",
-            "endDateTime": "2016-11-01 22:00:00"
+            "startDateTime": "2016-11-01 16:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 10,
         "Length": 19
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "laten we laat op dinsdagavond afspreken",
+    "Input": "laten we dinsdagavond laat afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Extraction goes OK, but parsing cannot be done on both sides of the day/date, and time(-related) entities ('laat', 'avond') need to be placed together",
     "Results": [
       {
-        "Text": "laat op dinsdagavond",
+        "Text": "dinsdagavond laat",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TNI",
+          "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 22:00:00",
-            "endDateTime": "2016-11-08 23:59:59"
+            "startDateTime": "2016-11-08 18:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 22:00:00",
-            "endDateTime": "2016-11-01 23:59:59"
+            "startDateTime": "2016-11-01 18:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 9,
-        "Length": 20
+        "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1454,7 +1460,6 @@
         "Length": 15
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1481,7 +1486,6 @@
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1508,7 +1512,6 @@
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1535,7 +1538,6 @@
         "Length": 16
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1543,9 +1545,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "Comment": "Other test cases where 'rest' is used, 'de' is not extracted so it is also removed from this test case",
     "Results": [
       {
-        "Text": "de rest van vandaag",
+        "Text": "rest van vandaag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T23:59:59,PT28079S)",
@@ -1558,48 +1561,47 @@
             "endDateTime": "2016-11-07 23:59:59"
           }
         },
-        "Start": 9,
-        "Length": 19
+        "Start": 12,
+        "Length": 16
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "ik ben afwezig van 2016-02-21 14:00 uur tot 2016-02-21 15:32",
+    "Input": "ik ben afwezig van 2016-02-21 14:00 uur tot 2016-02-23 03:32",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
     "Results": [
       {
-        "Text": "van 2016-02-21 14:00 uur tot 2016-02-21 15:32",
+        "Text": "van 2016-02-21 14:00 uur tot 2016-02-23 03:32",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
+          "Timex": "(2016-02-21T14:00,2016-02-23T03:32,PT38H)",
           "FutureResolution": {
             "startDateTime": "2016-02-21 14:00:00",
-            "endDateTime": "2016-04-23 03:32:00"
+            "endDateTime": "2016-02-23 03:32:00"
           },
           "PastResolution": {
             "startDateTime": "2016-02-21 14:00:00",
-            "endDateTime": "2016-04-23 03:32:00"
+            "endDateTime": "2016-02-23 03:32:00"
           }
         },
         "Start": 15,
         "Length": 45
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 1 en 4 uur ‘s middags.",
+    "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 13 en 16 uur ‘s middags.",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "vrijdag tussen 1 en 4 uur ‘s middags",
+        "Text": "vrijdag tussen 13 en 16 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-WXX-5T13,XXXX-WXX-5T16,PT3H)",
@@ -1613,20 +1615,47 @@
           }
         },
         "Start": 58,
-        "Length": 36
+        "Length": 38
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Kan je ons morgen tussen 8 uur ‘s ochtends en 2 uur ’s middags inplannen?",
+    "Input": "Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 13 en 16 uur.",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
+    "Comment": "Added this test case for debugging purposes",
     "Results": [
       {
-        "Text": "morgen tussen 8 uur ‘s ochtends en 2 uur ’s middags",
+        "Text": "vrijdag tussen 13 en 16 uur",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-WXX-5T13,XXXX-WXX-5T16,PT3H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-10 13:00:00",
+            "endDateTime": "2017-11-10 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-03 13:00:00",
+            "endDateTime": "2017-11-03 16:00:00"
+          }
+        },
+        "Start": 58,
+        "Length": 27
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Kan je ons morgen tussen 8 uur ‘s ochtends en 14 uur ’s middags inplannen?",
+    "Context": {
+      "ReferenceDateTime": "2017-11-09T16:12:00"
+    },
+    "Comment": "Am and pm are not used in Dutch so double digit hours are used for the afternoon and evening",
+    "Results": [
+      {
+        "Text": "morgen tussen 8 uur ‘s ochtends en 14 uur ’s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2017-11-10T08,2017-11-10T14,PT6H)",
@@ -1640,20 +1669,20 @@
           }
         },
         "Start": 11,
-        "Length": 51
+        "Length": 52
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Kan je ons op 9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags in plannen?",
+    "Input": "Kan je ons op 9 december tussen 8 uur ‘s ochtends en 14 uur ‘s middags in plannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags",
+        "Text": "9 december tussen 8 uur ‘s ochtends en 14 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-12-09T08,XXXX-12-09T14,PT6H)",
@@ -1667,20 +1696,20 @@
           }
         },
         "Start": 14,
-        "Length": 55
+        "Length": 56
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Hi Cortana, plan een skype meeting in met Jennifer. Ik heb een afspraak van 30 minuten op vrijdagmiddag aanstaande nodig. ",
+    "Input": "Hi Cortana, plan een skype meeting in met Jennifer. Ik heb een afspraak van 30 minuten op aanstaande vrijdagmiddag nodig. ",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
+    "Comment": "Words that are related to each other, such as 'aanstaande' and 'vrijdag', may not be seperated by other words from a different entity such as 'middag''",
     "Results": [
       {
-        "Text": "vrijdagmiddag aanstaande",
+        "Text": "aanstaande vrijdagmiddag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2017-11-17TAF",
@@ -1697,7 +1726,6 @@
         "Length": 24
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1724,7 +1752,6 @@
         "Length": 18
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1751,7 +1778,6 @@
         "Length": 22
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -1778,17 +1804,17 @@
         "Length": 23
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdagmiddag tussen 1 en 4. ",
+    "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdagmiddag tussen 13 en 16. ",
     "Context": {
       "ReferenceDateTime": "2017-11-14T19:12:00"
     },
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "vrijdagmiddag tussen 1 en 4",
+        "Text": "vrijdagmiddag tussen 13 en 16",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-WXX-5T13,XXXX-WXX-5T16,PT3H)",
@@ -1802,21 +1828,47 @@
           }
         },
         "Start": 63,
-        "Length": 27
+        "Length": 29
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "laten we 5 februari in ochtend afspreken",
+    "Input": "Cortane, maak een afspraak met skype for business met Wayne op vrijdag tussen 13 en 16. ",
+    "Context": {
+      "ReferenceDateTime": "2017-11-14T19:12:00"
+    },
+    "Comment": "Added this test case for debugging purposes",
+    "Results": [
+      {
+        "Text": "vrijdag tussen 13 en 16",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(XXXX-WXX-5T13,XXXX-WXX-5T16,PT3H)",
+          "FutureResolution": {
+            "startDateTime": "2017-11-17 13:00:00",
+            "endDateTime": "2017-11-17 16:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2017-11-10 13:00:00",
+            "endDateTime": "2017-11-10 16:00:00"
+          }
+        },
+        "Start": 63,
+        "Length": 23
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "laten we 5 februari in de ochtend afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "Corrected the translation into Dutch, 'in ochtend afspreken' does not make sense",
     "Results": [
       {
-        "Text": "5 februari in ochtend",
+        "Text": "5 februari in de ochtend",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-02-05TMO",
@@ -1830,7 +1882,7 @@
           }
         },
         "Start": 9,
-        "Length": 21
+        "Length": 24
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -1840,7 +1892,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "dinsdagochtend",
@@ -1867,7 +1918,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "dinsdag in de middag",
@@ -1894,10 +1944,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "The word 'over' already means 'after'",
     "Results": [
       {
-        "Text": "2 uur in de toekomst",
+        "Text": "over 2 uur",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
@@ -1910,8 +1960,8 @@
             "endDateTime": "2016-11-07 18:12:00"
           }
         },
-        "Start": 13,
-        "Length": 20
+        "Start": 8,
+        "Length": 10
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -1921,7 +1971,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "binnen 15 seconden",
@@ -1948,7 +1997,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "binnen 5 minuten",
@@ -1975,7 +2023,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "binnen 5 uur",
@@ -2002,7 +2049,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "binnen een dag en 5 uur",
@@ -2029,13 +2075,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "The Timex value from the English test case is used",
     "Results": [
       {
-        "Text": "2 dagen, 1 uur, 5 minuten en 30 seconden",
+        "Text": "binnen 2 dagen, 1 uur, 5 minuten en 30 seconden",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1HT5MT30S)",
+          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:12:00",
             "endDateTime": "2016-11-09 17:17:30"
@@ -2045,8 +2091,8 @@
             "endDateTime": "2016-11-09 17:17:30"
           }
         },
-        "Start": 23,
-        "Length": 40
+        "Start": 16,
+        "Length": 47
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -2056,13 +2102,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "The Timex value from the English test case is used",
     "Results": [
       {
         "Text": "binnen 2 dagen, 1 uur, 5 minuten en 30 seconden",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1HT5MT30S)",
+          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:12:00",
             "endDateTime": "2016-11-09 17:17:30"
@@ -2083,13 +2129,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "The Timex value from the English test case is used",
     "Results": [
       {
         "Text": "binnen aankomende 2 dagen, 1 uur, 5 minuten en 30 seconden",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1HT5MT30S)",
+          "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:12:00",
             "endDateTime": "2016-11-09 17:17:30"
@@ -2110,7 +2156,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "binnen 5 uur",
@@ -2137,7 +2182,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "maandag tussen 8 en 9",
@@ -2164,7 +2208,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "maandag 11-4",
@@ -2191,10 +2234,9 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "op 1/1/2015 tussen 10 en 11:30",
+        "Text": "1/1/2015 tussen 10 en 11:30",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2015-01-01T10,2015-01-01T11:30,PT1H30M)",
@@ -2207,8 +2249,8 @@
             "endDateTime": "2015-01-01 11:30:00"
           }
         },
-        "Start": 8,
-        "Length": 30
+        "Start": 11,
+        "Length": 27
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -2218,7 +2260,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1/1/2015 tussen 10 en 11:30",
@@ -2241,14 +2282,14 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Het zal gebeuren van 10:30 tot 3 op 1/1/2015",
+    "Input": "Het zal gebeuren van 10:30 tot 15 op 1/1/2015",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "van 10:30 tot 3 op 1/1/2015",
+        "Text": "van 10:30 tot 15 op 1/1/2015",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2015-01-01T10:30,2015-01-01T15,PT4H30M)",
@@ -2262,7 +2303,7 @@
           }
         },
         "Start": 17,
-        "Length": 27
+        "Length": 28
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -2272,7 +2313,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1/1/2015",
@@ -2299,10 +2339,9 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "op 1/1/2015 van 3:30 tot 5:55",
+        "Text": "1/1/2015 van 3:30 tot 5:55",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2015-01-01T03:30,2015-01-01T05:55,PT2H25M)",
@@ -2315,8 +2354,8 @@
             "endDateTime": "2015-01-01 05:55:00"
           }
         },
-        "Start": 7,
-        "Length": 29
+        "Start": 10,
+        "Length": 26
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"
@@ -2326,8 +2365,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vandaag vijf tot zeven",
@@ -2344,17 +2381,16 @@
           }
         },
         "Start": 7,
-        "Length": 19
+        "Length": 22
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben van 5 tot 6 op 22-4-2016 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22-4-2016",
@@ -2373,15 +2409,14 @@
         "Start": 7,
         "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben van 5 tot 6 op 22 april weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op 22 april",
@@ -2400,21 +2435,21 @@
         "Start": 7,
         "Length": 23
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik van van 5 tot 18:00 op 22 april weg",
+    "Input": "Ik ga van 17 tot 18:00 op 22 april weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "Correction to the translation, and am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
-        "Text": "van 5 tot 18:00 op 22 april ",
+        "Text": "van 17 tot 18:00 op 22 april",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(XXXX-04-22T17,XXXX-04-22T18,PT1H)",
+          "Timex": "(XXXX-04-22T17,XXXX-04-22T18:00,PT1H)",
           "FutureResolution": {
             "startDateTime": "2017-04-22 17:00:00",
             "endDateTime": "2017-04-22 18:00:00"
@@ -2424,18 +2459,17 @@
             "endDateTime": "2016-04-22 18:00:00"
           }
         },
-        "Start": 7,
-        "Length": 25
+        "Start": 6,
+        "Length": 28
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben van 5 tot 6 op de 1e van jan weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 5 tot 6 op de 1e van jan",
@@ -2452,20 +2486,19 @@
           }
         },
         "Start": 7,
-        "Length": 22
+        "Length": 28
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben morgen van 15:00 tot 16:00 weg",
+    "Input": "Ik ben morgen van 15 tot 16 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "morgen van 15:00 tot 16:00",
+        "Text": "morgen van 15 tot 16",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
@@ -2479,17 +2512,16 @@
           }
         },
         "Start": 7,
-        "Length": 19
+        "Length": 20
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben 3:00 tot 4:00 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3:00 tot 4:00 morgen",
@@ -2506,20 +2538,19 @@
           }
         },
         "Start": 7,
-        "Length": 21
+        "Length": 20
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben half acht tot 16:00 morgen weg",
+    "Input": "Ik ben half acht tot 16 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "half acht tot 16:00 morgen",
+        "Text": "half acht tot 16 morgen",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
@@ -2533,20 +2564,20 @@
           }
         },
         "Start": 7,
-        "Length": 31
+        "Length": 23
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben van 16:00 vandaag tot 17:00 morgen weg",
+    "Input": "Ik ben van 16 vandaag tot 17 morgen weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "Added this test case for debugging purposes",
     "Results": [
       {
-        "Text": "van 16:00 vandaag tot 17:00 morgen ",
+        "Text": "van 16 vandaag tot 17 morgen",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16,2016-11-08T17,PT25H)",
@@ -2560,20 +2591,45 @@
           }
         },
         "Start": 7,
-        "Length": 30
+        "Length": 28
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Ik ben van 16:00 vandaag tot 17:00 morgen weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Results": [
+      {
+        "Text": "van 16:00 vandaag tot 17:00 morgen",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-07T16:00,2016-11-08T17:00,PT25H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-08 17:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-08 17:00:00"
+          }
+        },
+        "Start": 7,
+        "Length": 34
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben van 14:00, 21-2-2016 tot 3:32, 23-04-2016 weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "14:00, 21-2-2016 tot 3:32, 23-04-2016",
+        "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
@@ -2586,24 +2642,23 @@
             "endDateTime": "2016-04-23 03:32:00"
           }
         },
-        "Start": 11,
-        "Length": 42
+        "Start": 7,
+        "Length": 41
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben tussen 16:00 en 17:00 vandaag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 16:00 en 17:00 vandaag",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16,2016-11-07T17,PT1H)",
+          "Timex": "(2016-11-07T16:00,2016-11-07T17:00,PT1H)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:00:00",
             "endDateTime": "2016-11-07 17:00:00"
@@ -2614,23 +2669,22 @@
           }
         },
         "Start": 7,
-        "Length": 25
+        "Length": 29
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben tussen 16:00 op 1 jan, 2016 en 17:00 vandaag weg",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 16:00 op 1 jan, 2016 en 17:00 vandaag",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-01-01T16,2016-11-07T17,PT7465H)",
+          "Timex": "(2016-01-01T16:00,2016-11-07T17:00,PT7465H)",
           "FutureResolution": {
             "startDateTime": "2016-01-01 16:00:00",
             "endDateTime": "2016-11-07 17:00:00"
@@ -2641,44 +2695,43 @@
           }
         },
         "Start": 7,
-        "Length": 40
+        "Length": 44
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ga vanavond voor 8 terug",
+    "Input": "Ik ga vanavond voor 20 terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "Am and pm are not used in Dutch so the 24 hour format is used to specify before (AM) or after noon (PM)",
     "Results": [
       {
         "Text": "vanavond",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-07TNI",
+          "Timex": "2016-11-07TEV",
           "FutureResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-07 20:00:00",
-            "endDateTime": "2016-11-07 23:59:59"
+            "startDateTime": "2016-11-07 16:00:00",
+            "endDateTime": "2016-11-07 20:00:00"
           }
         },
         "Start": 6,
-        "Length": 7
+        "Length": 8
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga deze nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze nacht",
@@ -2697,15 +2750,14 @@
         "Start": 6,
         "Length": 10
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga deze avond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze avond",
@@ -2722,17 +2774,16 @@
           }
         },
         "Start": 6,
-        "Length": 12
+        "Length": 10
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga deze ochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze ochtend",
@@ -2751,15 +2802,14 @@
         "Start": 6,
         "Length": 12
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga deze middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze middag",
@@ -2776,17 +2826,16 @@
           }
         },
         "Start": 6,
-        "Length": 14
+        "Length": 11
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga de volgende nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende nacht",
@@ -2803,20 +2852,47 @@
           }
         },
         "Start": 9,
-        "Length": 10
+        "Length": 14
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga afgelopen nacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "The word 'afgelopen' means last. See the next added test case, where 'vorige' is used, which means previous",
     "Results": [
       {
         "Text": "afgelopen nacht",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2016-11-07TNI",
+          "FutureResolution": {
+            "startDateTime": "2016-11-07 20:00:00",
+            "endDateTime": "2016-11-07 23:59:59"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-07 20:00:00",
+            "endDateTime": "2016-11-07 23:59:59"
+          }
+        },
+        "Start": 6,
+        "Length": 15
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Ik ga vorige nacht terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Comment": "Added this test case for debugging purposes",
+    "Results": [
+      {
+        "Text": "vorige nacht",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2016-11-06TNI",
@@ -2830,17 +2906,16 @@
           }
         },
         "Start": 6,
-        "Length": 10
+        "Length": 12
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga morgennacht terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgennacht",
@@ -2857,17 +2932,16 @@
           }
         },
         "Start": 6,
-        "Length": 14
+        "Length": 11
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga volgende maandagmiddag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende maandagmiddag",
@@ -2884,17 +2958,16 @@
           }
         },
         "Start": 6,
-        "Length": 21
+        "Length": 22
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga afgelopen 3 min terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "afgelopen 3 min",
@@ -2911,17 +2984,16 @@
           }
         },
         "Start": 6,
-        "Length": 14
+        "Length": 15
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga de volgende 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "volgende 5 uren",
@@ -2938,17 +3010,16 @@
           }
         },
         "Start": 9,
-        "Length": 10
+        "Length": 15
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga laatste minuut terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laatste minuut",
@@ -2965,17 +3036,16 @@
           }
         },
         "Start": 6,
-        "Length": 11
+        "Length": 14
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga komend uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komend uur",
@@ -2992,44 +3062,42 @@
           }
         },
         "Start": 6,
-        "Length": 9
+        "Length": 10
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga komende paar uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "komende paar uur",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16:12:00,2016-11-07T19:12:00,PT3H)",
+          "Timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:12:00",
-            "endDateTime": "2016-11-07 19:12:00"
+            "endDateTime": "2016-11-07 18:12:00"
           },
           "PastResolution": {
             "startDateTime": "2016-11-07 16:12:00",
-            "endDateTime": "2016-11-07 19:12:00"
+            "endDateTime": "2016-11-07 18:12:00"
           }
         },
         "Start": 6,
-        "Length": 14
+        "Length": 16
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga dinsdag in de ochtend terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de ochtend",
@@ -3046,17 +3114,16 @@
           }
         },
         "Start": 6,
-        "Length": 22
+        "Length": 21
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Kunt u ons alstublieft helpen een tijdstip te vinden in de ochtend van deze dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "in de ochtend van deze dinsdag",
@@ -3075,15 +3142,14 @@
         "Start": 53,
         "Length": 30
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Organiseer alsjeblieft een meeting van 30 minuten op dinsdag, in the ochtend",
+    "Input": "Organiseer alsjeblieft een meeting van 30 minuten op dinsdag, in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag, in de ochtend",
@@ -3099,18 +3165,17 @@
             "endDateTime": "2016-11-01 12:00:00"
           }
         },
-        "Start": -1,
-        "Length": 23
+        "Start": 53,
+        "Length": 22
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga dinsdag in de middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de middag",
@@ -3127,17 +3192,16 @@
           }
         },
         "Start": 6,
-        "Length": 24
+        "Length": 20
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ga dinsdag in de avond terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag in de avond",
@@ -3154,23 +3218,23 @@
           }
         },
         "Start": 6,
-        "Length": 22
+        "Length": 19
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken vroeg in de ochtend dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de ochtend dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -3181,23 +3245,23 @@
           }
         },
         "Start": 19,
-        "Length": 28
+        "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken vroeg in de ochtend op dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de ochtend op dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -3208,23 +3272,23 @@
           }
         },
         "Start": 19,
-        "Length": 31
+        "Length": 30
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken laat in de ochtend dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de ochtend dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 10:00:00",
             "endDateTime": "2016-11-08 12:00:00"
@@ -3235,23 +3299,23 @@
           }
         },
         "Start": 19,
-        "Length": 27
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken vroeg in de middag dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de middag dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 12:00:00",
             "endDateTime": "2016-11-08 14:00:00"
@@ -3262,23 +3326,23 @@
           }
         },
         "Start": 19,
-        "Length": 30
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken laat in de middag dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de middag dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 14:00:00",
             "endDateTime": "2016-11-08 16:00:00"
@@ -3289,23 +3353,23 @@
           }
         },
         "Start": 19,
-        "Length": 29
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken vroeg in de avond dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de avond dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 16:00:00",
             "endDateTime": "2016-11-08 18:00:00"
@@ -3316,23 +3380,23 @@
           }
         },
         "Start": 19,
-        "Length": 28
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken laat in de avond dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de avond dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 18:00:00",
             "endDateTime": "2016-11-08 20:00:00"
@@ -3343,23 +3407,23 @@
           }
         },
         "Start": 19,
-        "Length": 27
+        "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken vroeg in de nacht dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vroeg in de nacht dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 20:00:00",
             "endDateTime": "2016-11-08 22:00:00"
@@ -3370,23 +3434,23 @@
           }
         },
         "Start": 19,
-        "Length": 26
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken laat in de nacht dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "laat in de nacht dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 22:00:00",
             "endDateTime": "2016-11-08 23:59:59"
@@ -3397,23 +3461,23 @@
           }
         },
         "Start": 19,
-        "Length": 25
+        "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de ochtend",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 08:00:00",
             "endDateTime": "2016-11-08 10:00:00"
@@ -3424,23 +3488,23 @@
           }
         },
         "Start": 19,
-        "Length": 21
+        "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag laat in de ochtend",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de ochtend",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TMO",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 10:00:00",
             "endDateTime": "2016-11-08 12:00:00"
@@ -3451,23 +3515,23 @@
           }
         },
         "Start": 19,
-        "Length": 20
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 12:00:00",
             "endDateTime": "2016-11-08 14:00:00"
@@ -3478,23 +3542,23 @@
           }
         },
         "Start": 19,
-        "Length": 23
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag laat in de middag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de middag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TAF",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 14:00:00",
             "endDateTime": "2016-11-08 16:00:00"
@@ -3505,23 +3569,23 @@
           }
         },
         "Start": 19,
-        "Length": 22
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de avond",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de avond",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 16:00:00",
             "endDateTime": "2016-11-08 18:00:00"
@@ -3532,23 +3596,23 @@
           }
         },
         "Start": 19,
-        "Length": 21
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag laat in de avond",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de avond",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TEV",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 18:00:00",
             "endDateTime": "2016-11-08 20:00:00"
@@ -3559,23 +3623,23 @@
           }
         },
         "Start": 19,
-        "Length": 20
+        "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag vroeg in de nacht",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag vroeg in de nacht",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
+          "Mod": "start",
           "FutureResolution": {
             "startDateTime": "2016-11-08 20:00:00",
             "endDateTime": "2016-11-08 22:00:00"
@@ -3586,23 +3650,23 @@
           }
         },
         "Start": 19,
-        "Length": 19
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken dinsdag laat in de nacht",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "dinsdag laat in de nacht",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 22:00:00",
             "endDateTime": "2016-11-08 23:59:59"
@@ -3613,20 +3677,20 @@
           }
         },
         "Start": 19,
-        "Length": 18
+        "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we de rest van de huidige dag afspreken",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "Other test cases where 'rest' is used, 'de' is not extracted so it is also removed from this test case",
     "Results": [
       {
-        "Text": "de rest van de huidige dag",
+        "Text": "rest van de huidige dag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T23:59:59,PT28079S)",
@@ -3639,18 +3703,17 @@
             "endDateTime": "2016-11-07 23:59:59"
           }
         },
-        "Start": 9,
-        "Length": 19
+        "Start": 12,
+        "Length": 23
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben weg van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 14:00, 21-2-2016 tot 3:32, 23-04-2016",
@@ -3667,23 +3730,23 @@
           }
         },
         "Start": 11,
-        "Length": 42
+        "Length": 41
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken in de late nacht op dinsdag",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "in de late nacht op dinsdag",
         "Type": "datetimerange",
         "Value": {
           "Timex": "XXXX-WXX-2TNI",
+          "Mod": "end",
           "FutureResolution": {
             "startDateTime": "2016-11-08 22:00:00",
             "endDateTime": "2016-11-08 23:59:59"
@@ -3694,23 +3757,22 @@
           }
         },
         "Start": 19,
-        "Length": 28
+        "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Kan je ons morgen tussen 8:00 en 14:00 inplannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen tussen 8:00 en 14:00",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2017-11-10T08,2017-11-10T14,PT6H)",
+          "Timex": "(2017-11-10T08:00,2017-11-10T14:00,PT6H)",
           "FutureResolution": {
             "startDateTime": "2017-11-10 08:00:00",
             "endDateTime": "2017-11-10 14:00:00"
@@ -3721,23 +3783,22 @@
           }
         },
         "Start": 11,
-        "Length": 28
+        "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Kan je ons 9 dec tussen 8:00 en 14:00 inplannen?",
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9 dec tussen 8:00 en 14:00",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(XXXX-12-09T08,XXXX-12-09T14,PT6H)",
+          "Timex": "(XXXX-12-09T08:00,XXXX-12-09T14:00,PT6H)",
           "FutureResolution": {
             "startDateTime": "2017-12-09 08:00:00",
             "endDateTime": "2017-12-09 14:00:00"
@@ -3748,17 +3809,16 @@
           }
         },
         "Start": 11,
-        "Length": 27
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Hoi Cortana, plan alsjeblieft een Skypegesprek met Jennifer. Ik heb een meeting van 30 min nodig op deze vrijdag, in de middag.",
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze vrijdag, in de middag",
@@ -3775,17 +3835,16 @@
           }
         },
         "Start": 100,
-        "Length": 29
+        "Length": 26
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "laten we afspreken op 5 feb 's ochtends",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5 feb 's ochtends",
@@ -3802,17 +3861,16 @@
           }
         },
         "Start": 22,
-        "Length": 8
+        "Length": 17
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal 2 uren in de toekomst gebeuren",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 uren in de toekomst",
@@ -3831,18 +3889,18 @@
         "Start": 8,
         "Length": 21
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben binnen 15 seconden terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "The word 'binnen' (within) is part of the entity and part of the meaning",
     "Results": [
       {
-        "Text": "15 seconden",
+        "Text": "binnen 15 seconden",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T16:12:15,PT15S)",
@@ -3855,18 +3913,17 @@
             "endDateTime": "2016-11-07 16:12:15"
           }
         },
-        "Start": 14,
-        "Length": 17
+        "Start": 7,
+        "Length": 18
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben binnen 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 5 uren",
@@ -3883,17 +3940,16 @@
           }
         },
         "Start": 7,
-        "Length": 14
+        "Length": 13
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben binnen 1 dag en 5 uren terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 1 dag en 5 uren",
@@ -3910,17 +3966,16 @@
           }
         },
         "Start": 7,
-        "Length": 24
+        "Length": 22
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Deze taak zou af zijn binnen 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen 2 dagen, 1 uur, 5 minuten, 30 seconden",
@@ -3937,17 +3992,16 @@
           }
         },
         "Start": 22,
-        "Length": 41
+        "Length": 45
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Deze taak zou af zijn binnen volgende 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen volgende 2 dagen, 1 uur, 5 minuten, 30 seconden",
@@ -3964,20 +4018,20 @@
           }
         },
         "Start": 22,
-        "Length": 46
+        "Length": 54
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Deze taak zou af zijn binnen aankomende 2 dagen, 1 uur, 5 minuten, 30 seconden",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "The word 'binnen' (within) is part of the entity and part of the meaning",
     "Results": [
       {
-        "Text": "aankomende 2 dagen, 1 uur, 5 minuten, 30 seconden",
+        "Text": "binnen aankomende 2 dagen, 1 uur, 5 minuten, 30 seconden",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
@@ -3990,18 +4044,17 @@
             "endDateTime": "2016-11-09 17:17:30"
           }
         },
-        "Start": 29,
-        "Length": 54
+        "Start": 22,
+        "Length": 56
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben binnen de volgende 5 uur terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "binnen de volgende 5 uur",
@@ -4018,17 +4071,16 @@
           }
         },
         "Start": 7,
-        "Length": 23
+        "Length": 24
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik ben maandag 8 tot 9 terug",
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 8 tot 9",
@@ -4045,17 +4097,16 @@
           }
         },
         "Start": 7,
-        "Length": 13
+        "Length": 15
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 12-4",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 12-4",
@@ -4072,17 +4123,16 @@
           }
         },
         "Start": 46,
-        "Length": 11
+        "Length": 12
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 11-4",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 11-4",
@@ -4099,17 +4149,16 @@
           }
         },
         "Start": 46,
-        "Length": 11
+        "Length": 12
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal tussen 10 en 11:30 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 10 en 11:30 op 1-1-2015",
@@ -4126,17 +4175,16 @@
           }
         },
         "Start": 8,
-        "Length": 32
+        "Length": 30
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal 1-1-2015 tussen 10 en 11:30 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1-1-2015 tussen 10 en 11:30",
@@ -4153,17 +4201,16 @@
           }
         },
         "Start": 8,
-        "Length": 29
+        "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal van 10:30 tot 3 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 10:30 tot 3 op 1-1-2015",
@@ -4182,15 +4229,14 @@
         "Start": 8,
         "Length": 27
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal tussen 3 en 5 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 3 en 5 op 1-1-2015",
@@ -4207,17 +4253,43 @@
           }
         },
         "Start": 8,
-        "Length": 27
+        "Length": 25
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
+  },
+  {
+    "Input": "Het zal tussen 3 en 5 op 1/1/2015 gebeuren",
+    "Context": {
+      "ReferenceDateTime": "2018-05-16T08:12:00"
+    },
+    "Comment": "Added this test case for debugging purposes",
+    "Results": [
+      {
+        "Text": "tussen 3 en 5 op 1/1/2015",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2015-01-01T03,2015-01-01T05,PT2H)",
+          "FutureResolution": {
+            "startDateTime": "2015-01-01 03:00:00",
+            "endDateTime": "2015-01-01 05:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2015-01-01 03:00:00",
+            "endDateTime": "2015-01-01 05:00:00"
+          }
+        },
+        "Start": 8,
+        "Length": 25
+      }
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Het zal van 3:30 tot 5:55 op 1-1-2015 gebeuren",
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "van 3:30 tot 5:55 op 1-1-2015",
@@ -4236,6 +4308,7 @@
         "Start": 8,
         "Length": 29
       }
-    ]
+    ],
+    "NotSupportedByDesign": "javascript,python,java"
   }
 ]

--- a/Specs/DateTime/Dutch/TimePeriodParser.json
+++ b/Specs/DateTime/Dutch/TimePeriodParser.json
@@ -1009,7 +1009,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "ochtend",
+        "Text": "de ochtend",
         "Type": "timerange",
         "Value": {
           "Timex": "TMO",
@@ -1022,8 +1022,8 @@
             "endTime": "12:00:00"
           }
         },
-        "Start": 20,
-        "Length": 7
+        "Start": 17,
+        "Length": 10
       }
     ]
   },


### PR DESCRIPTION
In Extractor all cases pass.
In Parser 6 cases are not supported.

Not supported cases are of the form: "laten we vroeg op de dinsdagochtend afspreken" (let's meet in the early-morning Tuesday) where 'early' (vroeg) and 'morning' (ochtend) are not contiguous. Alternative expressions have been added to the spec.

Following cases have been modified because they do not represent DateTimePeriod entities, are not grammatically correct or do not match the corresponding English Resolution. Original cases have been kept in the spec with updated resolution or moved to the Model.

Modified and moved to Model:
- ik ben vandaag weg tussen vijf en zeven
- ik ben op 1 januari weg van 5 tot 6
- Morgen ben ik weg tussen 3 en 4 uur ’s middags
- Morgen ben ik weg van half acht tot 4 uur ‘s middags
- Vandaag ben ik tussen 4 en 5 uur in de middag weg
- Ik ga deze middag terugI'll go back this afternoon
- ik ga een minuut terug
- Ik ga over een uur terug
- Het zal over 2 uur in de toekomst gebeuren 

Modified and kept in DateTimePeriodParser:
- Ik ben weg van 2016-2-21 vanaf 14:00 tot 2016-04-23 15:32
- Ik ben niet beschikbaar tussen 1 januari 2016 vanaf 4 uur tot vandaag 5 uur in de middag
- laten we vroeg op de dinsdagochtend afspreken
- laten we in het begin van dinsdagmiddag afspreken
- laten we aan het einde van dinsdagochtend afspreken
- zullen we aan het einde van dinsdagmiddag afspreken
- laten we laat op dinsdagavond afspreken
- ik ben afwezig van 2016-02-21 14:00 uur tot 2016-02-21 15:32
- Cortana, plan een skype for business meeting met Wayne op vrijdag tussen 1 en 4 uur ‘s middags.
- Kan je ons morgen tussen 8 uur ‘s ochtends en 2 uur ’s middags inplannen?
- Kan je ons op 9 december tussen 8 uur ‘s ochtends en 2 uur ‘s middags in plannen?
- Hi Cortana, plan een skype meeting in met Jennifer. Ik heb een afspraak van 30 minuten op vrijdagmiddag aanstaande nodig. 
- Cortane, maak een afspraak met skype for business met Wayne op vrijdagmiddag tussen 1 en 4. 
- Het zal gebeuren van 10:30 tot 3 op 1/1/2015
- Ik ben morgen van 15:00 tot 16:00 weg
- Ik ben van 16:00 vandaag tot 17:00 morgen weg
- Ik ga vanavond voor 8 terug

Modified and deleted because not grammatically correct:
- laten we 5 februari in ochtend afspreken
- Ik van van 5 tot 18:00 op 22 april weg
- Ik ben half acht tot 16:00 morgen weg
- Organiseer alsjeblieft een meeting van 30 minuten op dinsdag, in the ochtend



