### PR TITLE
[EN DateTimeV2] Fix for relative Holidays to take reference date into account (#2246)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.English;
 
@@ -10,29 +11,38 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public EnglishHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
+            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = EnglishHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
+
+        public Regex ThisPrefixRegex { get; }
+
+        public Regex NextPrefixRegex { get; }
+
+        public Regex PreviousPrefixRegex { get; }
 
         public override int GetSwiftYear(string text)
         {
             var trimmedText = text.Trim();
             var swift = -10;
 
-            // @TODO move hardcoded terms to resources file
-
-            if (trimmedText.StartsWith("next", StringComparison.Ordinal))
+            if (NextPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (trimmedText.StartsWith("last", StringComparison.Ordinal))
+            else if (PreviousPrefixRegex.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (trimmedText.StartsWith("this", StringComparison.Ordinal))
+            else if (ThisPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseHolidayParser.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var orderStr = match.Groups["order"].Value;
             int year;
             var hasYear = false;
+            var swift = 0;
 
             if (!string.IsNullOrEmpty(yearStr))
             {
@@ -102,7 +103,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
             else if (!string.IsNullOrEmpty(orderStr))
             {
-                var swift = this.config.GetSwiftYear(orderStr);
+                swift = this.config.GetSwiftYear(orderStr);
                 if (swift < -1)
                 {
                     return ret;
@@ -132,7 +133,24 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var value = referenceDate;
                 if (this.config.HolidayFuncDictionary.TryGetValue(holidayKey, out Func<int, DateObject> function))
                 {
-                    value = function(year);
+                    // With relative holidays like 'next(last) easter' the year must not be shifted
+                    // when the reference date precedes(follows) the holiday date.
+                    if (string.IsNullOrEmpty(yearStr) && swift != 0)
+                    {
+                        value = function(referenceDate.Year);
+                        if ((swift > 0 && value < referenceDate) || (swift < 0 && value > referenceDate))
+                        {
+                            value = function(year);
+                        }
+                        else
+                        {
+                            year = referenceDate.Year;
+                        }
+                    }
+                    else
+                    {
+                        value = function(year);
+                    }
 
                     // @TODO should be checking if variable holiday to produce better timex. Fixing is a breaking change.
                     this.config.VariableHolidaysTimexDictionary.TryGetValue(holidayKey, out timexStr);

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17067,5 +17067,101 @@
         }
       }
     ]
+  },
+  {
+    "Input": "When was the previous easter?",
+    "Context": {
+      "ReferenceDateTime": "2019-02-12T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "previous easter",
+        "Start": 13,
+        "End": 27,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-04-01",
+              "type": "date",
+              "value": "2018-04-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "When was the last easter?",
+    "Context": {
+      "ReferenceDateTime": "2019-06-12T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "last easter",
+        "Start": 13,
+        "End": 23,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-04-21",
+              "type": "date",
+              "value": "2019-04-21"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "When was the next easter?",
+    "Context": {
+      "ReferenceDateTime": "2019-02-12T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "next easter",
+        "Start": 13,
+        "End": 23,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-04-21",
+              "type": "date",
+              "value": "2019-04-21"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "When was the following easter?",
+    "Context": {
+      "ReferenceDateTime": "2019-06-12T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "following easter",
+        "Start": 13,
+        "End": 28,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-04-12",
+              "type": "date",
+              "value": "2020-04-12"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
fix for issues pointed out in #2246. 
When the reference date is smaller than the holiday date for the reference year, 'next [holiday]' now returns the date for the reference year (instead of the date for the following year). Similarly for 'last [holiday].
Removed hard coded values from configuration file so that also other relative expressions such as 'previous(following) [holiday]' works correctly.
Relevant test cases added to DateTimeModel.