### PR TITLE
[EN DateTimeV2] Fix for specific datetimeperiod phrase not extracted (#2262)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateTimePeriodExtractor.cs
@@ -756,6 +756,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             return new Token(startOut, endOut);
         }
 
+        // The method matches pure number ranges. It is used inside MatchTimeOfDay, so the condition IsNullOrWhiteSpace(midStr) implies
+        // that the range must be contiguous to a TimeOfDay expression (e.g. "last night from 7 to 9").
         private List<Token> MatchPureNumberCases(string text, Token tok, bool before)
         {
             var ret = new List<Token>();

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17816,5 +17816,30 @@
         }
       }
     ]
+  },
+  {
+    "Input": "They were working between 7 and 9 last morning.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-01T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "between 7 and 9 last morning",
+        "Start": 18,
+        "End": 45,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-05-31T07,2018-05-31T09,PT2H)",
+              "type": "datetimerange",
+              "start": "2018-05-31 07:00:00",
+              "end": "2018-05-31 09:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17674,8 +17674,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-01T16:12:00"
     },
-    "Comment": "Not currently supported because 'between 7 and 9' is not recognized as TimePeriod",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript, python, java",
     "Results": [
       {
@@ -17788,6 +17786,31 @@
               "timex": "P1WE",
               "type": "set",
               "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out next evening from 7 to 9",
+    "Context": {
+      "ReferenceDateTime": "2018-06-01T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "next evening from 7 to 9",
+        "Start": 12,
+        "End": 35,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-06-02T19,2018-06-02T21,PT2H)",
+              "type": "datetimerange",
+              "start": "2018-06-02 19:00:00",
+              "end": "2018-06-02 21:00:00"
             }
           ]
         }


### PR DESCRIPTION
Fix for DateTimePeriods containing pure numbers (e.g. "between 7 and 9 last night") not being extracted (#2262).
Test cases added to DateTimeModel.