### PR TITLE
[DE DateTimeV2] DateTime support for "übernächste Woche"

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -25,10 +25,11 @@ namespace Microsoft.Recognizers.Definitions.German
       public const bool CheckBothBeforeAfter = false;
       public const string TillRegex = @"(?<till>zu|bis\s*zum|zum|bis|bis\s*hin(\s*zum)?|--|-|—|——)";
       public const string RangeConnectorRegex = @"(?<and>und|--|-|—|——)";
-      public const string RelativeRegex = @"(?<order>nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?|de[rmsn]|am)";
-      public const string StrictRelativeRegex = @"(?<order>nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?)";
+      public const string RelativeRegex = @"(?<order>(über)?nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?|de[rmsn]|am)";
+      public const string StrictRelativeRegex = @"(?<order>(über)?nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?)";
       public const string UpcomingPrefixRegex = @".^";
-      public static readonly string NextPrefixRegex = $@"\b(nächste[rns]?|kommende[rns]?|{UpcomingPrefixRegex})\b";
+      public static readonly string NextPrefixRegex = $@"\b((über)?nächste[rns]?|kommende[rns]?|{UpcomingPrefixRegex})\b";
+      public const string AfterNextPrefixRegex = @"\bübernächste[rns]?\b";
       public const string PastPrefixRegex = @".^";
       public static readonly string PreviousPrefixRegex = $@"\b(letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vor(ige[rns]?)?|{PastPrefixRegex})\b";
       public const string ThisPrefixRegex = @"\b(diese[rnms]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?)\b";
@@ -177,7 +178,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string EachUnitRegex = $@"(?<each>(jede(s|r|n|m)?|alle)(?<other>\s+andere(n)?)?\s*{DurationUnitRegex})";
       public const string EachPrefixRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*$)";
       public const string SetEachRegex = @"\b(?<each>(jede(r|n|s|m)?|alle)\s*)";
-      public const string SetLastRegex = @"(?<last>nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b";
+      public const string SetLastRegex = @"(?<last>(über)?nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b";
       public const string EachDayRegex = @"\s*(jeden)\s*tag\s*\b";
       public const string BeforeEachDayRegex = @"(jeden)\s*tag\s*";
       public static readonly string DurationFollowedUnit = $@"(^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             RelativeWeekDayRegex = GermanDateExtractorConfiguration.RelativeWeekDayRegex;
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            AfterNextPrefixRegex = new Regex(DateTimeDefinitions.AfterNextPrefixRegex, RegexOptions.Singleline);
             PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
             UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
             PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
@@ -113,6 +114,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public Regex NextPrefixRegex { get; }
 
+        public Regex AfterNextPrefixRegex { get; }
+
         public Regex PreviousPrefixRegex { get; }
 
         public Regex UpcomingPrefixRegex { get; }
@@ -145,7 +148,14 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             var trimmedText = text.Trim();
             var swift = 0;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+
+            var afterNextMatch = AfterNextPrefixRegex.Match(text);
+
+            if (afterNextMatch.Success)
+            {
+                swift = 2;
+            }
+            else if (NextPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.German;
+using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
@@ -22,6 +23,9 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public static readonly Regex UnspecificEndOfRangeRegex =
             new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+
+        public static readonly Regex AfterNextPrefixRegex =
+            new Regex(DateTimeDefinitions.AfterNextPrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -226,7 +230,14 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             var trimmedText = text.Trim();
             var swift = 0;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+
+            var afterNextMatch = AfterNextPrefixRegex.Match(text);
+
+            if (afterNextMatch.Success)
+            {
+                swift = 2;
+            }
+            else if (NextPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -308,6 +308,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     value = referenceDate.Upcoming((DayOfWeek)this.config.DayOfWeek[weekdayStr]);
                 }
+                else if (config.GetSwiftMonthOrYear(trimmedText) == 2)
+                {
+                    value = value.AddDays(7);
+                }
 
                 ret.Timex = DateTimeFormatUtil.LuisDate(value);
                 ret.FutureValue = ret.PastValue = DateObject.MinValue.SafeCreateFromValue(value.Year, value.Month, value.Day);

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -7,15 +7,17 @@ TillRegex: !simpleRegex
 RangeConnectorRegex : !simpleRegex
   def: (?<and>und|--|-|—|——)
 RelativeRegex: !simpleRegex
-  def: (?<order>nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?|de[rmsn]|am)
+  def: (?<order>(über)?nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?|de[rmsn]|am)
 StrictRelativeRegex: !simpleRegex
-  def: (?<order>nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?)
+  def: (?<order>(über)?nächste[rns]?|kommende[rns]?|diese[rmns]?|letzte[rns]?|vergangene[rns]?|vorherige[rns]?|vorige[rns]?|jetzige[rns]?|heutige[rns]?|aktuelle[rns]?|gestrige[rns]?|morgige[rns]?)
 UpcomingPrefixRegex: !simpleRegex
   def: .^
 # TODO: modify below regex according to the counterpart in English
 NextPrefixRegex: !nestedRegex
-  def: \b(nächste[rns]?|kommende[rns]?|{UpcomingPrefixRegex})\b
+  def: \b((über)?nächste[rns]?|kommende[rns]?|{UpcomingPrefixRegex})\b
   references: [ UpcomingPrefixRegex ]
+AfterNextPrefixRegex: !simpleRegex
+  def: \bübernächste[rns]?\b
 PastPrefixRegex: !simpleRegex
   def: .^
 # TODO: modify below regex according to the counterpart in English
@@ -92,7 +94,7 @@ MonthWithYear: !nestedRegex
   references: [ YearRegex ]
 OneWordPeriodRegex: !nestedRegex
   def: \b((((im\s+)?monat\s+)?({RelativeRegex}\s*(jahr\s*(im\s*)?)?)?(?<month>apr(il|\.)|aug(ust|\.)|dez(ember|\.)|feb(ruar|ber|\.)|j[äa]n(uar|ner|\.)|jul(e?i|l\.)|jun([io]|\.)|märz|mai|nov(ember|\.)|okt(ober|\.)|sept?(ember|\.)))|({RelativeRegex}\s+)?(woche(nende)?|monat(s)?|jahr)|(monat|jahr))\b
-  references: [ RelativeRegex ]
+  references: [ RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: ({YearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-\.](\s*){YearRegex})
   references: [ YearRegex, MonthNumRegex ]
@@ -405,7 +407,7 @@ EachPrefixRegex: !simpleRegex
 SetEachRegex: !simpleRegex
   def: \b(?<each>(jede(r|n|s|m)?|alle)\s*)
 SetLastRegex: !simpleRegex
-  def: (?<last>nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b
+  def: (?<last>(über)?nächste(r|n|s)?|kommende(r|n|s)?|diese(r|n|m|s)?|letzte(r|n|s)?|vorige(r|n|s)?|vorherige(r|n|s)?|jetzige(r|n|s)?|derzeitige(r|n|s)?)\b
 EachDayRegex: !simpleRegex
   def: \s*(jeden)\s*tag\s*\b
 BeforeEachDayRegex: !simpleRegex

--- a/Specs/DateTime/German/DateExtractor.json
+++ b/Specs/DateTime/German/DateExtractor.json
@@ -196,6 +196,18 @@
     ]
   },
   {
+    "Input": "Ich komme übernächste Woche Freitag zurück.",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "übernächste Woche Freitag",
+        "Type": "date",
+        "Start": 10,
+        "Length": 25
+      }
+    ]
+  },
+  {
     "Input": "Ich komme irgendwann nächstes Jahr im Sommer wieder.",
     "NotSupported": "javascript, python",
     "Results": [

--- a/Specs/DateTime/German/DateParser.json
+++ b/Specs/DateTime/German/DateParser.json
@@ -694,5 +694,29 @@
         "Length": 17
       }
     ]
+  },
+  {
+    "Input": "Übernächste Woche am Freitag ist er wieder da",
+    "Context": {
+      "ReferenceDateTime": "2020-07-27T18:00:00"
+    },
+    "NotSupported": "python, javascript, java",
+    "Results": [
+      {
+        "Text": "Übernächste Woche am Freitag",
+        "Type": "date",
+        "Value": {
+          "Timex": "2020-08-14",
+          "FutureResolution": {
+            "date": "2020-08-14"
+          },
+          "PastResolution": {
+            "date": "2020-08-14"
+          }
+        },
+        "Start": 0,
+        "Length": 28
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/German/DatePeriodExtractor.json
+++ b/Specs/DateTime/German/DatePeriodExtractor.json
@@ -444,6 +444,18 @@
     ]
   },
   {
+    "Input": "Übernächste Woche bin ich nicht hier.",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "Übernächste Woche",
+        "Type": "daterange",
+        "Start": 0,
+        "Length": 17
+      }
+    ]
+  },
+  {
     "Input": "Nächsten Monat bin ich nicht hier.",
     "NotSupported": "javascript, python",
     "Results": [

--- a/Specs/DateTime/German/DatePeriodParser.json
+++ b/Specs/DateTime/German/DatePeriodParser.json
@@ -134,7 +134,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "python",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "übernächste Woche",

--- a/Specs/DateTime/German/DatePeriodParser.json
+++ b/Specs/DateTime/German/DatePeriodParser.json
@@ -130,6 +130,32 @@
     ]
   },
   {
+    "Input": "Wie ist das Wetter übernächste Woche?",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "übernächste Woche",
+        "Type": "daterange",
+        "Value": {
+          "Timex": "2016-W47",
+          "FutureResolution": {
+            "startDate": "2016-11-21",
+            "endDate": "2016-11-28"
+          },
+          "PastResolution": {
+            "startDate": "2016-11-21",
+            "endDate": "2016-11-28"
+          }
+        },
+        "Start": 19,
+        "Length": 17
+      }
+    ]
+  },
+  {
     "Input": "Letzten September war ich nicht hier.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -1213,6 +1213,56 @@
     ]
   },
   {
+    "Input": "Kommen Sie in der übernächsten Woche am Donnerstag zwischen 4 und 6 Uhr nachmittags",
+    "Context": {
+      "ReferenceDateTime": "2020-07-29T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "übernächsten woche am donnerstag zwischen 4 und 6 uhr nachmittags",
+        "Start": 18,
+        "End": 82,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-08-13T16,2020-08-13T18,PT2H)",
+              "type": "datetimerange",
+              "start": "2020-08-13 16:00:00",
+              "end": "2020-08-13 18:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Wie sieht es übernächste Woche aus?",
+    "Context": {
+      "ReferenceDateTime": "2020-07-29T00:00:00"
+    },
+    "NotSupported": "python, javascript",
+    "Results": [
+      {
+        "Text": "übernächste woche",
+        "Start": 13,
+        "End": 29,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-W33",
+              "type": "daterange",
+              "start": "2020-08-10",
+              "end": "2020-08-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
     "Input": "Der Euro ist im harten Handel heute um 15% gegenüber dem US-Dollar gefallen.",
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"

--- a/Specs/DateTime/German/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/German/DateTimePeriodExtractor.json
@@ -48,6 +48,18 @@
     ]
   },
   {
+    "Input": "Lass uns den übernächsten Mittwoch von 16 bis 20 Uhr anpeilen.",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "übernächsten Mittwoch von 16 bis 20 Uhr",
+        "Type": "datetimerange",
+        "Start": 13,
+        "Length": 39
+      }
+    ]
+  },
+  {
     "Input": "Das Projekt ging vom 7. April 2017 um 4 Uhr bis heute um 4 Uhr.",
     "NotSupported": "javascript, python",
     "Results": [

--- a/Specs/DateTime/German/DateTimePeriodParser.json
+++ b/Specs/DateTime/German/DateTimePeriodParser.json
@@ -622,5 +622,31 @@
         "Length": 21
       }
     ]
+  },
+  {
+    "Input": "Er kommt voraussichtlich übernächste Woche am Donnerstag zwischen 2 und 3 Uhr zurück",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "übernächste Woche am Donnerstag zwischen 2 und 3 Uhr",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "(2016-11-24T02,2016-11-24T03,PT1H)",
+          "FutureResolution": {
+            "startDateTime": "2016-11-24 02:00:00",
+            "endDateTime": "2016-11-24 03:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-24 02:00:00",
+            "endDateTime": "2016-11-24 03:00:00"
+          }
+        },
+        "Start": 25,
+        "Length": 52
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Add support for german "übernächste" (particularly applicable to weeks like in "the week after next"), implementing #1854.  