### PR TITLE
[ES DateTimeV2] Added support for "de 2015" as a date range under Experimental mode (#2210)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -183,7 +183,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string HolidayRegex3 = $@"\b(?<holiday>(d[ií]a( del?( las?)?)? )(trabajador|madres?|padres?|[aá]rbol|mujer(es)?|solteros?|niños?|marmota|san valent[ií]n|maestro))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public const string BeforeRegex = @"(antes(\s+del?(\s+las?)?)?)";
       public const string AfterRegex = @"(despu[eé]s(\s*del?(\s+las?)?)?)";
-      public const string SinceRegex = @"(desde(\s+(las?|el))?|de)";
+      public const string SinceRegex = @"(desde(\s+(las?|el))?)";
+      public const string SinceRegex1 = @"(desde(\s+(las?|el))?|de)";
       public const string AroundRegex = @"(?:\b(?:cerca|alrededor|aproximadamente)(\s+de\s+(las?|el))?\s*\b)";
       public const string PeriodicRegex = @"\b(?<periodic>a\s*diario|diariamente|mensualmente|semanalmente|quincenalmente|anualmente)\b";
       public const string EachExpression = @"cada|tod[oa]s\s*(l[oa]s)?";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string HolidayRegex3 = $@"\b(?<holiday>(d[ií]a( del?( las?)?)? )(trabajador|madres?|padres?|[aá]rbol|mujer(es)?|solteros?|niños?|marmota|san valent[ií]n|maestro))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public const string BeforeRegex = @"(antes(\s+del?(\s+las?)?)?)";
       public const string AfterRegex = @"(despu[eé]s(\s*del?(\s+las?)?)?)";
-      public const string SinceRegex = @"(desde(\s+(las?|el))?)";
+      public const string SinceRegex = @"(desde(\s+(las?|el))?|de)";
       public const string AroundRegex = @"(?:\b(?:cerca|alrededor|aproximadamente)(\s+de\s+(las?|el))?\s*\b)";
       public const string PeriodicRegex = @"\b(?<periodic>a\s*diario|diariamente|mensualmente|semanalmente|quincenalmente|anualmente)\b";
       public const string EachExpression = @"cada|tod[oa]s\s*(l[oa]s)?";

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Spanish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/DateTime/TestDateTime_Spanish.cs
@@ -185,5 +185,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Tests
         {
             TestDateTime(testSpec);
         }
+
+        [NetCoreTestDataSource]
+        [TestMethod]
+        public void DateTimeModelExperimentalMode(TestModel testSpec)
+        {
+            TestDateTime(testSpec);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -87,6 +87,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityFiltersDict);
         }
 
+        // Used in Standard mode
+        public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
@@ -142,9 +145,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IMergedExtractorConfiguration.UnspecificTimePeriodRegex => null;
 
         public Regex FailFastRegex { get; } = null;
-
-        // Used in Standard mode
-        public Regex SinceRegex { get; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         IEnumerable<Regex> IMergedExtractorConfiguration.TermFilterRegexes => TermFilterRegexes;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -16,8 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex AfterRegex =
             new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+        // used in Experimental mode
+        public static readonly Regex SinceRegex1 =
+            new Regex(DateTimeDefinitions.SinceRegex1, RegexFlags);
 
         public static readonly Regex AroundRegex =
             new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
@@ -72,6 +73,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             if ((config.Options & DateTimeOptions.NoProtoCache) != 0)
             {
                 numOptions = NumberOptions.NoProtoCache;
+            }
+
+            if ((config.Options & DateTimeOptions.ExperimentalMode) != 0)
+            {
+                SinceRegex = SinceRegex1;
             }
 
             var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
@@ -136,6 +142,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IMergedExtractorConfiguration.UnspecificTimePeriodRegex => null;
 
         public Regex FailFastRegex { get; } = null;
+
+        // Used in Standard mode
+        public Regex SinceRegex { get; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         IEnumerable<Regex> IMergedExtractorConfiguration.TermFilterRegexes => TermFilterRegexes;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -6,12 +6,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public SpanishMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
             BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = SpanishMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = SpanishMergedExtractorConfiguration.SinceRegex;
+            SinceRegex = (config.Options & DateTimeOptions.ExperimentalMode) != 0 ?
+                new Regex(DateTimeDefinitions.SinceRegex1, RegexFlags) : new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
             AroundRegex = SpanishMergedExtractorConfiguration.AroundRegex;
             EqualRegex = SpanishMergedExtractorConfiguration.EqualRegex;
             SuffixAfter = SpanishMergedExtractorConfiguration.SuffixAfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             BeforeRegex = SpanishMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = SpanishMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = (config.Options & DateTimeOptions.ExperimentalMode) != 0 ?
-                new Regex(DateTimeDefinitions.SinceRegex1, RegexFlags) : new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            SinceRegex = (config.Options & DateTimeOptions.ExperimentalMode) != 0 ? SpanishMergedExtractorConfiguration.SinceRegex1 :
+                SpanishMergedExtractorConfiguration.SinceRegex;
             AroundRegex = SpanishMergedExtractorConfiguration.AroundRegex;
             EqualRegex = SpanishMergedExtractorConfiguration.EqualRegex;
             SuffixAfter = SpanishMergedExtractorConfiguration.SuffixAfterRegex;

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -463,7 +463,7 @@ BeforeRegex: !simpleRegex
 AfterRegex: !simpleRegex
   def: (despu[eé]s(\s*del?(\s+las?)?)?)
 SinceRegex: !simpleRegex
-  def: (desde(\s+(las?|el))?)
+  def: (desde(\s+(las?|el))?|de)
 AroundRegex: !simpleRegex
   def: (?:\b(?:cerca|alrededor|aproximadamente)(\s+de\s+(las?|el))?\s*\b)
 # SpanishSetExtractorConfiguration

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -463,6 +463,8 @@ BeforeRegex: !simpleRegex
 AfterRegex: !simpleRegex
   def: (despu[eé]s(\s*del?(\s+las?)?)?)
 SinceRegex: !simpleRegex
+  def: (desde(\s+(las?|el))?)
+SinceRegex1: !simpleRegex
   def: (desde(\s+(las?|el))?|de)
 AroundRegex: !simpleRegex
   def: (?:\b(?:cerca|alrededor|aproximadamente)(\s+de\s+(las?|el))?\s*\b)

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -1590,31 +1590,5 @@
         }
       }
     ]
-  },
-  {
-    "Input": "El rango es de 2014.",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "javascript, python",
-    "Results": [
-      {
-        "Text": "de 2014",
-        "Start": 12,
-        "End": 18,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2014",
-              "type": "daterange",
-              "Mod": "since",
-              "start": "2014-01-01",
-              "sourceEntity": "datetimerange"
-            }
-          ]
-        }
-      }
-    ]
   }
 ]

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -1590,5 +1590,31 @@
         }
       }
     ]
+  },
+  {
+    "Input": "El rango es de 2014.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "de 2014",
+        "Start": 12,
+        "End": 18,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014",
+              "type": "daterange",
+              "Mod": "since",
+              "start": "2014-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -1590,5 +1590,30 @@
         }
       }
     ]
+  },
+  {
+    "Input": "El rango es de 2014.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2014",
+        "Start": 15,
+        "End": 18,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014",
+              "type": "daterange",
+              "start": "2014-01-01",
+              "end": "2015-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/Spanish/DateTimeModelExperimentalMode.json
@@ -1,0 +1,28 @@
+[
+  {
+    "Input": "El rango es de 2014.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "de 2014",
+        "Start": 12,
+        "End": 18,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014",
+              "type": "daterange",
+              "Mod": "since",
+              "start": "2014-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/Specs/DateTime/Spanish/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/Spanish/DateTimeModelExperimentalMode.json
@@ -4,7 +4,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
         "Text": "de 2014",


### PR DESCRIPTION
Added support for ranges like "de 2015" in Spanish (under Experimental mode) in analogy to the English case "from 2015" (#2210). 
Test case added to the new spec file DateTimeModelExperimentalMode.json