### PR TITLE
[EN Number/Currency] Support for "half million" (#1934)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)(?=\b)";
+      public static readonly string RoundMultiplierRegex = $@"\b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$";
+      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
       public static readonly string RoundMultiplierRegex = $@"\b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Recognizers.Text.Number.Tests
 
         public Regex FractionPrepositionRegex { get; }
 
+        public Regex RoundMultiplierRegex { get; }
+
         public string FractionMarkerToken { get; }
 
         public Regex HalfADozenRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Recognizers.Text.Number.English
             this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
             this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
             this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.RoundMultiplierRegex = new Regex(NumbersDefinitions.RoundMultiplierRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -363,6 +363,17 @@ namespace Microsoft.Recognizers.Text.Number
             }
             else
             {
+                long multiplier = 1;
+                if (Config.RoundMultiplierRegex != null)
+                {
+                    var match = Config.RoundMultiplierRegex.Match(resultText);
+                    if (match.Success)
+                    {
+                        resultText = resultText.Replace(match.Value, string.Empty);
+                        multiplier = Config.RoundNumberMap[match.Groups["multiplier"].Value];
+                    }
+                }
+
                 var fracWords = Config.NormalizeTokenSet(resultText.Split(null), result).ToList();
 
                 // Split fraction with integer
@@ -373,7 +384,7 @@ namespace Microsoft.Recognizers.Text.Number
                 // For case like "half"
                 if (fracWords.Count == 1)
                 {
-                   result.Value = 1 / GetIntValue(fracWords);
+                   result.Value = (1 / GetIntValue(fracWords)) * multiplier;
                    return result;
                 }
 
@@ -481,11 +492,11 @@ namespace Microsoft.Recognizers.Text.Number
                 // Find mixed number
                 if (mixedIndex != fracWords.Count && numerValue < denominator)
                 {
-                    result.Value = intValue + (numerValue / denominator);
+                    result.Value = intValue + (multiplier * numerValue / denominator);
                 }
                 else
                 {
-                    result.Value = (intValue + numerValue) / denominator;
+                    result.Value = multiplier * (intValue + numerValue) / denominator;
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/INumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/INumberParserConfiguration.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Recognizers.Text.Number
 
         Regex FractionPrepositionRegex { get; }
 
+        Regex RoundMultiplierRegex { get; }
+
         string FractionMarkerToken { get; }
 
         Regex HalfADozenRegex { get; }
@@ -104,6 +106,8 @@ namespace Microsoft.Recognizers.Text.Number
         public Regex DigitalNumberRegex { get; set; }
 
         public Regex FractionPrepositionRegex { get; set; }
+
+        public Regex RoundMultiplierRegex { get; set; } = null;
 
         public string FractionMarkerToken { get; set; }
 

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -95,8 +95,8 @@ FractionNounRegex: !nestedRegex
   def: (?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]
+  def: (?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)
+  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)
   references: [ AllIntRegex, BaseNumbers.CommonCurrencySymbol ]

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -88,9 +88,12 @@ FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
 FractionNotationRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+RoundMultiplierRegex: !nestedRegex
+  def: \b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$
+  references: [ RoundNumberIntegerRegex ]
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+(and\s+)?)?({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]
+  def: (?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)
+  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
   def: (?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|half|quarter))|(half))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2838,5 +2838,69 @@
         "End": 16
       }
     ]
+  },
+  {
+    "Input": " half million",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "half million",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "500000"
+        },
+        "Start": 1,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": " quarter million",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "quarter million",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "250000"
+        },
+        "Start": 1,
+        "End": 15
+      }
+    ]
+  },
+  {
+    "Input": " two thirds of a million",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two thirds of a million",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "666666.666666667"
+        },
+        "Start": 1,
+        "End": 23
+      }
+    ]
+  },
+  {
+    "Input": " one billion and three quarters million",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "one billion and three quarters million",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "1000750000"
+        },
+        "Start": 1,
+        "End": 38
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2354,6 +2354,23 @@
     ]
   },
   {
+    "Input": "It costs a quarter million us dollars.",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "a quarter million us dollars",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "unit": "United States dollar",
+          "value": "250000"
+        },
+        "Start": 9,
+        "End": 36
+      }
+    ]
+  },
+  {
     "Input": "It costs three quarters billion us dollars.",
     "NotSupported": "javascript, java, python",
     "Results": [

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2318,5 +2318,56 @@
         "End": 40
       }
     ]
+  },
+  {
+    "Input": "It costs half million usd.",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "half million usd",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "unit": "United States dollar",
+          "value": "500000"
+        },
+        "Start": 9,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "It costs quarter million us dollars.",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "quarter million us dollars",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "unit": "United States dollar",
+          "value": "250000"
+        },
+        "Start": 9,
+        "End": 34
+      }
+    ]
+  },
+  {
+    "Input": "It costs three quarters billion us dollars.",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "three quarters billion us dollars",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "unit": "United States dollar",
+          "value": "750000000"
+        },
+        "Start": 9,
+        "End": 41
+      }
+    ]
   }
 ]


### PR DESCRIPTION
added support for fractional round numbers (in EN .NET) e.g. 'half million', 'quarter million', 'two thirds billion'... (#1934).
Test cases added to NumberModel and CurrencyModel.