### PR TITLE
[ZH NumberRange] Improve support for “*[多几][千万]” in Chinese (#2268)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string LessOrEqualSuffix = @"(或|或者)\s*(以下|之下|更[小少低])";
       public static readonly string OneNumberRangeMoreRegex1 = $@"({MoreOrEqual}|{MoreRegex})\s*(?<number1>((?!([并且而並的同時时]|([,，](?!\d+))|。)).)+)";
       public const string OneNumberRangeMoreRegex2 = @"比\s*(?<number1>((?!(([,，](?!\d+))|。)).)+)\s*更?[大多高]";
-      public const string OneNumberRangeMoreRegex3 = @"(?<number1>((?!(([,，](?!\d+))|。|[或者])).)+)\s*(或|或者)?\s*([多几余幾餘]|以上|之上|更[大多高])(?![万亿萬億]{1,2})";
+      public const string OneNumberRangeMoreRegex3 = @"(?<number1>((?!(([,，](?!\d+))|。|[或者])).)+)\s*(或|或者)?\s*([多几余幾餘]|以上|之上|更[大多高])([万亿萬億]{0,2})";
       public static readonly string OneNumberRangeLessRegex1 = $@"({LessOrEqual}|{LessRegex})\s*(?<number2>((?!([并且而並的同時时]|([,，](?!\d+))|。)).)+)";
       public const string OneNumberRangeLessRegex2 = @"比\s*(?<number2>((?!(([,，](?!\d+))|。)).)+)\s*更?[小少低]";
       public const string OneNumberRangeLessRegex3 = @"(?<number2>((?!(([,，](?!\d+))|。|[或者])).)+)\s*(或|或者)?\s*(以下|之下|更[小少低])";

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/ChineseNumeric.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/ChineseNumeric.java
@@ -426,7 +426,7 @@ public class ChineseNumeric {
 
     public static final String OneNumberRangeMoreRegex2 = "比\\s*(?<number1>((?!(([,，](?!\\d+))|。)).)+)\\s*更?[大多高]";
 
-    public static final String OneNumberRangeMoreRegex3 = "(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])(?![万亿萬億]{1,2})";
+    public static final String OneNumberRangeMoreRegex3 = "(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])([万亿萬億]{0,2})";
 
     public static final String OneNumberRangeLessRegex1 = "({LessOrEqual}|{LessRegex})\\s*(?<number2>((?!([并且而並的同時时]|([,，](?!\\d+))|。)).)+)"
             .replace("{LessOrEqual}", LessOrEqual)

--- a/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
+++ b/JavaScript/packages/recognizers-number/src/resources/chineseNumeric.ts
@@ -106,7 +106,7 @@ export namespace ChineseNumeric {
     export const LessOrEqualSuffix = `(或|或者)\\s*(以下|之下|更[小少低])`;
     export const OneNumberRangeMoreRegex1 = `(${MoreOrEqual}|${MoreRegex})\\s*(?<number1>((?!([并且而並的同時时]|([,，](?!\\d+))|。)).)+)`;
     export const OneNumberRangeMoreRegex2 = `比\\s*(?<number1>((?!(([,，](?!\\d+))|。)).)+)\\s*更?[大多高]`;
-    export const OneNumberRangeMoreRegex3 = `(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])(?![万亿萬億]{1,2})`;
+    export const OneNumberRangeMoreRegex3 = `(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])([万亿萬億]{0,2})`;
     export const OneNumberRangeLessRegex1 = `(${LessOrEqual}|${LessRegex})\\s*(?<number2>((?!([并且而並的同時时]|([,，](?!\\d+))|。)).)+)`;
     export const OneNumberRangeLessRegex2 = `比\\s*(?<number2>((?!(([,，](?!\\d+))|。)).)+)\\s*更?[小少低]`;
     export const OneNumberRangeLessRegex3 = `(?<number2>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*(以下|之下|更[小少低])`;

--- a/Patterns/Chinese/Chinese-Numbers.yaml
+++ b/Patterns/Chinese/Chinese-Numbers.yaml
@@ -355,7 +355,7 @@ OneNumberRangeMoreRegex1: !nestedRegex
 OneNumberRangeMoreRegex2: !simpleRegex
   def: 比\s*(?<number1>((?!(([,，](?!\d+))|。)).)+)\s*更?[大多高]
 OneNumberRangeMoreRegex3: !simpleRegex
-  def: (?<number1>((?!(([,，](?!\d+))|。|[或者])).)+)\s*(或|或者)?\s*([多几余幾餘]|以上|之上|更[大多高])(?![万亿萬億]{1,2})
+  def: (?<number1>((?!(([,，](?!\d+))|。|[或者])).)+)\s*(或|或者)?\s*([多几余幾餘]|以上|之上|更[大多高])([万亿萬億]{0,2})
 OneNumberRangeLessRegex1: !nestedRegex
   def: ({LessOrEqual}|{LessRegex})\s*(?<number2>((?!([并且而並的同時时]|([,，](?!\d+))|。)).)+)
   references: [ LessOrEqual, LessRegex ]

--- a/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/chinese_numeric.py
@@ -201,7 +201,7 @@ class ChineseNumeric:
     LessOrEqualSuffix = f'(或|或者)\\s*(以下|之下|更[小少低])'
     OneNumberRangeMoreRegex1 = f'({MoreOrEqual}|{MoreRegex})\\s*(?<number1>((?!([并且而並的同時时]|([,，](?!\\d+))|。)).)+)'
     OneNumberRangeMoreRegex2 = f'比\\s*(?<number1>((?!(([,，](?!\\d+))|。)).)+)\\s*更?[大多高]'
-    OneNumberRangeMoreRegex3 = f'(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])(?![万亿萬億]{{1,2}})'
+    OneNumberRangeMoreRegex3 = f'(?<number1>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*([多几余幾餘]|以上|之上|更[大多高])([万亿萬億]{{0,2}})'
     OneNumberRangeLessRegex1 = f'({LessOrEqual}|{LessRegex})\\s*(?<number2>((?!([并且而並的同時时]|([,，](?!\\d+))|。)).)+)'
     OneNumberRangeLessRegex2 = f'比\\s*(?<number2>((?!(([,，](?!\\d+))|。)).)+)\\s*更?[小少低]'
     OneNumberRangeLessRegex3 = f'(?<number2>((?!(([,，](?!\\d+))|。|[或者])).)+)\\s*(或|或者)?\\s*(以下|之下|更[小少低])'

--- a/Specs/Number/Chinese/NumberRangeModel.json
+++ b/Specs/Number/Chinese/NumberRangeModel.json
@@ -853,5 +853,80 @@
         "End": 5
       }
     ]
+  },
+  {
+    "Input": "十几万",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "十几万",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(100000,)"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "二百三十余万",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "二百三十余万",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(2300000,)"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "三千四百五十几万",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "三千四百五十几万",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(34500000,)"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "肆拾幾亿",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "肆拾幾亿",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(4000000000,)"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "500多亿",
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "500多亿",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(50000000000,)"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summarization
1. improve support recognize count unit behind “[多几]” as number range in Chinese like "十多万", "二十几亿". Refer to #2268 

## ⏳ The detail of fixing the bug

> This part is only supported in c sharp.

Due to `OneNumberRangeMoreRegex3` limit matching the end `[万亿]` pattern, the previous model can't recognizer the count unit behind “[多几]”.

So we reopen the limitation in this pattern. 