### PR TITLE
[ES DateTimeV2] Fixed Spanish DateRange extraction issues (#2372)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -80,19 +80,19 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string MonthOfRegex = $@"(mes)(\s+)({OfPrepositionRegex})";
       public const string RangeUnitRegex = @"\b(?<unit>años?|mes(es)?|semanas?)\b";
       public const string BeforeAfterRegex = @"^[.]";
-      public const string InConnectorRegex = @"\b(in)\b";
+      public const string InConnectorRegex = @"\b(en)\b";
       public const string SinceYearSuffixRegex = @"^[.]";
       public const string WithinNextPrefixRegex = @"\b(dentro\s+de)\b";
       public const string TodayNowRegex = @"\b(hoy|ahora|este entonces)\b";
       public const string FromRegex = @"((\bde(sde)?)(\s*la(s)?)?)$";
       public const string BetweenRegex = @"(\bentre\s*(la(s)?)?)";
       public const string WeekDayRegex = @"\b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)\b";
-      public static readonly string OnRegex = $@"((?<=\b(e[ln])\s+)|(\be[ln]\s+d[ií]a\s+))({DayRegex}s?)\b";
-      public const string RelaxedOnRegex = @"(?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)\b";
+      public static readonly string OnRegex = $@"((?<=\b(e[ln])\s+)|(\be[ln]\s+d[ií]a\s+))({DayRegex}s?)(?![.,]\d)\b";
+      public const string RelaxedOnRegex = @"(?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)(?![.,]\d)\b";
       public const string SpecialDayRegex = @"\b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+d)|ayer|mañana|hoy)\b";
       public const string SpecialDayWithNumRegex = @"^[.]";
       public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
-      public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+))((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.|!|\?|-|$)))";
+      public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+))((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.|!|\?|-|$))(?!\d))";
       public const string WeekDayAndDayOfMonthRegex = @"^[.]";
       public const string WeekDayAndDayRegex = @"^[.]";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3er|cuarto|4to|quinto|5to|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
@@ -105,16 +105,16 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string WeekDayEnd = $@"{WeekDayRegex}\s*,?\s*$";
       public const string WeekDayStart = @"^[\.]";
       public static readonly string DateYearRegex = $@"(?<year>{YearRegex}|{TwoDigitYearRegex})";
-      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}?((\s*(de)|[/\\\.\-])\s*)?{MonthRegex}\b";
-      public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}\s*([\.\-]|de)\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b";
-      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s+de\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+de\s+|\s*-\s*){DateYearRegex})?\b";
-      public static readonly string DateExtractor4 = $@"\b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
-      public static readonly string DateExtractor5 = $@"\b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
-      public static readonly string DateExtractor6 = $@"(?<=\b(en|el)\s+){MonthNumRegex}[\-\.]{DayRegex}\b";
-      public static readonly string DateExtractor7 = $@"\b{MonthNumRegex}\s*/\s*{DayRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b";
-      public static readonly string DateExtractor8 = $@"(?<=\b(en|el)\s+){DayRegex}[\\\-]{MonthNumRegex}\b";
-      public static readonly string DateExtractor9 = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b";
-      public static readonly string DateExtractor10 = $@"\b{YearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)";
+      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}((\s*(de)|[/\\\.\-])\s*)?{MonthRegex}\b";
+      public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|de)\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b";
+      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+de\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+de\s+|\s*-\s*){DateYearRegex})?\b";
+      public static readonly string DateExtractor4 = $@"\b(?<!\d[.,]){MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
+      public static readonly string DateExtractor5 = $@"\b(?<!\d[.,]){DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
+      public static readonly string DateExtractor6 = $@"(?<=\b(en|el)\s+){MonthNumRegex}[\-\.]{DayRegex}\b(?!\s*[/\\\.]\s*\d+)";
+      public static readonly string DateExtractor7 = $@"\b(?<!\d[.,]){MonthNumRegex}\s*/\s*{DayRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b(?!\s*[/\\\.]\s*\d+)";
+      public static readonly string DateExtractor8 = $@"(?<=\b(en|el)\s+){DayRegex}[\\\-]{MonthNumRegex}\b(?!\s*[/\\\.]\s*\d+)";
+      public static readonly string DateExtractor9 = $@"\b({WeekDayRegex}\s+)?(?<!\d[.,]){DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b(?!\s*[/\\\.]\s*\d+)";
+      public static readonly string DateExtractor10 = $@"\b(?<!\d[.,]){YearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)";
       public const string HourNumRegex = @"\b(?<hournum>cero|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce)\b";
       public const string MinuteNumRegex = @"(?<minnum>uno?|d[óo]s|tr[eé]s|cuatro|cinco|s[eé]is|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|diecis[eé]is|diecisiete|dieciocho|diecinueve|veinte|treinta|cuarenta|cincuenta)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>uno?|d[óo]s|tr[eé]s|cuatro|cinco|s[eé]is|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|diecis[eé]is|diecisiete|dieciocho|diecinueve|veinte|treinta|cuarenta|cincuenta)";
@@ -148,12 +148,13 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string LaterEarlyRegex = @"((?<early>temprano)|(?<late>fin(al)?(\s+de)?|m[aá]s\s+tarde))";
       public const string NowRegex = @"\b(?<now>(justo\s+)?ahora(\s+mismo)?|en\s+este\s+momento|tan\s+pronto\s+como\s+sea\s+posible|tan\s+pronto\s+como\s+(pueda|puedas|podamos|puedan)|lo\s+m[aá]s\s+pronto\s+posible|recientemente|previamente|este entonces)\b";
       public const string SuffixRegex = @"^\s*(((y|a|en|por)\s+la|al)\s+)?(mañana|madrugada|medio\s*d[ií]a|(?<!(m[áa]s\s+))tarde|noche)\b";
-      public static readonly string TimeOfDayRegex = $@"\b(?<timeOfDay>(({LaterEarlyRegex}\s+)((del?|en|por)(\s+(el|los?|las?))?\s+)?)?(mañana|madrugada|pasado\s+(el\s+)?medio\s?d[ií]a|(?<!((m[áa]s|tan)\s+))tarde|a?noche))\b";
-      public static readonly string SpecificTimeOfDayRegex = $@"\b(((((a\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\s+)?{TimeOfDayRegex}))\b";
+      public static readonly string TimeOfDayRegex = $@"\b(?<timeOfDay>(({LaterEarlyRegex}\s+)((del?|en|por)(\s+(el|los?|las?))?\s+)?)?(mañana|madrugada|pasado\s+(el\s+)?medio\s?d[ií]a|(?<!((m[áa]s|tan)\s+))tarde|noche))\b";
+      public static readonly string SpecificTimeOfDayRegex = $@"\b(((((a\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\s+)?{TimeOfDayRegex})|anoche)\b";
       public static readonly string TimeOfTodayAfterRegex = $@"^\s*(,\s*)?(en|de(l)?\s+)?{SpecificTimeOfDayRegex}";
       public static readonly string TimeOfTodayBeforeRegex = $@"({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la(s)?|para))?\s*$)";
-      public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex})\s*(,\s*)?((en|de(l)?)?\s+)?{SpecificTimeOfDayRegex}";
-      public static readonly string SimpleTimeOfTodayBeforeRegex = $@"({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la|para))?\s*({HourNumRegex}|{BaseDateTime.HourRegex}))";
+      public const string NonTimeContextTokens = @"(edificio)";
+      public static readonly string SimpleTimeOfTodayAfterRegex = $@"(?<!{NonTimeContextTokens}\s*)\b({HourNumRegex}|{BaseDateTime.HourRegex})\s*(,\s*)?((en|de(l)?)?\s+)?{SpecificTimeOfDayRegex}\b";
+      public static readonly string SimpleTimeOfTodayBeforeRegex = $@"({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la|para))?\s*({HourNumRegex}|{BaseDateTime.HourRegex}))\b";
       public const string SpecificEndOfRegex = @"((a|e)l\s+)?fin(alizar|al)?(\s+(el|de(l)?)(\s+d[ií]a)?(\s+de)?)?\s*$";
       public const string UnspecificEndOfRegex = @"\b([ae]l\s+)?(fin(al)?\s+del?\s+d[ií]a)\b";
       public const string UnspecificEndOfRangeRegex = @"^[.]";
@@ -566,7 +567,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string CommonDatePrefixRegex = @"^[\.]";
       public const string SuffixAfterRegex = @"\b((a\s+)?(o|y)\s+(arriba|despu[eé]s|posterior|mayor|m[aá]s\s+tarde)(?!\s+(que|de)))\b";
       public static readonly string YearPeriodRegex = $@"((((de(sde)?|durante|en)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((entre)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
-      public const string FutureSuffixRegex = @"\b((en\s+el\s+)?futuro|a\s+partir\s+de\s+ahora)\b";
+      public const string FutureSuffixRegex = @"\b(siguiente(s)?|pr[oó]xim[oa](s)?|(en\s+el\s+)?futuro|a\s+partir\s+de\s+ahora)\b";
       public static readonly Dictionary<string, int> WrittenDecades = new Dictionary<string, int>
         {
             { @"", 0 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Turkish/DateTimeDefinitions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Recognizers.Definitions.Turkish
       public const string RangePrefixRegex = @"(arası(nda|na)?|'s[iı]n[ae](\s+(kadar|dek|değin))?|((gününe|'[ae]|y[ae]|n[ae])\s+)?(kadar|dek|değin)|'y[ae](\s+(kadar|dek|değin))?|'[ea]|(?<!'\p{L}+)[ea](\s+(kadar|dek|değin)\b))";
       public const string CenturySuffixRegex = @"(^yüzyıl)";
       public const string ReferencePrefixRegex = @"(o|şu|aynı)\b";
-      public const string FutureSuffixRegex = @"\b(ileride|gelecekte)\b";
+      public static readonly string FutureSuffixRegex = $@"\b({NextPrefixRegex}|ileride|gelecekte)\b";
       public const string DayRegex = @"((?<day>10|20|30|31|(1|2)[1-9]|0?[1-9])('i|'si|'sı|'ü|'u)?)";
       public const string ImplicitDayRegex = @"(?<day>(10|20|30|31|(1|2)[1-9])('i|'si|'sı|'ü|'u))(?=\b)";
       public const string DayFromSuffixRegex = @"(?<day>(1|5|8|11|15|18|21|25|28|31)'inden|(2|7|12|17|20|22|27)'sinden|(3|4|13|14|23|24)'ünden|(6|16|26)'sından|(9|10|19|29|30)'undan)";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -154,14 +154,6 @@ namespace Microsoft.Recognizers.Text.DateTime
                     continue;
                 }
 
-                match = this.config.FutureRegex.MatchBegin(afterStr, trim: true);
-
-                if (match.Success)
-                {
-                    ret.Add(new Token(duration.Start, duration.End + match.Index + match.Length));
-                    continue;
-                }
-
                 match = this.config.FutureSuffixRegex.MatchBegin(afterStr, trim: true);
 
                 if (match.Success)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1613,6 +1613,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // Handle the "within two weeks" case which means from today to the end of next two weeks
                     // Cases like "within 3 days before/after today" is not handled here (4th condition)
+                    var isMatch = false;
                     if (config.WithinNextPrefixRegex.IsExactMatch(beforeStr, trim: true) &&
                         DurationParsingUtil.IsDateDuration(durationResult.Timex) && string.IsNullOrEmpty(afterStr))
                     {
@@ -1622,6 +1623,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         // but for the "within" case it should start from the current day.
                         beginDate = modAndDateResult.BeginDate.AddDays(-1);
                         endDate = modAndDateResult.EndDate.AddDays(-1);
+                        isMatch = true;
                     }
                     else if (this.config.CheckBothBeforeAfter)
                     {
@@ -1644,12 +1646,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         modAndDateResult = GetModAndDate(beginDate, endDate, referenceDate, durationResult.Timex, true);
                         beginDate = modAndDateResult.BeginDate;
                         endDate = modAndDateResult.EndDate;
-                    }
-                    else if (config.FutureRegex.IsMatch(afterStr))
-                    {
-                        modAndDateResult = GetModAndDate(beginDate, endDate, referenceDate, durationResult.Timex, true);
-                        beginDate = modAndDateResult.BeginDate;
-                        endDate = modAndDateResult.EndDate;
+                        isMatch = true;
                     }
 
                     if (config.FutureSuffixRegex.IsMatch(afterStr))
@@ -1661,7 +1658,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     // Handle the "in two weeks" case which means the second week
                     if (config.InConnectorRegex.IsExactMatch(beforeStr, trim: true) &&
-                        !DurationParsingUtil.IsMultipleDuration(durationResult.Timex))
+                        !DurationParsingUtil.IsMultipleDuration(durationResult.Timex) && !isMatch)
                     {
                         modAndDateResult = GetModAndDate(beginDate, endDate, referenceDate, durationResult.Timex, true);
 

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/extractors/BaseDatePeriodExtractor.java
@@ -273,13 +273,6 @@ public class BaseDatePeriodExtractor implements IDateTimeExtractor {
                 continue;
             }
 
-            match = RegexExtension.matchBegin(config.getFutureRegex(), afterStr, true);
-            if (match.getSuccess()) {
-                int matchLength = match.getMatch().get().index + match.getMatch().get().length;
-                results.add(new Token(duration.getStart(), duration.getEnd() + matchLength));
-                continue;
-            }
-
             match = RegexExtension.matchBegin(config.getFutureSuffixRegex(), afterStr, true);
             if (match.getSuccess()) {
                 int matchLength = match.getMatch().get().index + match.getMatch().get().length;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
@@ -1110,6 +1110,7 @@ public class BaseDatePeriodParser implements IDateTimeParser {
 
                 // Handle the "within two weeks" case which means from today to the end of next two weeks
                 // Cases like "within 3 days before/after today" is not handled here (4th condition)
+                boolean isMatch = false;
                 if (RegexExtension.isExactMatch(config.getWithinNextPrefixRegex(), beforeStr, true)) {
                     getModAndDateResult = getModAndDate(beginDate, endDate, referenceDate, durationResult.getTimex(), true);
                     beginDate = getModAndDateResult.beginDate;
@@ -1118,19 +1119,14 @@ public class BaseDatePeriodParser implements IDateTimeParser {
                     // In GetModAndDate, this "future" resolution will add one day to beginDate/endDate, but for the "within" case it should start from the current day.
                     beginDate = beginDate.minusDays(1);
                     endDate = endDate.minusDays(1);
+                    isMatch = true;
                 }
 
                 if (RegexExtension.isExactMatch(config.getFutureRegex(), beforeStr, true)) {
                     getModAndDateResult = getModAndDate(beginDate, endDate, referenceDate, durationResult.getTimex(), true);
                     beginDate = getModAndDateResult.beginDate;
                     endDate = getModAndDateResult.endDate;
-                } else {
-                    suffixMatch = Arrays.stream(RegExpUtility.getMatches(config.getFutureRegex(), afterStr)).findFirst();
-                    if (suffixMatch.isPresent()) {
-                        getModAndDateResult = getModAndDate(beginDate, endDate, referenceDate, durationResult.getTimex(), true);
-                        beginDate = getModAndDateResult.beginDate;
-                        endDate = getModAndDateResult.endDate;
-                    }
+                    isMatch = true;
                 }
 
                 Optional<Match> futureSuffixMatch = Arrays.stream(RegExpUtility.getMatches(config.getFutureSuffixRegex(), afterStr)).findFirst();
@@ -1142,7 +1138,7 @@ public class BaseDatePeriodParser implements IDateTimeParser {
 
                 // Handle the "in two weeks" case which means the second week
                 if (RegexExtension.isExactMatch(config.getInConnectorRegex(), beforeStr, true) &&
-                        !DurationParsingUtil.isMultipleDuration(durationResult.getTimex())) {
+                        !DurationParsingUtil.isMultipleDuration(durationResult.getTimex()) && !isMatch) {
                     getModAndDateResult = getModAndDate(beginDate, endDate, referenceDate, durationResult.getTimex(), true);
                     beginDate = getModAndDateResult.beginDate;
                     endDate = getModAndDateResult.endDate;

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -149,7 +149,7 @@ RangeUnitRegex: !simpleRegex
 BeforeAfterRegex: !simpleRegex
   def: ^[.]
 InConnectorRegex: !simpleRegex
-  def: \b(in)\b
+  def: \b(en)\b
 SinceYearSuffixRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -164,10 +164,10 @@ BetweenRegex: !simpleRegex
 WeekDayRegex: !simpleRegex
   def: \b(?<weekday>domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)\b
 OnRegex: !nestedRegex
-  def: ((?<=\b(e[ln])\s+)|(\be[ln]\s+d[ií]a\s+))({DayRegex}s?)\b
+  def: ((?<=\b(e[ln])\s+)|(\be[ln]\s+d[ií]a\s+))({DayRegex}s?)(?![.,]\d)\b
   references: [ DayRegex ]
 RelaxedOnRegex: !simpleRegex
-  def: (?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)\b
+  def: (?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)(?![.,]\d)\b
 SpecialDayRegex: !simpleRegex
   def: \b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+d)|ayer|mañana|hoy)\b
 SpecialDayWithNumRegex: !simpleRegex
@@ -177,7 +177,7 @@ FlexibleDayRegex: !nestedRegex
   def: (?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))
   references: [WrittenDayRegex, DayRegex ]
 ForTheRegex: !nestedRegex
-  def: \b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+))((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.|!|\?|-|$)))
+  def: \b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+))((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.|!|\?|-|$))(?!\d))
   references: [FlexibleDayRegex, MonthRegex ]
 WeekDayAndDayOfMonthRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
@@ -216,44 +216,44 @@ DateYearRegex: !nestedRegex
   references: [ YearRegex, TwoDigitYearRegex ]
 DateExtractor1: !nestedRegex
   # (domingo,)? 5 de Abril
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}?((\s*(de)|[/\\\.\-])\s*)?{MonthRegex}\b
+  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}((\s*(de)|[/\\\.\-])\s*)?{MonthRegex}\b
   references: [ WeekDayRegex, DayRegex, MonthRegex ]
 DateExtractor2: !nestedRegex
   # (domingo,)? 5 de Abril 5, 2016
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}\s*([\.\-]|de)\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b
+  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|de)\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b
   references: [ MonthRegex, DayRegex, DateYearRegex, WeekDayRegex ]
 DateExtractor3: !nestedRegex
   # (domingo,)? 6 de Abril
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}(\s+|\s*,\s*|\s+de\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+de\s+|\s*-\s*){DateYearRegex})?\b
+  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+de\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+de\s+|\s*-\s*){DateYearRegex})?\b
   references: [ DayRegex, MonthRegex, WeekDayRegex, DateYearRegex ]
 # The final lookahead in DateExtractor4|5|A avoids extracting as date "10/1-11" from an input like "10/1-11/2/2017" 
 DateExtractor4: !nestedRegex
   # 3-23-2017
-  def: \b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
+  def: \b(?<!\d[.,]){MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
   references: [ MonthNumRegex, DayRegex, DateYearRegex ]
 DateExtractor5: !nestedRegex
   # 23-3-2015
-  def: \b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
+  def: \b(?<!\d[.,]){DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
   references: [ MonthNumRegex, MonthRegex, DayRegex, DateYearRegex ]
 DateExtractor6: !nestedRegex
   # el 1/3
-  def: (?<=\b(en|el)\s+){MonthNumRegex}[\-\.]{DayRegex}\b
+  def: (?<=\b(en|el)\s+){MonthNumRegex}[\-\.]{DayRegex}\b(?!\s*[/\\\.]\s*\d+)
   references: [ MonthNumRegex, DayRegex ]
 DateExtractor7: !nestedRegex
   # 7/23
-  def: \b{MonthNumRegex}\s*/\s*{DayRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b
+  def: \b(?<!\d[.,]){MonthNumRegex}\s*/\s*{DayRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b(?!\s*[/\\\.]\s*\d+)
   references: [ MonthNumRegex, DayRegex, DateYearRegex ]
 DateExtractor8: !nestedRegex
   # el 24-12
-  def: (?<=\b(en|el)\s+){DayRegex}[\\\-]{MonthNumRegex}\b
+  def: (?<=\b(en|el)\s+){DayRegex}[\\\-]{MonthNumRegex}\b(?!\s*[/\\\.]\s*\d+)
   references: [ MonthNumRegex, DayRegex ]
 DateExtractor9: !nestedRegex
   # 23/7
-  def: \b({WeekDayRegex}\s+)?{DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b
+  def: \b({WeekDayRegex}\s+)?(?<!\d[.,]){DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+de\s+){DateYearRegex})?\b(?!\s*[/\\\.]\s*\d+)
   references: [ WeekDayRegex, DayRegex, MonthNumRegex, DateYearRegex ]
 DateExtractor10: !nestedRegex
   # 2015-12-23
-  def: \b{YearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)
+  def: \b(?<!\d[.,]){YearRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)
   references: [ YearRegex, MonthNumRegex, DayRegex ]
 # SpanishTimeExtractorConfiguration
 HourNumRegex: !simpleRegex
@@ -360,10 +360,10 @@ NowRegex: !simpleRegex
 SuffixRegex: !simpleRegex
   def: ^\s*(((y|a|en|por)\s+la|al)\s+)?(mañana|madrugada|medio\s*d[ií]a|(?<!(m[áa]s\s+))tarde|noche)\b
 TimeOfDayRegex: !nestedRegex
-  def: \b(?<timeOfDay>(({LaterEarlyRegex}\s+)((del?|en|por)(\s+(el|los?|las?))?\s+)?)?(mañana|madrugada|pasado\s+(el\s+)?medio\s?d[ií]a|(?<!((m[áa]s|tan)\s+))tarde|a?noche))\b
+  def: \b(?<timeOfDay>(({LaterEarlyRegex}\s+)((del?|en|por)(\s+(el|los?|las?))?\s+)?)?(mañana|madrugada|pasado\s+(el\s+)?medio\s?d[ií]a|(?<!((m[áa]s|tan)\s+))tarde|noche))\b
   references: [ LaterEarlyRegex ]
 SpecificTimeOfDayRegex: !nestedRegex
-  def: \b(((((a\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\s+)?{TimeOfDayRegex}))\b
+  def: \b(((((a\s+)?la|esta|siguiente|pr[oó]xim[oa]|[uú]ltim[oa])\s+)?{TimeOfDayRegex})|anoche)\b
   references: [ TimeOfDayRegex ]
 TimeOfTodayAfterRegex: !nestedRegex
   def: ^\s*(,\s*)?(en|de(l)?\s+)?{SpecificTimeOfDayRegex}
@@ -371,11 +371,13 @@ TimeOfTodayAfterRegex: !nestedRegex
 TimeOfTodayBeforeRegex: !nestedRegex
   def: ({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la(s)?|para))?\s*$)
   references: [ SpecificTimeOfDayRegex ]
+NonTimeContextTokens: !simpleRegex
+  def: (edificio)
 SimpleTimeOfTodayAfterRegex: !nestedRegex
-  def: ({HourNumRegex}|{BaseDateTime.HourRegex})\s*(,\s*)?((en|de(l)?)?\s+)?{SpecificTimeOfDayRegex}
-  references: [ HourNumRegex, BaseDateTime.HourRegex, SpecificTimeOfDayRegex ]
+  def: (?<!{NonTimeContextTokens}\s*)\b({HourNumRegex}|{BaseDateTime.HourRegex})\s*(,\s*)?((en|de(l)?)?\s+)?{SpecificTimeOfDayRegex}\b
+  references: [ HourNumRegex, BaseDateTime.HourRegex, SpecificTimeOfDayRegex, NonTimeContextTokens ]
 SimpleTimeOfTodayBeforeRegex: !nestedRegex
-  def: ({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la|para))?\s*({HourNumRegex}|{BaseDateTime.HourRegex}))
+  def: ({SpecificTimeOfDayRegex}(\s*,)?(\s+(a\s+la|para))?\s*({HourNumRegex}|{BaseDateTime.HourRegex}))\b
   references: [ SpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
   def: ((a|e)l\s+)?fin(alizar|al)?(\s+(el|de(l)?)(\s+d[ií]a)?(\s+de)?)?\s*$
@@ -951,7 +953,7 @@ YearPeriodRegex: !nestedRegex
   def: ((((de(sde)?|durante|en)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((entre)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))
   references: [ YearRegex, TillRegex, RangeConnectorRegex ]
 FutureSuffixRegex: !simpleRegex
-  def: \b((en\s+el\s+)?futuro|a\s+partir\s+de\s+ahora)\b
+  def: \b(siguiente(s)?|pr[oó]xim[oa](s)?|(en\s+el\s+)?futuro|a\s+partir\s+de\s+ahora)\b
 WrittenDecades: !dictionary
   types: [ string, int ]
   # TODO: modify below dictionary according to the counterpart in English

--- a/Patterns/Turkish/Turkish-DateTime.yaml
+++ b/Patterns/Turkish/Turkish-DateTime.yaml
@@ -38,8 +38,9 @@ CenturySuffixRegex: !simpleRegex
   def: (^yüzyıl)
 ReferencePrefixRegex: !simpleRegex
   def: (o|şu|aynı)\b
-FutureSuffixRegex: !simpleRegex
-  def: \b(ileride|gelecekte)\b
+FutureSuffixRegex: !nestedRegex
+  def: \b({NextPrefixRegex}|ileride|gelecekte)\b
+  references: [ NextPrefixRegex ]
 DayRegex: !simpleRegex
   def: ((?<day>10|20|30|31|(1|2)[1-9]|0?[1-9])('i|'si|'sı|'ü|'u)?)
 ImplicitDayRegex: !simpleRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -670,12 +670,6 @@ class BaseDatePeriodExtractor(DateTimeExtractor):
                 tokens.append(Token(duration.start, duration.end + match.index + match.length))
                 continue
 
-            match = RegExpUtility.match_begin(self.config.future_regex, after_str, True)
-
-            if match and match.success:
-                tokens.append(Token(duration.start, duration.end + match.index + match.length))
-                continue
-
             match = RegExpUtility.match_begin(self.config.future_suffix_regex, after_str, True)
 
             if match and match.success:
@@ -1979,16 +1973,18 @@ class BaseDatePeriodParser(DateTimeParser):
                 mod = TimeTypeConstants.BEFORE_MOD
                 begin_date = self.__get_swift_date(end_date, duration_result.timex, False)
 
+            is_match = False
             prefix_match = self.config.future_regex.search(before_str)
 
             if prefix_match and len(prefix_match.string) == len(before_str):
                 mod = TimeTypeConstants.AFTER_MOD
                 begin_date = reference + timedelta(days=1)
                 end_date = self.__get_swift_date(begin_date, duration_result.timex, True)
+                is_match = True
 
             prefix_match = self.config.in_connector_regex.search(before_str)
 
-            if prefix_match and len(prefix_match.string) == len(before_str):
+            if prefix_match and len(prefix_match.string) == len(before_str) and not is_match:
                 mod = TimeTypeConstants.AFTER_MOD
                 begin_date = reference + timedelta(days=1)
                 end_date = self.__get_swift_date(begin_date, duration_result.timex, True)

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -5728,13 +5728,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "este viernes 15 de junio ",
+        "Text": "este viernes 15 de junio",
         "Start": 57,
-        "End": 81,
+        "End": 80,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7556,8 +7555,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "anoche",
@@ -9431,8 +9429,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": []
   },
   {
@@ -10848,8 +10845,7 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "fin de día",
@@ -13064,8 +13060,7 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "mié 26 de octubre 15:50:06 2016",
@@ -13616,13 +13611,12 @@
     "Context": {
       "ReferenceDateTime": "2019-05-23T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "después del año 202",
+        "Text": "después del año 2020",
         "Start": 20,
-        "End": 38,
+        "End": 39,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -14100,20 +14094,35 @@
     "Context": {
       "ReferenceDateTime": "2019-06-03T12:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "primero de 2000",
-        "Start": 3,
+        "Text": "2000",
+        "Start": 14,
         "End": 17,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "2000-01-01",
-              "type": "date",
-              "value": "2000-01-01"
+              "timex": "2000",
+              "type": "daterange",
+              "start": "2000-01-01",
+              "end": "2001-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "un día",
+        "Start": 23,
+        "End": 28,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1D",
+              "type": "duration",
+              "value": "86400"
             }
           ]
         }
@@ -14125,11 +14134,10 @@
     "Context": {
       "ReferenceDateTime": "2019-06-03T12:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "1 Ene 2012",
+        "Text": "1 ene 2012",
         "Start": 0,
         "End": 9,
         "TypeName": "datetimeV2.date",
@@ -14139,6 +14147,21 @@
               "timex": "2012-01-01",
               "type": "date",
               "value": "2012-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "un día",
+        "Start": 15,
+        "End": 20,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1D",
+              "type": "duration",
+              "value": "86400"
             }
           ]
         }
@@ -15633,8 +15656,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-30T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "esta tarde",
@@ -15644,10 +15666,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-07-30TAF",
+              "timex": "2019-07-30TEV",
               "type": "datetimerange",
-              "start": "2019-07-30 12:00:00",
-              "end": "2019-07-30 16:00:00"
+              "start": "2019-07-30 16:00:00",
+              "end": "2019-07-30 20:00:00"
             }
           ]
         }
@@ -15659,8 +15681,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-30T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "esta tarde",
@@ -15670,10 +15691,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-07-30TAF",
+              "timex": "2019-07-30TEV",
               "type": "datetimerange",
-              "start": "2019-07-30 12:00:00",
-              "end": "2019-07-30 16:00:00"
+              "start": "2019-07-30 16:00:00",
+              "end": "2019-07-30 20:00:00"
             }
           ]
         }
@@ -15685,8 +15706,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-30T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "esta tarde",
@@ -15696,10 +15716,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-07-30TAF",
+              "timex": "2019-07-30TEV",
               "type": "datetimerange",
-              "start": "2019-07-30 12:00:00",
-              "end": "2019-07-30 16:00:00"
+              "start": "2019-07-30 16:00:00",
+              "end": "2019-07-30 20:00:00"
             }
           ]
         }
@@ -15958,8 +15978,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-12T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "3 años",
@@ -15983,8 +16002,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-12T00:00:00"
     },
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "en 3 años",
@@ -16056,8 +16074,7 @@
   },
   {
     "Input": "6,107.31 ago-2019 no debe incluir el decimal",
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "ago-2019",
@@ -16079,14 +16096,12 @@
   },
   {
     "Input": "0.8/15 parece una fórmula",
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": []
   },
   {
     "Input": "8/1.5 parece una fórmula",
-    "Comment": "EXTERROR Extraction failures",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": []
   },
   {
@@ -19905,6 +19920,120 @@
               "type": "daterange",
               "start": "2018-01-01",
               "end": "2019-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "El primero de enero de 2000 fue un día especial para mí.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-03T12:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "primero de enero de 2000",
+        "Start": 3,
+        "End": 26,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2000-01-01",
+              "type": "date",
+              "value": "2000-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "un día",
+        "Start": 32,
+        "End": 37,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1D",
+              "type": "duration",
+              "value": "86400"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Vamos a tomar un café en el edificio 34 este pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-07-30T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "este pasado mediodia",
+        "Start": 40,
+        "End": 59,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-07-30TAF",
+              "type": "datetimerange",
+              "start": "2019-07-30 12:00:00",
+              "end": "2019-07-30 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Vamos a tomar un café en el edificio 4 este pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-07-30T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "este pasado mediodia",
+        "Start": 39,
+        "End": 58,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-07-30TAF",
+              "type": "datetimerange",
+              "start": "2019-07-30 12:00:00",
+              "end": "2019-07-30 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "134 este pasado mediodia",
+    "Context": {
+      "ReferenceDateTime": "2019-07-30T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "este pasado mediodia",
+        "Start": 4,
+        "End": 23,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-07-30TAF",
+              "type": "datetimerange",
+              "start": "2019-07-30 12:00:00",
+              "end": "2019-07-30 16:00:00"
             }
           ]
         }


### PR DESCRIPTION
Fix to issue #2372.
Modified DatePeriod to avoid matching FutureRegex in the afterStr of Duration extractions since FutureSuffixRegex already does that (and some expressions in FutureRegex only work as prefixes).
Also, added checker in the parser to avoid modifying the resolution when InConnector is ambiguous and can indicate both a precise point or a range (e.g. in Spanish and Turkish).

Some test cases have been updated to comply with their English counterparts (keeping also the originals):
- "El primero de 2000 fue un día especial para mí." (January first 2000 was a special day for me) -> "El primero de enero de 2000 fue un día especial para mí." ("primero de 2000" does not represent a date in Spanish)
- Cases with "esta tarde" (this afternoon) -> "este pasado mediodia"