### PR TITLE
[EN Number] Added support for vulgar fractions (#2347)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/BaseNumbers.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/BaseNumbers.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Recognizers.Definitions
       public const string NumberReplaceToken = @"@builtin.num";
       public const string FractionNumberReplaceToken = @"@builtin.num.fraction";
       public static readonly Func<string, string, string> IntegerRegexDefinition = (placeholder, thousandsmark) => $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!(\d+\.|\d+,))))\d{{1,3}}({thousandsmark}\d{{3}})+(?={placeholder})";
+      public const string FractionNotationRegex = @"((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])";
       public static readonly Func<string, string, string, string> DoubleRegexDefinition = (placeholder, thousandsmark, decimalmark) => $@"(((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+\.|\d+,)))\d{{1,3}}({thousandsmark}\d{{3}})+{decimalmark}\d+(?={placeholder})";
       public const string PlaceHolderDefault = @"\D|\b";
       public const string CaseSensitiveTerms = @"(?<=(\s|\d))(kB|K[Bb]?|M[BbM]?|G[Bb]?|B)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/NumbersDefinitions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!(één|een)\s+){RoundNumberOrdinalRegex}";
       public static readonly string OrdinalDutchRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public const string FractionUnitsRegex = @"((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)";
       public const string FractionHalfRegex = @"([eë]nhalf|[eë]nhalve|ëneenhal(f|ve))$";
       public static readonly string[] OneHalfTokens = { @"een", @"half" };

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!an?\s+){RoundNumberOrdinalRegex}";
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string RoundMultiplierRegex = $@"\b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!an?\s+){RoundNumberOrdinalRegex}";
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public const string FractionNotationRegex = @"((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])";
       public static readonly string RoundMultiplierRegex = $@"\b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/NumbersDefinitions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string OrdinalSuffixRegex = @"(?<=\b)((\d*(11e(me)?|1[eè]re?|[02-9]e(me)?)))(?=\b)";
       public static readonly string OrdinalFrenchRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demi[es]?|tiers?|quarts?)(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(et\s+)?)?(une?)(\s+)(({AllOrdinalRegex})|({SuffixOrdinalRegex})|(et\s+)?demi[es]?)(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+sur\s+(?<denominator>({AllIntRegex})|((\d+)(?!\.)))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!eine?\s+){RoundNumberOrdinalRegex}";
       public static readonly string OrdinalGermanRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public const string FractionUnitsRegex = @"((?<onehalf>anderthalb|einundhalb)|(?<quarter>dreiviertel))";
       public const string FractionHalfRegex = @"(einhalb)$";
       public static readonly string[] OneHalfTokens = { @"ein", @"halb" };

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/NumbersDefinitions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Recognizers.Definitions.Hindi
       public static readonly string AllOrdinalRegex = $@"(?:{CompoundNumberOrdinals}|{SuffixRoundNumberOrdinalRegex})";
       public const string OrdinalSuffixRegex = @"(?<=\b)(?:(\d*(1(ला|ली)|[2-3]रा|4था|[0-9](वां|वीं|वें|वाँ|वा)))|([०-९]*(१(ला|ली)|[२-३]रा|४था|[०-९](वां|वीं|वें|वाँ|वा))))";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string FractionNounRegex = $@"(?<=\b)(((({AllNumericalIntRegex})(\s?)((({RoundNumberIntegerRegex})|({RoundNumberOrdinalRegex}))\s?)?)((और\s)?))+((आधा|आधे|चौथाई|तिहाई)))(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(और\s+)?)?(एक)(\s+|\s*-\s*)(?!\bफ़र्स्ट)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(आधा|आधे|चौथाई|तिहाई)))|(आधा|आधे))";
       public static readonly string FractionPrepositionRegex = $@"(?<numerator>(({AllIntRegex}\s+)|((?<![\.,])\d+)(\s|\s+)|({RoundNumberOrdinalRegex})))(((बटा|बटे)\s*)|((का|की|के|कें|में)\s*))(?<denominator>(({AllOrdinalRegex})|({CompoundNumberOrdinals})|(\d+)|({AllIntRegex})|({AllNumericalIntRegex})))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Italian/NumbersDefinitions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Definitions.Italian
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!(un)\s+){RoundNumberOrdinalRegex}";
       public static readonly string OrdinalItalianRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+(e\s+)?\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(e\s+)?)?({AllIntRegex})(\s+|\s*-\s*)(?!\bprimo\b|\bsecondo\b)(mezzi|({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+e\s+mezzo)|(({AllIntRegex}\s+(e\s+)?)?(un)(\s+|\s*-\s*)(?!\bprimo\b|\bsecondo\b)(mezzo|({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+su\s+(?<denominator>({AllIntRegex})|(\d+)(?!\.))(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersDefinitions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public static readonly string AllOrdinalRegex = $@"{ComplexOrdinalRegex}|{SimpleRoundOrdinalRegex}|{ComplexRoundOrdinalRegex}";
       public const string OrdinalSuffixRegex = @"(?<=\b)(\d*((1|2|3|4|5|6|7|8|9|0)[oaºª]|(1|2|3|4|5|6|7|8|9)(\.[ºª])))(?=\b)";
       public static readonly string OrdinalEnglishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((e|com)\s+)?)?({AllIntRegex})(\s+((e|com)\s)?)((({AllOrdinalRegex})s?|({SpecialFractionInteger})|({SuffixRoundOrdinalRegex})s?)|mei[oa]?|ter[çc]o?)(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(e\s+)?)?(um|um[as])(\s+)(({AllOrdinalRegex})|({SuffixRoundOrdinalRegex})|(e\s+)?mei[oa]?)(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string OrdinalSuffixRegex = @"(?<=\b)(\d*((1r[oa]|2d[oa]|3r[oa]|4t[oa]|5t[oa]|6t[oa]|7m[oa]|8v[oa]|9n[oa]|0m[oa]|11[vm][oa]|12[vm][oa])|(1|2|3|4|5|6|7|8|9|0)[ºª]))(?=\b)";
       public static readonly string OrdinalNounRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public static readonly string SpecialFractionInteger = $@"((({AllIntRegex})i?({ZeroToNineIntegerRegex})|({AllIntRegex}))a?v[oa]s?)";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?({AllIntRegex})(\s+((y|con)\s)?)((({AllOrdinalRegex})s?|({SpecialFractionInteger})|({SufixRoundOrdinalRegex})s?)|medi[oa]s?|tercios?)(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)({AllIntRegex}\s+(y\s+)?)?(un|un[oa])(\s+)(({AllOrdinalRegex})|({SufixRoundOrdinalRegex})|(y\s+)?medi[oa]s?)(?=\b)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Swedish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Swedish/NumbersDefinitions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Definitions.Swedish
       public static readonly string OrdinalSwedishRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public const string RoundNumberFractionSwedishRegex = @"(hundradel(s|ar)?|tusendel(s|ar)?|miljon(te)?del(s|ar)?|miljarddel(s|ar)?|biljon(te)?del(s|ar)?|biljarddel(s|ar)?|triljon(te)?del(s|ar)?|triljarddel(s|ar)?)";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(och\s+)?)?({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberFractionSwedishRegex}))((de)?l(s|ar)?)?|halvor|kvart(ar|s))(?=\b)";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)((({AllIntRegex}\s+(och\s+)?)?(en|ett)?(\s+|\s*-\s*)(?!\bförsta\b|\bandra\b)(({AllOrdinalRegex})|({RoundNumberFractionSwedishRegex})|halv(t)?|kvart(s)?))|(halva|hälften))(?=\b)";
       public const string FractionOverRegex = @"(genom|delat\s+(med|på)|delad\s+(med|på)|dividerat\s+(med|på)|dividerad\s+(med|på)|(ut)?av|på)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/NumbersDefinitions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string OrdinalNumericRegex = @"(?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*('inci|'ıncı|'uncu|'üncü|'nci|'ncı))(?=\b)";
       public static readonly string OrdinalTurkishRegex = $@"(?<=\b)({AllOrdinalRegex}(?=\b)|{AllOrdinalSuffix})";
       public const string FractionNotationWithSpacesRegex = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))";
-      public const string FractionNotationRegex = @"(((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))";
+      public static readonly string FractionNotationRegex = $@"{BaseNumbers.FractionNotationRegex}";
       public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}\s+)?(buçuk|çeyrek|yarım))(?=(t[ae]n|d[[ae]n|y?[ae])?\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(eksi\s+)?(?<numerator>({AllIntRegex})|((?<!,)\d+))\s+(bölü)\s+(?<denominator>({AllIntRegex})|(\d+)(?!,))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s{ZeroToNineIntegerRegex})+|(\s{AllIntRegex}))";

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -565,6 +565,17 @@ namespace Microsoft.Recognizers.Text.Number
             var isNegative = false;
             var isFrac = digitsStr.Contains('/');
 
+            // Try to parse vulgar fraction chars
+            if (digitsStr.Length == 1 && !char.IsDigit(digitsStr.ToCharArray()[0]))
+            {
+                double fracResult = char.GetNumericValue(digitsStr.ToCharArray()[0]);
+
+                if (fracResult != -1.0)
+                {
+                    return fracResult;
+                }
+            }
+
             var calStack = new Stack<double>();
 
             for (var i = 0; i < digitsStr.Length; i++)

--- a/Patterns/Base-Numbers.yaml
+++ b/Patterns/Base-Numbers.yaml
@@ -4,6 +4,8 @@ FractionNumberReplaceToken: '@builtin.num.fraction'
 IntegerRegexDefinition: !paramsRegex
   def: (((?<!\d+\s*)-\s*)|((?<=\b)(?<!(\d+\.|\d+,))))\d{1,3}({thousandsmark}\d{3})+(?={placeholder})
   params: [ placeholder, thousandsmark  ]
+FractionNotationRegex: !simpleRegex
+  def: ((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])
 DoubleRegexDefinition: !paramsRegex
   def: (((?<!\d+\s*)-\s*)|((?<=\b)(?<!\d+\.|\d+,)))\d{1,3}({thousandsmark}\d{3})+{decimalmark}\d+(?={placeholder})
   params: [ placeholder, thousandsmark, decimalmark ]

--- a/Patterns/Dutch/Dutch-Numbers.yaml
+++ b/Patterns/Dutch/Dutch-Numbers.yaml
@@ -77,8 +77,9 @@ OrdinalDutchRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex         
-  def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionUnitsRegex: !simpleRegex
   def: ((?<onehalf>anderhalve|anderhalf)|(?<quarter>driekwart)|half|halve|helft|kwart)
 FractionHalfRegex: !simpleRegex

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -87,7 +87,7 @@ OrdinalEnglishRegex: !nestedRegex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
 FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+  def: ((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])
 RoundMultiplierRegex: !nestedRegex
   def: \b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$
   references: [ RoundNumberIntegerRegex ]

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -86,8 +86,9 @@ OrdinalEnglishRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: ((((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))|[\u00BC-\u00BE\u2150-\u215E])
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 RoundMultiplierRegex: !nestedRegex
   def: \b\s*((of\s+)?a\s+)?(?<multiplier>{RoundNumberIntegerRegex})$
   references: [ RoundNumberIntegerRegex ]

--- a/Patterns/French/French-Numbers.yaml
+++ b/Patterns/French/French-Numbers.yaml
@@ -104,8 +104,9 @@ OrdinalFrenchRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)({AllIntRegex}\s+((et)\s+)?)?({AllIntRegex})(\s+((et)\s)?)((({AllOrdinalRegex})s?|({SuffixOrdinalRegex})s?)|demi[es]?|tiers?|quarts?)(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, SuffixOrdinalRegex ]

--- a/Patterns/German/German-Numbers.yaml
+++ b/Patterns/German/German-Numbers.yaml
@@ -76,8 +76,9 @@ OrdinalGermanRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionUnitsRegex: !simpleRegex
   def: ((?<onehalf>anderthalb|einundhalb)|(?<quarter>dreiviertel))
 FractionHalfRegex: !simpleRegex

--- a/Patterns/Hindi/Hindi-Numbers.yaml
+++ b/Patterns/Hindi/Hindi-Numbers.yaml
@@ -214,8 +214,9 @@ OrdinalSuffixRegex: !simpleRegex
 #FractionPrepositionRegex s used to catch all fraction cases which includes cardina/cardinal or cardinal/ordinal
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)(((({AllNumericalIntRegex})(\s?)((({RoundNumberIntegerRegex})|({RoundNumberOrdinalRegex}))\s?)?)((और\s)?))+((आधा|आधे|चौथाई|तिहाई)))(?=\b)
   references: [AllNumericalIntRegex, RoundNumberIntegerRegex,RoundNumberOrdinalRegex ]

--- a/Patterns/Italian/Italian-Numbers.yaml
+++ b/Patterns/Italian/Italian-Numbers.yaml
@@ -88,8 +88,9 @@ OrdinalItalianRegex: !nestedRegex
 #Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+(e\s+)?\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)({AllIntRegex}\s+(e\s+)?)?({AllIntRegex})(\s+|\s*-\s*)(?!\bprimo\b|\bsecondo\b)(mezzi|({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex]

--- a/Patterns/Portuguese/Portuguese-Numbers.yaml
+++ b/Patterns/Portuguese/Portuguese-Numbers.yaml
@@ -106,8 +106,9 @@ OrdinalEnglishRegex: !nestedRegex
   def: (?<=\b){AllOrdinalRegex}(?=\b)
   references: [ AllOrdinalRegex ]
 #Fraction Regex
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
 FractionNounRegex: !nestedRegex

--- a/Patterns/Spanish/Spanish-Numbers.yaml
+++ b/Patterns/Spanish/Spanish-Numbers.yaml
@@ -102,8 +102,9 @@ OrdinalNounRegex: !nestedRegex
 SpecialFractionInteger: !nestedRegex
   def: ((({AllIntRegex})i?({ZeroToNineIntegerRegex})|({AllIntRegex}))a?v[oa]s?)
   references: [ AllIntRegex, ZeroToNineIntegerRegex ]
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
 FractionNounRegex: !nestedRegex

--- a/Patterns/Swedish/Swedish-Numbers.yaml
+++ b/Patterns/Swedish/Swedish-Numbers.yaml
@@ -86,8 +86,9 @@ RoundNumberFractionSwedishRegex: !simpleRegex
   def: (hundradel(s|ar)?|tusendel(s|ar)?|miljon(te)?del(s|ar)?|miljarddel(s|ar)?|biljon(te)?del(s|ar)?|biljarddel(s|ar)?|triljon(te)?del(s|ar)?|triljarddel(s|ar)?)
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNounRegex: !nestedRegex
   def: (?<=\b)({AllIntRegex}\s+(och\s+)?)?({AllIntRegex})(\s*|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberFractionSwedishRegex}))((de)?l(s|ar)?)?|halvor|kvart(ar|s))(?=\b)
   references: [ AllIntRegex, AllOrdinalRegex, RoundNumberFractionSwedishRegex ]

--- a/Patterns/Turkish/Turkish-Numbers.yaml
+++ b/Patterns/Turkish/Turkish-Numbers.yaml
@@ -143,8 +143,9 @@ OrdinalTurkishRegex: !nestedRegex
 # Fraction Regex
 FractionNotationWithSpacesRegex: !simpleRegex
   def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+\d+[/]\d+(?=(\b[^/]|$))
-FractionNotationRegex: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<![/-])(?<=\b))\d+[/]\d+(?=(\b[^/]|$))
+FractionNotationRegex: !nestedRegex
+  def: '{BaseNumbers.FractionNotationRegex}'
+  references: [ BaseNumbers.FractionNotationRegex ]
 FractionNounWithArticleRegex: !nestedRegex
   def: (?<=\b)(({AllIntRegex}\s+)?(buçuk|çeyrek|yarım))(?=(t[ae]n|d[[ae]n|y?[ae])?\b)
   references: [ AllIntRegex ]

--- a/Specs/Number/Dutch/NumberModel.json
+++ b/Specs/Number/Dutch/NumberModel.json
@@ -2055,5 +2055,29 @@
         }
       }
     ]
+  },
+  {
+    "Input": "het resultaat is ⅙ en soms ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,166666666666667"
+        },
+        "Start": 17,
+        "End": 17
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,5"
+        },
+        "Start": 27,
+        "End": 27
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -2902,5 +2902,63 @@
         "End": 38
       }
     ]
+  },
+  {
+    "Input": "the result is ⅔",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅔",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0.666666666666667"
+        },
+        "Start": 14,
+        "End": 14
+      }
+    ]
+  },
+  {
+    "Input": "the result is ¾",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "¾",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0.75"
+        },
+        "Start": 14,
+        "End": 14
+      }
+    ]
+  },
+  {
+    "Input": "the result is ⅙ and sometimes ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0.166666666666667"
+        },
+        "Start": 14,
+        "End": 14
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0.5"
+        },
+        "Start": 30,
+        "End": 30
+      }
+    ]
   }
 ]

--- a/Specs/Number/French/NumberModel.json
+++ b/Specs/Number/French/NumberModel.json
@@ -1816,5 +1816,29 @@
         "End": 15
       }
     ]
+  },
+  {
+    "Input": "le résultat est ⅙ et parfois ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,166666666666667"
+        },
+        "Start": 16,
+        "End": 16
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,5"
+        },
+        "Start": 29,
+        "End": 29
+      }
+    ]
   }
 ]

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -856,5 +856,29 @@
         "End": 18
       }
     ]
+  },
+  {
+    "Input": "das Ergebnis ist ⅙ und manchmal ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,166666666666667"
+        },
+        "Start": 17,
+        "End": 17
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,5"
+        },
+        "Start": 32,
+        "End": 32
+      }
+    ]
   }
 ]

--- a/Specs/Number/Italian/NumberModel.json
+++ b/Specs/Number/Italian/NumberModel.json
@@ -1871,5 +1871,29 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Comment": "Elided expressions (e.g. 'settant') should be recognized only in compound numbers or when followed by an apostrophe",
     "Results": []
+  },
+  {
+    "Input": "il risultato è ⅙ e talvolta ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,166666666666667"
+        },
+        "Start": 15,
+        "End": 15
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0,5"
+        },
+        "Start": 28,
+        "End": 28
+      }
+    ]
   }
 ]

--- a/Specs/Number/Portuguese/NumberModel.json
+++ b/Specs/Number/Portuguese/NumberModel.json
@@ -2606,5 +2606,31 @@
         "End": 16
       }
     ]
+  },
+  {
+    "Input": "o resultado é ⅙ e às vezes ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,166666666666667"
+        },
+        "Start": 14,
+        "End": 14
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,5"
+        },
+        "Start": 27,
+        "End": 27
+      }
+    ]
   }
 ]

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -2815,5 +2815,31 @@
         }
       }
     ]
+  },
+  {
+    "Input": "el resultado es ⅙ y, a veces, ½",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "⅙",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,166666666666667"
+        },
+        "Start": 16,
+        "End": 16
+      },
+      {
+        "Text": "½",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,5"
+        },
+        "Start": 30,
+        "End": 30
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for single character fractions (¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞) in English (#2347).
Test cases added to DateTimeModel.