### PR TITLE
[JavaScript/Python | EN DateTime V2] Fixed missing resolution for years spelled out as words (#2332)

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/datePeriodConfiguration.ts
@@ -139,6 +139,7 @@ class ChineseDatePeriodParserConfiguration implements IDatePeriodParserConfigura
     readonly dateParser: BaseDateParser
     readonly durationExtractor: ChineseDurationExtractor
     readonly durationParser: BaseDurationParser
+    readonly numberParser: BaseNumberParser
     readonly monthFrontBetweenRegex: RegExp
     readonly betweenRegex: RegExp
     readonly monthFrontSimpleCasesRegex: RegExp

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/english/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/english/datePeriodConfiguration.ts
@@ -101,6 +101,7 @@ export class EnglishDatePeriodParserConfiguration implements IDatePeriodParserCo
     readonly dateParser: BaseDateParser
     readonly durationExtractor: IDateTimeExtractor
     readonly durationParser: BaseDurationParser
+    readonly numberParser: BaseNumberParser
     readonly monthFrontBetweenRegex: RegExp
     readonly betweenRegex: RegExp
     readonly monthFrontSimpleCasesRegex: RegExp
@@ -141,6 +142,7 @@ export class EnglishDatePeriodParserConfiguration implements IDatePeriodParserCo
         this.dateParser = config.dateParser;
         this.durationExtractor = config.durationExtractor;
         this.durationParser = config.durationParser;
+        this.numberParser = config.numberParser;
         this.monthFrontBetweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontBetweenRegex);
         this.betweenRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.BetweenRegex);
         this.monthFrontSimpleCasesRegex = RegExpUtility.getSafeRegExp(EnglishDateTime.MonthFrontSimpleCasesRegex);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/french/datePeriodConfiguration.ts
@@ -137,7 +137,7 @@ export class FrenchDatePeriodParserConfiguration implements IDatePeriodParserCon
     readonly weekWithWeekDayRangeRegex: RegExp;
 
     readonly cardinalExtractor: IExtractor;
-    readonly numberParser: IParser;
+    readonly numberParser: BaseNumberParser;
     readonly nowRegex: RegExp
 
     constructor(config: ICommonDateTimeParserConfiguration) {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/spanish/datePeriodConfiguration.ts
@@ -135,7 +135,7 @@ export class SpanishDatePeriodParserConfiguration implements IDatePeriodParserCo
     readonly numberCombinedWithUnit: RegExp;
 
     readonly cardinalExtractor: IExtractor;
-    readonly numberParser: IParser;
+    readonly numberParser: BaseNumberParser;
     readonly nowRegex: RegExp
 
     constructor(config: ICommonDateTimeParserConfiguration) {

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1767,7 +1767,7 @@ class BaseDatePeriodParser(DateTimeParser):
         if not (match and len(match.group()) == len(trimmed_source)):
             return result
 
-        year = int(match.group())
+        year = int(self.config.date_extractor.get_year_from_text(match))
         begin_date = DateUtils.safe_create_from_value(
             DateUtils.min_value, year, 1, 1)
         end_date = DateUtils.safe_create_from_value(

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -18957,5 +18957,71 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Show sales in two thousand and twenty",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "two thousand and twenty",
+        "Start": 14,
+        "End": 36,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2021-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "They left in nineteen ninety six and came back in two thousand and fifteen",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupported": "java",
+    "Results": [
+      {
+        "Text": "nineteen ninety six",
+        "Start": 13,
+        "End": 31,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1996",
+              "type": "daterange",
+              "start": "1996-01-01",
+              "end": "1997-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "two thousand and fifteen",
+        "Start": 50,
+        "End": 73,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2015",
+              "type": "daterange",
+              "start": "2015-01-01",
+              "end": "2016-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added support for years spelled out as words (e.g. "two thousand twenty") in DatePeriod in Javascript and Python (#2332).
Test cases added to DateTimeModel.