### PR TITLE
[EN DateTime V2] Fixed resolution for "by the end of" in Java, JavaScript, and Python (#2309)

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
@@ -186,9 +186,9 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
 
             if (!hasInclusiveModifier) {
-                val.setMod(Constants.BEFORE_MOD);
+                val.setMod(combineMod(val.getMod(), Constants.BEFORE_MOD));
             } else {
-                val.setMod(Constants.UNTIL_MOD);
+                val.setMod(combineMod(val.getMod(), Constants.UNTIL_MOD));
             }
 
             pr.setValue(val);
@@ -203,9 +203,9 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
 
             if (!hasInclusiveModifier) {
-                val.setMod(Constants.AFTER_MOD);
+                val.setMod(combineMod(val.getMod(), Constants.AFTER_MOD));
             } else {
-                val.setMod(Constants.SINCE_MOD);
+                val.setMod(combineMod(val.getMod(), Constants.SINCE_MOD));
             }
 
             pr.setValue(val);
@@ -218,7 +218,7 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             pr.setLength(pr.getLength() + modStr.length());
 
             DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
-            val.setMod(Constants.SINCE_MOD);
+            val.setMod(combineMod(val.getMod(), Constants.SINCE_MOD));
             pr.setValue(val);
         }
 
@@ -229,7 +229,7 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             pr.setLength(pr.getLength() + modStr.length());
 
             DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
-            val.setMod(Constants.APPROX_MOD);
+            val.setMod(combineMod(val.getMod(), Constants.APPROX_MOD));
             pr.setValue(val);
         }
 
@@ -239,7 +239,7 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             pr.setLength(pr.getLength() + modStr.length());
 
             DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
-            val.setMod(Constants.SINCE_MOD);
+            val.setMod(combineMod(val.getMod(), Constants.SINCE_MOD));
             pr.setValue(val);
             hasSince = true;
         }
@@ -249,7 +249,7 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             Optional<Match> match = Arrays.stream(RegExpUtility.getMatches(config.getSuffixAfterRegex(), pr.getText())).findFirst();
             if (match.isPresent() && match.get().index != 0) {
                 DateTimeResolutionResult val = (DateTimeResolutionResult)pr.getValue();
-                val.setMod(Constants.SINCE_MOD);
+                val.setMod(combineMod(val.getMod(), Constants.SINCE_MOD));
                 pr.setValue(val);
                 hasSince = true;
             }
@@ -575,6 +575,14 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
         result.put(ResolutionKey.ValueSet, resolutions);
 
         return result;
+    }
+    
+    private String combineMod(String originalMod, String newMod) {
+        String combinedMod = newMod;
+        if (originalMod != null && originalMod != "") {
+            combinedMod = newMod + "-" + originalMod;
+        }
+        return combinedMod;
     }
 
     private String determineResolutionDateTimeType(LinkedHashMap<String, String> pastResolutionStr) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
@@ -772,8 +772,8 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             // For the 'before' mod
             // 1. Cases like "Before December", the start of the period should be the end of the new period, not the start
             // 2. Cases like "More than 3 days before today", the date point should be the end of the new period
-            if (mod.equals(Constants.BEFORE_MOD)) {
-                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end)) {
+            if (mod.startsWith(Constants.BEFORE_MOD)) {
+                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end) && !mod.endsWith(Constants.LATE_MOD)) {
                     res.put(DateTimeResolutionKey.END, start);
                 } else {
                     res.put(DateTimeResolutionKey.END, end);
@@ -785,8 +785,8 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
             // For the 'after' mod
             // 1. Cases like "After January", the end of the period should be the start of the new period, not the end 
             // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
-            if (mod.equals(Constants.AFTER_MOD)) {
-                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end)) {
+            if (mod.startsWith(Constants.AFTER_MOD)) {
+                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end) && !mod.endsWith(Constants.EARLY_MOD)) {
                     res.put(DateTimeResolutionKey.START, end);
                 } else {
                     res.put(DateTimeResolutionKey.START, start);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -353,7 +353,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = this.combineMod(val.Mod, TimeTypeConstants.beforeMod);
+            val.mod = this.combineMod(val.mod, TimeTypeConstants.beforeMod);
             pr.value = val;
         }
 
@@ -362,7 +362,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = this.combineMod(val.Mod, TimeTypeConstants.afterMod);
+            val.mod = this.combineMod(val.mod, TimeTypeConstants.afterMod);
             pr.value = val;
         }
 
@@ -371,7 +371,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = this.combineMod(val.Mod, TimeTypeConstants.sinceMod);
+            val.mod = this.combineMod(val.mod, TimeTypeConstants.sinceMod);
             pr.value = val;
         }
 

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -353,7 +353,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = TimeTypeConstants.beforeMod;
+            val.mod = combineMod(val.Mod, TimeTypeConstants.beforeMod);
             pr.value = val;
         }
 
@@ -362,7 +362,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = TimeTypeConstants.afterMod;
+            val.mod = combineMod(val.Mod, TimeTypeConstants.afterMod);
             pr.value = val;
         }
 
@@ -371,7 +371,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = TimeTypeConstants.sinceMod;
+            val.mod = combineMod(val.Mod, TimeTypeConstants.sinceMod);
             pr.value = val;
         }
 
@@ -426,6 +426,15 @@ export class BaseMergedParser implements IDateTimeParser {
             return this.config.setParser.parse(extractorResult, referenceDate);
         }
         return null;
+    }
+    
+    protected combineMod(originalMod: string, newMod: string): string {
+        let combinedMod = newMod;
+        if (!originalMod) {
+            combineMod = newMod + "-" + originalMod;
+        }
+        
+        return combineMod;
     }
 
     protected determineDateTimeType(type: string, hasMod: boolean): string {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -661,8 +661,8 @@ export class BaseMergedParser implements IDateTimeParser {
             // For the 'before' mod
             // 1. Cases like "Before December", the start of the period should be the end of the new period, not the start
             // 2. Cases like "More than 3 days before today", the date point should be the end of the new period
-            if (mod === TimeTypeConstants.beforeMod) {
-                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end)) {
+            if (mod.startsWith(TimeTypeConstants.beforeMod)) {
+                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end) && !mod.endsWith(Constants.LATE_MOD)) {
                     result[TimeTypeConstants.END] = start;
                 }
                 else {
@@ -674,8 +674,8 @@ export class BaseMergedParser implements IDateTimeParser {
             // For the 'after' mod
             // 1. Cases like "After January". the end of the period should be the start of the new period, not the end
             // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
-            if (mod === TimeTypeConstants.afterMod) {
-                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end)) {
+            if (mod.startsWith(TimeTypeConstants.afterMod)) {
+                if (!StringUtility.isNullOrEmpty(start) && !StringUtility.isNullOrEmpty(end) && !mod.endsWith(Constants.EARLY_MOD)) {
                     result[TimeTypeConstants.START] = end;
                 }
                 else {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -353,7 +353,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = combineMod(val.Mod, TimeTypeConstants.beforeMod);
+            val.mod = this.combineMod(val.Mod, TimeTypeConstants.beforeMod);
             pr.value = val;
         }
 
@@ -362,7 +362,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = combineMod(val.Mod, TimeTypeConstants.afterMod);
+            val.mod = this.combineMod(val.Mod, TimeTypeConstants.afterMod);
             pr.value = val;
         }
 
@@ -371,7 +371,7 @@ export class BaseMergedParser implements IDateTimeParser {
             pr.start -= modStr.length;
             pr.text = modStr + pr.text;
             let val = pr.value;
-            val.mod = combineMod(val.Mod, TimeTypeConstants.sinceMod);
+            val.mod = this.combineMod(val.Mod, TimeTypeConstants.sinceMod);
             pr.value = val;
         }
 
@@ -430,11 +430,11 @@ export class BaseMergedParser implements IDateTimeParser {
     
     protected combineMod(originalMod: string, newMod: string): string {
         let combinedMod = newMod;
-        if (!originalMod) {
-            combineMod = newMod + "-" + originalMod;
+        if (originalMod) {
+            combinedMod = newMod + "-" + originalMod;
         }
         
-        return combineMod;
+        return combinedMod;
     }
 
     protected determineDateTimeType(type: string, hasMod: boolean): string {

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_merged.py
@@ -1007,11 +1007,17 @@ class BaseMergedParser(DateTimeParser):
         start = resolutions.get(start_type, None)
         end = resolutions.get(end_type, None)
         if mod:
-            if mod == TimeTypeConstants.BEFORE_MOD:
-                result[TimeTypeConstants.END] = start
+            if mod.startswith(TimeTypeConstants.BEFORE_MOD):
+                if mod.endswith(TimeTypeConstants.LATE_MOD):
+                    result[TimeTypeConstants.END] = end
+                else:
+                    result[TimeTypeConstants.END] = start
                 return
-            if mod == TimeTypeConstants.AFTER_MOD:
-                result[TimeTypeConstants.START] = end
+            if mod.startswith(TimeTypeConstants.AFTER_MOD):
+                if mod.endswith(TimeTypeConstants.EARLY_MOD):
+                    result[TimeTypeConstants.START] = start
+                else:
+                    result[TimeTypeConstants.START] = end
                 return
             if mod == TimeTypeConstants.SINCE_MOD:
                 result[TimeTypeConstants.START] = start

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17181,7 +17181,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java",
     "Results": [
       {
         "Text": "by end of this month",
@@ -17207,7 +17206,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java",
     "Results": [
       {
         "Text": "before end of this year",
@@ -17258,7 +17256,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java",
     "Results": [
       {
         "Text": "after the beginning of march",
@@ -17291,7 +17288,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java",
     "Results": [
       {
         "Text": "before the end of december",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -17181,7 +17181,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "java",
     "Results": [
       {
         "Text": "by end of this month",
@@ -17207,7 +17207,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "java",
     "Results": [
       {
         "Text": "before end of this year",
@@ -17258,7 +17258,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "java",
     "Results": [
       {
         "Text": "after the beginning of march",
@@ -17291,7 +17291,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "java",
     "Results": [
       {
         "Text": "before the end of december",


### PR DESCRIPTION
Ported fixes from PR #2247 to Java, JavaScript and Python (#2309).
Enabled test cases in DateTimeModel.