### PR TITLE
[SV Number] Performance upgrade (cache implementation)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/CardinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/CardinalExtractor.cs
@@ -2,18 +2,21 @@
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
-using Microsoft.Recognizers.Definitions.Swedish;
-
 namespace Microsoft.Recognizers.Text.Number.Swedish
 {
-    public class CardinalExtractor : BaseNumberExtractor
+    public class CardinalExtractor : CachedNumberExtractor
     {
         private static readonly ConcurrentDictionary<string, CardinalExtractor> Instances =
             new ConcurrentDictionary<string, CardinalExtractor>();
 
+        private readonly string keyPrefix;
+
         private CardinalExtractor(BaseNumberOptionsConfiguration config)
             : base(config.Options)
         {
+
+            keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Placeholder + "_" + config.Culture);
+
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Integer Regexes
@@ -29,11 +32,11 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
-        // "Cardinal";
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL;
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_CARDINAL; // "Cardinal";
 
         public static CardinalExtractor GetInstance(BaseNumberOptionsConfiguration config)
         {
+
             var extractorKey = config.Placeholder;
 
             if (!Instances.ContainsKey(extractorKey))
@@ -43,6 +46,11 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             }
 
             return Instances[extractorKey];
+        }
+
+        protected override object GenKey(string input)
+        {
+            return (keyPrefix, input);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/IntegerExtractor.cs
@@ -7,17 +7,20 @@ using Microsoft.Recognizers.Definitions.Swedish;
 
 namespace Microsoft.Recognizers.Text.Number.Swedish
 {
-    public class IntegerExtractor : BaseNumberExtractor
+    public class IntegerExtractor : CachedNumberExtractor
     {
-
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances =
-            new ConcurrentDictionary<string, IntegerExtractor>();
+        private static readonly ConcurrentDictionary<string, IntegerExtractor> Instances = new ConcurrentDictionary<string, IntegerExtractor>();
+
+        private readonly string keyPrefix;
 
         private IntegerExtractor(BaseNumberOptionsConfiguration config)
             : base(config.Options)
         {
+
+            keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Placeholder + "_" + config.Culture);
+
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
@@ -45,7 +48,7 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SWEDISH)
                 },
                 /*{
-                    GenerateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, placeholder, RegexFlags),
+                    GenerateLongFormatNumberRegexes(LongFormatType.IntegerNumComma, config.Placeholder, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },*/
                 {
@@ -63,11 +66,11 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
-        // "Integer";
-        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER;
+        protected sealed override string ExtractType { get; } = Constants.SYS_NUM_INTEGER; // "Integer";
 
         public static IntegerExtractor GetInstance(BaseNumberOptionsConfiguration config)
         {
+
             var extractorKey = config.Placeholder;
 
             if (!Instances.ContainsKey(extractorKey))
@@ -78,5 +81,11 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
             return Instances[extractorKey];
         }
+
+        protected override object GenKey(string input)
+        {
+            return (keyPrefix, input);
+        }
+
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
@@ -6,28 +6,22 @@ using Microsoft.Recognizers.Definitions.Swedish;
 
 namespace Microsoft.Recognizers.Text.Number.Swedish
 {
-    public class NumberExtractor : BaseNumberExtractor
+    public class NumberExtractor : CachedNumberExtractor
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor> Instances =
             new ConcurrentDictionary<(NumberMode, NumberOptions), NumberExtractor>();
 
-        private readonly NumberMode mode;
+        private readonly string keyPrefix;
 
         private NumberExtractor(BaseNumberOptionsConfiguration config)
             : base(config.Options)
         {
 
-            this.mode = config.Mode;
+            keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + "$", RegexFlags);
-
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
-
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
-
-            Options = config.Options;
+            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
@@ -44,8 +38,6 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
                     builder.Add(
                         BaseNumberExtractor.CurrencyRegex,
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX));
-                    break;
-                case NumberMode.Unit:
                     break;
                 case NumberMode.Default:
                     break;
@@ -66,8 +58,8 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
             var ambiguityBuilder = ImmutableDictionary.CreateBuilder<Regex, Regex>();
 
-            // Do not filter the ambiguous number cases like 'that one' in NumberWithUnit, otherwise they can't be resolved.
-            if (mode != NumberMode.Unit)
+            // Do not filter the ambiguous number cases like '$2000' in NumberWithUnit, otherwise they can't be resolved.
+            if (config.Mode != NumberMode.Unit)
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
@@ -78,8 +70,6 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             AmbiguityFiltersDict = ambiguityBuilder.ToImmutable();
         }
 
-        public sealed override NumberOptions Options { get; }
-
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
 
         protected sealed override ImmutableDictionary<Regex, Regex> AmbiguityFiltersDict { get; }
@@ -88,20 +78,22 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
         protected sealed override Regex NegativeNumberTermsRegex { get; }
 
-        protected sealed override Regex AmbiguousFractionConnectorsRegex { get; }
-
-        protected sealed override Regex RelativeReferenceRegex { get; }
-
         public static NumberExtractor GetInstance(BaseNumberOptionsConfiguration config)
         {
-            var cacheKey = (config.Mode, config.Options);
-            if (!Instances.ContainsKey(cacheKey))
+            var extractorKey = (config.Mode, config.Options);
+
+            if (!Instances.ContainsKey(extractorKey))
             {
                 var instance = new NumberExtractor(config);
-                Instances.TryAdd(cacheKey, instance);
+                Instances.TryAdd(extractorKey, instance);
             }
 
-            return Instances[cacheKey];
+            return Instances[extractorKey];
+        }
+
+        protected override object GenKey(string input)
+        {
+            return (keyPrefix, input);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
             NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
+            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+
+            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
             // Add Cardinal
@@ -77,6 +81,10 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM; // "Number";
 
         protected sealed override Regex NegativeNumberTermsRegex { get; }
+
+        protected sealed override Regex AmbiguousFractionConnectorsRegex { get; }
+
+        protected sealed override Regex RelativeReferenceRegex { get; }
 
         public static NumberExtractor GetInstance(BaseNumberOptionsConfiguration config)
         {


### PR DESCRIPTION
Existing number extractors have been upgraded to use the CachedNumberExtractor where applicable. They should now be aligned w/ the English extractor implementations.