### PR TITLE
[Python/.NET | EN DateTimeV2] Fixed datetimerange start range ignoring pm (#2330)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -64,6 +65,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -66,6 +67,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
+
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
@@ -65,6 +67,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -65,6 +66,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimePeriodParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -65,6 +66,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
+
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
@@ -70,6 +72,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -682,8 +682,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                         dateResult = this.Config.DateExtractor.Extract(Config.TokenBeforeDate + trimmedText.Substring(0, (int)ers[0].Start), referenceTime);
                     }
 
-                    // check if TokenBeforeDate is null
-                    var dateText = !string.IsNullOrEmpty(Config.TokenBeforeDate) ? trimmedText.Replace(ers[0].Text, string.Empty).Replace(Config.TokenBeforeDate, string.Empty).Trim() : trimmedText.Replace(ers[0].Text, string.Empty).Trim();
+                    // check if TokenBeforeDate and TokenBeforeTime are null
+                    var dateText = trimmedText.Replace(ers[0].Text, string.Empty).Trim();
+                    dateText = !string.IsNullOrEmpty(Config.TokenBeforeDate) ? dateText.Replace(Config.TokenBeforeDate, string.Empty).Trim() : dateText;
+                    dateText = !string.IsNullOrEmpty(Config.TokenBeforeTime) ? dateText.Replace(Config.TokenBeforeTime.Trim(), string.Empty).Trim() : dateText;
                     if (this.Config.CheckBothBeforeAfter)
                     {
                         List<string> tokenListBeforeDate = Config.TokenBeforeDate.Split('|').ToList();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateTimePeriodParserConfiguration.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         string TokenBeforeDate { get; }
 
+        string TokenBeforeTime { get; }
+
         IDateExtractor DateExtractor { get; }
 
         IDateTimeExtractor TimeExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public PortugueseDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
-            TokenBeforeDate = Definitions.Portuguese.DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -52,6 +53,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
-            TokenBeforeDate = Definitions.Spanish.DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeDate = DateTimeDefinitions.TokenBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -53,6 +54,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             : base(config)
         {
             TokenBeforeDate = DateTimeDefinitions.TokenListBeforeDate;
+            TokenBeforeTime = DateTimeDefinitions.TokenBeforeTime;
 
             DateExtractor = config.DateExtractor;
             TimeExtractor = config.TimeExtractor;
@@ -65,6 +66,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         }
 
         public string TokenBeforeDate { get; }
+
+        public string TokenBeforeTime { get; }
 
         public IDateExtractor DateExtractor { get; }
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_datetimeperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_datetimeperiod.py
@@ -850,6 +850,11 @@ class DateTimePeriodParserConfiguration:
 
     @property
     @abstractmethod
+    def token_before_time(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def check_both_before_after(self) -> bool:
         raise NotImplementedError
 
@@ -1055,9 +1060,12 @@ class BaseDateTimePeriodParser(DateTimeParser):
             if TimexUtil.is_range_timex(time_period_timex):
                 date_result = self.config.date_extractor.extract(trimmed_source.replace(extracted_results[0].text, ''), reference)
 
-                # Check if token_before_date is null
-                date_text = trimmed_source.replace(extracted_results[0].text, '').replace(self.config.token_before_date, ''). \
-                    strip() if self.config.token_before_date else trimmed_source.replace(extracted_results[0].text, '').strip()
+                # Check if token_before_date and token_before_time are null
+                date_text = trimmed_source.replace(extracted_results[0].text, '').strip()
+                if self.config.token_before_date:
+                    date_text = date_text.replace(self.config.token_before_date, '').strip()
+                if self.config.token_before_time:
+                    date_text = date_text.replace(self.config.token_before_time.strip(), '').strip()
                 if self.config.check_both_before_after:
                     token_list_before_date = list(self.config.token_before_date.split('|'))
                     for token in filter(lambda n: n, token_list_before_date):

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_timeperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_timeperiod.py
@@ -346,6 +346,16 @@ class TimePeriodParserConfiguration:
 
     @property
     @abstractmethod
+    def specific_time_from_to_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def specific_time_between_and_regex(self) -> Pattern:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
     def time_of_day_regex(self) -> Pattern:
         raise NotImplementedError
 
@@ -413,6 +423,15 @@ class BaseTimePeriodParser(DateTimeParser):
         return result
 
     def parse_simple_cases(self, source: str, reference: datetime) -> DateTimeResolutionResult:
+        result = DateTimeResolutionResult()
+
+        result = self.parse_pure_numbers(source, reference)
+        if not result.success:
+            result = self.parse_specific_time(source, reference)
+
+        return result
+
+    def parse_pure_numbers(self, source: str, reference: datetime) -> DateTimeResolutionResult:
         result = DateTimeResolutionResult()
         year = reference.year
         month = reference.month
@@ -496,6 +515,176 @@ class BaseTimePeriodParser(DateTimeParser):
             year, month, day) + timedelta(hours=begin_hour)
         result.future_value.end = datetime(
             year, month, day) + timedelta(hours=end_hour)
+        result.past_value.start = result.future_value.start
+        result.past_value.end = result.future_value.end
+        result.success = True
+
+        return result
+
+    def parse_specific_time(self, source: str, reference: datetime) -> DateTimeResolutionResult:
+        result = DateTimeResolutionResult()
+        year = reference.year
+        month = reference.month
+        day = reference.day
+
+        source = source.strip().lower()
+
+        match = regex.search(self.config.specific_time_from_to_regex, source)
+        if not match:
+            match = regex.search(
+                self.config.specific_time_between_and_regex, source)
+
+        if not match or match.start() != 0:
+            return result
+
+        # this "from .. to .." pattern is valid if followed by a Date OR "pm"
+        valid = False
+
+        time1 = RegExpUtility.get_group(match, "time1")
+        time2 = RegExpUtility.get_group(match, "time2")
+
+        # get hours
+        hour_group_list = RegExpUtility.get_group_list(match, Constants.HOUR_GROUP_NAME)
+
+        hour_str = hour_group_list[0]
+        begin_hour = self.config.numbers.get(hour_str, None)
+        if not begin_hour:
+            begin_hour = int(hour_str)
+
+        hour_str = hour_group_list[1]
+        end_hour = self.config.numbers.get(hour_str, None)
+        if not end_hour:
+            end_hour = int(hour_str)
+
+        # get minutes
+        minute_group_list = RegExpUtility.get_group_list(match, Constants.MINUTE_GROUP_NAME)
+
+        begin_minute = end_minute = -1;
+        if len(minute_group_list) > 1:
+            minute_str = minute_group_list[0]
+            begin_minute = self.config.numbers.get(minute_str, None)
+            if not begin_minute:
+                begin_minute = int(minute_str)
+
+            minute_str = minute_group_list[1]
+            end_minute = self.config.numbers.get(minute_str, None)
+            if not end_minute:
+                end_minute = int(minute_str)
+        elif len(minute_group_list) == 1:
+            minute_str = minute_group_list[0]
+            if minute_str in time1:
+                begin_minute = self.config.numbers.get(minute_str, None)
+                if not begin_minute:
+                    begin_minute = int(minute_str)
+            elif minute_str in time2:
+                end_minute = self.config.numbers.get(minute_str, None)
+                if not end_minute:
+                    end_minute = int(minute_str)
+
+
+        # parse AM/PM
+        left_desc: str = RegExpUtility.get_group(match, Constants.LEFT_DESC_GROUP_NAME)
+        right_desc: str = RegExpUtility.get_group(match, Constants.RIGHT_DESC_GROUP_NAME)
+
+        desc_capture_list = RegExpUtility.get_group_list(match, Constants.DESC_GROUP_NAME)
+        for desc_capture in desc_capture_list:
+            if desc_capture in time1 and not left_desc:
+                left_desc: str = desc_capture
+            elif desc_capture in time2 and not right_desc:
+                right_desc: str = desc_capture
+
+        has_left_am = left_desc != '' and left_desc.startswith('a')
+        has_left_pm = left_desc != '' and left_desc.startswith('p')
+        has_right_am = right_desc != '' and right_desc.startswith('a')
+        has_right_pm = right_desc != '' and right_desc.startswith('p')
+        has_left = has_left_am or has_left_pm
+        has_right = has_right_am or has_right_pm
+
+        # both time point has description like 'am' or 'pm'
+        if has_left and has_right:
+            if has_left_am:
+                if begin_hour >= 12:
+                    begin_hour -= 12
+            else:
+                if begin_hour < 12:
+                    begin_hour += 12
+            if has_right_am:
+                if end_hour > 12:
+                    end_hour -= 12
+            else:
+                if end_hour < 12:
+                    end_hour += 12
+        elif has_left or has_right:
+            # one of the time point has description like 'am' or 'pm'
+            if has_left_am:
+                if begin_hour >= 12:
+                    begin_hour -= 12
+                if end_hour < 12:
+                    if end_hour < begin_hour or (end_hour == begin_hour and end_minute < begin_minute):
+                        end_hour += 12
+            elif has_left_pm:
+                if begin_hour < 12:
+                    begin_hour += 12
+                if end_hour < 12:
+                    if end_hour < begin_hour or (end_hour == begin_hour and end_minute < begin_minute):
+                        span = begin_hour - end_hour
+                        end_hour += 24 if span >= 12 else 12
+
+            if has_right_am:
+                if end_hour >= 12:
+                    end_hour -= 12
+                if begin_hour < 12:
+                    begin_hour -= 12
+            elif has_right_pm:
+                if end_hour < 12:
+                    end_hour += 12
+                if begin_hour < 12:
+                    if end_hour < begin_hour or (end_hour == begin_hour and end_minute < begin_minute):
+                        begin_hour -= 12
+                    else:
+                        span = end_hour - begin_hour
+                        if span > 12:
+                            begin_hour += 12
+        # no 'am' or 'pm' indicator
+        elif begin_hour <= 12 and end_hour <= 12:
+            if begin_hour > end_hour or (begin_hour == end_hour and begin_minute > end_minute):
+                if begin_hour == 12:
+                    begin_hour -= 12
+                else:
+                    end_hour += 12
+            result.comment = Constants.AM_PM_GROUP_NAME
+
+        if begin_minute >= 0:
+            begin = f'T{begin_hour:02d}:{begin_minute:02d}'
+        else:
+            begin = f'T{begin_hour:02d}'
+            begin_minute = 0
+        if end_minute >= 0:
+            end = f'T{end_hour:02d}:{end_minute:02d}'
+        else:
+            end = f'T{end_hour:02d}'
+            end_minute = 0
+
+        if begin_hour > end_hour or (begin_hour == end_hour and begin_minute > end_minute):
+            end_hour += 24
+
+        difference_hour = end_hour - begin_hour
+        difference_minute = end_minute - begin_minute
+        if difference_minute < 0:
+            difference_hour -= 1
+            difference_minute += 60
+        if difference_minute != 0 and difference_hour != 0:
+            result.timex = f'({begin},{end},PT{difference_hour}H{difference_minute}M)'
+        elif difference_minute != 0 and difference_hour == 0:
+            result.timex = f'({begin},{end},PT{difference_minute}M)'
+        else:
+            result.timex = f'({begin},{end},PT{difference_hour}H)'
+        result.future_value = ResolutionStartEnd()
+        result.past_value = ResolutionStartEnd()
+        result.future_value.start = datetime(
+            year, month, day) + timedelta(hours=begin_hour, minutes = begin_minute)
+        result.future_value.end = datetime(
+            year, month, day) + timedelta(hours=end_hour, minutes = end_minute)
         result.past_value.start = result.future_value.start
         result.past_value.end = result.future_value.end
         result.success = True

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/datetimeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/datetimeperiod_parser_config.py
@@ -33,6 +33,7 @@ class EnglishDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration
         self._am_desc_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.AmDescRegex)
         self._pm_desc_regex = RegExpUtility.get_safe_reg_exp(EnglishDateTime.PmDescRegex)
         self._token_before_date = EnglishDateTime.TokenBeforeDate
+        self._token_before_time = EnglishDateTime.TokenBeforeTime
         self._check_both_before_after = EnglishDateTime.CheckBothBeforeAfter
         self._pure_number_from_to_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.PureNumFromTo)
@@ -109,6 +110,10 @@ class EnglishDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration
     @property
     def token_before_date(self) -> str:
         return self._token_before_date
+
+    @property
+    def token_before_time(self):
+        return self._token_before_time
 
     @property
     def check_both_before_after(self) -> bool:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/timeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/english/timeperiod_parser_config.py
@@ -36,6 +36,14 @@ class EnglishTimePeriodParserConfiguration(TimePeriodParserConfiguration):
     @property
     def pure_number_between_and_regex(self) -> Pattern:
         return self._pure_number_between_and_regex
+    
+    @property
+    def specific_time_from_to_regex(self) -> Pattern:
+        return self._specific_time_from_to_regex
+
+    @property
+    def specific_time_between_and_regex(self) -> Pattern:
+        return self._specific_time_between_and_regex
 
     @property
     def time_of_day_regex(self) -> Pattern:
@@ -62,6 +70,10 @@ class EnglishTimePeriodParserConfiguration(TimePeriodParserConfiguration):
             EnglishDateTime.PureNumFromTo)
         self._pure_number_between_and_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.PureNumBetweenAnd)
+        self._specific_time_from_to_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.SpecificTimeFromTo)
+        self._specific_time_between_and_regex = RegExpUtility.get_safe_reg_exp(
+            EnglishDateTime.SpecificTimeBetweenAnd)
         self._time_of_day_regex = RegExpUtility.get_safe_reg_exp(
             EnglishDateTime.TimeOfDayRegex)
         self._till_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/datetimeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/datetimeperiod_parser_config.py
@@ -44,6 +44,7 @@ class FrenchDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration)
 
         self._check_both_before_after = FrenchDateTime.CheckBothBeforeAfter
         self._token_before_date = FrenchDateTime.TokenBeforeDate
+        self._token_before_time = FrenchDateTime.TokenBeforeTime
         self._prefix_day_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.PrefixDayRegex)
         self._before_regex = RegExpUtility.get_safe_reg_exp(
@@ -119,6 +120,10 @@ class FrenchDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration)
     @property
     def token_before_date(self) -> str:
         return self._token_before_date
+
+    @property
+    def token_before_time(self):
+        return self._token_before_time
 
     @property
     def check_both_before_after(self) -> bool:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/timeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/french/timeperiod_parser_config.py
@@ -33,6 +33,14 @@ class FrenchTimePeriodParserConfiguration(TimePeriodParserConfiguration):
     @property
     def pure_number_between_and_regex(self) -> Pattern:
         return self._pure_number_between_and_regex
+    
+    @property
+    def specific_time_from_to_regex(self) -> Pattern:
+        return self._specific_time_from_to_regex
+
+    @property
+    def specific_time_between_and_regex(self) -> Pattern:
+        return self._specific_time_between_and_regex
 
     @property
     def time_of_day_regex(self) -> Pattern:
@@ -64,6 +72,10 @@ class FrenchTimePeriodParserConfiguration(TimePeriodParserConfiguration):
             FrenchDateTime.PureNumFromTo)
         self._pure_number_between_and_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.PureNumBetweenAnd)
+        self._specific_time_from_to_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.SpecificTimeFromTo)
+        self._specific_time_between_and_regex = RegExpUtility.get_safe_reg_exp(
+            FrenchDateTime.SpecificTimeBetweenAnd)
         self._time_of_day_regex = RegExpUtility.get_safe_reg_exp(
             FrenchDateTime.TimeOfDayRegex)
         self._till_regex = RegExpUtility.get_safe_reg_exp(

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/datetimeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/datetimeperiod_parser_config.py
@@ -65,6 +65,7 @@ class SpanishDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration
         self._after_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.AfterRegex)
         self._before_regex = RegExpUtility.get_safe_reg_exp(SpanishDateTime.BeforeRegex)
         self._token_before_date = SpanishDateTime.TokenBeforeDate
+        self._token_before_time = SpanishDateTime.TokenBeforeTime
         self._check_both_before_after = SpanishDateTime.CheckBothBeforeAfter
         self.next_prefix_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.NextPrefixRegex)
@@ -112,6 +113,10 @@ class SpanishDateTimePeriodParserConfiguration(DateTimePeriodParserConfiguration
     @property
     def token_before_date(self):
         return self._token_before_date
+
+    @property
+    def token_before_time(self):
+        return self._token_before_time
 
     @property
     def check_both_before_after(self) -> bool:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/timeperiod_parser_config.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/spanish/timeperiod_parser_config.py
@@ -28,6 +28,14 @@ class SpanishTimePeriodParserConfiguration(TimePeriodParserConfiguration):
     @property
     def pure_number_from_to_regex(self) -> Pattern:
         return self._pure_number_from_to_regex
+    
+    @property
+    def specific_time_from_to_regex(self) -> Pattern:
+        return self._specific_time_from_to_regex
+
+    @property
+    def specific_time_between_and_regex(self) -> Pattern:
+        return self._specific_time_between_and_regex
 
     @property
     def pure_number_between_and_regex(self) -> Pattern:
@@ -63,6 +71,10 @@ class SpanishTimePeriodParserConfiguration(TimePeriodParserConfiguration):
             SpanishDateTime.PureNumFromTo)
         self._pure_number_between_and_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.PureNumBetweenAnd)
+        self._specific_time_from_to_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.SpecificTimeFromTo)
+        self._specific_time_between_and_regex = RegExpUtility.get_safe_reg_exp(
+            SpanishDateTime.SpecificTimeBetweenAnd)
         self._time_of_day_regex = RegExpUtility.get_safe_reg_exp(
             SpanishDateTime.TimeOfDayRegex)
         self._till_regex = RegExpUtility.get_safe_reg_exp(

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18731,6 +18731,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
+    "NotSupported": "java, javascript",
     "Results": [
       {
         "Text": "tuesday at 2:00 - 2:30 pm",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18694,5 +18694,153 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I'll be out Tuesday from 2:00 to 2:30 pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "tuesday from 2:00 to 2:30 pm",
+        "Start": 12,
+        "End": 39,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-01 14:00:00",
+              "end": "2016-11-01 14:30:00"
+            },
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-08 14:00:00",
+              "end": "2016-11-08 14:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out Tuesday at 2:00 - 2:30 pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "Results": [
+      {
+        "Text": "tuesday at 2:00 - 2:30 pm",
+        "Start": 12,
+        "End": 36,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-01 14:00:00",
+              "end": "2016-11-01 14:30:00"
+            },
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-08 14:00:00",
+              "end": "2016-11-08 14:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out on December 12th at 4 - 6:30 pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "december 12th at 4 - 6:30 pm",
+        "Start": 15,
+        "End": 42,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-12-12T16,XXXX-12-12T18:30,PT2H30M)",
+              "type": "datetimerange",
+              "start": "2015-12-12 16:00:00",
+              "end": "2015-12-12 18:30:00"
+            },
+            {
+              "timex": "(XXXX-12-12T16,XXXX-12-12T18:30,PT2H30M)",
+              "type": "datetimerange",
+              "start": "2016-12-12 16:00:00",
+              "end": "2016-12-12 18:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out at 2:00 - 2:30 pm on Tuesday",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "2:00 - 2:30 pm on tuesday",
+        "Start": 15,
+        "End": 39,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-01 14:00:00",
+              "end": "2016-11-01 14:30:00"
+            },
+            {
+              "timex": "(XXXX-WXX-2T14:00,XXXX-WXX-2T14:30,PT30M)",
+              "type": "datetimerange",
+              "start": "2016-11-08 14:00:00",
+              "end": "2016-11-08 14:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out from 2:30 to 2:15 pm",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "from 2:30 to 2:15 pm",
+        "Start": 12,
+        "End": 31,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T02:30,T14:15,PT11H45M)",
+              "type": "timerange",
+              "start": "02:30:00",
+              "end": "14:15:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
- Fixed datetimerange start range ignoring 'pm' in expressions like  "Tuesday at 2:00 - 2:30 pm" (#2330) in Python and .NET.
- Ported method ParseSpecificTimeCases to Python to avoid discrepancies in TimePeriodParser results between the two platforms.
Test cases added to DateTimeModel.