### PR TITLE
[FR DateTimeV2] Fix for handling space as date separator (#547)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public static readonly string DateYearRegex = $@"(?<year>{YearRegex}|{TwoDigitYearRegex})";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{MonthRegex}\s*[/\\\.\-]?\s*{DayRegex}\b";
       public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s+){MonthRegex}\s*[\.\-]?\s*{DateYearRegex}\b";
-      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s*-\s*){MonthRegex}((\s+|\s*,\s*){DateYearRegex})?\b";
+      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d\s)(?<!\d){DayRegex}(\s+|\s*,\s*|\s*-\s*)({MonthRegex}((\s+|\s*,\s*){DateYearRegex}(?!\s*\d))?|{MonthNumRegex}(\s+|\s*,\s*){DateYearRegex}(?!\s*\d))\b";
       public static readonly string DateExtractor4 = $@"\b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
       public static readonly string DateExtractor5 = $@"\b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
       public static readonly string DateExtractor6 = $@"(?<=\b(le|sur(\sl[ae])?)\s+){MonthNumRegex}[\-\.\/]{DayRegex}\b";

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -165,8 +165,8 @@ DateExtractor2: !nestedRegex
   def: \b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s+){MonthRegex}\s*[\.\-]?\s*{DateYearRegex}\b
   references: [ WeekDayRegex, MonthRegex, DayRegex, DateYearRegex ]
 DateExtractor3: !nestedRegex
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s*-\s*){MonthRegex}((\s+|\s*,\s*){DateYearRegex})?\b
-  references: [ WeekDayRegex, DayRegex, MonthRegex, DateYearRegex ]
+  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d\s)(?<!\d){DayRegex}(\s+|\s*,\s*|\s*-\s*)({MonthRegex}((\s+|\s*,\s*){DateYearRegex}(?!\s*\d))?|{MonthNumRegex}(\s+|\s*,\s*){DateYearRegex}(?!\s*\d))\b
+  references: [ WeekDayRegex, DayRegex, MonthRegex, MonthNumRegex, DateYearRegex ]
 # The final lookahead in DateExtractor4|5|A avoids extracting as date "10/1-11" from an input like "10/1-11/2/2017" 
 DateExtractor4: !nestedRegex
   def: \b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2817,5 +2817,143 @@
         "End": 63
       }
     ]
+  },
+  {
+    "Input": "Je retournerai 02 04 2009.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "02 04 2009",
+        "Start": 15,
+        "End": 24,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2009-04-02",
+              "type": "date",
+              "value": "2009-04-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je retournerai 2 4 2009.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2 4 2009",
+        "Start": 15,
+        "End": 22,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2009-04-02",
+              "type": "date",
+              "value": "2009-04-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je retournerai 18 08 1978.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "18 08 1978",
+        "Start": 15,
+        "End": 24,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1978-08-18",
+              "type": "date",
+              "value": "1978-08-18"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je retournerai 18 8 1978.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "18 8 1978",
+        "Start": 15,
+        "End": 23,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1978-08-18",
+              "type": "date",
+              "value": "1978-08-18"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je retournerai 18 08 78.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "18 08 78",
+        "Start": 15,
+        "End": 22,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1978-08-18",
+              "type": "date",
+              "value": "1978-08-18"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Je retournerai 18 8 78.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "18 8 78",
+        "Start": 15,
+        "End": 21,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1978-08-18",
+              "type": "date",
+              "value": "1978-08-18"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2819,7 +2819,7 @@
     ]
   },
   {
-    "Input": "Je retournerai 02 04 2009.",
+    "Input": "Je retournerai 02 04 2009 à la maison.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
@@ -2846,6 +2846,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "2 4 2009",
@@ -2865,7 +2867,7 @@
     ]
   },
   {
-    "Input": "Je retournerai 18 08 1978.",
+    "Input": "Je retournerai 18 08 1978 à la maison.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
@@ -2892,6 +2894,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "18 8 1978",
@@ -2911,7 +2915,7 @@
     ]
   },
   {
-    "Input": "Je retournerai 18 08 78.",
+    "Input": "Je retournerai 18 08 78 à la maison.",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
@@ -2938,6 +2942,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "18 8 78",


### PR DESCRIPTION
Added support for space separated dates in French e.g. '02 04 2009', '18 8 78' (#547).
These patterns are already implemented in German.
Test cases added to DateTimeModel.