### PR TITLE
[* Unit] Fix unit extraction in utterances with compound entity (#2037)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -75,7 +75,17 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             var prefixMatches = prefixMatcher.Find(source).OrderBy(o => o.Start).ToList();
             var suffixMatches = suffixMatcher.Find(source).OrderBy(o => o.Start).ToList();
 
-            if (prefixMatches.Any() || suffixMatches.Any())
+            // Remove matches with wrong length, e.g. both 'm2' and 'm 2' are extracted but only 'm2' represents a unit.
+            for (int i = suffixMatches.Count - 1; i >= 0; i--)
+            {
+                var m = suffixMatches[i];
+                if (m.CanonicalValues.All(l => l.Length != m.Length))
+                {
+                    suffixMatches.RemoveAt(i);
+                }
+            }
+
+            if (prefixMatches.Count > 0 || suffixMatches.Count > 0)
             {
                 var numbers = this.config.UnitNumExtractor.Extract(source).OrderBy(o => o.Start);
 

--- a/Specs/NumberWithUnit/English/DimensionModel.json
+++ b/Specs/NumberWithUnit/English/DimensionModel.json
@@ -898,5 +898,57 @@
         "End": 38
       }
     ]
+  },
+  {
+    "Input": "The length is 12 m 2 dm more or less",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12 m",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "12",
+          "unit": "Meter"
+        },
+        "Start": 14,
+        "End": 17
+      },
+      {
+        "Text": "2 dm",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "2",
+          "unit": "Decimeter"
+        },
+        "Start": 19,
+        "End": 22
+      }
+    ]
+  },
+  {
+    "Input": "The length is 12 ft 2 in more or less",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "12 ft",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "12",
+          "unit": "Foot"
+        },
+        "Start": 14,
+        "End": 18
+      },
+      {
+        "Text": "2 in",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "2",
+          "unit": "Inch"
+        },
+        "Start": 20,
+        "End": 23
+      }
+    ]
   }
 ]


### PR DESCRIPTION
fix to first issue pointed out in #2037 ("12 ft 2 in" returning "12 ft 2", instead of the two separate entities)
added relevant test cases to DimensionModel