### PR TITLE
[FR DateTimeV2] Fix for hours duration wrongly recognized (#445)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -717,7 +717,7 @@ namespace Microsoft.Recognizers.Definitions.French
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
-            { @"heures?$", @"\b(pour|durée\s+de)\s+(\S+\s+){1,2}heures?\b" }
+            { @"heures?$", @"\b(pour|durée\s+de|pendant)\s+(\S+\s+){1,2}heures?\b" }
         };
       public static readonly IList<string> MorningTermList = new List<string>
         {

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -1059,7 +1059,7 @@ AmbiguityFiltersDict: !dictionary
 AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    'heures?$': '\b(pour|durée\s+de)\s+(\S+\s+){1,2}heures?\b'
+    'heures?$': '\b(pour|durée\s+de|pendant)\s+(\S+\s+){1,2}heures?\b'
 # For TimeOfDay resolution
 MorningTermList: !list
   types: [ string ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2778,5 +2778,44 @@
         "End": 38
       }
     ]
+  },
+  {
+    "Input": "Quelles sont les salles disponibles aujourd'hui pendant 2 heures ?",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "aujourd'hui",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-07",
+              "type": "date",
+              "value": "2016-11-07"
+            }
+          ]
+        },
+        "Start": 36,
+        "End": 46
+      },
+      {
+        "Text": "2 heures",
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT2H",
+              "type": "duration",
+              "value": "7200"
+            }
+          ]
+        },
+        "Start": 56,
+        "End": 63
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix for hours durations wrongly recognized as time when introduced by "pendant" (during) e.g. "pendant 2 heures" (#445).
Test case added to DateTimeModel.