### PR TITLE
[NL DateTimeV2] Change Dutch init in .NET to utilise BaseTimeOptions

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -129,13 +129,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                         new HindiMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Hindi, options)))));
 
             // TODO to be uncommented when all tests for Dutch are green.
-            RegisterModel<DateTimeModel>(
-                 Culture.Dutch,
-                 options => new DateTimeModel(
-                     new BaseMergedDateTimeParser(
-                         new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options))),
-                     new BaseMergedDateTimeExtractor(
-                         new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options)))));
+            // RegisterModel<DateTimeModel>(
+            //     Culture.Dutch,
+            //     options => new DateTimeModel(
+            //         new BaseMergedDateTimeParser(
+            //             new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options))),
+            //         new BaseMergedDateTimeExtractor(
+            //             new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options)))));
 
             // TODO to be uncommented when all tests for Japanese are green.
             // RegisterModel<DateTimeModel>(

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -129,13 +129,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                         new HindiMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Hindi, options)))));
 
             // TODO to be uncommented when all tests for Dutch are green.
-            // RegisterModel<DateTimeModel>(
-            //     Culture.Dutch,
-            //     options => new DateTimeModel(
-            //         new BaseMergedDateTimeParser(
-            //             new DutchMergedParserConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: true))),
-            //         new BaseMergedDateTimeExtractor(
-            //             new DutchMergedExtractorConfiguration(new BaseOptionsConfiguration(options, dmyDateFormat: true)))));
+            RegisterModel<DateTimeModel>(
+                 Culture.Dutch,
+                 options => new DateTimeModel(
+                     new BaseMergedDateTimeParser(
+                         new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options))),
+                     new BaseMergedDateTimeExtractor(
+                         new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options)))));
 
             // TODO to be uncommented when all tests for Japanese are green.
             // RegisterModel<DateTimeModel>(


### PR DESCRIPTION
Even though this code is still uncommented, would be good to have this adapting the new way. Makes it easier to work on Dutch DateTime. :-)