### PR TITLE
[IT Number] fix String "tr" recognized as number zero (#2226)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public const bool CompoundNumberLanguage = true;
       public const bool MultiDecimalSeparatorCulture = false;
       public const string DigitsNumberRegex = @"\d|\d{1,3}(\.\d{3})";
-      public const string RoundNumberIntegerRegex = @"(cento?|mille?|mila|milion[ei]?|miliard[oi]?|bilion[ei]?|trilion[ei]?)";
-      public const string ZeroToNineIntegerRegex = @"(un[oa]?|due?|tre?|quattro?|cinque?|sei|sette?|otto?|nove?|zero)";
-      public const string TwoToNineIntegerRegex = @"(due?|tre?|quattro?|cinque?|sei|sette?|otto?|nove?)";
+      public const string RoundNumberIntegerRegex = @"(cent(o|(?!\b)|(?='))|mill(e|(?!\b)|(?='))|mila|miliard([oi]|(?!\b)|(?='))|(milion|bilion|trilion)([ei]|(?!\b)|(?=')))";
+      public const string ZeroToNineIntegerRegex = @"(un[oa]?|due|tre|quattro|cinque|sei|sette|otto|nove|zero)";
+      public const string TwoToNineIntegerRegex = @"(due|tre|quattro|cinque|sei|sette|otto|nove)";
       public const string NegativeNumberTermsRegex = @"(?<negTerm>meno\s+)";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*";
       public const string AnIntRegex = @"(un)(?=\s)";
-      public const string TenToNineteenIntegerRegex = @"(diciassette?|tredici?|quattordici?|diciotto?|diciannove?|quindici?|sedici?|undici?|dodici?|dieci?)";
-      public const string TensNumberIntegerRegex = @"(settanta?|venti?|trenta?|ottanta?|novanta?|quaranta?|cinquanta?|sessanta?)";
+      public const string TenToNineteenIntegerRegex = @"(diciott(o|(?!\b)|(?='))|(diciassett|diciannov)(e|(?!\b)|(?='))|(tredic|quattordic|quindic|sedic|undic|dodic|diec)(i|(?!\b)|(?=')))";
+      public const string TensNumberIntegerRegex = @"(vent(i|(?!\b)|(?='))|(settant|trent|ottant|novant|quarant|cinquant|sessant)(a|(?!\b)|(?=')))";
       public static readonly string SeparaIntRegex = $@"((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|((({AnIntRegex})?(\s*{RoundNumberIntegerRegex})+))";
       public static readonly string AllIntRegex = $@"(((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({AnIntRegex})?)(\s*{RoundNumberIntegerRegex})+)\s*(e\s+)?)*{SeparaIntRegex})";
       public const string PlaceHolderPureNumber = @"\b";
@@ -46,9 +46,10 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public const string RoundNumberOrdinalRegex = @"(centesim[oaie]|millesim[oaie]|milionesim[oaie]|miliardesim[oaie]|bilionesim[oaie]|trilionesim[oaie])";
       public const string OneToNineOrdinalRegex = @"(prim[oaie]|second[oaie]|terz[oaie]|quart[oaie]|quint[oaie]|sest[oaie]|settim[oaie]|ottav[oaie]|non[oaie])";
       public const string NumberOrdinalRegex = @"(prim[oaie]|second[oaie]|terz[oaie]|quart[oaie]|quint[oaie]|sest[oaie]|settim[oaie]|ottav[oaie]|non[oaie]|decim[oaie]|undicesim[oaie]|dodicesim[oaie]|tredicesim[oaie]|quattordicesim[oaie]|quindicesim[oaie]|sedicesim[oaie]|diciassettesim[oaie]|diciottesim[oaie]|diciannovesim[oaie]|ventesim[oaie]|trentesim[oaie]|quarantesim[oaie]|cinquantesim[oaie]|sessantesim[oaie]|settantesim[oaie]|ottantesim[oaie]|novantesim[oaie])";
+      public const string OneToNineOrdinalCompoundRegex = @"(un|du|tre|quattr|cinqu|sei|sett|ott|nov)esim[oaie]";
       public const string RelativeOrdinalRegex = @"(precedente|seguente|penultim[oa]|terzultim[oa]|ultim[oa])";
       public static readonly string BasicOrdinalRegex = $@"(({NumberOrdinalRegex}|{RelativeOrdinalRegex})(?!\s*({TwoToNineIntegerRegex}|([2-9]+))\b))";
-      public static readonly string SuffixBasicOrdinalRegex = $@"((((({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({AnIntRegex})|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*)\s*(e\s+)?)*({TensNumberIntegerRegex}?{ZeroToNineIntegerRegex}esim[oaie]|{BasicOrdinalRegex}))";
+      public static readonly string SuffixBasicOrdinalRegex = $@"((((({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({AnIntRegex})|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*)\s*(e\s+)?)*({TensNumberIntegerRegex}?{OneToNineOrdinalCompoundRegex}|{BasicOrdinalRegex}))";
       public static readonly string SuffixRoundNumberOrdinalRegex = $@"(({AllIntRegex}\s*)?{RoundNumberOrdinalRegex})";
       public static readonly string AllOrdinalRegex = $@"({SuffixRoundNumberOrdinalRegex}|{SuffixBasicOrdinalRegex})";
       public const string OrdinalSuffixRegex = @"(?<=\b)(\d+(°|(esi)?m[oaie]))";
@@ -155,6 +156,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
             { @"novanta", 90 },
             { @"novant", 90 },
             { @"cento", 100 },
+            { @"cent", 100 },
             { @"mille", 1000 },
             { @"mila", 1000 },
             { @"milione", 1000000 },

--- a/Patterns/Italian/Italian-Numbers.yaml
+++ b/Patterns/Italian/Italian-Numbers.yaml
@@ -9,11 +9,11 @@ MultiDecimalSeparatorCulture: !bool false
 DigitsNumberRegex: !simpleRegex
   def: \d|\d{1,3}(\.\d{3})
 RoundNumberIntegerRegex: !simpleRegex
-  def: (cento?|mille?|mila|milion[ei]?|miliard[oi]?|bilion[ei]?|trilion[ei]?)
+  def: (cent(o|(?!\b)|(?='))|mill(e|(?!\b)|(?='))|mila|miliard([oi]|(?!\b)|(?='))|(milion|bilion|trilion)([ei]|(?!\b)|(?=')))
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (un[oa]?|due?|tre?|quattro?|cinque?|sei|sette?|otto?|nove?|zero)
+  def: (un[oa]?|due|tre|quattro|cinque|sei|sette|otto|nove|zero)
 TwoToNineIntegerRegex: !simpleRegex
-  def: (due?|tre?|quattro?|cinque?|sei|sette?|otto?|nove?)
+  def: (due|tre|quattro|cinque|sei|sette|otto|nove)
 NegativeNumberTermsRegex: !simpleRegex
   def: (?<negTerm>meno\s+)
 NegativeNumberSignRegex: !nestedRegex
@@ -22,9 +22,9 @@ NegativeNumberSignRegex: !nestedRegex
 AnIntRegex: !simpleRegex
   def: (un)(?=\s)
 TenToNineteenIntegerRegex: !simpleRegex
-  def: (diciassette?|tredici?|quattordici?|diciotto?|diciannove?|quindici?|sedici?|undici?|dodici?|dieci?)
+  def: (diciott(o|(?!\b)|(?='))|(diciassett|diciannov)(e|(?!\b)|(?='))|(tredic|quattordic|quindic|sedic|undic|dodic|diec)(i|(?!\b)|(?=')))
 TensNumberIntegerRegex: !simpleRegex
-  def: (settanta?|venti?|trenta?|ottanta?|novanta?|quaranta?|cinquanta?|sessanta?)
+  def: (vent(i|(?!\b)|(?='))|(settant|trent|ottant|novant|quarant|cinquant|sessant)(a|(?!\b)|(?=')))
 SeparaIntRegex: !nestedRegex
   def: ((({TenToNineteenIntegerRegex}|({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex})(\s*{RoundNumberIntegerRegex})*))|((({AnIntRegex})?(\s*{RoundNumberIntegerRegex})+))
   references: [ TenToNineteenIntegerRegex, TensNumberIntegerRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex, AnIntRegex ]
@@ -59,14 +59,16 @@ OneToNineOrdinalRegex: !simpleRegex
   def: (prim[oaie]|second[oaie]|terz[oaie]|quart[oaie]|quint[oaie]|sest[oaie]|settim[oaie]|ottav[oaie]|non[oaie])
 NumberOrdinalRegex: !simpleRegex
   def: (prim[oaie]|second[oaie]|terz[oaie]|quart[oaie]|quint[oaie]|sest[oaie]|settim[oaie]|ottav[oaie]|non[oaie]|decim[oaie]|undicesim[oaie]|dodicesim[oaie]|tredicesim[oaie]|quattordicesim[oaie]|quindicesim[oaie]|sedicesim[oaie]|diciassettesim[oaie]|diciottesim[oaie]|diciannovesim[oaie]|ventesim[oaie]|trentesim[oaie]|quarantesim[oaie]|cinquantesim[oaie]|sessantesim[oaie]|settantesim[oaie]|ottantesim[oaie]|novantesim[oaie])
+OneToNineOrdinalCompoundRegex: !simpleRegex
+  def: (un|du|tre|quattr|cinqu|sei|sett|ott|nov)esim[oaie]
 RelativeOrdinalRegex: !simpleRegex
   def: (precedente|seguente|penultim[oa]|terzultim[oa]|ultim[oa])
 BasicOrdinalRegex: !nestedRegex
   def: (({NumberOrdinalRegex}|{RelativeOrdinalRegex})(?!\s*({TwoToNineIntegerRegex}|([2-9]+))\b))
   references: [ NumberOrdinalRegex, RelativeOrdinalRegex, TwoToNineIntegerRegex ]
 SuffixBasicOrdinalRegex: !nestedRegex
-  def: ((((({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({AnIntRegex})|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*)\s*(e\s+)?)*({TensNumberIntegerRegex}?{ZeroToNineIntegerRegex}esim[oaie]|{BasicOrdinalRegex}))
-  references: [ TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, BasicOrdinalRegex ]
+  def: ((((({TensNumberIntegerRegex}{ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|({AnIntRegex})|{RoundNumberIntegerRegex})(\s*{RoundNumberIntegerRegex})*)\s*(e\s+)?)*({TensNumberIntegerRegex}?{OneToNineOrdinalCompoundRegex}|{BasicOrdinalRegex}))
+  references: [ TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, BasicOrdinalRegex, OneToNineOrdinalCompoundRegex ]
 SuffixRoundNumberOrdinalRegex: !nestedRegex
   def: (({AllIntRegex}\s*)?{RoundNumberOrdinalRegex})
   references: [ AllIntRegex, RoundNumberOrdinalRegex ]
@@ -262,6 +264,7 @@ CardinalNumberMap: !dictionary
     novanta: 90
     novant: 90
     cento: 100
+    cent: 100
     mille: 1000
     mila: 1000
     milione: 1000000

--- a/Specs/Number/Italian/NumberModel.json
+++ b/Specs/Number/Italian/NumberModel.json
@@ -1847,5 +1847,28 @@
         }
       }
     ]
+  },
+  {
+    "Input": "tr",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "ha compiuto settant'anni",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "settant",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "70"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "ha compiuto settant anni",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
   }
 ]

--- a/Specs/Number/Italian/NumberModel.json
+++ b/Specs/Number/Italian/NumberModel.json
@@ -1869,6 +1869,7 @@
   {
     "Input": "ha compiuto settant anni",
     "NotSupportedByDesign": "javascript,python,java",
+    "Comment": "Elided expressions (e.g. 'settant') should be recognized only in compound numbers or when followed by an apostrophe",
     "Results": []
   }
 ]


### PR DESCRIPTION
Fixes instances of elided numbers being wrongly extracted (#2226).
For example 'settant' should be extracted only when occurring in compound numbers e.g. 'settantotto' (seventy-eight) or in elided form e.g. 'settant'anni' (seventy years).
Relevant test cases added to NumberModel.