### PR TITLE
[EN DateTimeV2] Added support for duration-relative calculations for Holidays (#2295)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new DutchDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new DutchHolidayExtractorConfiguration(this));
             UtilityConfiguration = new DutchDatetimeUtilityConfiguration();
 
             ImplicitDateList = new List<Regex>
@@ -239,6 +240,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new DutchHolidayParserConfiguration(this));
             DateRegexes = new DutchDateExtractorConfiguration(this).DateRegexList;
             OnRegex = DutchDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
@@ -74,6 +75,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IEnumerable<Regex> DateRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
             NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(numConfig));
             DurationExtractor = new BaseDurationExtractor(new EnglishDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new EnglishHolidayExtractorConfiguration(this));
             UtilityConfiguration = new EnglishDatetimeUtilityConfiguration();
 
             ImplicitDateList = new List<Regex>
@@ -239,6 +240,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DateExtractor = config.DateExtractor;
             DurationExtractor = config.DurationExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new EnglishHolidayParserConfiguration(this));
 
             DateRegexes = new EnglishDateExtractorConfiguration(this).DateRegexList;
             OnRegex = EnglishDateExtractorConfiguration.OnRegex;
@@ -79,6 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IEnumerable<Regex> DateRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/IDateExtractorConfiguration.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor DurationExtractor { get; }
 
+        IDateTimeExtractor HolidayExtractor { get; }
+
         IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 
         IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             NumberParser = new BaseNumberParser(new FrenchNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new FrenchDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new FrenchHolidayExtractorConfiguration(this));
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
 
             // 3-23-2017
@@ -208,6 +209,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new FrenchHolidayParserConfiguration(this));
 
             DateRegexes = new FrenchDateExtractorConfiguration(this).DateRegexList;
             OnRegex = FrenchDateExtractorConfiguration.OnRegex;
@@ -76,6 +77,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             NumberParser = new BaseNumberParser(new GermanNumberParserConfiguration(new BaseNumberOptionsConfiguration(numConfig)));
 
             DurationExtractor = new BaseDurationExtractor(new GermanDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new GermanHolidayExtractorConfiguration(this));
             UtilityConfiguration = new GermanDatetimeUtilityConfiguration();
 
             // 3-23-2017
@@ -203,6 +204,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new GermanHolidayParserConfiguration(this));
 
             DateRegexes = new GermanDateExtractorConfiguration(this).DateRegexList;
             OnRegex = GermanDateExtractorConfiguration.OnRegex;
@@ -75,6 +76,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IEnumerable<Regex> DateRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             NumberParser = new BaseIndianNumberParser(new HindiNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new HindiDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new HindiHolidayExtractorConfiguration(this));
             UtilityConfiguration = new HindiDatetimeUtilityConfiguration();
 
             ImplicitDateList = new List<Regex>
@@ -239,6 +240,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new HindiHolidayParserConfiguration(this));
             DateRegexes = new HindiDateExtractorConfiguration(this).DateRegexList;
             OnRegex = HindiDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = HindiDateExtractorConfiguration.SpecialDayRegex;
@@ -79,6 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IEnumerable<Regex> DateRegexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new ItalianDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new ItalianHolidayExtractorConfiguration(this));
             UtilityConfiguration = new ItalianDatetimeUtilityConfiguration();
 
             const RegexOptions dateRegexOption = RegexOptions.Singleline;
@@ -206,6 +207,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new ItalianHolidayParserConfiguration(this));
             DateRegexes = new ItalianDateExtractorConfiguration(this).DateRegexList;
             OnRegex = ItalianDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
@@ -80,6 +81,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -791,6 +791,20 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 innerResult = ParseSingleNumber(dateString, referenceDate);
                             }
 
+                            if (!innerResult.Success)
+                            {
+                                var holidayEr = new ExtractResult
+                                {
+                                    Start = 0,
+                                    Length = dateString.Length,
+                                    Text = dateString,
+                                    Type = Constants.SYS_DATETIME_DATE,
+                                    Data = null,
+                                    Metadata = new Metadata { IsHoliday = true },
+                                };
+                                innerResult = (DateTimeResolutionResult)config.HolidayParser.Parse(holidayEr, referenceDate).Value;
+                            }
+
                             // Combine parsed results Duration + Date
                             if (innerResult.Success)
                             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeParser DurationParser { get; }
 
+        IDateTimeParser HolidayParser { get; }
+
         IEnumerable<Regex> DateRegexes { get; }
 
         Regex OnRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             NumberParser = new BaseNumberParser(new PortugueseNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new PortugueseDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new PortugueseHolidayExtractorConfiguration(this));
             UtilityConfiguration = new PortugueseDatetimeUtilityConfiguration();
 
             // 3-23-2017
@@ -199,6 +200,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             DateExtractor = config.DateExtractor;
             DurationExtractor = config.DurationExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new PortugueseHolidayParserConfiguration(this));
             UnitMap = config.UnitMap;
             UtilityConfiguration = config.UtilityConfiguration;
 
@@ -79,6 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(numConfig));
 
             DurationExtractor = new BaseDurationExtractor(new SpanishDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new SpanishHolidayExtractorConfiguration(this));
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 
             // 3-23-2017
@@ -196,6 +197,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             DateExtractor = config.DateExtractor;
             DurationExtractor = config.DurationExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new SpanishHolidayParserConfiguration(this));
             UnitMap = config.UnitMap;
             UtilityConfiguration = config.UtilityConfiguration;
 
@@ -79,6 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
             NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(new BaseNumberOptionsConfiguration(numConfig)));
             DurationExtractor = new BaseDurationExtractor(new TurkishDurationExtractorConfiguration(this));
+            HolidayExtractor = new BaseHolidayExtractor(new TurkishHolidayExtractorConfiguration(this));
             UtilityConfiguration = new TurkishDatetimeUtilityConfiguration();
 
             ImplicitDateList = new List<Regex>
@@ -245,6 +246,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public IParser NumberParser { get; }
 
         public IDateTimeExtractor DurationExtractor { get; }
+
+        public IDateTimeExtractor HolidayExtractor { get; }
 
         public IDateTimeUtilityConfiguration UtilityConfiguration { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             DurationExtractor = config.DurationExtractor;
             DateExtractor = config.DateExtractor;
             DurationParser = config.DurationParser;
+            HolidayParser = new BaseHolidayParser(new TurkishHolidayParserConfiguration(this));
             DateRegexes = new TurkishDateExtractorConfiguration(this).DateRegexList;
             OnRegex = TurkishDateExtractorConfiguration.OnRegex;
             SpecialDayRegex = TurkishDateExtractorConfiguration.SpecialDayRegex;
@@ -80,6 +81,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public IDateExtractor DateExtractor { get; }
 
         public IDateTimeParser DurationParser { get; }
+
+        public IDateTimeParser HolidayParser { get; }
 
         public IEnumerable<Regex> DateRegexes { get; }
 

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18885,5 +18885,77 @@
         }
       }
     ]
+  },
+  {
+    "Input": "It happened 2 weeks before Christmas.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "2 weeks before christmas",
+        "Start": 12,
+        "End": 35,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-12-11",
+              "type": "date",
+              "value": "2016-12-11"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "It happened three months after Easter.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "three months after easter",
+        "Start": 12,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-07-16",
+              "type": "date",
+              "value": "2017-07-16"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "We will meet 5 days before new year.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "5 days before new year",
+        "Start": 13,
+        "End": 34,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-12-27",
+              "type": "date",
+              "value": "2016-12-27"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for pattern [Duration] + "before/after" + [Holiday], e.g. "1 week before Christmas", "two months after Easter"... (#2295).
Test cases added to DateTimeModel.