### PR TITLE
[FR DateTimeV2] Fixed No resolution in DateTimeRange (#456)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -597,6 +597,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     var dateResult = this.Config.DateExtractor.Extract(trimmedText.Replace(ers[0].Text, string.Empty), referenceTime);
 
+                    // Try to add TokenBeforeDate if no result is found because it is not always included in the DateTimePeriod extraction
+                    // (e.g. "I'll leave on the 17 from 2 to 4 pm" -> "the 17 from 2 to 4 pm")
+                    if (dateResult.Count == 0)
+                    {
+                        dateResult = this.Config.DateExtractor.Extract(Config.TokenBeforeDate + trimmedText.Substring(0, (int)ers[0].Start), referenceTime);
+                    }
+
                     // check if TokenBeforeDate is null
                     var dateText = !string.IsNullOrEmpty(Config.TokenBeforeDate) ? trimmedText.Replace(ers[0].Text, string.Empty).Replace(Config.TokenBeforeDate, string.Empty).Trim() : trimmedText.Replace(ers[0].Text, string.Empty).Trim();
                     if (this.Config.CheckBothBeforeAfter)
@@ -710,6 +717,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 // Parse following date
                 var dateExtractResult = this.Config.DateExtractor.Extract(trimmedText.Replace(match.Value, string.Empty), referenceTime);
+
+                // Try to add TokenBeforeDate if no result is found because it is not always included in the DateTimePeriod extraction
+                // (e.g. "I'll leave on the 17 from 2 to 4 pm" -> "the 17 from 2 to 4 pm")
+                if (dateExtractResult.Count == 0)
+                {
+                    dateExtractResult = this.Config.DateExtractor.Extract(Config.TokenBeforeDate + trimmedText.Substring(0, match.Index), referenceTime);
+                }
 
                 DateObject futureDate, pastDate;
                 if (dateExtractResult.Count > 0)

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17516,5 +17516,67 @@
         }
       }
     ]
+  },
+  {
+    "Input": "It will happen on the 17 from 2pm to 4pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "the 17 from 2pm to 4pm",
+        "Start": 18,
+        "End": 39,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It will happen on the 17 between 2 and 4pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "the 17 between 2 and 4pm",
+        "Start": 18,
+        "End": 41,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2465,5 +2465,129 @@
         "End": 20
       }
     ]
+  },
+  {
+    "Input": "Je serai le 17 de 14h à 16h",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17 de 14h à 16h",
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        },
+        "Start": 12,
+        "End": 26
+      }
+    ]
+  },
+  {
+    "Input": "Je serai le 17 de 14 à 16",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17 de 14 à 16",
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        },
+        "Start": 12,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "Je serai le 17 entre 14 et 16",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17 entre 14 et 16",
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        },
+        "Start": 12,
+        "End": 28
+      }
+    ]
+  },
+  {
+    "Input": "Je serai le 17 entre 14h et 16h",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17 entre 14h et 16h",
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-10-17 14:00:00",
+              "end": "2016-10-17 16:00:00"
+            },
+            {
+              "timex": "(XXXX-XX-17T14,XXXX-XX-17T16,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-17 14:00:00",
+              "end": "2016-11-17 16:00:00"
+            }
+          ]
+        },
+        "Start": 12,
+        "End": 30
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixed missing resolution for DateTimeRanges where Date precedes Time (e.g. "It will happen on the 17 between 2 and 4pm").
The issue has been reported in French, but other languages are affected too (observed also in English and Italian).
Relevant test cases added to EN and FR DateTimeModels.
