### PR TITLE
[DE DateTimeV2] Fixed extraction of time expressions like "in 3 Wochen" (#2291)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string DateExtractor3 = $@"\b({DayRegex}{MonthRegex})";
       public static readonly string DateExtractor4 = $@"\b({DayRegex}\s*{MonthNumRegex}\s*{DateYearRegex})\b";
       public static readonly string DateExtractor5 = $@"\b({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)";
-      public static readonly string DateExtractor6 = $@"\b(({WeekDayRegex}\s*)?(in)\s*(\d(\d)?)\s*(woche(n)?))\b";
+      public static readonly string DateExtractor6 = $@"^[.]";
       public static readonly string DateExtractor7 = $@"({DayRegex}\s*[\.]\s*{MonthNumRegex}[\.])";
       public static readonly string DateExtractor8 = $@"(?<=\b(am)\s+){DayRegex}[/\\\.]{MonthNumRegex}[/\\\.]({DateYearRegex})?\b";
       public static readonly string DateExtractor9 = $@"\b({DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*){DateYearRegex})?)\b";

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -194,7 +194,7 @@ DateExtractor5: !nestedRegex
   def: \b({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)
   references: [ DayRegex, MonthNumRegex, MonthRegex, DateYearRegex ]
 DateExtractor6: !nestedRegex
-  def: \b(({WeekDayRegex}\s*)?(in)\s*(\d(\d)?)\s*(woche(n)?))\b
+  def: ^[.]
   references: [ WeekDayRegex ]
 DateExtractor7: !nestedRegex
   def: ({DayRegex}\s*[\.]\s*{MonthNumRegex}[\.])

--- a/Specs/DateTime/German/DateExtractor.json
+++ b/Specs/DateTime/German/DateExtractor.json
@@ -128,10 +128,16 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "Sonntag in 2 Wochen",
+        "Text": "Sonntag",
         "Type": "date",
         "Start": 11,
-        "Length": 19
+        "Length": 7
+      },
+      {
+        "Text": "in 2 Wochen",
+        "Type": "date",
+        "Start": 19,
+        "Length": 11
       }
     ]
   },

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -2615,5 +2615,53 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Was kommt in drei Wochen auf ARD",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "in drei wochen",
+        "Start": 10,
+        "End": 23,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-09-02",
+              "type": "date",
+              "value": "2019-09-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Was kommt in 3 Wochen auf ARD",
+    "Context": {
+      "ReferenceDateTime": "2019-08-12T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "in 3 wochen",
+        "Start": 10,
+        "End": 20,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-09-02",
+              "type": "date",
+              "value": "2019-09-02"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixed issue #2291. The problem was due to a duration pattern wrongly included in the German DateRegexList and it is not observed on other languages.
Test cases added to DateTimeModel.