### PR TITLE
[EN DateTimeV2] Fix for "end of" related bugs (#2011)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -98,10 +98,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 // For the 'before' mod
                 // 1. Cases like "Before December", the start of the period should be the end of the new period, not the start
+                // (but not for cases like "Before the end of December")
                 // 2. Cases like "More than 3 days before today", the date point should be the end of the new period
                 if (mod.StartsWith(Constants.BEFORE_MOD, StringComparison.Ordinal))
                 {
-                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end))
+                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.LATE_MOD, StringComparison.Ordinal))
                     {
                         res.Add(DateTimeResolutionKey.End, start);
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -116,10 +116,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 // For the 'after' mod
                 // 1. Cases like "After January", the end of the period should be the start of the new period, not the end
+                // (but not for cases like "After the beginning of January")
                 // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
                 if (mod.StartsWith(Constants.AFTER_MOD, StringComparison.Ordinal))
                 {
-                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end))
+                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.EARLY_MOD, StringComparison.Ordinal))
                     {
                         res.Add(DateTimeResolutionKey.Start, end);
                     }

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17163,5 +17163,82 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I'll go back by end of this month",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "by end of this month",
+        "Start": 13,
+        "End": 32,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11",
+              "Mod": "before-end",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2016-12-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back before end of this year",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "before end of this year",
+        "Start": 13,
+        "End": 35,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "before-end",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2017-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll go back end of this year",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "end of this year",
+        "Start": 13,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "Mod": "end",
+              "type": "daterange",
+              "start": "2016-07-01",
+              "end": "2017-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17273,5 +17273,38 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I'll go back before the end of December",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "before the end of december",
+        "Start": 13,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12",
+              "Mod": "before-end",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2016-01-01"
+            },
+            {
+              "timex": "XXXX-12",
+              "Mod": "before-end",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "end": "2017-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17240,5 +17240,38 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I'll go back after the beginning of March",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "after the beginning of march",
+        "Start": 13,
+        "End": 40,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-03",
+              "Mod": "after-start",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2016-03-01"
+            },
+            {
+              "timex": "XXXX-03",
+              "Mod": "after-start",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2017-03-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixed resolution for the first and second patterns pointed out in #2011. 
The resolution of the third pattern "end of this year" does not seem wrong (but as pointed out in #2232, there is a discrepancy in the start value respect to "end of 2016").
Also fixed analogous issue for patterns like "after the beginning of March".
Relevant test cases added to DateTimeModel.