### PR TITLE
[FR DateTimeV2] Fix to get hours duration (#450)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -128,8 +128,10 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex3 = $@"\b{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})(\s+{TimePrefix})?";
       public static readonly string TimeRegex4 = $@"\b{BasicTime}(\s*{DescRegex})?(\s+{TimePrefix})?\s+{TimeSuffix}\b";
+      public static readonly string TimeRegex4CS = $@"(?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex4}(?(DurationPrep)(?<!heures?))";
       public static readonly string TimeRegex5 = $@"\b{BasicTime}((\s*{DescRegex})(\s+{TimePrefix})?|\s+{TimePrefix})";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
+      public static readonly string TimeRegex6CS = $@"(?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex6}(?(DurationPrep)(?<!heures?))";
       public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+[àa]\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex8 = $@"\b{TimeSuffix}\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s+{FivesRegex}((\s*{DescRegex})|\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Recognizers.Definitions.French
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
-            { @"heures?$", @"(pour|durée\s+de)\s*" }
+            { @"heures?$", @"\b(pour|durée\s+de)\s+(\S+\s+){1,2}heures?\b" }
         };
       public static readonly IList<string> MorningTermList = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -128,10 +128,8 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex3 = $@"\b{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})(\s+{TimePrefix})?";
       public static readonly string TimeRegex4 = $@"\b{BasicTime}(\s*{DescRegex})?(\s+{TimePrefix})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex4CS = $@"(?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex4}(?(DurationPrep)(?<!heures?))";
       public static readonly string TimeRegex5 = $@"\b{BasicTime}((\s*{DescRegex})(\s+{TimePrefix})?|\s+{TimePrefix})";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex6CS = $@"(?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex6}(?(DurationPrep)(?<!heures?))";
       public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+[àa]\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex8 = $@"\b{TimeSuffix}\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s+{FivesRegex}((\s*{DescRegex})|\b)";
@@ -716,6 +714,10 @@ namespace Microsoft.Recognizers.Definitions.French
         {
             { @"^([eé]t[eé])$", @"(?<!((l\s*['`]\s*)|(cet(te)?|en)\s+))[eé]t[eé]\b" },
             { @"^(mer)$", @"(?<!((le|ce)\s+))mer\b" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
+        {
+            { @"heures?$", @"(pour|durée\s+de)\s*" }
         };
       public static readonly IList<string> MorningTermList = new List<string>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -148,5 +148,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -142,5 +142,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (regex.Key.IsMatch(extractResult.Text))
                         {
                             var matches = regex.Value.Matches(text).Cast<Match>();
-                            extractResults = extractResults.Where(er => !matches.Any(m => m.Index + m.Length == er.Start))
+                            extractResults = extractResults.Where(er => !matches.Any(m => m.Index < er.Start + er.Length && m.Index + m.Length > er.Start))
                                 .ToList();
                         }
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions;
@@ -72,6 +73,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 timeErs = TimeZoneUtility.MergeTimeZones(timeErs, config.TimeZoneExtractor.Extract(text, reference), text);
             }
+
+            // Remove common ambiguous cases
+            timeErs = FilterAmbiguity(timeErs, text);
 
             return timeErs;
         }
@@ -162,6 +166,27 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             return result;
+        }
+
+        private List<ExtractResult> FilterAmbiguity(List<ExtractResult> extractResults, string text)
+        {
+            if (this.config.AmbiguityFiltersDict != null)
+            {
+                foreach (var regex in this.config.AmbiguityFiltersDict)
+                {
+                    foreach (var extractResult in extractResults)
+                    {
+                        if (regex.Key.IsMatch(extractResult.Text))
+                        {
+                            var matches = regex.Value.Matches(text).Cast<Match>();
+                            extractResults = extractResults.Where(er => !matches.Any(m => m.Index + m.Length == er.Start))
+                                .ToList();
+                        }
+                    }
+                }
+            }
+
+            return extractResults;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/ITimeExtractorConfiguration.cs
@@ -17,5 +17,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         string TimeTokenPrefix { get; }
 
+        Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -99,13 +99,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            new Regex(DateTimeDefinitions.TimeRegex4CS, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            new Regex(DateTimeDefinitions.TimeRegex6CS, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 
 using Microsoft.Recognizers.Definitions.French;
+using Microsoft.Recognizers.Definitions.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
@@ -99,13 +100,13 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4CS, RegexFlags),
+            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6CS, RegexFlags),
+            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
@@ -143,5 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => DefinitionLoader.LoadAmbiguityFilters(DateTimeDefinitions.AmbiguityTimeFiltersDict);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
@@ -141,5 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimeExtractorConfiguration.cs
@@ -144,5 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
@@ -141,5 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
@@ -131,5 +131,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -129,5 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
@@ -144,5 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public IDateTimeExtractor TimeZoneExtractor { get; }
 
         public string TimeTokenPrefix => DateTimeDefinitions.TimeTokenPrefix;
+
+        public Dictionary<Regex, Regex> AmbiguityFiltersDict => null;
     }
 }

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -1059,7 +1059,7 @@ AmbiguityFiltersDict: !dictionary
 AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    'heures?$': '(pour|durée\s+de)\s*'
+    'heures?$': '\b(pour|durée\s+de)\s+(\S+\s+){1,2}heures?\b'
 # For TimeOfDay resolution
 MorningTermList: !list
   types: [ string ]

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -277,20 +277,12 @@ TimeRegex3: !nestedRegex
 TimeRegex4: !nestedRegex
   def: \b{BasicTime}(\s*{DescRegex})?(\s+{TimePrefix})?\s+{TimeSuffix}\b
   references: [ TimePrefix, BasicTime, DescRegex, TimeSuffix ]
-#Same as Timeregex4 but with conditional statement to avoid to extract durations like "pour 3 heures"
-TimeRegex4CS: !nestedRegex
-  def: (?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex4}(?(DurationPrep)(?<!heures?))
-  references: [ TimeRegex4 ]
 TimeRegex5: !nestedRegex
   def: \b{BasicTime}((\s*{DescRegex})(\s+{TimePrefix})?|\s+{TimePrefix})
   references: [ TimePrefix, BasicTime, DescRegex ]
 TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
-#Same as Timeregex6 but with conditional statement to avoid to extract durations like "pour 3 heures"
-TimeRegex6CS: !nestedRegex
-  def: (?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex6}(?(DurationPrep)(?<!heures?))
-  references: [ TimeRegex6 ]
 TimeRegex7: !nestedRegex
   def: \b{TimeSuffix}\s+[àa]\s+{BasicTime}((\s*{DescRegex})|\b)
   references: [ TimeSuffix, BasicTime, DescRegex ]
@@ -1063,6 +1055,11 @@ AmbiguityFiltersDict: !dictionary
   entries:
     '^([eé]t[eé])$': '(?<!((l\s*[''`]\s*)|(cet(te)?|en)\s+))[eé]t[eé]\b'
     '^(mer)$': '(?<!((le|ce)\s+))mer\b'
+# Used to exclude duration matches (e.g. "pour 3 heures") from time extractions
+AmbiguityTimeFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    'heures?$': '(pour|durée\s+de)\s*'
 # For TimeOfDay resolution
 MorningTermList: !list
   types: [ string ]

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -277,12 +277,20 @@ TimeRegex3: !nestedRegex
 TimeRegex4: !nestedRegex
   def: \b{BasicTime}(\s*{DescRegex})?(\s+{TimePrefix})?\s+{TimeSuffix}\b
   references: [ TimePrefix, BasicTime, DescRegex, TimeSuffix ]
+#Same as Timeregex4 but with conditional statement to avoid to extract durations like "pour 3 heures"
+TimeRegex4CS: !nestedRegex
+  def: (?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex4}(?(DurationPrep)(?<!heures?))
+  references: [ TimeRegex4 ]
 TimeRegex5: !nestedRegex
   def: \b{BasicTime}((\s*{DescRegex})(\s+{TimePrefix})?|\s+{TimePrefix})
   references: [ TimePrefix, BasicTime, DescRegex ]
 TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
+#Same as Timeregex6 but with conditional statement to avoid to extract durations like "pour 3 heures"
+TimeRegex6CS: !nestedRegex
+  def: (?<=(?<DurationPrep>(pour|durée de)\s+)|){TimeRegex6}(?(DurationPrep)(?<!heures?))
+  references: [ TimeRegex6 ]
 TimeRegex7: !nestedRegex
   def: \b{TimeSuffix}\s+[àa]\s+{BasicTime}((\s*{DescRegex})|\b)
   references: [ TimeSuffix, BasicTime, DescRegex ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2705,5 +2705,78 @@
         "End": 32
       }
     ]
+  },
+  {
+    "Input": "Je vais partir pour la ville à 3 heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "3 heures",
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T03",
+              "type": "time",
+              "value": "03:00:00"
+            },
+            {
+              "timex": "T15",
+              "type": "time",
+              "value": "15:00:00"
+            }
+          ]
+        },
+        "Start": 31,
+        "End": 38
+      }
+    ]
+  },
+  {
+    "Input": "Je vais partir à 3 heures pour 2 heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "3 heures",
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T03",
+              "type": "time",
+              "value": "03:00:00"
+            },
+            {
+              "timex": "T15",
+              "type": "time",
+              "value": "15:00:00"
+            }
+          ]
+        },
+        "Start": 17,
+        "End": 24
+      },
+      {
+        "Text": "2 heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT2H",
+              "type": "duration",
+              "value": "7200"
+            }
+          ]
+        },
+        "Start": 31,
+        "End": 38
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2589,5 +2589,121 @@
         "End": 30
       }
     ]
+  },
+  {
+    "Input": "Je vais partir pour 3 heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "3 heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT3H",
+              "type": "duration",
+              "value": "10800"
+            }
+          ]
+        },
+        "Start": 20,
+        "End": 27
+      }
+    ]
+  },
+  {
+    "Input": "Je vais partir pour une durée de 3 heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "3 heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT3H",
+              "type": "duration",
+              "value": "10800"
+            }
+          ]
+        },
+        "Start": 33,
+        "End": 40
+      }
+    ]
+  },
+  {
+    "Input": "Je vais partir le 17 pour trois heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-XX-17",
+              "type": "date",
+              "value": "2016-10-17"
+            },
+            {
+              "timex": "XXXX-XX-17",
+              "type": "date",
+              "value": "2016-11-17"
+            }
+          ]
+        },
+        "Start": 18,
+        "End": 19
+      },
+      {
+        "Text": "trois heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT3H",
+              "type": "duration",
+              "value": "10800"
+            }
+          ]
+        },
+        "Start": 26,
+        "End": 37
+      }
+    ]
+  },
+  {
+    "Input": "Je vais partir pour quatre heures",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "quatre heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT4H",
+              "type": "duration",
+              "value": "14400"
+            }
+          ]
+        },
+        "Start": 20,
+        "End": 32
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to avoid extracting expressions like "3 heures" as time when preceded by "pour" or "durée de". The problem is "3 heures" is ambiguous in general and can also represent a time e.g. "il est 3 heures" (it is 3 o'clock).
Fix implemented only in .NET, test cases added to DateTimeModel.