### PR TITLE
[EN DateTimeV2] Support for [n] [dateUnit] from [date] (#1564)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -249,6 +249,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string AroundRegex = @"(\b(rond(om)?|ongeveer(\s+om)?)\s*\b)";
       public const string AgoRegex = @"\b(geleden|voor\s+(?<day>gisteren|vandaag))\b";
       public const string LaterRegex = @"\b(later|vanaf\s+nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(in|over)(\s+de)?\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}((vanaf|sedert|sinds)\s+(het\s+)?jaar\s+)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b((binnen)(\s+de|het)?(\s+(?<next>{NextPrefixRegex}))?)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -242,6 +242,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string SinceRegexExp = $@"({SinceRegex}|\bfrom(\s+the)?\b)";
       public const string AgoRegex = @"\b(ago|before\s+(?<day>yesterday|today))\b";
       public static readonly string LaterRegex = $@"\b(?:later(?!((\s+in)?\s*{OneWordPeriodRegex})|(\s+{TimeOfDayRegex})|\s+than\b)|from now|(from|after)\s+(?<day>tomorrow|tmr|today))\b";
+      public const string BeforeAfterRegex = @"\b((?<before>before)|(?<after>from|after))\b";
       public const string InConnectorRegex = @"\b(in)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(the\s+)?year\s*)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(within(\s+the)?(\s+(?<next>{NextPrefixRegex}))?)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -196,6 +196,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string AgoPrefixRegex = @"\b(y a)\b";
       public const string LaterRegex = @"\b(plus tard)\b";
       public const string AgoRegex = @"^[.]";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(dans|en|sur)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -203,6 +203,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string AgoRegex = @"\b(danach)\b";
       public const string AroundRegex = @"(\b(ca\.?|gegen|circa)\s*\b)";
       public const string LaterRegex = @"\b(später|von jetzt|(ab|nach) (?<day>morgen|heute))\b";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public static readonly string WithinNextPrefixRegex = $@"\b(innerhalb|während(\s+der|de(s|m))?(\s+(?<next>{NextPrefixRegex}))?)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/DateTimeDefinitions.cs
@@ -256,6 +256,7 @@ namespace Microsoft.Recognizers.Definitions.Hindi
       public const string AroundRegex = @"(?:\b(?:around|circa|लगभग|(के\s+)?आसपास))";
       public const string AgoRegex = @"((?<day>(कल से पहले)|कल|आज)(\s+(से|के)\s*पहले)?|पहले)";
       public static readonly string LaterRegex = $@"\b(?:(?<day>(कल|अब|आज)\s+से)\s+बाद|बाद(?!((\s+में)?\s*{OneWordPeriodRegex})|(\s+{TimeOfDayRegex}))|(?<day>कल|आज) (से|बाद)|अब\s+से|के\s+बाद)";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(में|को)";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(the\s+)?year\s*)?{YearSuffix})";
       public static readonly string WithinNextPrefixRegex = $@"\b(((?<next>{NextPrefixRegex}?के)\s+)?(अंदर|भीतर))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/DateTimeDefinitions.cs
@@ -230,6 +230,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public const string AgoPrefixRegex = @"\b(di)\b";
       public const string LaterRegex = @"\b(dopo|da\s+adesso|da\s+questo\s+momento)\b";
       public const string AgoRegex = @"\b(fa|prima|addietro)\b";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(in|tra|fra|a)\b";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}\s*(ann[oi]\s*)?({DateYearRegex}|{FullTextYearRegex}))";
       public static readonly string WithinNextPrefixRegex = $@"\b(entro(\s+(?<next>{NextPrefixRegex}))?)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string WeekOfRegex = @"(semana)(\s*)((do|da|de))";
       public const string MonthOfRegex = @"(mes)(\s*)((do|da|de))";
       public const string RangeUnitRegex = @"\b(?<unit>anos?|meses|m[êe]s|semanas?)\b";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(em)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"^[.]";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string WeekOfRegex = $@"((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex})";
       public static readonly string MonthOfRegex = $@"(mes)(\s+)({OfPrepositionRegex})";
       public const string RangeUnitRegex = @"\b(?<unit>años?|mes(es)?|semanas?)\b";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(in)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"\b(dentro\s+de)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -284,6 +284,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string AroundRegex = @"(?:\b((?:takriben|yaklaşık)\s*|\s*(?:civarı(nd?a)?|dolaylarında|sularında))\b)";
       public const string AgoRegex = @"\b((?<day>bugünden|gün|dünden|dün)\s+)?(önce(ki)?|evvel)\b";
       public const string LaterRegex = @"\b((?<day>yarından|yarın|bugünden|gün)\s+(itibaren|sonra(ki)?)|sonra|şu\s+andan\s+itibaren)(\s+gelecek)?";
+      public const string BeforeAfterRegex = @"^[.]";
       public const string InConnectorRegex = @"\b(içinde)\b";
       public const string SinceNumSuffixRegex = @"\b^(?!0)(\d{0,3}((1|2|7|8)'den|(3|4|5)'ten|(6|9)'dan)|\d{0,2}(10'dan|20'den|30'dan|40'tan|50'den|60'tan|70'ten|80'den|90'dan|00'den)|\d000'den)\b";
       public static readonly string SinceYearSuffixRegex = $@"({YearSuffix}\s+(yılından beri)|{SinceNumSuffixRegex}\s+beri)";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -117,6 +117,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly ImmutableDictionary<string, int> MonthOfYear =
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
@@ -284,5 +287,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             StrictRelativeRegex = DutchDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = DutchDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = DutchDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = DutchDateExtractorConfiguration.BeforeAfterRegex;
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
             PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
@@ -121,6 +122,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -112,6 +112,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex RangeConnectorSymbolRegex =
             new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -284,5 +287,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             StrictRelativeRegex = EnglishDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = EnglishDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = EnglishDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = EnglishDateExtractorConfiguration.BeforeAfterRegex;
 
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
@@ -126,6 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex RangeConnectorSymbolRegex { get; }
 
+        Regex BeforeAfterRegex { get; }
+
         IExtractor IntegerExtractor { get; }
 
         IExtractor OrdinalExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -134,6 +134,9 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly Regex NonDateUnitRegex =
             new Regex(@"(?<unit>heures?|hrs|secondes?|secs?|minutes?|mins?)\b", RegexFlags);
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public FrenchDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
@@ -253,5 +256,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             RelativeMonthRegex = FrenchDateExtractorConfiguration.RelativeMonthRegex;
             StrictRelativeRegex = FrenchDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = FrenchDateExtractorConfiguration.YearSuffix;
+            BeforeAfterRegex = FrenchDateExtractorConfiguration.BeforeAfterRegex;
             RelativeWeekDayRegex = FrenchDateExtractorConfiguration.RelativeWeekDayRegex;
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
@@ -125,6 +126,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -126,6 +126,9 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public static readonly ImmutableDictionary<string, int> MonthOfYear =
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public GermanDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
@@ -248,5 +251,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             RelativeMonthRegex = GermanDateExtractorConfiguration.RelativeMonthRegex;
             StrictRelativeRegex = GermanDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = GermanDateExtractorConfiguration.YearSuffix;
+            BeforeAfterRegex = GermanDateExtractorConfiguration.BeforeAfterRegex;
             RelativeWeekDayRegex = GermanDateExtractorConfiguration.RelativeWeekDayRegex;
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
@@ -124,6 +125,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public static readonly Regex RangeConnectorSymbolRegex =
             new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -284,5 +287,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             StrictRelativeRegex = HindiDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = HindiDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = HindiDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = HindiDateExtractorConfiguration.BeforeAfterRegex;
 
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
@@ -126,6 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -130,6 +130,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public static readonly ImmutableDictionary<string, int> MonthOfYear =
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public ItalianDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
@@ -251,5 +254,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             StrictRelativeRegex = ItalianDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = ItalianDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = ItalianDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = ItalianDateExtractorConfiguration.BeforeAfterRegex;
 
             // @TODO move to config
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
@@ -129,6 +130,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                     innerResult = ParseDurationWithAgoAndLater(er.Text, referenceDate);
                 }
 
+                if (!innerResult.Success)
+                {
+                    innerResult = ParseDurationWithDate(er.Text, referenceDate);
+                }
+
                 // NumberWithMonth must be the second last one, because it only need to find a number and a month to get a "success"
                 if (!innerResult.Success)
                 {
@@ -727,6 +732,71 @@ namespace Microsoft.Recognizers.Text.DateTime
                 config.UnitRegex,
                 config.UtilityConfiguration,
                 GetSwiftDay);
+        }
+
+        // Parse combined patterns Duration + Date, e.g. '3 days before Monday', '4 weeks after January 15th'
+        private DateTimeResolutionResult ParseDurationWithDate(string text, DateObject referenceDate)
+        {
+            var ret = new DateTimeResolutionResult();
+            var durationRes = config.DurationExtractor.Extract(text, referenceDate);
+
+            foreach (var duration in durationRes)
+            {
+                var matches = config.UnitRegex.Matches(duration.Text);
+                if (matches.Count > 0)
+                {
+                    var afterStr = text.Substring((int)duration.Start + (int)duration.Length);
+
+                    // Check if the Duration entity is followed by "before|from|after"
+                    var connector = config.BeforeAfterRegex.MatchBegin(afterStr, trim: true);
+                    if (connector.Success)
+                    {
+                        // Parse Duration
+                        var pr = config.DurationParser.Parse(duration, referenceDate);
+
+                        // Parse Date
+                        if (pr.Value != null)
+                        {
+                            var dateString = afterStr.Substring(connector.Index + connector.Length).Trim();
+                            var innerResult = ParseBasicRegexMatch(dateString, referenceDate);
+                            if (!innerResult.Success)
+                            {
+                                innerResult = ParseImplicitDate(dateString, referenceDate);
+                            }
+
+                            if (!innerResult.Success)
+                            {
+                                innerResult = ParseWeekdayOfMonth(dateString, referenceDate);
+                            }
+
+                            if (!innerResult.Success)
+                            {
+                                innerResult = ParseNumberWithMonth(dateString, referenceDate);
+                            }
+
+                            if (!innerResult.Success)
+                            {
+                                innerResult = ParseSingleNumber(dateString, referenceDate);
+                            }
+
+                            // Combine parsed results Duration + Date
+                            if (innerResult.Success)
+                            {
+                                var isFuture = connector.Groups["after"].Success ? true : false;
+                                DateObject date = (DateObject)innerResult.FutureValue;
+                                var resultDateTime = DurationParsingUtil.ShiftDateTime(pr.TimexStr, date, future: isFuture);
+                                ret.Timex = $"{DateTimeFormatUtil.LuisDate(resultDateTime)}";
+
+                                ret.FutureValue = ret.PastValue = resultDateTime;
+                                ret.SubDateTimeEntities = new List<object> { pr };
+                                ret.Success = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return ret;
         }
 
         // Parse a regex match which includes 'day', 'month' and 'year' (optional) group

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex PreviousPrefixRegex { get; }
 
+        Regex BeforeAfterRegex { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> DayOfMonth { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
         public static readonly ImmutableDictionary<string, int> MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
@@ -244,5 +247,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             StrictRelativeRegex = PortugueseDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = PortugueseDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = PortugueseDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = PortugueseDateExtractorConfiguration.BeforeAfterRegex;
 
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
@@ -126,6 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex RangeUnitRegex =
             new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         public static readonly ImmutableDictionary<string, int> DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
         public static readonly ImmutableDictionary<string, int> MonthOfYear = DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
@@ -241,5 +244,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             StrictRelativeRegex = SpanishDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = SpanishDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = SpanishDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = SpanishDateExtractorConfiguration.BeforeAfterRegex;
 
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
@@ -126,6 +127,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -118,6 +118,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public static readonly ImmutableDictionary<string, int> MonthOfYear =
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
+        public static readonly Regex BeforeAfterRegex =
+            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
@@ -290,5 +293,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         Regex IDateExtractorConfiguration.RangeUnitRegex => RangeUnitRegex;
 
         Regex IDateExtractorConfiguration.RangeConnectorSymbolRegex => RangeConnectorSymbolRegex;
+
+        Regex IDateExtractorConfiguration.BeforeAfterRegex => BeforeAfterRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             StrictRelativeRegex = TurkishDateExtractorConfiguration.StrictRelativeRegex;
             YearSuffix = TurkishDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = TurkishDateExtractorConfiguration.RelativeWeekDayRegex;
+            BeforeAfterRegex = TurkishDateExtractorConfiguration.BeforeAfterRegex;
 
             RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
             NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
@@ -127,6 +128,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public Regex UpcomingPrefixRegex { get; }
 
         public Regex PastPrefixRegex { get; }
+
+        public Regex BeforeAfterRegex { get; }
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -598,6 +598,8 @@ AgoRegex: !simpleRegex
   def: \b(geleden|voor\s+(?<day>gisteren|vandaag))\b
 LaterRegex: !simpleRegex
   def: \b(later|vanaf\s+nu|(vanaf|na)\s+(?<day>morgen|vandaag))\b
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(in|over)(\s+de)?\b
 SinceYearSuffixRegex: !nestedRegex

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -573,6 +573,8 @@ AgoRegex: !simpleRegex
 LaterRegex: !nestedRegex
   def: \b(?:later(?!((\s+in)?\s*{OneWordPeriodRegex})|(\s+{TimeOfDayRegex})|\s+than\b)|from now|(from|after)\s+(?<day>tomorrow|tmr|today))\b
   references: [ OneWordPeriodRegex, TimeOfDayRegex ]
+BeforeAfterRegex: !simpleRegex
+  def: \b((?<before>before)|(?<after>from|after))\b
 InConnectorRegex: !simpleRegex
   def: \b(in)\b
 SinceYearSuffixRegex: !nestedRegex

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -445,6 +445,8 @@ LaterRegex: !simpleRegex
 AgoRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(dans|en|sur)\b
 SinceYearSuffixRegex: !simpleRegex

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -458,6 +458,8 @@ AroundRegex: !simpleRegex
   def: (\b(ca\.?|gegen|circa)\s*\b)
 LaterRegex: !simpleRegex
   def: \b(später|von jetzt|(ab|nach) (?<day>morgen|heute))\b
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(in)\b
 SinceYearSuffixRegex: !simpleRegex

--- a/Patterns/Hindi/Hindi-DateTime.yaml
+++ b/Patterns/Hindi/Hindi-DateTime.yaml
@@ -605,6 +605,8 @@ AgoRegex: !simpleRegex
 LaterRegex: !nestedRegex
   def: \b(?:(?<day>(कल|अब|आज)\s+से)\s+बाद|बाद(?!((\s+में)?\s*{OneWordPeriodRegex})|(\s+{TimeOfDayRegex}))|(?<day>कल|आज) (से|बाद)|अब\s+से|के\s+बाद)
   references: [ OneWordPeriodRegex, TimeOfDayRegex ]
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(में|को)
 SinceYearSuffixRegex: !nestedRegex

--- a/Patterns/Italian/Italian-DateTime.yaml
+++ b/Patterns/Italian/Italian-DateTime.yaml
@@ -527,6 +527,8 @@ LaterRegex: !simpleRegex
   def: \b(dopo|da\s+adesso|da\s+questo\s+momento)\b
 AgoRegex: !simpleRegex
   def: \b(fa|prima|addietro)\b
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(in|tra|fra|a)\b
 SinceYearSuffixRegex: !nestedRegex

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -117,6 +117,8 @@ MonthOfRegex: !simpleRegex
   def: (mes)(\s*)((do|da|de))
 RangeUnitRegex: !simpleRegex
   def: \b(?<unit>anos?|meses|m[êe]s|semanas?)\b
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(em)\b
 SinceYearSuffixRegex: !simpleRegex

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -144,6 +144,8 @@ MonthOfRegex: !nestedRegex
   references: [ OfPrepositionRegex ]
 RangeUnitRegex: !simpleRegex
   def: \b(?<unit>años?|mes(es)?|semanas?)\b
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(in)\b
 SinceYearSuffixRegex: !simpleRegex

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -661,6 +661,8 @@ AgoRegex: !simpleRegex
   def: \b((?<day>bugünden|gün|dünden|dün)\s+)?(önce(ki)?|evvel)\b
 LaterRegex: !simpleRegex
   def: \b((?<day>yarından|yarın|bugünden|gün)\s+(itibaren|sonra(ki)?)|sonra|şu\s+andan\s+itibaren)(\s+gelecek)?
+BeforeAfterRegex: !simpleRegex
+  def: ^[.]
 InConnectorRegex: !simpleRegex
   def: \b(içinde)\b
 SinceNumSuffixRegex: !simpleRegex

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18380,6 +18380,78 @@
     ]
   },
   {
+    "Input": "It will happen 2 weeks from January 15.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 weeks from january 15",
+        "Start": 15,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-01-29",
+              "type": "date",
+              "value": "2017-01-29"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 4 months from tomorrow.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "4 months from tomorrow",
+        "Start": 15,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-03-08",
+              "type": "date",
+              "value": "2017-03-08"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 16 days from 01/02/2018.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "16 days from 01/02/2018",
+        "Start": 15,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-01-18",
+              "type": "date",
+              "value": "2018-01-18"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
     "Input": "It will end two months after next Friday.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18354,5 +18354,101 @@
         }
       }
     ]
+  },
+  {
+    "Input": "It will happen 3 days from Tuesday.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "3 days from tuesday",
+        "Start": 15,
+        "End": 33,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-11",
+              "type": "date",
+              "value": "2016-11-11"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will end two months after next Friday.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "two months after next friday",
+        "Start": 12,
+        "End": 39,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-01-18",
+              "type": "date",
+              "value": "2017-01-18"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 3 days after January 12th.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "3 days after january 12th",
+        "Start": 15,
+        "End": 39,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-01-15",
+              "type": "date",
+              "value": "2017-01-15"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It happened 2 weeks before May 13 1999.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 weeks before may 13 1999",
+        "Start": 12,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1999-04-29",
+              "type": "date",
+              "value": "1999-04-29"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -7819,5 +7819,101 @@
         }
       }
     ]
+  },
+  {
+    "Input": "It will happen 3 days from Tuesday.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "3 days from tuesday",
+        "Start": 15,
+        "End": 33,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-11",
+              "type": "date",
+              "value": "2016-11-11"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 2 weeks from January 15.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 weeks from january 15",
+        "Start": 15,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-01-29",
+              "type": "date",
+              "value": "2017-01-29"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 4 months from tomorrow.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "4 months from tomorrow",
+        "Start": 15,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-03-08",
+              "type": "date",
+              "value": "2017-03-08"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen 16 days from 01/02/2018.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "16 days from 01/02/2018",
+        "Start": 15,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-01-18",
+              "type": "date",
+              "value": "2018-01-18"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for cases like "3 days before Monday", "4 weeks after January 15th", "5 months from next Friday" (#1564).
Relevant test cases added to DateTimeModel