### PR TITLE
[EN DateTimeV2] Fixed inconsistency between English and Spanish in handling "from" and issue with list (#2287)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -238,7 +238,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string AroundRegex = @"(?:\b(?:around|circa)\s*?\b)(\s+the)?";
       public static readonly string BeforeRegex = $@"((\b{InclusiveModPrepositions}?(?:before|in\s+advance\s+of|prior\s+to|(no\s+later|earlier|sooner)\s+than|ending\s+(with|on)|by|(un)?till?|(?<include>as\s+late\s+as)){InclusiveModPrepositions}?\b\s*?)|(?<!\w|>)((?<include><\s*=)|<))(\s+the)?";
       public static readonly string AfterRegex = $@"((\b{InclusiveModPrepositions}?((after|(starting|beginning)(\s+on)?(?!\sfrom)|(?<!no\s+)later than)|(year greater than))(?!\s+or equal to){InclusiveModPrepositions}?\b\s*?)|(?<!\w|<)((?<include>>\s*=)|>))(\s+the)?";
-      public const string SinceRegex = @"(?:(?:\b(?:since|after\s+or\s+equal\s+to|starting\s+(?:from|on|with)|as\s+early\s+as|(any\s+time\s+)?from)\b\s*?)|(?<!\w|<)(>=))(\s+the)?";
+      public const string SinceRegex = @"(?:(?:\b(?:since|after\s+or\s+equal\s+to|starting\s+(?:from|on|with)|as\s+early\s+as|(any\s+time\s+)from)\b\s*?)|(?<!\w|<)(>=))(\s+the)?";
+      public static readonly string SinceRegexExp = $@"({SinceRegex}|\bfrom(\s+the)?\b)";
       public const string AgoRegex = @"\b(ago|before\s+(?<day>yesterday|today))\b";
       public static readonly string LaterRegex = $@"\b(?:later(?!((\s+in)?\s*{OneWordPeriodRegex})|(\s+{TimeOfDayRegex}))|from now|(from|after) (?<day>tomorrow|tmr|today))\b";
       public const string InConnectorRegex = @"\b(in)\b";
@@ -255,7 +256,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string RelativeDurationUnitRegex = $@"(?:(?:(?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+(?<duration>week|month|year|decade|weekend)\b";
       public const string ConnectorRegex = @"^(-|,|for|t|around|@)$";
-      public const string FromToRegex = @"\b(from).+(to)\b.+";
+      public const string FromToRegex = @"(\b(from).+(to)\b.+|\b(from)\s+\d{4}\s+and\s+\d{4})";
       public const string SingleAmbiguousMonthRegex = @"^(the\s+)?(may|march)$";
       public const string SingleAmbiguousTermsRegex = @"^(the\s+)?(day|week|month|year)$";
       public const string UnspecificDatePeriodRegex = @"^(week|month|year)$";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string RelativeDurationUnitRegex = $@"(?:(?:(?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+(?<duration>week|month|year|decade|weekend)\b";
       public const string ConnectorRegex = @"^(-|,|for|t|around|@)$";
-      public const string FromToRegex = @"(\b(from).+(to)\b.+|\b(from)\s+\d{4}\s+and\s+\d{4})";
+      public const string FromToRegex = @"(\b(from).+(to|and|or)\b.+)";
       public const string SingleAmbiguousMonthRegex = @"^(the\s+)?(may|march)$";
       public const string SingleAmbiguousTermsRegex = @"^(the\s+)?(day|week|month|year)$";
       public const string UnspecificDatePeriodRegex = @"^(week|month|year)$";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -16,10 +16,6 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex AfterRegex =
             new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        // used in Experimental mode
-        public static readonly Regex SinceRegexExp =
-            new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
-
         public static readonly Regex AroundRegex =
             new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
 
@@ -106,6 +102,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
         // Used in Standard mode
         public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+
+        // used in Experimental mode
+        public static Regex SinceRegexExp { get; } = new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -16,8 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public static readonly Regex AfterRegex =
             new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+        // used in Experimental mode
+        public static readonly Regex SinceRegexExp =
+            new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
 
         public static readonly Regex AroundRegex =
             new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
@@ -86,6 +87,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 numOptions = NumberOptions.NoProtoCache;
             }
 
+            if ((config.Options & DateTimeOptions.ExperimentalMode) != 0)
+            {
+                SinceRegex = SinceRegexExp;
+            }
+
             var numConfig = new BaseNumberOptionsConfiguration(config.Culture, numOptions);
 
             IntegerExtractor = Number.English.IntegerExtractor.GetInstance(numConfig);
@@ -97,6 +103,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                 SuperfluousWordMatcher.Init(DateTimeDefinitions.SuperfluousWordList);
             }
         }
+
+        // Used in Standard mode
+        public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishMergedParserConfiguration.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             BeforeRegex = EnglishMergedExtractorConfiguration.BeforeRegex;
             AfterRegex = EnglishMergedExtractorConfiguration.AfterRegex;
-            SinceRegex = EnglishMergedExtractorConfiguration.SinceRegex;
+            SinceRegex = (config.Options & DateTimeOptions.ExperimentalMode) != 0 ? EnglishMergedExtractorConfiguration.SinceRegexExp :
+                EnglishMergedExtractorConfiguration.SinceRegex;
             AroundRegex = EnglishMergedExtractorConfiguration.AroundRegex;
             EqualRegex = EnglishMergedExtractorConfiguration.EqualRegex;
             SuffixAfter = EnglishMergedExtractorConfiguration.SuffixAfterRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -16,10 +16,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex AfterRegex =
             new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        // used in Experimental mode
-        public static readonly Regex SinceRegexExp =
-            new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
-
         public static readonly Regex AroundRegex =
             new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
 
@@ -89,6 +85,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         // Used in Standard mode
         public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+
+        // used in Experimental mode
+        public static Regex SinceRegexExp { get; } = new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishMergedParserConfiguration.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public sealed class SpanishMergedParserConfiguration : SpanishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
-        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
-
         public SpanishMergedParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -611,7 +611,7 @@ ReferenceDatePeriodRegex: !nestedRegex
 ConnectorRegex: !simpleRegex
   def: ^(-|,|for|t|around|@)$
 FromToRegex: !simpleRegex
-  def: (\b(from).+(to)\b.+|\b(from)\s+\d{4}\s+and\s+\d{4})
+  def: (\b(from).+(to|and|or)\b.+)
 SingleAmbiguousMonthRegex: !simpleRegex
   def: ^(the\s+)?(may|march)$
 # Filter ambiguous single word datetime extractions in CalendarMode or when adding a modifier

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -564,7 +564,10 @@ AfterRegex: !nestedRegex
   def: ((\b{InclusiveModPrepositions}?((after|(starting|beginning)(\s+on)?(?!\sfrom)|(?<!no\s+)later than)|(year greater than))(?!\s+or equal to){InclusiveModPrepositions}?\b\s*?)|(?<!\w|<)((?<include>>\s*=)|>))(\s+the)?
   references: [ InclusiveModPrepositions ]
 SinceRegex: !simpleRegex
-  def: (?:(?:\b(?:since|after\s+or\s+equal\s+to|starting\s+(?:from|on|with)|as\s+early\s+as|(any\s+time\s+)?from)\b\s*?)|(?<!\w|<)(>=))(\s+the)?
+  def: (?:(?:\b(?:since|after\s+or\s+equal\s+to|starting\s+(?:from|on|with)|as\s+early\s+as|(any\s+time\s+)from)\b\s*?)|(?<!\w|<)(>=))(\s+the)?
+SinceRegexExp: !nestedRegex
+  def: ({SinceRegex}|\bfrom(\s+the)?\b)
+  references: [ SinceRegex ]
 AgoRegex: !simpleRegex
   def: \b(ago|before\s+(?<day>yesterday|today))\b
 LaterRegex: !nestedRegex
@@ -608,7 +611,7 @@ ReferenceDatePeriodRegex: !nestedRegex
 ConnectorRegex: !simpleRegex
   def: ^(-|,|for|t|around|@)$
 FromToRegex: !simpleRegex
-  def: \b(from).+(to)\b.+
+  def: (\b(from).+(to)\b.+|\b(from)\s+\d{4}\s+and\s+\d{4})
 SingleAmbiguousMonthRegex: !simpleRegex
   def: ^(the\s+)?(may|march)$
 # Filter ambiguous single word datetime extractions in CalendarMode or when adding a modifier
@@ -691,7 +694,7 @@ StartMiddleEndRegex: !simpleRegex
   def: \b((?<StartOf>((the\s+)?(start|beginning)\s+of\s+)?)(?<MiddleOf>((the\s+)?middle\s+of\s+)?)(?<EndOf>((the\s+)?end\s+of\s+)?))
 ComplexDatePeriodRegex: !nestedRegex
   def: (?:((from|during|in)\s+)?{StartMiddleEndRegex}(?<start>.+)\s*({StrictTillRegex})\s*{StartMiddleEndRegex}(?<end>.+)|((between)\s+){StartMiddleEndRegex}(?<start>.+)\s*({StrictRangeConnectorRegex})\s*{StartMiddleEndRegex}(?<end>.+))
-  references: [ YearRegex, StrictTillRegex, StrictRangeConnectorRegex, StartMiddleEndRegex ]
+  references: [ StrictTillRegex, StrictRangeConnectorRegex, StartMiddleEndRegex ]
 # Do not localize FailFastRegex to other cultures at this momment. Experimental feature. To be improved.
 FailFastRegex: !nestedRegex
   def: '{BaseDateTime.DeltaMinuteRegex}|\b(?:{BaseDateTime.BaseAmDescRegex}|{BaseDateTime.BasePmDescRegex})|{BaseDateTime.BaseAmPmDescRegex}|\b(?:zero|{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}|{WrittenMonthRegex}|{SeasonDescRegex}|{DecadeRegex}|centur(y|ies)|weekends?|quarters?|hal(f|ves)|yesterday|to(morrow|day|night)|tmr|noonish|\d(-|——)?ish|((the\s+\w*)|\d)(th|rd|nd|st)|(mid\s*(-\s*)?)?(night|morning|afternoon|day)s?|evenings?||noon|lunch(time)?|dinner(time)?|(day|night)time|overnight|dawn|dusk|sunset|hours?|hrs?|h|minutes?|mins?|seconds?|secs?|eo[dmy]|mardi[ -]?gras|birthday|eve|christmas|xmas|thanksgiving|halloween|yuandan|easter|yuan dan|april fools|cinco de mayo|all (hallow|souls)|guy fawkes|(st )?patrick|hundreds?|noughties|aughts|thousands?)\b|{WeekDayRegex}|{SetWeekDayRegex}|{NowRegex}|{PeriodicRegex}|\b({DateUnitRegex}|{ImplicitDayRegex})'

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -4245,7 +4245,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "3 minutes",
@@ -4263,18 +4263,16 @@
         }
       },
       {
-        "Text": "from today",
-        "Start": 22,
+        "Text": "today",
+        "Start": 27,
         "End": 31,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "2018-05-29",
-              "Mod": "since",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "start": "2018-05-29"
+              "type": "date",
+              "value": "2018-05-29"
             }
           ]
         }
@@ -14436,27 +14434,26 @@
     "Context": {
       "ReferenceDateTime": "2019-08-24T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
-        "Text": "from october",
-        "Start": 23,
+        "Text": "october",
+        "Start": 28,
         "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "XXXX-10",
-              "Mod": "since",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "2018-10-01"
+              "start": "2018-10-01",
+              "end": "2018-11-01"
             },
             {
               "timex": "XXXX-10",
-              "Mod": "since",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "2019-10-01"
+              "start": "2019-10-01",
+              "end": "2019-11-01"
             }
           ]
         }
@@ -15447,18 +15444,18 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "from the end of 1989",
-        "Start": 19,
+        "Text": "end of 1989",
+        "Start": 28,
         "End": 38,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "1989",
-              "Mod": "since-end",
+              "Mod": "end",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "1989-09-01"
+              "start": "1989-09-01",
+              "end": "1990-01-01"
             }
           ]
         }
@@ -15473,18 +15470,18 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "from mid 1989",
-        "Start": 19,
+        "Text": "mid 1989",
+        "Start": 24,
         "End": 31,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "1989",
-              "Mod": "since-mid",
+              "Mod": "mid",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "1989-05-01"
+              "start": "1989-05-01",
+              "end": "1989-09-01"
             }
           ]
         }
@@ -18118,18 +18115,17 @@
     "NotSupported": "java, javascript, python",
     "Results": [
       {
-        "Text": "from around 1pm",
-        "Start": 18,
+        "Text": "around 1pm",
+        "Start": 23,
         "End": 32,
-        "TypeName": "datetimeV2.timerange",
+        "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T13",
-              "Mod": "since-approx",
+              "Mod": "approx",
               "type": "timerange",
-              "start": "13:00:00",
-              "sourceEntity": "datetimepoint"
+              "value": "13:00:00"
             }
           ]
         }
@@ -18207,6 +18203,72 @@
               "Mod": "approx",
               "type": "timerange",
               "value": "13:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The range is from 2014",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2014",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014",
+              "type": "daterange",
+              "start": "2014-01-01",
+              "end": "2015-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The range is from 2015 and 2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2015",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2016",
+        "Start": 27,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "end": "2017-01-01"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -3607,7 +3607,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "3 minutes",
@@ -3625,18 +3625,16 @@
         }
       },
       {
-        "Text": "from today",
-        "Start": 22,
+        "Text": "today",
+        "Start": 27,
         "End": 31,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "2018-05-29",
-              "Mod": "since",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "start": "2018-05-29"
+              "type": "date",
+              "value": "2018-05-29"
             }
           ]
         }
@@ -12334,27 +12332,26 @@
     "Context": {
       "ReferenceDateTime": "2019-08-24T00:00:00"
     },
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
-        "Text": "from october",
-        "Start": 23,
+        "Text": "october",
+        "Start": 28,
         "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "XXXX-10",
-              "Mod": "since",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "2018-10-01"
+              "start": "2018-10-01",
+              "end": "2018-11-01"
             },
             {
               "timex": "XXXX-10",
-              "Mod": "since",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "2019-10-01"
+              "start": "2019-10-01",
+              "end": "2019-11-01"
             }
           ]
         }
@@ -12780,18 +12777,18 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "from the end of 1989",
-        "Start": 19,
+        "Text": "end of 1989",
+        "Start": 28,
         "End": 38,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "1989",
-              "Mod": "since-end",
+              "Mod": "end",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "1989-09-01"
+              "start": "1989-09-01",
+              "end": "1990-01-01"
             }
           ]
         }
@@ -12806,18 +12803,18 @@
     "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "from mid 1989",
-        "Start": 19,
+        "Text": "mid 1989",
+        "Start": 24,
         "End": 31,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "1989",
-              "Mod": "since-mid",
+              "Mod": "mid",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "start": "1989-05-01"
+              "start": "1989-05-01",
+              "end": "1989-09-01"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -4152,7 +4152,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "3 minutes",

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -7641,5 +7641,183 @@
         }
       }
     ]
+  },
+  {
+    "Input": "my vacation will start from October",
+    "Context": {
+      "ReferenceDateTime": "2019-08-24T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from october",
+        "Start": 23,
+        "End": 34,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-10",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2018-10-01"
+            },
+            {
+              "timex": "XXXX-10",
+              "Mod": "since",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "2019-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "We have lived here from the end of 1989",
+    "Context": {
+      "ReferenceDateTime": "2020-04-27T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "from the end of 1989",
+        "Start": 19,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1989",
+              "Mod": "since-end",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "1989-09-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "We have lived here from mid 1989",
+    "Context": {
+      "ReferenceDateTime": "2020-04-27T18:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "from mid 1989",
+        "Start": 19,
+        "End": 31,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1989",
+              "Mod": "since-mid",
+              "type": "daterange",
+              "sourceEntity": "datetimerange",
+              "start": "1989-05-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I am feeling sick from around 1pm",
+    "Context": {
+      "ReferenceDateTime": "2018-08-17T15:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from around 1pm",
+        "Start": 18,
+        "End": 32,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T13",
+              "Mod": "since-approx",
+              "type": "timerange",
+              "start": "13:00:00",
+              "sourceEntity": "datetimepoint"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The range is from 2014",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 2014",
+        "Start": 13,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2014",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2014-01-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The range is from 2015 and 2016",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2015",
+        "Start": 18,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "2016",
+        "Start": 27,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "end": "2017-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/MergedExtractor.json
+++ b/Specs/DateTime/English/MergedExtractor.json
@@ -1183,7 +1183,7 @@
   },
   {
     "Input": "Let's start 3 minutes from today",
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "3 minutes",
@@ -1192,10 +1192,10 @@
         "Length": 9
       },
       {
-        "Text": "from today",
+        "Text": "today",
         "Type": "date",
-        "Start": 22,
-        "Length": 10
+        "Start": 27,
+        "Length": 5
       }
     ]
   }

--- a/Specs/DateTime/English/MergedParser.json
+++ b/Specs/DateTime/English/MergedParser.json
@@ -3349,7 +3349,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "3 minutes",
@@ -3367,21 +3367,19 @@
         "Length": 9
       },
       {
-        "Text": "from today",
-        "Type": "datetimeV2.daterange",
+        "Text": "today",
+        "Type": "datetimeV2.date",
         "Value": {
           "values": [
             {
               "timex": "2018-05-29",
-              "Mod": "since",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "start": "2018-05-29"
+              "type": "date",
+              "value": "2018-05-29"
             }
           ]
         },
-        "Start": 22,
-        "Length": 10
+        "Start": 27,
+        "Length": 5
       }
     ]
   },


### PR DESCRIPTION
Moved support for ranges like "from 2015" from Standard to Experimental mode in analogy with Spanish behaviour (#2287).

Added pattern "from 2015 and 2016"  to PotentialAmbiguousRangeRegex (FromToRegex) to avoid considering 'from' a modifier in this case.

Updated affected test cases in DateTimeModel and moved the originals to DateTimeModelExperimentalMode.