### PR TITLE
[ZH Percent] Added support for percentage like "[Den]分之[Num]" (#2257)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string IntegerPercentageRegex = $@"{ZeroToNineFullHalfRegex}+\s*[个個]\s*[百佰]\s*分\s*[点點]";
       public static readonly string IntegerPercentageWithMultiplierRegex = $@"{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}\s*[个個]\s*[百佰]\s*分\s*[点點]";
       public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*[个個]\s*[百佰]\s*分\s*[点點]";
+      public static readonly string FractionPercentageRegex = $@"(?<denominator>{AllIntRegex})\s*分\s*之\s*(?<numerator>{AllIntRegex})";
       public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)";
       public static readonly string NumbersFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*折";
       public static readonly string FoldsPercentageRegex = $@"{ZeroToNineIntegerRegex}(\s*[点點]?\s*{ZeroToNineIntegerRegex})?\s*折";

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     new Regex(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
+                {
+                    // [Den]分之[Num] e.g. 十分之一
+                    new Regex(NumbersDefinitions.FractionPercentageRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.FRACTION_PREFIX)
+                },
             };
 
             Regexes = regexes.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -301,6 +301,28 @@ namespace Microsoft.Recognizers.Text.Number
 
                 result.Value = GetDigitValue(resultText, power);
             }
+            else if (extResult.Data.ToString().Contains("Frac"))
+            {
+                // Parse fraction percentages e.g. [Den]分之[Num] in Chinese
+                var splitResult = Config.FracSplitRegex.Split(resultText);
+                string demoPart = string.Empty, numPart = string.Empty;
+
+                if (splitResult.Length == 2)
+                {
+                    demoPart = splitResult[0];
+                    numPart = splitResult[1];
+                }
+
+                var numValue = Config.DigitNumRegex.IsMatch(numPart)
+                    ? GetDigitValue(numPart, 1.0)
+                    : GetIntValue(numPart);
+
+                var demoValue = Config.DigitNumRegex.IsMatch(demoPart)
+                    ? GetDigitValue(demoPart, 1.0)
+                    : GetIntValue(demoPart);
+
+                result.Value = (numValue / demoValue) * 100;
+            }
             else
             {
                 var doubleText = Config.PercentageRegex.Match(resultText).Value;

--- a/Patterns/Chinese/Chinese-Numbers.yaml
+++ b/Patterns/Chinese/Chinese-Numbers.yaml
@@ -305,6 +305,9 @@ IntegerPercentageWithMultiplierRegex: !nestedRegex
 NumbersFractionPercentageRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+\s*[个個]\s*[百佰]\s*分\s*[点點]'
   references: [ZeroToNineFullHalfRegex]
+FractionPercentageRegex: !nestedRegex
+  def: (?<denominator>{AllIntRegex})\s*分\s*之\s*(?<numerator>{AllIntRegex})
+  references: [ AllIntRegex ]
 SimpleIntegerPercentageRegex: !nestedRegex
   def: '(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)'
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]

--- a/Python/libraries/recognizers-number/recognizers_number/number/chinese/extractors.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/chinese/extractors.py
@@ -308,5 +308,9 @@ class ChinesePercentageExtractor(BaseNumberExtractor):
             ReVal(
                 re=RegExpUtility.get_safe_reg_exp(
                     ChineseNumeric.SpecialsFoldsPercentageRegex),
-                val='PerSpe')
+                val='PerSpe'),
+            ReVal(
+                re=RegExpUtility.get_safe_reg_exp(
+                    ChineseNumeric.FractionPercentageRegex),
+                val='PerFrac')
         ]

--- a/Python/libraries/recognizers-number/recognizers_number/number/cjk_parsers.py
+++ b/Python/libraries/recognizers-number/recognizers_number/number/cjk_parsers.py
@@ -244,6 +244,22 @@ class CJKNumberParser(BaseNumberParser):
             elif any(x for x in ['T', 'Ｔ'] if x in double_text):
                 power = 1000000000000
             result.value = self.get_digit_value(double_text, power)
+            
+        elif 'Frac' in source.data:
+            # Parse fraction percentages e.g. [Den]分之[Num] in Chinese
+            split_result = regex.split(self.config.frac_split_regex, source_text)
+            parts = namedtuple('parts', ['demo', 'num'])
+            result_part: parts
+            if len(split_result) == 2:
+                result_part = parts(
+                    demo=split_result[0],
+                    num=split_result[1]
+                )
+
+            num_value = Decimal(self.get_value_from_part(result_part.num))
+            demo_value = Decimal(self.get_value_from_part(result_part.demo))
+
+            result.value = (num_value / demo_value) * 100
 
         else:
             double_match = regex.search(

--- a/Specs/Number/Chinese/PercentModel.json
+++ b/Specs/Number/Chinese/PercentModel.json
@@ -2025,5 +2025,50 @@
         }
       }
     ]
+  },
+  {
+    "Input": "十分之一",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "十分之一",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "10%"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "四分之三",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "四分之三",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "75%"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "两百分之一百五十二",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "两百分之一百五十二",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "76%"
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for percentage like "[Den]分之[Num]" e.g. "十分之一" (10%) in .NET and Python (#2257).
Test cases added to PercentModel.