### PR TITLE
[* Currency] Fix for currency 'USD' not recognized when used before value (#1850)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },
-            { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $" },
+            { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $|usd" },
             { @"East Caribbean dollar", @"east caribbean $" },
             { @"Australian dollar", @"australian $|australia $" },
             { @"Bahamian dollar", @"bahamian $|bahamia $" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"Rwandan franc", @"RWF" },
             { @"Russian ruble", @"RUB" },
             { @"Transnistrian ruble", @"PRB" },
-            { @"Belarusian ruble", @"BYN" },
+            { @"New Belarusian ruble", @"BYN" },
             { @"Algerian dinar", @"DZD" },
             { @"Bahraini dinar", @"BHD" },
             { @"Iraqi dinar", @"IQD" },
@@ -562,7 +562,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dollar", @"$" },
-            { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $|usd" },
+            { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $" },
             { @"East Caribbean dollar", @"east caribbean $" },
             { @"Australian dollar", @"australian $|australia $" },
             { @"Bahamian dollar", @"bahamian $|bahamia $" },
@@ -619,6 +619,7 @@ namespace Microsoft.Recognizers.Definitions.English
             @"toea",
             @"vatu",
             @"yuan",
+            @"all",
             @"ang",
             @"ban",
             @"bob",

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/CurrencyExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/CurrencyExtractorConfiguration.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 
 using Microsoft.Recognizers.Definitions.English;
 
@@ -10,8 +13,14 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         public static readonly ImmutableDictionary<string, string> CurrencySuffixList =
             NumbersWithUnitDefinitions.CurrencySuffixList.ToImmutableDictionary();
 
-        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList =
-            NumbersWithUnitDefinitions.CurrencyPrefixList.ToImmutableDictionary();
+        // Merge CurrencyNameToIsoCodeMap with CurrencyPrefixList (excluding fake and unofficial Iso codes starting with underscore)
+        public static readonly Dictionary<string, string> CurrencyPrefixDict =
+            NumbersWithUnitDefinitions.CurrencyPrefixList
+            .Concat(NumbersWithUnitDefinitions.CurrencyNameToIsoCodeMap.Where(x => !x.Value.StartsWith("_"))
+                .ToDictionary(x => x.Key, x => x.Value.ToLower())).GroupBy(x => x.Key)
+            .ToDictionary(x => x.Key, y => y.Count() > 1 ? string.Join("|", new string[] { y.First().Value, y.Last().Value }) : y.First().Value);
+
+        public static readonly ImmutableDictionary<string, string> CurrencyPrefixList = CurrencyPrefixDict.ToImmutableDictionary();
 
         public static readonly ImmutableDictionary<string, string> FractionalUnitNameToCodeMap =
             NumbersWithUnitDefinitions.FractionalUnitNameToCodeMap.ToImmutableDictionary();

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -642,7 +642,7 @@ CurrencyPrefixList: !dictionary
   entries:
 # Currency Prefix Symbols/Terms
     Dollar: $
-    United States dollar: united states $|us$|us $|u.s. $|u.s $
+    United States dollar: united states $|us$|us $|u.s. $|u.s $|usd
     East Caribbean dollar: east caribbean $
     Australian dollar: australian $|australia $
     Bahamian dollar: bahamian $|bahamia $

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -473,7 +473,7 @@ CurrencyNameToIsoCodeMap: !dictionary
     Rwandan franc: RWF
     Russian ruble: RUB
     Transnistrian ruble: PRB
-    Belarusian ruble: BYN
+    New Belarusian ruble: BYN
     Algerian dinar: DZD
     Bahraini dinar: BHD
     Iraqi dinar: IQD
@@ -642,7 +642,7 @@ CurrencyPrefixList: !dictionary
   entries:
 # Currency Prefix Symbols/Terms
     Dollar: $
-    United States dollar: united states $|us$|us $|u.s. $|u.s $|usd
+    United States dollar: united states $|us$|us $|u.s. $|u.s $
     East Caribbean dollar: east caribbean $
     Australian dollar: australian $|australia $
     Bahamian dollar: bahamian $|bahamia $
@@ -699,6 +699,7 @@ AmbiguousCurrencyUnitList: !list
     - toea
     - vatu
     - yuan
+    - all
     - ang
     - ban
     - bob

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2270,6 +2270,7 @@
   },
   {
     "Input": "I would like to buy this item for USD 200.",
+    "NotSupported": "python, java, javascript",
     "Results": [
       {
         "Text": "usd 200",
@@ -2278,6 +2279,40 @@
           "value": "200",
           "unit": "United States dollar",
           "isoCurrency": "USD"
+        },
+        "Start": 34,
+        "End": 40
+      }
+    ]
+  },
+  {
+    "Input": "I would like to buy this item for EUR 125.",
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "eur 125",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "125",
+          "unit": "Euro",
+          "isoCurrency": "EUR"
+        },
+        "Start": 34,
+        "End": 40
+      }
+    ]
+  },
+  {
+    "Input": "I would like to buy this item for GBP 350.",
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "gbp 350",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "350",
+          "unit": "British pound",
+          "isoCurrency": "GBP"
         },
         "Start": 34,
         "End": 40

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2267,5 +2267,21 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I would like to buy this item for USD 200.",
+    "Results": [
+      {
+        "Text": "usd 200",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "200",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 34,
+        "End": 40
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added 'usd' to CurrencyPrefixList in order to solve issue #1850. 
Should other currencies be added to the list?
Test case added to CurrencyModel.