### PR TITLE
[DE DateTimeV2] Added support for expressions like "anderthalb", "einundhalb", "zweieinhalb" (#2271)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
@@ -52,8 +52,11 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string OrdinalGermanRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|halb(er|e|es)?|hälfte)(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(und\s+)?)?eine?(\s+|\s*-\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|halb(er|e|es)?|hälfte)(?=\b)";
+      public const string FractionUnitsRegex = @"((?<onehalf>anderthalb|einundhalb)|(?<quarter>dreiviertel))";
+      public const string FractionHalfRegex = @"(einhalb)$";
+      public static readonly string[] OneHalfTokens = { @"ein", @"halb" };
+      public static readonly string FractionNounRegex = $@"(?<=\b)(({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|halb(er|e|es)?|hälfte)|{FractionUnitsRegex})(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+(und\s+)?)?eine?(\s+|\s*-\s*)({AllOrdinalRegex}|{RoundNumberOrdinalRegex}|{FractionUnitsRegex}|({AllIntRegex}ein)?(halb(er|e|es)?|hälfte))|{AllIntRegex}ein(halb))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?!\.))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s*{ZeroToNineIntegerRegex})+|(\s*{SeparaIntRegex}))";
       public static readonly string AllFloatRegex = $@"({AllIntRegex}(\s*komma\s*){AllPointRegex})";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.German;
+using Microsoft.Recognizers.Text.Number;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
@@ -59,7 +60,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public GermanDurationExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
-            CardinalExtractor = Number.German.CardinalExtractor.GetInstance();
+            CardinalExtractor = Number.German.NumberExtractor.GetInstance();
             UnitMap = DateTimeDefinitions.UnitMap.ToImmutableDictionary();
             UnitValueMap = DateTimeDefinitions.UnitValueMap.ToImmutableDictionary();
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDurationParserConfiguration.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public GermanDurationParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
-            CardinalExtractor = config.CardinalExtractor;
+            CardinalExtractor = Number.German.NumberExtractor.GetInstance();
             NumberParser = config.NumberParser;
 
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this), false);

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Recognizers.Text.Number.German
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
+        private static readonly Regex FractionHalfRegex =
+            new Regex(NumbersDefinitions.FractionHalfRegex, RegexFlags);
+
+        private static readonly Regex FractionUnitsRegex =
+            new Regex(NumbersDefinitions.FractionUnitsRegex, RegexFlags);
+
+        private static readonly string[] OneHalfTokens = NumbersDefinitions.OneHalfTokens;
+
         public GermanNumberParserConfiguration(INumberOptionsConfiguration config)
         {
 
@@ -64,6 +72,34 @@ namespace Microsoft.Recognizers.Text.Number.German
                 else
                 {
                     fracWords.Add(tokenList[i]);
+                }
+            }
+
+            // The following piece of code is needed to compute the fraction pattern number+'einhalb'
+            // e.g. 'zweieinhalb' ('two and a half').
+            fracWords.RemoveAll(item => item == "/");
+            for (int i = fracWords.Count - 1; i >= 0; i--)
+            {
+                if (FractionHalfRegex.IsMatch(fracWords[i]))
+                {
+                    fracWords[i] = fracWords[i].Substring(0, fracWords[i].Length - 7);
+                    fracWords.Insert(i + 1, this.WrittenFractionSeparatorTexts.ElementAt(0));
+                    fracWords.Insert(i + 2, OneHalfTokens[0]);
+                    fracWords.Insert(i + 3, OneHalfTokens[1]);
+                }
+                else if (FractionUnitsRegex.Match(fracWords[i]).Groups["onehalf"].Success)
+                {
+                    fracWords[i] = OneHalfTokens[0];
+                    fracWords.Insert(i + 1, this.WrittenFractionSeparatorTexts.ElementAt(0));
+                    fracWords.Insert(i + 2, OneHalfTokens[0]);
+                    fracWords.Insert(i + 3, OneHalfTokens[1]);
+                }
+                else if (FractionUnitsRegex.Match(fracWords[i]).Groups["quarter"].Success)
+                {
+                    var tempWord = fracWords[i];
+                    fracWords[i] = tempWord.Substring(0, 4);
+                    fracWords.Insert(i + 1, this.WrittenFractionSeparatorTexts.ElementAt(0));
+                    fracWords.Insert(i + 2, tempWord.Substring(4, 5));
                 }
             }
 

--- a/Patterns/German/German-Numbers.yaml
+++ b/Patterns/German/German-Numbers.yaml
@@ -78,12 +78,17 @@ FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
 FractionNotationRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionUnitsRegex: !simpleRegex
+  def: ((?<onehalf>anderthalb|einundhalb)|(?<quarter>dreiviertel))
+FractionHalfRegex: !simpleRegex
+  def: (einhalb)$
+OneHalfTokens: [ein, halb]
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|halb(er|e|es)?|hälfte)(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]
+  def: (?<=\b)(({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))|halb(er|e|es)?|hälfte)|{FractionUnitsRegex})(?=\b)
+  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, FractionUnitsRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+(und\s+)?)?eine?(\s+|\s*-\s*)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|halb(er|e|es)?|hälfte)(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]
+  def: (?<=\b)(({AllIntRegex}\s+(und\s+)?)?eine?(\s+|\s*-\s*)({AllOrdinalRegex}|{RoundNumberOrdinalRegex}|{FractionUnitsRegex}|({AllIntRegex}ein)?(halb(er|e|es)?|hälfte))|{AllIntRegex}ein(halb))(?=\b)
+  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, FractionUnitsRegex ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?!\.))(?=\b)
   references: [ AllIntRegex, BaseNumbers.CommonCurrencySymbol ]

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -2247,5 +2247,102 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Spule anderthalb Stunden vor",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "anderthalb stunden vor",
+        "Start": 6,
+        "End": 27,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-06T22:30:00,2016-11-07T00:00:00,PT1.5H)",
+              "type": "datetimerange",
+              "start": "2016-11-06 22:30:00",
+              "end": "2016-11-07 00:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Spring zweieinhalb Stunden nach vorne",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "zweieinhalb stunden",
+        "Start": 7,
+        "End": 25,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT2.5H",
+              "type": "duration",
+              "value": "9000"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Wir haben anderthalb Stunden gewartet.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "anderthalb stunden",
+        "Start": 10,
+        "End": 27,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT1.5H",
+              "type": "duration",
+              "value": "5400"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Wir haben fünfeinhalb Stunden gewartet.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "python, java, javascript",
+    "Results": [
+      {
+        "Text": "fünfeinhalb stunden",
+        "Start": 10,
+        "End": 28,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT5.5H",
+              "type": "duration",
+              "value": "19800"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -784,7 +784,7 @@
   },
   {
     "Input": "Es gibt anderthalb Stücke",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "anderthalb",
@@ -799,7 +799,7 @@
   },
   {
     "Input": "Es gibt einundhalb Stücke",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "einundhalb",
@@ -814,7 +814,7 @@
   },
   {
     "Input": "Es gibt dreiviertel Stücke",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "dreiviertel",
@@ -829,7 +829,7 @@
   },
   {
     "Input": "Es gibt zweieinhalb Stücke",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "zweieinhalb",
@@ -844,7 +844,7 @@
   },
   {
     "Input": "Es gibt dreieinhalb Stücke",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "dreieinhalb",

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -781,5 +781,80 @@
   {
     "Input": "\\t0\\t0",
     "Results": []
+  },
+  {
+    "Input": "Es gibt anderthalb Stücke",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "anderthalb",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1,5"
+        },
+        "Start": 8,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "Es gibt einundhalb Stücke",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "einundhalb",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1,5"
+        },
+        "Start": 8,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "Es gibt dreiviertel Stücke",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "dreiviertel",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,75"
+        },
+        "Start": 8,
+        "End": 18
+      }
+    ]
+  },
+  {
+    "Input": "Es gibt zweieinhalb Stücke",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "zweieinhalb",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2,5"
+        },
+        "Start": 8,
+        "End": 18
+      }
+    ]
+  },
+  {
+    "Input": "Es gibt dreieinhalb Stücke",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "dreieinhalb",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3,5"
+        },
+        "Start": 8,
+        "End": 18
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for compound fraction expressions like "anderthalb", "einundhalb", "zweieinhalb" (#2271).
The fix follows the solution implemented in Dutch for similar patterns. 
Test cases added to NumberModel and DateTimeModel.