### PR TITLE
Implement Regex cache and add option to use Compiled Regex

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions/Utilities/DefinitionLoader.cs
+++ b/.NET/Microsoft.Recognizers.Definitions/Utilities/DefinitionLoader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Definitions.Utilities
                 {
                     if (!"null".Equals(item.Key, StringComparison.Ordinal))
                     {
-                        ambiguityFiltersDict.Add(new Regex(item.Key, RegexOptions.Singleline), new Regex(item.Value, RegexOptions.Singleline));
+                        ambiguityFiltersDict.Add(RegexCache.Get(item.Key, RegexOptions.Singleline), RegexCache.Get(item.Value, RegexOptions.Singleline));
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.Choice/Arabic/Extractors/ArabicBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Arabic/Extractors/ArabicBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Arabic
     public class ArabicBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline | RegexOptions.RightToLeft);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Bulgarian/Extractors/BulgarianBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Bulgarian/Extractors/BulgarianBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Bulgarian
     public class BulgarianBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Chinese/Extractors/ChineseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Chinese/Extractors/ChineseBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Chinese
     public class ChineseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Dutch/Extractors/DutchBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Dutch/Extractors/DutchBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Dutch
     public class DutchBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/English/Extractors/EnglishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/English/Extractors/EnglishBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.English
     public class EnglishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Extractors/ChoiceExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Extractors/ChoiceExtractor.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Recognizers.Text.Choice
                         token = string.Empty;
                     }
                 }
-                else if (!(config.TokenRegex.IsMatch(letter) || string.IsNullOrWhiteSpace(letter)))
+                else if (!(config.TokenRegexCache.IsMatch(letter) || string.IsNullOrWhiteSpace(letter)))
                 {
                     token = token + letter;
                 }

--- a/.NET/Microsoft.Recognizers.Text.Choice/French/Extractors/FrenchBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/French/Extractors/FrenchBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.French
     public class FrenchBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/German/Extractors/GermanBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/German/Extractors/GermanBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.German
     public class GermanBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Hindi/Extractors/HindiBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Hindi/Extractors/HindiBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Hindi
     public class HindiBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Italian/Extractors/ItalianBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Italian/Extractors/ItalianBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Italian
     public class ItalianBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Japanese/Extractors/JapaneseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Japanese/Extractors/JapaneseBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Japanese
     public class JapaneseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Portuguese/Extractors/PortugueseBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Portuguese/Extractors/PortugueseBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Portuguese
     public class PortugueseBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Spanish/Extractors/SpanishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Spanish/Extractors/SpanishBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Spanish
     public class SpanishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Swedish/Extractors/SwedishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Swedish/Extractors/SwedishBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Swedish
     public class SwedishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.Choice/Turkish/Extractors/TurkishBooleanExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Choice/Turkish/Extractors/TurkishBooleanExtractorConfiguration.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Recognizers.Text.Choice.Turkish
     public class TurkishBooleanExtractorConfiguration : IBooleanExtractorConfiguration
     {
         public static readonly Regex TrueRegex =
-            new Regex(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TrueRegex, RegexOptions.Singleline);
 
         public static readonly Regex FalseRegex =
-            new Regex(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.FalseRegex, RegexOptions.Singleline);
 
         public static readonly Regex TokenRegex =
-            new Regex(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
+            RegexCache.Get(ChoiceDefinitions.TokenizerRegex, RegexOptions.Singleline);
 
         public static readonly IDictionary<Regex, string> MapRegexes = new Dictionary<Regex, string>()
         {

--- a/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataDrivenTests/Number/LongFormTestConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
             this.CardinalNumberMap = ImmutableDictionary<string, long>.Empty;
             this.OrdinalNumberMap = ImmutableDictionary<string, long>.Empty;
             this.RoundNumberMap = ImmutableDictionary<string, long>.Empty;
-            this.DigitalNumberRegex = new Regex(
+            this.DigitalNumberRegex = RegexCache.Get(
                 @"((?<=\b)(hundred|thousand|million|billion|trillion|dozen(s)?)(?=\b))|((?<=(\d|\b))(k|t|m|g|b)(?=\b))", RegexOptions.Singleline);
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Text.Number.Tests
         public IEnumerable<string> WrittenFractionSeparatorTexts { get; }
 
         // Test-specific initialization: the Regex matches nothing.
-        public Regex NegativeNumberSignRegex { get; } = new Regex(@"[^\s\S]");
+        public Regex NegativeNumberSignRegex { get; } = RegexCache.Get(@"[^\s\S]");
 
         public bool IsCompoundNumberLanguage { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateExtractorConfiguration.cs
@@ -13,102 +13,102 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+        public static readonly Regex MonthRegex = RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+        public static readonly Regex DayRegex = RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public static readonly Regex DayRegexInChinese = new Regex(DateTimeDefinitions.DateDayRegexInChinese, RegexFlags);
+        public static readonly Regex DayRegexInChinese = RegexCache.Get(DateTimeDefinitions.DateDayRegexInChinese, RegexFlags);
 
-        public static readonly Regex DayRegexNumInChinese = new Regex(DateTimeDefinitions.DayRegexNumInChinese, RegexFlags);
+        public static readonly Regex DayRegexNumInChinese = RegexCache.Get(DateTimeDefinitions.DayRegexNumInChinese, RegexFlags);
 
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+        public static readonly Regex MonthNumRegex = RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+        public static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
-        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+        public static readonly Regex RelativeRegex = RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
-        public static readonly Regex ZeroToNineIntegerRegexChs = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexFlags);
+        public static readonly Regex ZeroToNineIntegerRegexChs = RegexCache.Get(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexFlags);
 
-        public static readonly Regex YearInChineseRegex = new Regex(DateTimeDefinitions.DateYearInChineseRegex, RegexFlags);
+        public static readonly Regex YearInChineseRegex = RegexCache.Get(DateTimeDefinitions.DateYearInChineseRegex, RegexFlags);
 
-        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+        public static readonly Regex WeekDayRegex = RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
-        public static readonly Regex LunarRegex = new Regex(DateTimeDefinitions.LunarRegex, RegexFlags);
+        public static readonly Regex LunarRegex = RegexCache.Get(DateTimeDefinitions.LunarRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DateThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DateLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DateLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DateNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DateNextRegex, RegexFlags);
 
-        public static readonly Regex SpecialDayRegex = new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+        public static readonly Regex SpecialDayRegex = RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
-        public static readonly Regex WeekDayOfMonthRegex = new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+        public static readonly Regex WeekDayOfMonthRegex = RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
-        public static readonly Regex ThisRe = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+        public static readonly Regex ThisRe = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
-        public static readonly Regex LastRe = new Regex(DateTimeDefinitions.LastPrefixRegex, RegexFlags);
+        public static readonly Regex LastRe = RegexCache.Get(DateTimeDefinitions.LastPrefixRegex, RegexFlags);
 
-        public static readonly Regex NextRe = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+        public static readonly Regex NextRe = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
-        public static readonly Regex SpecialDate = new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+        public static readonly Regex SpecialDate = RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly IParser NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(
                                                                                   new BaseNumberOptionsConfiguration(Culture.Chinese, NumberOptions.None)));
 
         public static readonly ImmutableDictionary<string, int> DynastyYearMap = DateTimeDefinitions.DynastyYearMap.ToImmutableDictionary();
 
-        public static readonly Regex DynastyYearRegex = new Regex(DateTimeDefinitions.DynastyYearRegex, RegexFlags);
+        public static readonly Regex DynastyYearRegex = RegexCache.Get(DateTimeDefinitions.DynastyYearRegex, RegexFlags);
 
         public static readonly string DynastyStartYear = DateTimeDefinitions.DynastyStartYear;
 
         public static readonly Regex[] DateRegexList =
         {
             // (农历)?(2016年)?一月三日(星期三)?
-            new Regex(DateTimeDefinitions.DateRegexList1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList1, RegexFlags),
 
             // (2015年)?(农历)?十月初一(星期三)?
-            new Regex(DateTimeDefinitions.DateRegexList2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList2, RegexFlags),
 
             // (2015年)?(农历)?十月二十(星期三)?
-            new Regex(DateTimeDefinitions.DateRegexList3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList3, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 23/7
-                new Regex(DateTimeDefinitions.DateRegexList5, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList5, RegexFlags) :
 
                 // 7/23
-                new Regex(DateTimeDefinitions.DateRegexList4, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList4, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 7/23
-                new Regex(DateTimeDefinitions.DateRegexList4, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList4, RegexFlags) :
 
                 // 23/7
-                new Regex(DateTimeDefinitions.DateRegexList5, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList5, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 23-3-2015
-                new Regex(DateTimeDefinitions.DateRegexList7, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList7, RegexFlags) :
 
                 // 3-23-2017
-                new Regex(DateTimeDefinitions.DateRegexList6, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList6, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 3-23-2017
-                new Regex(DateTimeDefinitions.DateRegexList6, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList6, RegexFlags) :
 
                 // 23-3-2015
-                new Regex(DateTimeDefinitions.DateRegexList7, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList7, RegexFlags),
 
             // 2015-12-23
-            new Regex(DateTimeDefinitions.DateRegexList8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList8, RegexFlags),
         };
 
         public static readonly Regex[] ImplicitDateList =
@@ -117,11 +117,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             WeekDayRegex, WeekDayOfMonthRegex, SpecialDate,
         };
 
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex DateTimePeriodUnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDatePeriodExtractorConfiguration.cs
@@ -13,73 +13,73 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
-        public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
+        public static readonly Regex TillRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
 
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+        public static readonly Regex DayRegex = RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public static readonly Regex DayRegexInChinese = new Regex(DateTimeDefinitions.DatePeriodDayRegexInChinese, RegexFlags);
+        public static readonly Regex DayRegexInChinese = RegexCache.Get(DateTimeDefinitions.DatePeriodDayRegexInChinese, RegexFlags);
 
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+        public static readonly Regex MonthNumRegex = RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DatePeriodThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DatePeriodLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DatePeriodNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodNextRegex, RegexFlags);
 
-        public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+        public static readonly Regex RelativeMonthRegex = RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+        public static readonly Regex MonthRegex = RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+        public static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
-        public static readonly Regex StrictYearRegex = new Regex(DateTimeDefinitions.StrictYearRegex, RegexFlags);
+        public static readonly Regex StrictYearRegex = RegexCache.Get(DateTimeDefinitions.StrictYearRegex, RegexFlags);
 
-        public static readonly Regex YearRegexInNumber = new Regex(DateTimeDefinitions.YearRegexInNumber, RegexFlags);
+        public static readonly Regex YearRegexInNumber = RegexCache.Get(DateTimeDefinitions.YearRegexInNumber, RegexFlags);
 
-        public static readonly Regex ZeroToNineIntegerRegexChs = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexFlags);
+        public static readonly Regex ZeroToNineIntegerRegexChs = RegexCache.Get(DateTimeDefinitions.ZeroToNineIntegerRegexChs, RegexFlags);
 
-        public static readonly Regex YearInChineseRegex = new Regex(DateTimeDefinitions.DatePeriodYearInChineseRegex, RegexFlags);
+        public static readonly Regex YearInChineseRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodYearInChineseRegex, RegexFlags);
 
-        public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+        public static readonly Regex MonthSuffixRegex = RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         // for case "(从)?(2017年)?一月十日到十二日"
-        public static readonly Regex SimpleCasesRegex = new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+        public static readonly Regex SimpleCasesRegex = RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
-        public static readonly Regex YearAndMonth = new Regex(DateTimeDefinitions.YearAndMonth, RegexFlags);
+        public static readonly Regex YearAndMonth = RegexCache.Get(DateTimeDefinitions.YearAndMonth, RegexFlags);
 
         // 2017.12, 2017-12, 2017/12, 12/2017
-        public static readonly Regex PureNumYearAndMonth = new Regex(DateTimeDefinitions.PureNumYearAndMonth, RegexFlags);
+        public static readonly Regex PureNumYearAndMonth = RegexCache.Get(DateTimeDefinitions.PureNumYearAndMonth, RegexFlags);
 
-        public static readonly Regex OneWordPeriodRegex = new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+        public static readonly Regex OneWordPeriodRegex = RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
-        public static readonly Regex WeekOfMonthRegex = new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+        public static readonly Regex WeekOfMonthRegex = RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
-        public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.FollowedUnit, RegexFlags);
+        public static readonly Regex FollowedUnit = RegexCache.Get(DateTimeDefinitions.FollowedUnit, RegexFlags);
 
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.NumberCombinedWithUnit, RegexFlags);
+        public static readonly Regex NumberCombinedWithUnit = RegexCache.Get(DateTimeDefinitions.NumberCombinedWithUnit, RegexFlags);
 
-        public static readonly Regex YearToYear = new Regex(DateTimeDefinitions.YearToYear, RegexFlags);
+        public static readonly Regex YearToYear = RegexCache.Get(DateTimeDefinitions.YearToYear, RegexFlags);
 
-        public static readonly Regex YearToYearSuffixRequired = new Regex(DateTimeDefinitions.YearToYearSuffixRequired, RegexFlags);
+        public static readonly Regex YearToYearSuffixRequired = RegexCache.Get(DateTimeDefinitions.YearToYearSuffixRequired, RegexFlags);
 
-        public static readonly Regex MonthToMonth = new Regex(DateTimeDefinitions.MonthToMonth, RegexFlags);
+        public static readonly Regex MonthToMonth = RegexCache.Get(DateTimeDefinitions.MonthToMonth, RegexFlags);
 
-        public static readonly Regex MonthToMonthSuffixRequired = new Regex(DateTimeDefinitions.MonthToMonthSuffixRequired, RegexFlags);
+        public static readonly Regex MonthToMonthSuffixRequired = RegexCache.Get(DateTimeDefinitions.MonthToMonthSuffixRequired, RegexFlags);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+        public static readonly Regex PastRegex = RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+        public static readonly Regex FutureRegex = RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
-        public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+        public static readonly Regex SeasonRegex = RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
-        public static readonly Regex SeasonWithYear = new Regex(DateTimeDefinitions.SeasonWithYear, RegexFlags);
+        public static readonly Regex SeasonWithYear = RegexCache.Get(DateTimeDefinitions.SeasonWithYear, RegexFlags);
 
-        public static readonly Regex QuarterRegex = new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+        public static readonly Regex QuarterRegex = RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
-        public static readonly Regex DecadeRegex = new Regex(DateTimeDefinitions.DecadeRegex, RegexFlags);
+        public static readonly Regex DecadeRegex = RegexCache.Get(DateTimeDefinitions.DecadeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimeExtractorConfiguration.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIME; // "DateTime";
 
-        public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+        public static readonly Regex PrepositionRegex = RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
-        public static readonly Regex NowRegex = new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+        public static readonly Regex NowRegex = RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
-        public static readonly Regex NightRegex = new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+        public static readonly Regex NightRegex = RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
-        public static readonly Regex TimeOfTodayRegex = new Regex(DateTimeDefinitions.TimeOfTodayRegex, RegexFlags);
+        public static readonly Regex TimeOfTodayRegex = RegexCache.Get(DateTimeDefinitions.TimeOfTodayRegex, RegexFlags);
 
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex DateTimePeriodUnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     }
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
-                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",") || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",") || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         var begin = ers[i].Start ?? 0;
                         var end = (ers[j].Start ?? 0) + (ers[j].Length ?? 0);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
@@ -14,35 +14,35 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
-        public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.DateTimePeriodTillRegex, RegexFlags);
+        public static readonly Regex TillRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodTillRegex, RegexFlags);
 
-        public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.DateTimePeriodPrepositionRegex, RegexFlags);
+        public static readonly Regex PrepositionRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodPrepositionRegex, RegexFlags);
 
-        public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+        public static readonly Regex HourRegex = RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+        public static readonly Regex HourNumRegex = RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
-        public static readonly Regex ZhijianRegex = new Regex(DateTimeDefinitions.ZhijianRegex, RegexFlags);
+        public static readonly Regex ZhijianRegex = RegexCache.Get(DateTimeDefinitions.ZhijianRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DateTimePeriodLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DateTimePeriodNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNextRegex, RegexFlags);
 
-        public static readonly Regex TimeOfDayRegex = new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+        public static readonly Regex TimeOfDayRegex = RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
-        public static readonly Regex SpecificTimeOfDayRegex = new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+        public static readonly Regex SpecificTimeOfDayRegex = RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
-        public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.DateTimePeriodFollowedUnit, RegexFlags);
+        public static readonly Regex FollowedUnit = RegexCache.Get(DateTimeDefinitions.DateTimePeriodFollowedUnit, RegexFlags);
 
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
+        public static readonly Regex NumberCombinedWithUnit = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+        public static readonly Regex PastRegex = RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+        public static readonly Regex FutureRegex = RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -128,7 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                     var middleEnd = timePoints[idx + 1].Start ?? 0;
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
-                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         var periodBegin = timePoints[idx].Start ?? 0;
                         var periodEnd = (timePoints[idx + 1].Start ?? 0) + (timePoints[idx + 1].Length ?? 0);
@@ -262,7 +262,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 if (match.Success)
                 {
                     var middleStr = afterStr.Substring(0, match.Index);
-                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         ret.Add(new Token(er.Start ?? 0, er.Start + er.Length + match.Index + match.Length ?? 0));
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDurationExtractorConfiguration.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 
-        private static readonly Regex YearRegex = new Regex(DateTimeDefinitions.DurationYearRegex, RegexFlags);
+        private static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.DurationYearRegex, RegexFlags);
 
-        private static readonly Regex HalfSuffixRegex = new Regex(DateTimeDefinitions.DurationHalfSuffixRegex, RegexFlags);
+        private static readonly Regex HalfSuffixRegex = RegexCache.Get(DateTimeDefinitions.DurationHalfSuffixRegex, RegexFlags);
 
-        private static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+        private static readonly Regex DurationUnitRegex = RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
-        private static readonly Regex DurationConnectorRegex = new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+        private static readonly Regex DurationConnectorRegex = RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         private static readonly Dictionary<string, string> UnitMap = DateTimeDefinitions.ParserConfigurationUnitMap.ToDictionary(k => k.Key, k => k.Value.Substring(0, 1) + k.Value.Substring(1).ToLower());
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseHolidayExtractorConfiguration.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     public class ChineseHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
 
-        public static readonly Regex LunarHolidayRegex = new Regex(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);
+        public static readonly Regex LunarHolidayRegex = RegexCache.Get(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {
-            new Regex(DateTimeDefinitions.HolidayRegexList1, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegexList2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegexList1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegexList2, RegexFlags),
             LunarHolidayRegex,
         };
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseMergedExtractorConfiguration.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 {
     public class ChineseMergedExtractorConfiguration : IDateTimeExtractor
     {
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
-        public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
-        public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
-        public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
-        public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
-        public static readonly Regex PotentialAmbiguousRangeRegex = new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
-        public static readonly Regex AmbiguousRangeModifierPrefix = new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
+        public static readonly Regex UntilRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
+        public static readonly Regex SincePrefixRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
+        public static readonly Regex SinceSuffixRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex EqualRegex = RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
+        public static readonly Regex PotentialAmbiguousRangeRegex = RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
+        public static readonly Regex AmbiguousRangeModifierPrefix = RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
@@ -10,15 +10,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.SetUnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.SetUnitRegex, RegexFlags);
 
-        public static readonly Regex EachUnitRegex = new Regex(DateTimeDefinitions.SetEachUnitRegex, RegexFlags);
+        public static readonly Regex EachUnitRegex = RegexCache.Get(DateTimeDefinitions.SetEachUnitRegex, RegexFlags);
 
-        public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
+        public static readonly Regex EachPrefixRegex = RegexCache.Get(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
-        public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
+        public static readonly Regex EachDayRegex = RegexCache.Get(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -38,7 +38,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             foreach (var er in ers)
             {
                 // "each last summer" doesn't make sense
-                if (LastRegex.IsMatch(er.Text))
+                if (LastRegexCache.IsMatch(er.Text))
                 {
                     continue;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimeExtractorConfiguration.cs
@@ -59,15 +59,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var regexes = new Dictionary<Regex, TimeType>
             {
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes1, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes1, RegexFlags),
                     TimeType.CjkTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes2, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes2, RegexFlags),
                     TimeType.DigitTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes3, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes3, RegexFlags),
                     TimeType.LessTime
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorChsConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseTimePeriodExtractorChsConfiguration.cs
@@ -36,15 +36,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var regexes = new Dictionary<Regex, PeriodType>
             {
                 {
-                    new Regex(DateTimeDefinitions.TimePeriodRegexes1, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimePeriodRegexes1, RegexFlags),
                     PeriodType.FullTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimePeriodRegexes2, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimePeriodRegexes2, RegexFlags),
                     PeriodType.ShortTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags),
                     PeriodType.ShortTime
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimeParser.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIME;
 
-        public static readonly Regex SimpleAmRegex = new Regex(DateTimeDefinitions.DateTimeSimpleAmRegex, RegexFlags);
+        public static readonly Regex SimpleAmRegex = RegexCache.Get(DateTimeDefinitions.DateTimeSimpleAmRegex, RegexFlags);
 
-        public static readonly Regex SimplePmRegex = new Regex(DateTimeDefinitions.DateTimeSimplePmRegex, RegexFlags);
+        public static readonly Regex SimplePmRegex = RegexCache.Get(DateTimeDefinitions.DateTimeSimplePmRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -162,7 +162,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 return true;
             }
 
-            return ChineseHolidayExtractorConfiguration.LunarHolidayRegex.IsMatch(trimmedText);
+            return ChineseHolidayExtractorConfiguration.LunarHolidayRegexCache.IsMatch(trimmedText);
         }
 
         // merge a Date entity and a Time entity
@@ -200,11 +200,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             var sec = time.Second;
 
             // handle morning, afternoon
-            if (SimplePmRegex.IsMatch(text) && hour < Constants.HalfDayHourCount)
+            if (SimplePmRegexCache.IsMatch(text) && hour < Constants.HalfDayHourCount)
             {
                 hour += Constants.HalfDayHourCount;
             }
-            else if (SimpleAmRegex.IsMatch(text) && hour >= Constants.HalfDayHourCount)
+            else if (SimpleAmRegexCache.IsMatch(text) && hour >= Constants.HalfDayHourCount)
             {
                 hour -= Constants.HalfDayHourCount;
             }
@@ -220,7 +220,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             var val = (DateTimeResolutionResult)pr2.Value;
 
-            if (hour <= Constants.HalfDayHourCount && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
+            if (hour <= Constants.HalfDayHourCount && !SimplePmRegexCache.IsMatch(text) && !SimpleAmRegexCache.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
                 // ret.Timex += "ampm";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
-        public static readonly Regex MORegex = new Regex(DateTimeDefinitions.DateTimePeriodMORegex, RegexFlags);
+        public static readonly Regex MORegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodMORegex, RegexFlags);
 
-        public static readonly Regex MIRegex = new Regex(DateTimeDefinitions.DateTimePeriodMIRegex, RegexFlags);
+        public static readonly Regex MIRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodMIRegex, RegexFlags);
 
-        public static readonly Regex AFRegex = new Regex(DateTimeDefinitions.DateTimePeriodAFRegex, RegexFlags);
+        public static readonly Regex AFRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodAFRegex, RegexFlags);
 
-        public static readonly Regex EVRegex = new Regex(DateTimeDefinitions.DateTimePeriodEVRegex, RegexFlags);
+        public static readonly Regex EVRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodEVRegex, RegexFlags);
 
-        public static readonly Regex NIRegex = new Regex(DateTimeDefinitions.DateTimePeriodNIRegex, RegexFlags);
+        public static readonly Regex NIRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNIRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -445,31 +445,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             // handle morning, afternoon..
-            if (MORegex.IsMatch(trimmedText))
+            if (MORegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (MIRegex.IsMatch(trimmedText))
+            else if (MIRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMI";
                 beginHour = 11;
                 endHour = 13;
             }
-            else if (AFRegex.IsMatch(trimmedText))
+            else if (AFRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EVRegex.IsMatch(trimmedText))
+            else if (EVRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NIRegex.IsMatch(trimmedText))
+            else if (NIRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -484,11 +484,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             if (ChineseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex.IsExactMatch(trimmedText, trim: true))
             {
                 var swift = 0;
-                if (ChineseDateTimePeriodExtractorConfiguration.NextRegex.IsMatch(trimmedText))
+                if (ChineseDateTimePeriodExtractorConfiguration.NextRegexCache.IsMatch(trimmedText))
                 {
                     swift = 1;
                 }
-                else if (ChineseDateTimePeriodExtractorConfiguration.LastRegex.IsMatch(trimmedText))
+                else if (ChineseDateTimePeriodExtractorConfiguration.LastRegexCache.IsMatch(trimmedText))
                 {
                     swift = -1;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        private static readonly Regex DurationUnitRegex = new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+        private static readonly Regex DurationUnitRegex = RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         private static readonly IParser InternalParser = new NumberWithUnitParser(new DurationParserConfiguration());
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseMergedDateTimeParserConfiguration.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
     {
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.MergedBeforeRegex, RegexFlags);
+        private static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.MergedBeforeRegex, RegexFlags);
 
-        private static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
+        private static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
 
         // TODO implement SinceRegex
-        private static readonly Regex SinceRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
+        private static readonly Regex SinceRegex = RegexCache.Get(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
 
         public ChineseMergedDateTimeParserConfiguration(IMergedParserConfiguration configuration)
             : base(configuration)
@@ -34,15 +34,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             // push, save teh MOD string
             bool hasBefore = false, hasAfter = false, hasSince = false;
-            if (BeforeRegex.IsMatch(er.Text))
+            if (BeforeRegexCache.IsMatch(er.Text))
             {
                 hasBefore = true;
             }
-            else if (AfterRegex.IsMatch(er.Text))
+            else if (AfterRegexCache.IsMatch(er.Text))
             {
                 hasAfter = true;
             }
-            else if (SinceRegex.IsMatch(er.Text))
+            else if (SinceRegexCache.IsMatch(er.Text))
             {
                 hasSince = true;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            if (ChineseSetExtractorConfiguration.EachPrefixRegex.IsMatch(beforeStr))
+            if (ChineseSetExtractorConfiguration.EachPrefixRegexCache.IsMatch(beforeStr))
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
                 ret.Timex = pr.TimexStr;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateExtractorConfiguration.cs
@@ -13,103 +13,103 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexOptions.Singleline);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex SingleWeekDayRegex =
-            new Regex(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -118,12 +118,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
         public DutchDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -188,39 +188,39 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             }
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // on (Sunday,)? 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // on (Sunday,)? 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // "(Sunday,)? 7/23, 2018", year part is required
-            var dateRegex7L = new Regex(DateTimeDefinitions.DateExtractor7L, RegexFlags);
+            var dateRegex7L = RegexCache.Get(DateTimeDefinitions.DateExtractor7L, RegexFlags);
 
             // "(Sunday,)? 7/23", year part is not required
-            var dateRegex7S = new Regex(DateTimeDefinitions.DateExtractor7S, RegexFlags);
+            var dateRegex7S = RegexCache.Get(DateTimeDefinitions.DateExtractor7S, RegexFlags);
 
             // "(Sunday,)? 23/7, 2018", year part is required
-            var dateRegex9L = new Regex(DateTimeDefinitions.DateExtractor9L, RegexFlags);
+            var dateRegex9L = RegexCache.Get(DateTimeDefinitions.DateExtractor9L, RegexFlags);
 
             // "(Sunday,)? 23/7", year part is not required
-            var dateRegex9S = new Regex(DateTimeDefinitions.DateExtractor9S, RegexFlags);
+            var dateRegex9S = RegexCache.Get(DateTimeDefinitions.DateExtractor9S, RegexFlags);
 
             // (Sunday,)? 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (Sunday,)? April 5 or (Sunday,)? April 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (Sunday,)? 6th of April
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDatePeriodExtractorConfiguration.cs
@@ -13,166 +13,166 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     {
         // Base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromTokenRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex BetweenTokenRegex =
-            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public DutchDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimeExtractorConfiguration.cs
@@ -9,58 +9,58 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -12,75 +12,75 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex WeekDaysRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex FromTokenRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex BetweenTokenRegex =
-            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCases =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDurationExtractorConfiguration.cs
@@ -9,51 +9,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchHolidayExtractorConfiguration.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H =
-            new Regex(DateTimeDefinitions.HolidayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
@@ -11,48 +11,48 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
-            new Regex(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
 
             // (the)? (day|week|month|year)
-            new Regex(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
         };
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
@@ -9,28 +9,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeExtractorConfiguration.cs
@@ -10,117 +10,117 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... in the morning"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // at 2.30, "at" prefix is required here
             // 3.30pm, "am/pm" suffix is required here
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // 16 from "16 vandaag"
-            new Regex(DateTimeDefinitions.TimeRegex12, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex12, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimePeriodExtractorConfiguration.cs
@@ -12,69 +12,69 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex TimeDateFromTo =
-            new Regex(DateTimeDefinitions.TimeDateFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeDateFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public DutchTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchTimeZoneExtractorConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex DirectUtcRegex =
-            new Regex(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexCache.Get(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly List<string> AbbreviationsList =
             new List<string>(TimeZoneDefinitions.AbbreviationsList);
@@ -23,7 +23,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             TimeZoneUtility.BuildMatcherFromLists(AbbreviationsList, FullNameList);
 
         public static readonly Regex LocationTimeSuffixRegex =
-            new Regex(TimeZoneDefinitions.LocationTimeSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexCache.Get(TimeZoneDefinitions.LocationTimeSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly StringMatcher LocationMatcher = new StringMatcher();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             YearSuffix = DutchDateExtractorConfiguration.YearSuffix;
             RelativeWeekDayRegex = DutchDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = DutchDateExtractorConfiguration.BeforeAfterRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
             MonthOfYear = config.MonthOfYear;
@@ -155,12 +155,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDatePeriodParserConfiguration.cs
@@ -11,22 +11,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             MoreThanRegex = DutchDatePeriodExtractorConfiguration.MoreThanRegex;
             CenturySuffixRegex = DutchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = DutchDatePeriodExtractorConfiguration.NowRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             SpecialDayRegex = DutchDateExtractorConfiguration.SpecialDayRegex;
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -245,15 +245,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -267,19 +267,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -303,7 +303,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (MonthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (MonthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsMonthToDate(string text)
@@ -316,23 +316,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (WeekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (WeekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (WeekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (WeekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (YearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText)) ||
+                   (YearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText)) ||
                    (DateTimeDefinitions.GenericYearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) &&
-                    UnspecificEndOfRangeRegex.IsMatch(trimmedText));
+                    UnspecificEndOfRangeRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimeParserConfiguration.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
-            new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
 
         public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
     public class DutchDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -145,25 +145,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -184,11 +184,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             var trimmedText = text.Trim();
 
             var swift = 0;
-            if (FutureRegex.IsMatch(trimmedText))
+            if (FutureRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchHolidayParserConfiguration.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public DutchHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
-            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            ThisPrefixRegex = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = DutchHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
@@ -31,15 +31,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             var trimmedText = text.Trim();
             var swift = -10;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchTimeParserConfiguration.cs
@@ -15,31 +15,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex TimeSuffixFull =
-            new Regex(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
 
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexFlags);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
         private static readonly Regex HalfTokenRegex =
-            new Regex(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
 
         private static readonly Regex QuarterTokenRegex =
-            new Regex(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
 
         private static readonly Regex ThreeQuarterTokenRegex =
-            new Regex(DateTimeDefinitions.ThreeQuarterTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThreeQuarterTokenRegex, RegexFlags);
 
         private static readonly Regex ToTokenRegex =
-            new Regex(DateTimeDefinitions.ToTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ToTokenRegex, RegexFlags);
 
         private static readonly Regex ToHalfTokenRegex =
-            new Regex(DateTimeDefinitions.ToHalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ToHalfTokenRegex, RegexFlags);
 
         private static readonly Regex ForHalfTokenRegex =
-            new Regex(DateTimeDefinitions.ForHalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForHalfTokenRegex, RegexFlags);
 
         public DutchTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -72,15 +72,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
             var trimmedPrefix = prefix.Trim();
 
-            if (HalfTokenRegex.IsMatch(trimmedPrefix))
+            if (HalfTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -30;
             }
-            else if (QuarterTokenRegex.IsMatch(trimmedPrefix))
+            else if (QuarterTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = 15;
             }
-            else if (ThreeQuarterTokenRegex.IsMatch(trimmedPrefix))
+            else if (ThreeQuarterTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = 45;
             }
@@ -99,15 +99,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                 }
             }
 
-            if (ToHalfTokenRegex.IsMatch(trimmedPrefix))
+            if (ToHalfTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = deltaMin - 30;
             }
-            else if (ForHalfTokenRegex.IsMatch(trimmedPrefix))
+            else if (ForHalfTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -deltaMin - 30;
             }
-            else if (ToTokenRegex.IsMatch(trimmedPrefix))
+            else if (ToTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -deltaMin;
             }
@@ -155,7 +155,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(stringPm))
+                        if (LunchRegexCache.IsMatch(stringPm))
                         {
                             // for hour>=10, <12
                             if (hour >= 10 && hour <= Constants.HalfDayHourCount)
@@ -175,7 +175,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(stringPm))
+                        else if (NightRegexCache.IsMatch(stringPm))
                         {
                             // For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Utilities/DutchDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Utilities/DutchDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch.Utilities
     public class DutchDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateExtractorConfiguration.cs
@@ -14,106 +14,106 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     {
 
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex SingleWeekDayRegex =
-            new Regex(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -124,7 +124,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
         public EnglishDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -188,39 +188,39 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             }
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // on (Sunday,)? 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // on (Sunday,)? 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // "(Sunday,)? 7/23, 2018", year part is required
-            var dateRegex7L = new Regex(DateTimeDefinitions.DateExtractor7L, RegexFlags);
+            var dateRegex7L = RegexCache.Get(DateTimeDefinitions.DateExtractor7L, RegexFlags);
 
             // "(Sunday,)? 7/23", year part is not required
-            var dateRegex7S = new Regex(DateTimeDefinitions.DateExtractor7S, RegexFlags);
+            var dateRegex7S = RegexCache.Get(DateTimeDefinitions.DateExtractor7S, RegexFlags);
 
             // "(Sunday,)? 23/7, 2018", year part is required
-            var dateRegex9L = new Regex(DateTimeDefinitions.DateExtractor9L, RegexFlags);
+            var dateRegex9L = RegexCache.Get(DateTimeDefinitions.DateExtractor9L, RegexFlags);
 
             // "(Sunday,)? 23/7", year part is not required
-            var dateRegex9S = new Regex(DateTimeDefinitions.DateExtractor9S, RegexFlags);
+            var dateRegex9S = RegexCache.Get(DateTimeDefinitions.DateExtractor9S, RegexFlags);
 
             // (Sunday,)? 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (Sunday,)? April 5 or (Sunday,)? April 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (Sunday,)? 6th of April
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDatePeriodExtractorConfiguration.cs
@@ -13,166 +13,166 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     {
         // Base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-             new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromTokenRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex BetweenTokenRegex =
-            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public EnglishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimeExtractorConfiguration.cs
@@ -9,58 +9,58 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDateTimePeriodExtractorConfiguration.cs
@@ -12,49 +12,49 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex WeekDaysRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -65,22 +65,22 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         };
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public EnglishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishDurationExtractorConfiguration.cs
@@ -9,51 +9,51 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishHolidayExtractorConfiguration.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H =
-            new Regex(DateTimeDefinitions.HolidayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishMergedExtractorConfiguration.cs
@@ -11,51 +11,51 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex UnspecificTimePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificTimePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificTimePeriodRegex, RegexFlags);
 
         public static readonly Regex FailFastRegex =
-            new Regex(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
+            RegexCache.Get(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
 
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
-            new Regex(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
 
             // (the)? (day|week|month|year)
-            new Regex(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
         };
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
@@ -101,10 +101,10 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         }
 
         // Used in Standard mode
-        public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+        public static Regex SinceRegex { get; set; } = RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         // used in Experimental mode
-        public static Regex SinceRegexExp { get; } = new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
+        public static Regex SinceRegexExp { get; } = RegexCache.Get(DateTimeDefinitions.SinceRegexExp, RegexFlags);
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishSetExtractorConfiguration.cs
@@ -9,28 +9,28 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeExtractorConfiguration.cs
@@ -10,111 +10,111 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... in the morning"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at? (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // at 2.30, "at" prefix is required here
             // 3.30pm, "am/pm" suffix is required here
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimePeriodExtractorConfiguration.cs
@@ -11,55 +11,55 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Extractors/EnglishTimeZoneExtractorConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishTimeZoneExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimeZoneExtractorConfiguration
     {
         public static readonly Regex DirectUtcRegex =
-            new Regex(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexCache.Get(TimeZoneDefinitions.DirectUtcRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly List<string> AbbreviationsList =
             new List<string>(TimeZoneDefinitions.AbbreviationsList);
@@ -23,7 +23,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             TimeZoneUtility.BuildMatcherFromLists(FullNameList, AbbreviationsList);
 
         public static readonly Regex LocationTimeSuffixRegex =
-            new Regex(TimeZoneDefinitions.LocationTimeSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            RegexCache.Get(TimeZoneDefinitions.LocationTimeSuffixRegex, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
         public static readonly StringMatcher LocationMatcher = new StringMatcher();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -45,11 +45,11 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             RelativeWeekDayRegex = EnglishDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = EnglishDateExtractorConfiguration.BeforeAfterRegex;
 
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -160,12 +160,12 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDatePeriodParserConfiguration.cs
@@ -11,22 +11,22 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         public static readonly Regex NowParseRegex =
-            new Regex(DateTimeDefinitions.NowParseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowParseRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             DateTimeDefinitions.YearTerms.Select(str => $" {str} ").ToList();
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public EnglishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             CenturySuffixRegex = EnglishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = NowParseRegex;
             SpecialDayRegex = EnglishDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -250,15 +250,15 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -272,19 +272,19 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -308,7 +308,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsMonthToDate(string text)
@@ -321,23 +321,23 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText)) ||
+                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText)) ||
                    (DateTimeDefinitions.GenericYearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) &&
-                    UnspecificEndOfRangeRegex.IsMatch(trimmedText));
+                    UnspecificEndOfRangeRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimeParserConfiguration.cs
@@ -11,30 +11,30 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
-             new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
 
         public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
         public static readonly Regex NightTimeRegex =
-             new Regex(DateTimeDefinitions.NightTimeRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.NightTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex NowTimeRegex =
-            new Regex(DateTimeDefinitions.NowTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowTimeRegex, RegexFlags);
 
         private static readonly Regex RecentlyTimeRegex =
-            new Regex(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
 
         private static readonly Regex AsapTimeRegex =
-            new Regex(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         private static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public EnglishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateTimePeriodParserConfiguration.cs
@@ -9,16 +9,16 @@ namespace Microsoft.Recognizers.Text.DateTime.English
     public class EnglishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -149,25 +149,25 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishHolidayParserConfiguration.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public EnglishHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
-            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            ThisPrefixRegex = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = EnglishHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
@@ -34,15 +34,15 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             var trimmedText = text.Trim();
             var swift = -10;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishSetParserConfiguration.cs
@@ -12,28 +12,28 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DoubleMultiplierRegex =
-            new Regex(DateTimeDefinitions.DoubleMultiplierRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DoubleMultiplierRegex, RegexFlags);
 
         private static readonly Regex HalfMultiplierRegex =
-            new Regex(DateTimeDefinitions.HalfMultiplierRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfMultiplierRegex, RegexFlags);
 
         private static readonly Regex DayTypeRegex =
-            new Regex(DateTimeDefinitions.DayTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayTypeRegex, RegexFlags);
 
         private static readonly Regex WeekTypeRegex =
-            new Regex(DateTimeDefinitions.WeekTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekTypeRegex, RegexFlags);
 
         private static readonly Regex WeekendTypeRegex =
-            new Regex(DateTimeDefinitions.WeekendTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekendTypeRegex, RegexFlags);
 
         private static readonly Regex MonthTypeRegex =
-            new Regex(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
 
         private static readonly Regex QuarterTypeRegex =
-            new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
 
         private static readonly Regex YearTypeRegex =
-            new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearTypeRegex, RegexFlags);
 
         public EnglishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -113,37 +113,37 @@ namespace Microsoft.Recognizers.Text.DateTime.English
             float multiplier = 1;
             string durationType;
 
-            if (DoubleMultiplierRegex.IsMatch(trimmedText))
+            if (DoubleMultiplierRegexCache.IsMatch(trimmedText))
             {
                 multiplier = 2;
             }
-            else if (HalfMultiplierRegex.IsMatch(trimmedText))
+            else if (HalfMultiplierRegexCache.IsMatch(trimmedText))
             {
                 multiplier = 0.5f;
             }
 
-            if (DayTypeRegex.IsMatch(trimmedText))
+            if (DayTypeRegexCache.IsMatch(trimmedText))
             {
                 durationType = "D";
             }
-            else if (WeekTypeRegex.IsMatch(trimmedText))
+            else if (WeekTypeRegexCache.IsMatch(trimmedText))
             {
                 durationType = "W";
             }
-            else if (WeekendTypeRegex.IsMatch(trimmedText))
+            else if (WeekendTypeRegexCache.IsMatch(trimmedText))
             {
                 durationType = "WE";
             }
-            else if (MonthTypeRegex.IsMatch(trimmedText))
+            else if (MonthTypeRegexCache.IsMatch(trimmedText))
             {
                 durationType = "M";
             }
-            else if (QuarterTypeRegex.IsMatch(trimmedText))
+            else if (QuarterTypeRegexCache.IsMatch(trimmedText))
             {
                 durationLength = 3;
                 durationType = "M";
             }
-            else if (YearTypeRegex.IsMatch(trimmedText))
+            else if (YearTypeRegexCache.IsMatch(trimmedText))
             {
                 durationType = "Y";
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishTimeParserConfiguration.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex TimeSuffixFull =
-            new Regex(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
 
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexFlags);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
         public EnglishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)
@@ -128,7 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(matchPmStr))
+                        if (LunchRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                             {
@@ -147,7 +147,7 @@ namespace Microsoft.Recognizers.Text.DateTime.English
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(matchPmStr))
+                        else if (NightRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnglishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Utilities/EnglishDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.English.Utilities
     public class EnglishDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private static void StripInequality(ExtractResult er, Regex regex, bool inPrefix)
         {
-            if (regex.IsMatch(er.Text))
+            if (RegexCache.IsMatch(er.Text))
             {
                 var originalLength = er.Text.Length;
                 er.Text = regex.Replace(er.Text, string.Empty).Trim();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -457,14 +457,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                         }
                     }
 
-                    if (match.Length == Constants.FourDigitsYearLength && this.config.YearRegex.IsMatch(match.Value))
+                    if (match.Length == Constants.FourDigitsYearLength && this.config.YearRegexCache.IsMatch(match.Value))
                     {
                         // handle single year which is surrounded by '-' at both sides, e.g., a single year falls in a GUID
                         if (InfixBoundaryCheck(match, text))
                         {
                             var substr = text.Substring(match.Index - 1, 6);
 
-                            if (this.config.IllegalYearRegex.IsMatch(substr))
+                            if (this.config.IllegalYearRegexCache.IsMatch(substr))
                             {
                                 continue;
                             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedDateTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseMergedDateTimeExtractor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseMergedDateTimeExtractor : IDateTimeExtractor
     {
-        private static readonly Regex NumberOrConnectorRegex = new Regex(@"^[0-9-]+$", RegexOptions.Compiled);
+        private static readonly Regex NumberOrConnectorRegex = RegexCache.Get(@"^[0-9-]+$", RegexOptions.Compiled);
 
         private readonly IMergedExtractorConfiguration config;
 
@@ -186,7 +186,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private bool IsFailFastCase(string input)
         {
-            return (config.FailFastRegex != null) && (!config.FailFastRegex.IsMatch(input));
+            return (config.FailFastRegex != null) && (!config.FailFastRegexCache.IsMatch(input));
         }
 
         private List<ExtractResult> CheckCalendarModeFilters(List<ExtractResult> ers, string text)
@@ -262,12 +262,12 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         private bool ShouldSkipFromToMerge(ExtractResult er)
         {
-            return config.FromToRegex.IsMatch(er.Text);
+            return config.FromToRegexCache.IsMatch(er.Text);
         }
 
         private List<ExtractResult> FilterUnspecificDatePeriod(List<ExtractResult> ers)
         {
-            ers.RemoveAll(o => this.config.UnspecificDatePeriodRegex.IsMatch(o.Text));
+            ers.RemoveAll(o => this.config.UnspecificDatePeriodRegexCache.IsMatch(o.Text));
             return ers;
         }
 
@@ -290,7 +290,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // @TODO: Refactor to remove this method and use the general ambiguity filter approach
-            extractResults = extractResults.Where(er => !(NumberOrConnectorRegex.IsMatch(er.Text) && (text.Substring(0, (int)er.Start).Trim().EndsWith("-") || text.Substring((int)(er.Start + er.Length)).Trim().StartsWith("-"))))
+            extractResults = extractResults.Where(er => !(NumberOrConnectorRegexCache.IsMatch(er.Text) && (text.Substring(0, (int)er.Start).Trim().EndsWith("-") || text.Substring((int)(er.Start + er.Length)).Trim().StartsWith("-"))))
                     .ToList();
 
             return extractResults;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             foreach (var er in ers)
             {
                 // "each last summer" doesn't make sense
-                if (this.config.LastRegex.IsMatch(er.Text))
+                if (this.config.LastRegexCache.IsMatch(er.Text))
                 {
                     continue;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseTimeExtractor.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Recognizers.Text.DateTime
     public class BaseTimeExtractor : IDateTimeExtractor
     {
         public static readonly Regex HourRegex =
-            new Regex(BaseDateTime.HourRegex, RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexCache.Get(BaseDateTime.HourRegex, RegexOptions.Singleline | RegexOptions.Compiled);
 
         public static readonly Regex MinuteRegex =
-            new Regex(BaseDateTime.MinuteRegex, RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexCache.Get(BaseDateTime.MinuteRegex, RegexOptions.Singleline | RegexOptions.Compiled);
 
         public static readonly Regex SecondRegex =
-            new Regex(BaseDateTime.SecondRegex, RegexOptions.Singleline | RegexOptions.Compiled);
+            RegexCache.Get(BaseDateTime.SecondRegex, RegexOptions.Singleline | RegexOptions.Compiled);
 
         private const string ExtractorName = Constants.SYS_DATETIME_TIME; // "Time";
 
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var result = new List<Token>();
 
             // handle "at 5", "at seven"
-            if (this.config.AtRegex.IsMatch(text))
+            if (this.config.AtRegexCache.IsMatch(text))
             {
                 var matches = this.config.AtRegex.Matches(text);
                 foreach (Match match in matches)
@@ -137,7 +137,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 // handle "before 3", "after three"
                 var beforeAfterRegex = this.config.TimeBeforeAfterRegex;
-                if (beforeAfterRegex.IsMatch(text))
+                if (beforeAfterRegexCache.IsMatch(text))
                 {
                     var matches = beforeAfterRegex.Matches(text);
                     foreach (Match match in matches)
@@ -155,7 +155,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var result = new List<Token>();
 
             // handle "ish"
-            if (this.config.IshRegex != null && this.config.IshRegex.IsMatch(text))
+            if (this.config.IshRegex != null && this.config.IshRegexCache.IsMatch(text))
             {
                 var matches = this.config.IshRegex.Matches(text);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateExtractorConfiguration.cs
@@ -13,77 +13,77 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         // day before yesterday, day after tomorrow, next day, last day, the day yesterday, the day tomorrow
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex StrictWeekDay =
-            new Regex(DateTimeDefinitions.StrictWeekDay, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictWeekDay, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -92,37 +92,37 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         };
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -132,10 +132,10 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         // @TODO move out to resources file
         public static readonly Regex NonDateUnitRegex =
-            new Regex(@"(?<unit>heures?|hrs|secondes?|secs?|minutes?|mins?)\b", RegexFlags);
+            RegexCache.Get(@"(?<unit>heures?|hrs|secondes?|secs?|minutes?|mins?)\b", RegexFlags);
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -160,36 +160,36 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             UtilityConfiguration = new FrenchDatetimeUtilityConfiguration();
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // on 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // on 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // 7/23
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, RegexFlags);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, RegexFlags);
 
             // 23/7
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, RegexFlags);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, RegexFlags);
 
             // 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (Sunday,)? April 5
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (Sunday,)? April 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor2, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor2, RegexFlags),
 
                 // (Sunday,)? 6th of April
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDatePeriodExtractorConfiguration.cs
@@ -13,185 +13,185 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         // until
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         // and
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         // this month, next month, last month
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         // in, of, no "on"...
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         // year, month, week, day
-        public static readonly Regex DateUnitRegex = new Regex(
+        public static readonly Regex DateUnitRegex = RegexCache.Get(
             DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         // **In French, Past/Next is suffix, but interface enforces this
         // past, last, previous
         public static readonly Regex PastPrefixRegex =
-            new Regex(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
 
         // **In French, Past/Next is suffix, but interface enforces this
         // next, in
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         // between 'x' until 'y', from 'x' until 'y'
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         // a cote de - 'next to', cette - 'this', dernier - 'last' (always after the noun, i.e annee dernier - 'last year'
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         // le/la - masc/fem 'the'
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         // 1st quarter of this year, 2nd quarter of next/last year, etc
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         // TODO: add regexs below
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-           new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-                    new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+                    RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex2, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {
@@ -332,7 +332,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeAltExtractorConfiguration.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -31,10 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public FrenchDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimeExtractorConfiguration.cs
@@ -9,60 +9,60 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     {
         // à - time at which, en - length of time, dans - amount of time
         public static readonly Regex PrepositionRegex =
-          new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+          RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         // right now, as soon as possible, recently, previously
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         // in the evening, afternoon, morning, night
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -118,7 +118,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public bool IsConnector(string text)
         {
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -9,52 +9,52 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex WeekDaysRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -66,22 +66,22 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         };
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex2, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public FrenchDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -204,7 +204,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDurationExtractorConfiguration.cs
@@ -8,52 +8,52 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         // quelques = "a few, some," etc
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchHolidayExtractorConfiguration.cs
@@ -8,20 +8,20 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H1 =
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags);
 
         public static readonly Regex H2 =
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags);
 
         public static readonly Regex H3 =
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags);
 
         // added to include more options, "fete des meres" mothers day, etc
         public static readonly Regex H4 =
-            new Regex(DateTimeDefinitions.HolidayRegex4, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex4, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchMergedExtractorConfiguration.cs
@@ -11,42 +11,42 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     {
         // avant - 'before'
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         // ensuite/puis are for adverbs, i.e 'i ate and then i walked', so we'll use apres
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         // 'Je vais du lundi au mecredi' - I will go from monday to weds
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex[] TermFilterRegexes = System.Array.Empty<Regex>();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchSetExtractorConfiguration.cs
@@ -11,29 +11,29 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         // TODO: Decide between adjective and adverb, i.e monthly - 'mensuel' vs 'mensuellement'
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimeExtractorConfiguration.cs
@@ -11,112 +11,112 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         // part 1: smallest component
         // --------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... heures (o'clock, en punto)"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... après midi (afternoon, tarde)"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... dans la matinee (in the morning)"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         // TODO - will have change below
         // handle "six heures et demie" (six thirty), "six heures et vingt-et-un" (six twenty one)
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         // midnight - le minuit, la zero heure
         // midday - midi
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchTimePeriodExtractorConfiguration.cs
@@ -13,66 +13,66 @@ namespace Microsoft.Recognizers.Text.DateTime.French
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.PeriodDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodDescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex2, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex2, RegexFlags);
 
         public FrenchTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -144,7 +144,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public bool IsConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text);
         }
 
         public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             YearSuffix = FrenchDateExtractorConfiguration.YearSuffix;
             BeforeAfterRegex = FrenchDateExtractorConfiguration.BeforeAfterRegex;
             RelativeWeekDayRegex = FrenchDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDatePeriodParserConfiguration.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     {
         // @TODO move to resources - French - relative
         public static readonly Regex NextPrefixRegex =
-            new Regex(@"(prochain|prochaine)\b", RegexFlags);
+            RegexCache.Get(@"(prochain|prochaine)\b", RegexFlags);
 
         public static readonly Regex PastPrefixRegex =
-            new Regex(@"(dernier)\b", RegexFlags);
+            RegexCache.Get(@"(dernier)\b", RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(@"(ce|cette)\b", RegexFlags);
+            RegexCache.Get(@"(ce|cette)\b", RegexFlags);
 
         public static readonly Regex NextSuffixRegex =
-            new Regex(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
 
         public static readonly Regex PastSuffixRegex =
-            new Regex(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -87,7 +87,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
             CenturySuffixRegex = FrenchDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = FrenchDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = FrenchDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -329,7 +329,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
             return (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
                    (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.Contains(o)) &&
-                   (NextSuffixRegex.IsMatch(trimmedText) || PastSuffixRegex.IsMatch(trimmedText)))) &&
+                   (NextSuffixRegexCache.IsMatch(trimmedText) || PastSuffixRegexCache.IsMatch(trimmedText)))) &&
                    !DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal));
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimeParserConfiguration.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
-            new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
 
         public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateTimePeriodParserConfiguration.cs
@@ -9,16 +9,16 @@ namespace Microsoft.Recognizers.Text.DateTime.French
     public class FrenchDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -148,25 +148,25 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
             var trimmedText = text.Trim();
 
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Utilities/FrenchDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Utilities/FrenchDatetimeUtilityConfiguration.cs
@@ -8,43 +8,43 @@ namespace Microsoft.Recognizers.Text.DateTime.French.Utilities
     public class FrenchDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoPrefixRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateExtractorConfiguration.cs
@@ -13,73 +13,73 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex SingleWeekDayRegex =
-            new Regex(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -88,37 +88,37 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         };
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -152,39 +152,39 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             UtilityConfiguration = new GermanDatetimeUtilityConfiguration();
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // am 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // am 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // 7/23
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, RegexFlags);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, RegexFlags);
 
             // 23/7
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, RegexFlags);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, RegexFlags);
 
             // Nächstes Jahr (im Sommer)?
-            var dateRegex10 = new Regex(DateTimeDefinitions.DateExtractor10, RegexFlags);
+            var dateRegex10 = RegexCache.Get(DateTimeDefinitions.DateExtractor10, RegexFlags);
 
             // 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (Sonntag,)? 5. April
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (Sonntag,)? 5. April, 2016
-                new Regex(DateTimeDefinitions.DateExtractor2, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor2, RegexFlags),
 
                 // (Sonntag,)? der 6. April, 2016
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDatePeriodExtractorConfiguration.cs
@@ -13,158 +13,158 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     {
         // base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public GermanDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimeExtractorConfiguration.cs
@@ -8,58 +8,58 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -117,8 +117,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             text = text.Trim();
             return string.IsNullOrEmpty(text)
-                    || PrepositionRegex.IsMatch(text)
-                    || ConnectorRegex.IsMatch(text);
+                    || PrepositionRegexCache.IsMatch(text)
+                    || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDateTimePeriodExtractorConfiguration.cs
@@ -11,43 +11,43 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -58,25 +58,25 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         };
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexOptions.Singleline);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public GermanDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -110,7 +110,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public Regex FutureSuffixRegex => GermanDatePeriodExtractorConfiguration.FutureSuffixRegex;
 
-        public Regex WeekDayRegex => new Regex(
+        public Regex WeekDayRegex => RegexCache.Get(
             DateTimeDefinitions.WeekDayRegex,
             RegexOptions.Singleline);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanDurationExtractorConfiguration.cs
@@ -8,52 +8,52 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex =
-            new Regex(DateTimeDefinitions.SpecialNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialNumberUnitRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanHolidayExtractorConfiguration.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H1 =
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags);
 
         public static readonly Regex H2 =
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags);
 
         public static readonly Regex H3 =
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanMergedExtractorConfiguration.cs
@@ -10,47 +10,47 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
-            new Regex(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
         };
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanSetExtractorConfiguration.cs
@@ -9,31 +9,31 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex BeforeEachDayRegex =
-            new Regex(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimeExtractorConfiguration.cs
@@ -10,110 +10,110 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... in the morning"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(senven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -10,55 +10,55 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             YearSuffix = GermanDateExtractorConfiguration.YearSuffix;
             BeforeAfterRegex = GermanDateExtractorConfiguration.BeforeAfterRegex;
             RelativeWeekDayRegex = GermanDateExtractorConfiguration.RelativeWeekDayRegex;
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
-            AfterNextPrefixRegex = new Regex(DateTimeDefinitions.AfterNextPrefixRegex, RegexOptions.Singleline);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexOptions.Singleline);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexOptions.Singleline);
+            AfterNextPrefixRegex = RegexCache.Get(DateTimeDefinitions.AfterNextPrefixRegex, RegexOptions.Singleline);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexOptions.Singleline);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexOptions.Singleline);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexOptions.Singleline);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -164,11 +164,11 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDatePeriodParserConfiguration.cs
@@ -10,25 +10,25 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex PenultimatePrefixRegex =
-            new Regex(DateTimeDefinitions.PenultimatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PenultimatePrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         public static readonly Regex AfterNextPrefixRegex =
-            new Regex(DateTimeDefinitions.AfterNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextPrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             CenturySuffixRegex = GermanDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = GermanDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = GermanDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -242,15 +242,15 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (PenultimatePrefixRegex.IsMatch(trimmedText))
+            else if (PenultimatePrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -2;
             }
@@ -262,19 +262,19 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         {
             var trimmedText = text.Trim();
             var swift = -10;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (PenultimatePrefixRegex.IsMatch(trimmedText))
+            else if (PenultimatePrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -2;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimeParserConfiguration.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
             NowRegex = GermanDateTimeExtractorConfiguration.NowRegex;
 
-            AMTimeRegex = new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            AMTimeRegex = RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+            PMTimeRegex = RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
             SimpleTimeOfTodayAfterRegex = GermanDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
             SimpleTimeOfTodayBeforeRegex = GermanDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateTimePeriodParserConfiguration.cs
@@ -9,16 +9,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
     public class GermanDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -146,25 +146,25 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanTimeParserConfiguration.cs
@@ -15,28 +15,28 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex TimeSuffixFull =
-            new Regex(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
 
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexFlags);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
         private static readonly Regex HalfTokenRegex =
-            new Regex(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
 
         private static readonly Regex QuarterToTokenRegex =
-            new Regex(DateTimeDefinitions.QuarterToTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterToTokenRegex, RegexFlags);
 
         private static readonly Regex QuarterPastTokenRegex =
-            new Regex(DateTimeDefinitions.QuarterPastTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterPastTokenRegex, RegexFlags);
 
         private static readonly Regex ThreeQuarterToTokenRegex =
-            new Regex(DateTimeDefinitions.ThreeQuarterToTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThreeQuarterToTokenRegex, RegexFlags);
 
         private static readonly Regex ThreeQuarterPastTokenRegex =
-            new Regex(DateTimeDefinitions.ThreeQuarterPastTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThreeQuarterPastTokenRegex, RegexFlags);
 
         public GermanTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -68,23 +68,23 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             var deltaMin = 0;
             var trimmedPrefix = prefix.Trim();
 
-            if (HalfTokenRegex.IsMatch(trimmedPrefix))
+            if (HalfTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -30;
             }
-            else if (QuarterToTokenRegex.IsMatch(trimmedPrefix))
+            else if (QuarterToTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -15;
             }
-            else if (QuarterPastTokenRegex.IsMatch(trimmedPrefix))
+            else if (QuarterPastTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = 15;
             }
-            else if (ThreeQuarterToTokenRegex.IsMatch(trimmedPrefix))
+            else if (ThreeQuarterToTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = -45;
             }
-            else if (ThreeQuarterPastTokenRegex.IsMatch(trimmedPrefix))
+            else if (ThreeQuarterPastTokenRegexCache.IsMatch(trimmedPrefix))
             {
                 deltaMin = 45;
             }
@@ -153,7 +153,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(matchPmStr))
+                        if (LunchRegexCache.IsMatch(matchPmStr))
                         {
                             // for hour>=10, <12
                             if (hour >= 10 && hour <= Constants.HalfDayHourCount)
@@ -173,7 +173,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(matchPmStr))
+                        else if (NightRegexCache.IsMatch(matchPmStr))
                         {
                             // For hour <=3 or ==12, we treat it as am, for example 1 in the night (midnight) == 1am
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Utilities/GermanDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.German.Utilities
     public class GermanDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateExtractorConfiguration.cs
@@ -13,106 +13,106 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
    public class HindiDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex SingleWeekDayRegex =
-            new Regex(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -123,7 +123,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
         public HindiDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
            : base(config)
@@ -188,39 +188,39 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             }
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // on (Sunday,)? 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // on (Sunday,)? 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // "(Sunday,)? 7/23, 2018", year part is required
-            var dateRegex7L = new Regex(DateTimeDefinitions.DateExtractor7L, RegexFlags);
+            var dateRegex7L = RegexCache.Get(DateTimeDefinitions.DateExtractor7L, RegexFlags);
 
             // "(Sunday,)? 7/23", year part is not required
-            var dateRegex7S = new Regex(DateTimeDefinitions.DateExtractor7S, RegexFlags);
+            var dateRegex7S = RegexCache.Get(DateTimeDefinitions.DateExtractor7S, RegexFlags);
 
             // "(Sunday,)? 23/7, 2018", year part is required
-            var dateRegex9L = new Regex(DateTimeDefinitions.DateExtractor9L, RegexFlags);
+            var dateRegex9L = RegexCache.Get(DateTimeDefinitions.DateExtractor9L, RegexFlags);
 
             // "(Sunday,)? 23/7", year part is not required
-            var dateRegex9S = new Regex(DateTimeDefinitions.DateExtractor9S, RegexFlags);
+            var dateRegex9S = RegexCache.Get(DateTimeDefinitions.DateExtractor9S, RegexFlags);
 
             // (Sunday,)? 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (Sunday,)? April 5 or (Sunday,)? April 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (Sunday,)? 6th of April
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDatePeriodExtractorConfiguration.cs
@@ -13,169 +13,169 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     {
         // Base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-             new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex NumberBeforeWeekRegex =
-            new Regex(DateTimeDefinitions.NumberBeforeWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberBeforeWeekRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromTokenRegex =
-            new Regex(DateTimeDefinitions.FromTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromTokenRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-           new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public HindiDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimeExtractorConfiguration.cs
@@ -8,58 +8,58 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -116,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDateTimePeriodExtractorConfiguration.cs
@@ -10,49 +10,49 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex WeekDaysRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -63,25 +63,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         };
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromTokenRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenTokenRegex, RegexFlags);
 
         public HindiDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -191,7 +191,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
 
         public bool HasConnectorToken(string text)
         {
-            var rangeConnetorRegex = new Regex(DateTimeDefinitions.RangeConnectorRegex);
+            var rangeConnetorRegex = RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex);
 
             return rangeConnetorRegex.IsExactMatch(text, trim: true);
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiDurationExtractorConfiguration.cs
@@ -8,51 +8,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiHolidayExtractorConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H1 =
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags);
 
         public static readonly Regex H2 =
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags);
 
         public static readonly Regex H3 =
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiMergedExtractorConfiguration.cs
@@ -10,51 +10,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-           new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex FailFastRegex =
-            new Regex(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
+            RegexCache.Get(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
 
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
-            new Regex(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
 
             // (the)? (day|week|month|year)
-            new Regex(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
         };
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiSetExtractorConfiguration.cs
@@ -9,33 +9,33 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
-           new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex EachDayRegexPrefix =
-            new Regex(DateTimeDefinitions.EachDayRegexPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegexPrefix, RegexFlags);
 
         public HindiSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimeExtractorConfiguration.cs
@@ -10,114 +10,114 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... in the morning"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at? (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (?<=to) 4
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // at 2.30, "at" prefix is required here
             // 3.30pm, "am/pm" suffix is required here
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Extractors/HindiTimePeriodExtractorConfiguration.cs
@@ -11,66 +11,66 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromTokenRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public HindiTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
@@ -45,11 +45,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             RelativeWeekDayRegex = HindiDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = HindiDateExtractorConfiguration.BeforeAfterRegex;
 
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -160,12 +160,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDatePeriodParserConfiguration.cs
@@ -10,19 +10,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -39,10 +39,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             DateTimeDefinitions.YearTerms.Select(str => $" {str} ").ToList();
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         private static readonly Regex NextPrefixRegexNoWeek =
-            new Regex(DateTimeDefinitions.NextPrefixRegexNoWeek, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegexNoWeek, RegexFlags);
 
         public HindiDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -96,7 +96,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             CenturySuffixRegex = HindiDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = HindiDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = HindiDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -249,15 +249,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -271,19 +271,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -307,7 +307,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsMonthToDate(string text)
@@ -320,23 +320,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText)) ||
+                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText)) ||
                    (DateTimeDefinitions.GenericYearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) &&
-                    UnspecificEndOfRangeRegex.IsMatch(trimmedText));
+                    UnspecificEndOfRangeRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimeParserConfiguration.cs
@@ -9,27 +9,27 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
-             new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
 
         public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex NowTimeRegex =
-            new Regex(DateTimeDefinitions.NowTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowTimeRegex, RegexFlags);
 
         private static readonly Regex RecentlyTimeRegex =
-            new Regex(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
 
         private static readonly Regex AsapTimeRegex =
-            new Regex(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         private static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public HindiDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateTimePeriodParserConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
     public class HindiDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -146,25 +146,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -185,11 +185,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             var trimmedText = text.Trim();
 
             var swift = 0;
-            if (FutureRegex.IsMatch(trimmedText))
+            if (FutureRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiHolidayParserConfiguration.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         public HindiHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
-            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            ThisPrefixRegex = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = HindiHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
@@ -32,15 +32,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
             var trimmedText = text.Trim();
             var swift = -10;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiSetParserConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public HindiSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiTimeParserConfiguration.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex TimeSuffixFull =
-            new Regex(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
 
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexFlags);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
         private static readonly Regex HalfTokenRegex =
-            new Regex(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
 
         private static readonly Regex QuarterTokenRegex =
-            new Regex(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
 
         private static readonly Regex ThreeQuarterTokenRegex =
-            new Regex(DateTimeDefinitions.ThreeQuarterTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThreeQuarterTokenRegex, RegexFlags);
 
         private static readonly Regex ToTokenRegex =
-            new Regex(DateTimeDefinitions.ToTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ToTokenRegex, RegexFlags);
 
         public HindiTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)
@@ -63,15 +63,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
 
             var trimedPrefix = prefix.Trim();
 
-            if (HalfTokenRegex.IsMatch(trimedPrefix))
+            if (HalfTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = 30;
             }
-            else if (QuarterTokenRegex.IsMatch(trimedPrefix))
+            else if (QuarterTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = 15;
             }
-            else if (ThreeQuarterTokenRegex.IsMatch(trimedPrefix))
+            else if (ThreeQuarterTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = 45;
             }
@@ -90,7 +90,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
                 }
             }
 
-            if (ToTokenRegex.IsMatch(trimedPrefix))
+            if (ToTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = -deltaMin;
             }
@@ -137,7 +137,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
                             deltaHour = Constants.HalfDayHourCount;
                         }
 
-                        if (LunchRegex.IsMatch(matchPmStr))
+                        if (LunchRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                             {
@@ -156,7 +156,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(matchPmStr))
+                        else if (NightRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiTimePeriodParserConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex PluralTokenRegex =
-            new Regex(DateTimeDefinitions.PluralTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PluralTokenRegex, RegexFlags);
 
         public HindiTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Utilities/HindiDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Utilities/HindiDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi.Utilities
     public class HindiDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-           new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateExtractorConfiguration.cs
@@ -13,77 +13,77 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         // day before yesterday, day after tomorrow, next day, last day, the day yesterday, the day tomorrow
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex StrictWeekDay =
-            new Regex(DateTimeDefinitions.StrictWeekDay, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictWeekDay, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -92,37 +92,37 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         };
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -131,7 +131,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -158,36 +158,36 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             const RegexOptions dateRegexOption = RegexOptions.Singleline;
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, dateRegexOption);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, dateRegexOption);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, dateRegexOption);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, dateRegexOption);
 
             // on 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, dateRegexOption);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, dateRegexOption);
 
             // on 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, dateRegexOption);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, dateRegexOption);
 
             // 7/23
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, dateRegexOption);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, dateRegexOption);
 
             // 23/7
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, dateRegexOption);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, dateRegexOption);
 
             // 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, dateRegexOption);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, dateRegexOption);
 
             DateRegexList = new List<Regex>
             {
                 // (Sunday,)? April 5
-                new Regex(DateTimeDefinitions.DateExtractor1, dateRegexOption),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, dateRegexOption),
 
                 // (Sunday,)? April 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor2, dateRegexOption),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor2, dateRegexOption),
 
                 // (Sunday,)? 6th of April
-                new Regex(DateTimeDefinitions.DateExtractor3, dateRegexOption),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, dateRegexOption),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDatePeriodExtractorConfiguration.cs
@@ -14,195 +14,195 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         // until
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
 
         public static readonly Regex FullTillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         // and
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         // this month, next month, last month
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-           new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex EngMonthRegex =
-            new Regex(DateTimeDefinitions.EngMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EngMonthRegex, RegexFlags);
 
         // in, of, no "on"...
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         // year, month, week, day
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         // **In Italian, Past/Next is suffix, but interface enforces this
         // past, last, previous
         public static readonly Regex PastPrefixRegex =
-            new Regex(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         // **In Italian, Past/Next is suffix, but interface enforces this
         // next, in
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         // between 'x' until 'y', from 'x' until 'y'
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         // @TODO localize comment?
         // a cote de - 'next to', cette - 'this', dernier - 'last' (always after the noun, i.e annee dernier - 'last year'
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         // le/la - masc/fem 'the'
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         // 1st quarter of this year, 2nd quarter of next/last year, etc
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         // TODO: add regexs below
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-          new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+          RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-           new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+           RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {
@@ -353,7 +353,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text) || FullTillRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text) || FullTillRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeAltExtractorConfiguration.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -31,10 +31,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public ItalianDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimeExtractorConfiguration.cs
@@ -10,60 +10,60 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         // à - time at which, en - length of time, dans - amount of time
         public static readonly Regex PrepositionRegex =
-          new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+          RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         // right now, as soon as possible, recently, previously
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         // in the evening, afternoon, morning, night
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex YearRegex =
-             new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public bool IsConnector(string text)
         {
             text = text.Trim();
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDateTimePeriodExtractorConfiguration.cs
@@ -10,49 +10,49 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-          new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+          RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -64,25 +64,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         };
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public ItalianDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -137,7 +137,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public Regex FutureSuffixRegex => ItalianDatePeriodExtractorConfiguration.FutureSuffixRegex;
 
-        public Regex WeekDayRegex => new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+        public Regex WeekDayRegex => RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         Regex IDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex => PeriodTimeOfDayWithDateRegex;
 
@@ -211,7 +211,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text) || FullTillRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text) || FullTillRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianDurationExtractorConfiguration.cs
@@ -8,51 +8,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianHolidayExtractorConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H1 =
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags);
 
         public static readonly Regex H2 =
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags);
 
         public static readonly Regex H3 =
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianMergedExtractorConfiguration.cs
@@ -11,43 +11,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags); // avant - 'before'
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags); // avant - 'before'
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags); // ensuite/puis are for adverbs, i.e 'i ate and then i walked', so we'll use apres
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags); // ensuite/puis are for adverbs, i.e 'i ate and then i walked', so we'll use apres
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags); // 'Je vais du lundi au mecredi' - I will go from monday to weds
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags); // 'Je vais du lundi au mecredi' - I will go from monday to weds
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex[] TermFilterRegexes = System.Array.Empty<Regex>();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianSetExtractorConfiguration.cs
@@ -10,28 +10,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimeExtractorConfiguration.cs
@@ -10,110 +10,110 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         // part 1: smallest component
         // --------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... heures (o'clock, en punto)"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... après midi (afternoon, tarde)"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... dans la matinee (in the morning)"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         public static readonly Regex FrTimeRegex =
-            new Regex(DateTimeDefinitions.EngTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EngTimeRegex, RegexFlags);
 
         // TODO - will have change below
         // handle "six heures et demie" (six thirty), "six heures et vingt-et-un" (six twenty one)
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         // midnight - le minuit, la zero heure
         // midday - midi
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (in the night) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Extractors/ItalianTimePeriodExtractorConfiguration.cs
@@ -13,75 +13,75 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestrictedTillRegex, RegexFlags);
 
         public static readonly Regex FullTillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.PeriodDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodDescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex ConnectorAndRegex =
-            new Regex(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorAndRegex, RegexFlags);
 
         private static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         private static readonly Regex RangePmRegex =
-            new Regex(DateTimeDefinitions.RangePmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePmRegex, RegexFlags);
 
         public ItalianTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -120,7 +120,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public static bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text);
+            return ConnectorAndRegexCache.IsMatch(text);
         }
 
         public bool GetFromTokenIndex(string text, out int index)
@@ -157,7 +157,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public bool IsConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text) || FullTillRegex.IsExactMatch(text, false);
+            return ConnectorAndRegexCache.IsMatch(text) || FullTillRegex.IsExactMatch(text, false);
         }
 
         public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs) => TimePeriodFunctions.ApplyPotentialPeriodAmbiguityHotfix(text, timePeriodErs);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -45,11 +45,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             BeforeAfterRegex = ItalianDateExtractorConfiguration.BeforeAfterRegex;
 
             // @TODO move to config
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -165,12 +165,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim();
-            return PreviousPrefixRegex.IsMatch(trimmedText);
+            return PreviousPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDatePeriodParserConfiguration.cs
@@ -10,34 +10,34 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex UpcomingPrefixRegex =
-            new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex PastPrefixRegex =
-            new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex NextSuffixRegex =
-            new Regex(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
 
         public static readonly Regex PastSuffixRegex =
-            new Regex(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             CenturySuffixRegex = ItalianDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = ItalianDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = ItalianDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -246,15 +246,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -268,19 +268,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -305,8 +305,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.MonthTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegex.IsMatch(trimmedText) ||
-                   ThisPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText) || PastSuffixRegex.IsMatch(trimmedText)));
+                   (DateTimeDefinitions.MonthTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegexCache.IsMatch(trimmedText) ||
+                   ThisPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText) || PastSuffixRegexCache.IsMatch(trimmedText)));
         }
 
         public bool IsMonthToDate(string text)
@@ -319,24 +319,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegex.IsMatch(trimmedText) ||
-                   ThisPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText) || PastSuffixRegex.IsMatch(trimmedText)));
+                   (DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegexCache.IsMatch(trimmedText) ||
+                   ThisPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText) || PastSuffixRegexCache.IsMatch(trimmedText)));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegex.IsMatch(trimmedText) ||
-                   ThisPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText) || PastSuffixRegex.IsMatch(trimmedText)));
+                   (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegexCache.IsMatch(trimmedText) ||
+                   ThisPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText) || PastSuffixRegexCache.IsMatch(trimmedText)));
         }
 
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegex.IsMatch(trimmedText) ||
-                   ThisPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText) || PastSuffixRegex.IsMatch(trimmedText)));
+                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && (AfterNextSuffixRegexCache.IsMatch(trimmedText) ||
+                   ThisPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText) || PastSuffixRegexCache.IsMatch(trimmedText)));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimeParserConfiguration.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             TimeParser = config.TimeParser;
 
             NowRegex = ItalianDateTimeExtractorConfiguration.NowRegex;
-            AMTimeRegex = new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            AMTimeRegex = RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+            PMTimeRegex = RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
             SimpleTimeOfTodayAfterRegex = ItalianDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
             SimpleTimeOfTodayBeforeRegex = ItalianDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
@@ -163,11 +163,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             var trimmedText = text.Trim();
             var swift = 0;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateTimePeriodParserConfiguration.cs
@@ -8,22 +8,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         public static readonly Regex PastSuffixRegex =
-            new Regex(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastSuffixRegex, RegexFlags);
 
         public static readonly Regex NextSuffixRegex =
-            new Regex(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -151,25 +151,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = 12;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = 12;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -190,11 +190,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             var trimmedText = text.Trim();
             var swift = 0;
-            if (NextSuffixRegex.IsMatch(trimmedText))
+            if (NextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PastSuffixRegex.IsMatch(trimmedText))
+            else if (PastSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDurationParserConfiguration.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 {
     public class ItalianDurationParserConfiguration : BaseDateTimeOptionsConfiguration, IDurationParserConfiguration
     {
-        public static readonly Regex InexactNumberUnitRegex2 = new Regex(DateTimeDefinitions.InexactNumberUnitRegex2, RegexFlags);
+        public static readonly Regex InexactNumberUnitRegex2 = RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex2, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianHolidayParserConfiguration.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         public ItalianHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
-            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            ThisPrefixRegex = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = ItalianHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
@@ -32,15 +32,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
         {
             var trimmedText = text.Trim();
             var swift = -10;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianTimeParserConfiguration.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
     public class ItalianTimeParserConfiguration : BaseDateTimeOptionsConfiguration, ITimeParserConfiguration
     {
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexOptions.Singleline);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexOptions.Singleline);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexOptions.Singleline);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexOptions.Singleline);
 
         public ItalianTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -122,7 +122,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                             deltaHour = 12;
                         }
 
-                        if (LunchRegex.IsMatch(matchPmStr))
+                        if (LunchRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                             {
@@ -141,7 +141,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
                                 hasPm = true;
                             }
                         }
-                        else if (NightRegex.IsMatch(matchPmStr))
+                        else if (NightRegexCache.IsMatch(matchPmStr))
                         {
                             if (hour <= 3 || hour == Constants.HalfDayHourCount)
                             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Utilities/ItalianDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Utilities/ItalianDatetimeUtilityConfiguration.cs
@@ -8,43 +8,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian.Utilities
     public class ItalianDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateExtractorConfiguration.cs
@@ -10,96 +10,96 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATE; // "Date";
 
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+        public static readonly Regex MonthRegex = RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+        public static readonly Regex DayRegex = RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public static readonly Regex DayRegexInJapanese = new Regex(DateTimeDefinitions.DateDayRegexInJapanese, RegexFlags);
+        public static readonly Regex DayRegexInJapanese = RegexCache.Get(DateTimeDefinitions.DateDayRegexInJapanese, RegexFlags);
 
-        public static readonly Regex DayRegexNumInJapanese = new Regex(DateTimeDefinitions.DayRegexNumInJapanese, RegexFlags);
+        public static readonly Regex DayRegexNumInJapanese = RegexCache.Get(DateTimeDefinitions.DayRegexNumInJapanese, RegexFlags);
 
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+        public static readonly Regex MonthNumRegex = RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+        public static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
-        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+        public static readonly Regex RelativeRegex = RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
-        public static readonly Regex ZeroToNineIntegerRegexJap = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexJap, RegexFlags);
+        public static readonly Regex ZeroToNineIntegerRegexJap = RegexCache.Get(DateTimeDefinitions.ZeroToNineIntegerRegexJap, RegexFlags);
 
-        public static readonly Regex YearInJapaneseRegex = new Regex(DateTimeDefinitions.DateYearInJapaneseRegex, RegexFlags);
+        public static readonly Regex YearInJapaneseRegex = RegexCache.Get(DateTimeDefinitions.DateYearInJapaneseRegex, RegexFlags);
 
-        public static readonly Regex WeekDayRegex = new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+        public static readonly Regex WeekDayRegex = RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
-        public static readonly Regex LunarRegex = new Regex(DateTimeDefinitions.LunarRegex, RegexFlags);
+        public static readonly Regex LunarRegex = RegexCache.Get(DateTimeDefinitions.LunarRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DateThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DateLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DateLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DateNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DateNextRegex, RegexFlags);
 
-        public static readonly Regex SpecialDayRegex = new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+        public static readonly Regex SpecialDayRegex = RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
-        public static readonly Regex SpecialMonthRegex = new Regex(DateTimeDefinitions.SpecialMonthRegex, RegexFlags);
+        public static readonly Regex SpecialMonthRegex = RegexCache.Get(DateTimeDefinitions.SpecialMonthRegex, RegexFlags);
 
-        public static readonly Regex SpecialYearRegex = new Regex(DateTimeDefinitions.SpecialYearRegex, RegexFlags);
+        public static readonly Regex SpecialYearRegex = RegexCache.Get(DateTimeDefinitions.SpecialYearRegex, RegexFlags);
 
-        public static readonly Regex WeekDayOfMonthRegex = new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+        public static readonly Regex WeekDayOfMonthRegex = RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
-        public static readonly Regex ThisRe = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+        public static readonly Regex ThisRe = RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
-        public static readonly Regex LastRe = new Regex(DateTimeDefinitions.LastPrefixRegex, RegexFlags);
+        public static readonly Regex LastRe = RegexCache.Get(DateTimeDefinitions.LastPrefixRegex, RegexFlags);
 
-        public static readonly Regex NextRe = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+        public static readonly Regex NextRe = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
-        public static readonly Regex SpecialDate = new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+        public static readonly Regex SpecialDate = RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex[] DateRegexList =
         {
             // ２０１６年１２月１日
-            new Regex(DateTimeDefinitions.DateRegexList1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList1, RegexFlags),
 
             // 2015/12/23
-            new Regex(DateTimeDefinitions.DateRegexList10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList10, RegexFlags),
 
             // # ２０１６年１２月
-            new Regex(DateTimeDefinitions.DateRegexList2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList2, RegexFlags),
 
             // １２月１日
-            new Regex(DateTimeDefinitions.DateRegexList9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList9, RegexFlags),
 
             // (2015年)?(农历)?十月二十(星期三)?
-            new Regex(DateTimeDefinitions.DateRegexList3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList3, RegexFlags),
 
             // 7/23
-            new Regex(DateTimeDefinitions.DateRegexList4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList4, RegexFlags),
 
             // 23/7
-            new Regex(DateTimeDefinitions.DateRegexList5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList5, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 23-3-2015
-                new Regex(DateTimeDefinitions.DateRegexList7, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList7, RegexFlags) :
 
                 // 3-23-2017
-                new Regex(DateTimeDefinitions.DateRegexList6, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList6, RegexFlags),
 
             DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY ?
 
                 // 3-23-2017
-                new Regex(DateTimeDefinitions.DateRegexList6, RegexFlags) :
+                RegexCache.Get(DateTimeDefinitions.DateRegexList6, RegexFlags) :
 
                 // 23-3-2015
-                new Regex(DateTimeDefinitions.DateRegexList7, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateRegexList7, RegexFlags),
 
             // 2015-12-23
-            new Regex(DateTimeDefinitions.DateRegexList8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList8, RegexFlags),
 
             // 2016/12
-            new Regex(DateTimeDefinitions.DateRegexList11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.DateRegexList11, RegexFlags),
         };
 
         public static readonly Regex[] ImplicitDateList =
@@ -108,11 +108,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             WeekDayRegex, WeekDayOfMonthRegex, SpecialMonthRegex, SpecialYearRegex, SpecialDate,
         };
 
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex DateTimePeriodUnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDatePeriodExtractorConfiguration.cs
@@ -12,81 +12,81 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATEPERIOD; // "DatePeriod";
 
-        public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
+        public static readonly Regex TillRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodTillRegex, RegexFlags);
 
-        public static readonly Regex DayRegex = new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+        public static readonly Regex DayRegex = RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
-        public static readonly Regex DayRegexForPeriod = new Regex(DateTimeDefinitions.DayRegexForPeriod, RegexFlags);
+        public static readonly Regex DayRegexForPeriod = RegexCache.Get(DateTimeDefinitions.DayRegexForPeriod, RegexFlags);
 
-        public static readonly Regex DayRegexInJapanese = new Regex(DateTimeDefinitions.DatePeriodDayRegexInJapanese, RegexFlags);
+        public static readonly Regex DayRegexInJapanese = RegexCache.Get(DateTimeDefinitions.DatePeriodDayRegexInJapanese, RegexFlags);
 
-        public static readonly Regex MonthNumRegex = new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+        public static readonly Regex MonthNumRegex = RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DatePeriodThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DatePeriodLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DatePeriodNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodNextRegex, RegexFlags);
 
-        public static readonly Regex RelativeMonthRegex = new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+        public static readonly Regex RelativeMonthRegex = RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
-        public static readonly Regex MonthRegex = new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+        public static readonly Regex MonthRegex = RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
-        public static readonly Regex YearRegex = new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+        public static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
-        public static readonly Regex StrictYearRegex = new Regex(DateTimeDefinitions.StrictYearRegex, RegexFlags);
+        public static readonly Regex StrictYearRegex = RegexCache.Get(DateTimeDefinitions.StrictYearRegex, RegexFlags);
 
-        public static readonly Regex YearRegexInNumber = new Regex(DateTimeDefinitions.YearRegexInNumber, RegexFlags);
+        public static readonly Regex YearRegexInNumber = RegexCache.Get(DateTimeDefinitions.YearRegexInNumber, RegexFlags);
 
-        public static readonly Regex ZeroToNineIntegerRegexJap = new Regex(DateTimeDefinitions.ZeroToNineIntegerRegexJap, RegexFlags);
+        public static readonly Regex ZeroToNineIntegerRegexJap = RegexCache.Get(DateTimeDefinitions.ZeroToNineIntegerRegexJap, RegexFlags);
 
-        public static readonly Regex YearInJapaneseRegex = new Regex(DateTimeDefinitions.DatePeriodYearInJapaneseRegex, RegexFlags);
+        public static readonly Regex YearInJapaneseRegex = RegexCache.Get(DateTimeDefinitions.DatePeriodYearInJapaneseRegex, RegexFlags);
 
-        public static readonly Regex MonthSuffixRegex = new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+        public static readonly Regex MonthSuffixRegex = RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         // for case "(从)?(2017年)?一月十日到十二日"
-        public static readonly Regex SimpleCasesRegex = new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+        public static readonly Regex SimpleCasesRegex = RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
-        public static readonly Regex YearAndMonth = new Regex(DateTimeDefinitions.YearAndMonth, RegexFlags);
+        public static readonly Regex YearAndMonth = RegexCache.Get(DateTimeDefinitions.YearAndMonth, RegexFlags);
 
-        public static readonly Regex SimpleYearAndMonth = new Regex(DateTimeDefinitions.SimpleYearAndMonth, RegexFlags);
+        public static readonly Regex SimpleYearAndMonth = RegexCache.Get(DateTimeDefinitions.SimpleYearAndMonth, RegexFlags);
 
         // 2017.12, 2017-12, 2017/12, 12/2017
-        public static readonly Regex PureNumYearAndMonth = new Regex(DateTimeDefinitions.PureNumYearAndMonth, RegexFlags);
+        public static readonly Regex PureNumYearAndMonth = RegexCache.Get(DateTimeDefinitions.PureNumYearAndMonth, RegexFlags);
 
-        public static readonly Regex OneWordPeriodRegex = new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+        public static readonly Regex OneWordPeriodRegex = RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
-        public static readonly Regex WeekOfMonthRegex = new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+        public static readonly Regex WeekOfMonthRegex = RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
-        public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.FollowedUnit, RegexFlags);
+        public static readonly Regex FollowedUnit = RegexCache.Get(DateTimeDefinitions.FollowedUnit, RegexFlags);
 
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.NumberCombinedWithUnit, RegexFlags);
+        public static readonly Regex NumberCombinedWithUnit = RegexCache.Get(DateTimeDefinitions.NumberCombinedWithUnit, RegexFlags);
 
-        public static readonly Regex YearToYear = new Regex(DateTimeDefinitions.YearToYear, RegexFlags);
+        public static readonly Regex YearToYear = RegexCache.Get(DateTimeDefinitions.YearToYear, RegexFlags);
 
-        public static readonly Regex MonthToMonth = new Regex(DateTimeDefinitions.MonthToMonth, RegexFlags);
+        public static readonly Regex MonthToMonth = RegexCache.Get(DateTimeDefinitions.MonthToMonth, RegexFlags);
 
-        public static readonly Regex DayToDay = new Regex(DateTimeDefinitions.DayToDay, RegexFlags);
+        public static readonly Regex DayToDay = RegexCache.Get(DateTimeDefinitions.DayToDay, RegexFlags);
 
-        public static readonly Regex MonthDayRange = new Regex(DateTimeDefinitions.MonthDayRange, RegexFlags);
+        public static readonly Regex MonthDayRange = RegexCache.Get(DateTimeDefinitions.MonthDayRange, RegexFlags);
 
-        public static readonly Regex YearMonthRange = new Regex(DateTimeDefinitions.YearMonthRange, RegexFlags);
+        public static readonly Regex YearMonthRange = RegexCache.Get(DateTimeDefinitions.YearMonthRange, RegexFlags);
 
-        public static readonly Regex YearMonthDayRange = new Regex(DateTimeDefinitions.YearMonthDayRange, RegexFlags);
+        public static readonly Regex YearMonthDayRange = RegexCache.Get(DateTimeDefinitions.YearMonthDayRange, RegexFlags);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+        public static readonly Regex PastRegex = RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+        public static readonly Regex FutureRegex = RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
-        public static readonly Regex SeasonRegex = new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+        public static readonly Regex SeasonRegex = RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
-        public static readonly Regex SeasonWithYear = new Regex(DateTimeDefinitions.SeasonWithYear, RegexFlags);
+        public static readonly Regex SeasonWithYear = RegexCache.Get(DateTimeDefinitions.SeasonWithYear, RegexFlags);
 
-        public static readonly Regex QuarterRegex = new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+        public static readonly Regex QuarterRegex = RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
-        public static readonly Regex DecadeRegex = new Regex(DateTimeDefinitions.DecadeRegex, RegexFlags);
+        public static readonly Regex DecadeRegex = RegexCache.Get(DateTimeDefinitions.DecadeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimeExtractorConfiguration.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIME; // "DateTime";
 
-        public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+        public static readonly Regex PrepositionRegex = RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
-        public static readonly Regex NowRegex = new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+        public static readonly Regex NowRegex = RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
-        public static readonly Regex NightRegex = new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+        public static readonly Regex NightRegex = RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
-        public static readonly Regex TimeOfTodayRegex = new Regex(DateTimeDefinitions.TimeOfTodayRegex, RegexFlags);
+        public static readonly Regex TimeOfTodayRegex = RegexCache.Get(DateTimeDefinitions.TimeOfTodayRegex, RegexFlags);
 
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
-        public static readonly Regex DateTimePeriodUnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex DateTimePeriodUnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     }
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
-                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",", StringComparison.Ordinal) || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrEmpty(middleStr) || middleStr.Equals(",", StringComparison.Ordinal) || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         var begin = ers[i].Start ?? 0;
                         var end = (ers[j].Start ?? 0) + (ers[j].Length ?? 0);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
@@ -13,35 +13,35 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
-        public static readonly Regex TillRegex = new Regex(DateTimeDefinitions.DateTimePeriodTillRegex, RegexFlags);
+        public static readonly Regex TillRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodTillRegex, RegexFlags);
 
-        public static readonly Regex PrepositionRegex = new Regex(DateTimeDefinitions.DateTimePeriodPrepositionRegex, RegexFlags);
+        public static readonly Regex PrepositionRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodPrepositionRegex, RegexFlags);
 
-        public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+        public static readonly Regex HourRegex = RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
-        public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+        public static readonly Regex HourNumRegex = RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
-        public static readonly Regex ZhijianRegex = new Regex(DateTimeDefinitions.ZhijianRegex, RegexFlags);
+        public static readonly Regex ZhijianRegex = RegexCache.Get(DateTimeDefinitions.ZhijianRegex, RegexFlags);
 
-        public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
+        public static readonly Regex ThisRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.DateTimePeriodLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodLastRegex, RegexFlags);
 
-        public static readonly Regex NextRegex = new Regex(DateTimeDefinitions.DateTimePeriodNextRegex, RegexFlags);
+        public static readonly Regex NextRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNextRegex, RegexFlags);
 
-        public static readonly Regex TimeOfDayRegex = new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+        public static readonly Regex TimeOfDayRegex = RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
-        public static readonly Regex SpecificTimeOfDayRegex = new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+        public static readonly Regex SpecificTimeOfDayRegex = RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
-        public static readonly Regex UnitRegex = new Regex(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
+        public static readonly Regex UnitRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodUnitRegex, RegexFlags);
 
-        public static readonly Regex FollowedUnit = new Regex(DateTimeDefinitions.DateTimePeriodFollowedUnit, RegexFlags);
+        public static readonly Regex FollowedUnit = RegexCache.Get(DateTimeDefinitions.DateTimePeriodFollowedUnit, RegexFlags);
 
-        public static readonly Regex NumberCombinedWithUnit = new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
+        public static readonly Regex NumberCombinedWithUnit = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
 
-        public static readonly Regex PastRegex = new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+        public static readonly Regex PastRegex = RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
-        public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+        public static readonly Regex FutureRegex = RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -114,7 +114,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                     var middleEnd = timePoints[idx + 1].Start ?? 0;
 
                     var middleStr = text.Substring(middleBegin, middleEnd - middleBegin).Trim();
-                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         var periodBegin = timePoints[idx].Start ?? 0;
                         var periodEnd = (timePoints[idx + 1].Start ?? 0) + (timePoints[idx + 1].Length ?? 0);
@@ -249,7 +249,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 if (match.Success)
                 {
                     var middleStr = afterStr.Substring(0, match.Index);
-                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegex.IsMatch(middleStr))
+                    if (string.IsNullOrWhiteSpace(middleStr) || PrepositionRegexCache.IsMatch(middleStr))
                     {
                         ret.Add(new Token(er.Start ?? 0, er.Start + er.Length + match.Index + match.Length ?? 0));
                     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDurationExtractorConfiguration.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private static readonly IExtractor InternalExtractor = new NumberWithUnitExtractor(new DurationExtractorConfiguration());
 
-        private static readonly Regex YearRegex = new Regex(DateTimeDefinitions.DurationYearRegex, RegexFlags);
+        private static readonly Regex YearRegex = RegexCache.Get(DateTimeDefinitions.DurationYearRegex, RegexFlags);
 
-        private static readonly Regex HalfSuffixRegex = new Regex(DateTimeDefinitions.DurationHalfSuffixRegex, RegexFlags);
+        private static readonly Regex HalfSuffixRegex = RegexCache.Get(DateTimeDefinitions.DurationHalfSuffixRegex, RegexFlags);
 
         internal override ImmutableDictionary<Regex, DurationType> Regexes { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseHolidayExtractorConfiguration.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     public class JapaneseHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex LunarHolidayRegex =
-            new Regex(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunarHolidayRegex, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {
-            new Regex(DateTimeDefinitions.HolidayRegexList1, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegexList2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegexList1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegexList2, RegexFlags),
             LunarHolidayRegex,
         };
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseMergedExtractorConfiguration.cs
@@ -11,21 +11,21 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
     public class JapaneseMergedExtractorConfiguration : IDateTimeExtractor
     {
-        public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
+        public static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationBefore, RegexFlags);
 
-        public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
+        public static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationAfter, RegexFlags);
 
-        public static readonly Regex UntilRegex = new Regex(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
+        public static readonly Regex UntilRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationUntil, RegexFlags);
 
-        public static readonly Regex SincePrefixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
+        public static readonly Regex SincePrefixRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationSincePrefix, RegexFlags);
 
-        public static readonly Regex SinceSuffixRegex = new Regex(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
+        public static readonly Regex SinceSuffixRegex = RegexCache.Get(DateTimeDefinitions.ParserConfigurationSinceSuffix, RegexFlags);
 
-        public static readonly Regex EqualRegex = new Regex(BaseDateTime.EqualRegex, RegexFlags);
+        public static readonly Regex EqualRegex = RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        private static readonly Regex DenyFilterRegex = new Regex(@"^\d{1,2}号", RegexFlags);
+        private static readonly Regex DenyFilterRegex = RegexCache.Get(@"^\d{1,2}号", RegexFlags);
 
         private static readonly JapaneseDateExtractorConfiguration DateExtractor = new JapaneseDateExtractorConfiguration();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
-        public static readonly Regex EachUnitRegex = new Regex(DateTimeDefinitions.SetEachUnitRegex, RegexFlags);
+        public static readonly Regex EachUnitRegex = RegexCache.Get(DateTimeDefinitions.SetEachUnitRegex, RegexFlags);
 
-        public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
+        public static readonly Regex EachPrefixRegex = RegexCache.Get(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
 
-        public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+        public static readonly Regex LastRegex = RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
-        public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
+        public static readonly Regex EachDayRegex = RegexCache.Get(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -35,7 +35,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             foreach (var er in ers)
             {
                 // "each last summer" doesn't make sense
-                if (LastRegex.IsMatch(er.Text))
+                if (LastRegexCache.IsMatch(er.Text))
                 {
                     continue;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimeExtractorConfiguration.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var regexes = new Dictionary<Regex, TimeType>
             {
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes1, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes1, RegexFlags),
                     TimeType.CjkTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes2, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes2, RegexFlags),
                     TimeType.DigitTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeRegexes3, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeRegexes3, RegexFlags),
                     TimeType.LessTime
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseTimePeriodExtractorConfiguration.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var regexes = new Dictionary<Regex, PeriodType>
             {
                 {
-                    new Regex(DateTimeDefinitions.TimePeriodRegexes1, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimePeriodRegexes1, RegexFlags),
                     PeriodType.FullTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimePeriodRegexes2, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimePeriodRegexes2, RegexFlags),
                     PeriodType.ShortTime
                 },
                 {
-                    new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags),
+                    RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags),
                     PeriodType.ShortTime
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimeParser.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIME;
 
-        public static readonly Regex SimpleAmRegex = new Regex(DateTimeDefinitions.DateTimeSimpleAmRegex, RegexFlags);
+        public static readonly Regex SimpleAmRegex = RegexCache.Get(DateTimeDefinitions.DateTimeSimpleAmRegex, RegexFlags);
 
-        public static readonly Regex SimplePmRegex = new Regex(DateTimeDefinitions.DateTimeSimplePmRegex, RegexFlags);
+        public static readonly Regex SimplePmRegex = RegexCache.Get(DateTimeDefinitions.DateTimeSimplePmRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 return true;
             }
 
-            return JapaneseHolidayExtractorConfiguration.LunarHolidayRegex.IsMatch(trimmedText);
+            return JapaneseHolidayExtractorConfiguration.LunarHolidayRegexCache.IsMatch(trimmedText);
         }
 
         // Merge a Date entity and a Time entity
@@ -198,11 +198,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             var sec = time.Second;
 
             // handle morning, afternoon
-            if (SimplePmRegex.IsMatch(text) && hour < Constants.HalfDayHourCount)
+            if (SimplePmRegexCache.IsMatch(text) && hour < Constants.HalfDayHourCount)
             {
                 hour += Constants.HalfDayHourCount;
             }
-            else if (SimpleAmRegex.IsMatch(text) && hour >= Constants.HalfDayHourCount)
+            else if (SimpleAmRegexCache.IsMatch(text) && hour >= Constants.HalfDayHourCount)
             {
                 hour -= Constants.HalfDayHourCount;
             }
@@ -218,7 +218,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             var val = (DateTimeResolutionResult)pr2.Value;
 
-            if (hour <= Constants.HalfDayHourCount && !SimplePmRegex.IsMatch(text) && !SimpleAmRegex.IsMatch(text) &&
+            if (hour <= Constants.HalfDayHourCount && !SimplePmRegexCache.IsMatch(text) && !SimpleAmRegexCache.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
                 // ret.Timex += "ampm";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_DATETIMEPERIOD;
 
-        public static readonly Regex MORegex = new Regex(DateTimeDefinitions.DateTimePeriodMORegex, RegexFlags);
+        public static readonly Regex MORegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodMORegex, RegexFlags);
 
-        public static readonly Regex AFRegex = new Regex(DateTimeDefinitions.DateTimePeriodAFRegex, RegexFlags);
+        public static readonly Regex AFRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodAFRegex, RegexFlags);
 
-        public static readonly Regex EVRegex = new Regex(DateTimeDefinitions.DateTimePeriodEVRegex, RegexFlags);
+        public static readonly Regex EVRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodEVRegex, RegexFlags);
 
-        public static readonly Regex NIRegex = new Regex(DateTimeDefinitions.DateTimePeriodNIRegex, RegexFlags);
+        public static readonly Regex NIRegex = RegexCache.Get(DateTimeDefinitions.DateTimePeriodNIRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -447,25 +447,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             // handle morning, afternoon..
-            if (MORegex.IsMatch(trimmedText))
+            if (MORegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AFRegex.IsMatch(trimmedText))
+            else if (AFRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EVRegex.IsMatch(trimmedText))
+            else if (EVRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NIRegex.IsMatch(trimmedText))
+            else if (NIRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -482,11 +482,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             if (exactMatch.Success)
             {
                 var swift = 0;
-                if (JapaneseDateTimePeriodExtractorConfiguration.NextRegex.IsMatch(trimmedText))
+                if (JapaneseDateTimePeriodExtractorConfiguration.NextRegexCache.IsMatch(trimmedText))
                 {
                     swift = 1;
                 }
-                else if (JapaneseDateTimePeriodExtractorConfiguration.LastRegex.IsMatch(trimmedText))
+                else if (JapaneseDateTimePeriodExtractorConfiguration.LastRegexCache.IsMatch(trimmedText))
                 {
                     swift = -1;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseMergedDateTimeParserConfiguration.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
-        private static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.MergedBeforeRegex, RegexFlags);
+        private static readonly Regex BeforeRegex = RegexCache.Get(DateTimeDefinitions.MergedBeforeRegex, RegexFlags);
 
-        private static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
+        private static readonly Regex AfterRegex = RegexCache.Get(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
 
         // TODO implement SinceRegex
-        private static readonly Regex SinceRegex = new Regex(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
+        private static readonly Regex SinceRegex = RegexCache.Get(DateTimeDefinitions.MergedAfterRegex, RegexFlags);
 
         public JapaneseMergedDateTimeParserConfiguration(IMergedParserConfiguration configuration)
             : base(configuration)
@@ -34,15 +34,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             // push, save teh MOD string
             bool hasBefore = false, hasAfter = false, hasSince = false;
-            if (BeforeRegex.IsMatch(er.Text))
+            if (BeforeRegexCache.IsMatch(er.Text))
             {
                 hasBefore = true;
             }
-            else if (AfterRegex.IsMatch(er.Text))
+            else if (AfterRegexCache.IsMatch(er.Text))
             {
                 hasAfter = true;
             }
-            else if (SinceRegex.IsMatch(er.Text))
+            else if (SinceRegexCache.IsMatch(er.Text))
             {
                 hasSince = true;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            if (JapaneseSetExtractorConfiguration.EachPrefixRegex.IsMatch(beforeStr))
+            if (JapaneseSetExtractorConfiguration.EachPrefixRegexCache.IsMatch(beforeStr))
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
                 ret.Timex = pr.TimexStr;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -1021,11 +1021,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             var trimmedText = text.Trim();
 
             var swift = 0;
-            if (this.config.NextPrefixRegex.IsMatch(trimmedText))
+            if (this.config.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (this.config.PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (this.config.PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     var isMoreThan = false;
 
                     // cases like "within 3 days from yesterday/tomorrow" does not make any sense
-                    if (this.config.TodayNowRegex.IsMatch(er.Text))
+                    if (this.config.TodayNowRegexCache.IsMatch(er.Text))
                     {
                         MatchWithinNextPrefix(beforeString, isAgo, ref isLessThanOrWithIn, ref isMoreThan);
                     }
@@ -714,7 +714,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // Expressions like "today", "tomorrow",... should keep their original year
-                if (dateContext != null && !this.config.SpecialDayRegex.IsMatch(er.Text))
+                if (dateContext != null && !this.config.SpecialDayRegexCache.IsMatch(er.Text))
                 {
                     ret = dateContext.ProcessDateEntityResolution(ret);
                 }
@@ -927,7 +927,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // Handle the abbreviation of DatePeriod, e.g., 'eoy(end of year)', the behavior of 'eoy' should be the same as 'end of year'
-                if (this.config.UnspecificEndOfRangeRegex.IsMatch(match.Value))
+                if (this.config.UnspecificEndOfRangeRegexCache.IsMatch(match.Value))
                 {
                     latePrefix = true;
                     trimmedText = match.Value;
@@ -1484,12 +1484,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
 
                 // Expressions like "today", "tomorrow",... should keep their original year
-                if (!this.config.SpecialDayRegex.IsMatch(pr1.Text))
+                if (!this.config.SpecialDayRegexCache.IsMatch(pr1.Text))
                 {
                     pr1 = dateContext.ProcessDateEntityParsingResult(pr1);
                 }
 
-                if (!this.config.SpecialDayRegex.IsMatch(pr2.Text))
+                if (!this.config.SpecialDayRegexCache.IsMatch(pr2.Text))
                 {
                     pr2 = dateContext.ProcessDateEntityParsingResult(pr2);
                 }
@@ -1605,7 +1605,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         return ret;
                     }
 
-                    if (config.PastRegex.IsMatch(beforeStr) || config.PastRegex.IsMatch(afterStr))
+                    if (config.PastRegexCache.IsMatch(beforeStr) || config.PastRegexCache.IsMatch(afterStr))
                     {
                         modAndDateResult = GetModAndDate(beginDate, endDate, referenceDate, durationResult.Timex, false);
                         beginDate = modAndDateResult.BeginDate;
@@ -1649,7 +1649,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         isMatch = true;
                     }
 
-                    if (config.FutureSuffixRegex.IsMatch(afterStr))
+                    if (config.FutureSuffixRegexCache.IsMatch(afterStr))
                     {
                         modAndDateResult = GetModAndDate(beginDate, endDate, referenceDate, durationResult.Timex, true);
                         beginDate = modAndDateResult.BeginDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimeParser.cs
@@ -230,11 +230,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             var sec = time.Second;
 
             // Handle morning, afternoon
-            if (this.config.PMTimeRegex.IsMatch(text) && WithinAfternoonHours(hour))
+            if (this.config.PMTimeRegexCache.IsMatch(text) && WithinAfternoonHours(hour))
             {
                 hour += Constants.HalfDayHourCount;
             }
-            else if (this.config.AMTimeRegex.IsMatch(text) && WithinMorningHoursAndNoon(hour, min, sec))
+            else if (this.config.AMTimeRegexCache.IsMatch(text) && WithinMorningHoursAndNoon(hour, min, sec))
             {
                 hour -= Constants.HalfDayHourCount;
             }
@@ -249,7 +249,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             ret.Timex = pr1.TimexStr + timeStr;
 
             var val = (DateTimeResolutionResult)pr2.Value;
-            if (hour <= Constants.HalfDayHourCount && !this.config.PMTimeRegex.IsMatch(text) && !this.config.AMTimeRegex.IsMatch(text) &&
+            if (hour <= Constants.HalfDayHourCount && !this.config.PMTimeRegexCache.IsMatch(text) && !this.config.AMTimeRegexCache.IsMatch(text) &&
                 !string.IsNullOrEmpty(val.Comment))
             {
                 ret.Comment = Constants.Comment_AmPm;
@@ -404,7 +404,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
             var afterStr = text.Substring(ers[0].Start + ers[0].Length ?? 0);
-            if (this.config.SpecificEndOfRegex.IsMatch(beforeStr) || this.config.SpecificEndOfRegex.IsMatch(afterStr))
+            if (this.config.SpecificEndOfRegexCache.IsMatch(beforeStr) || this.config.SpecificEndOfRegexCache.IsMatch(afterStr))
             {
                 var pr = this.config.DateParser.Parse(ers[0], refDateTime);
                 var futureDate = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var ret = new DateTimeResolutionResult();
 
             // For the rest of datetime, it will be handled in next function
-            if (Config.RestOfDateTimeRegex.IsMatch(text))
+            if (Config.RestOfDateTimeRegexCache.IsMatch(text))
             {
                 return ret;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             var beforeStr = text.Substring(0, ers[0].Start ?? 0);
-            if (this.config.EachPrefixRegex.IsMatch(beforeStr))
+            if (this.config.EachPrefixRegexCache.IsMatch(beforeStr))
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimeZoneParser.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         public static readonly string ParserName = Constants.SYS_DATETIME_TIMEZONE; // "TimeZone";
 
-        public static readonly Regex TimeZoneEndRegex = new Regex(TimeZoneDefinitions.TimeZoneEndRegex, RegexOptions.Singleline);
+        public static readonly Regex TimeZoneEndRegex = RegexCache.Get(TimeZoneDefinitions.TimeZoneEndRegex, RegexOptions.Singleline);
 
         // Compute UTC offset in minutes from matched timezone offset in text. e.g. "-4:30" -> -270; "+8"-> 480.
         public static int ComputeMinutes(string utcOffset)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateExtractorConfiguration.cs
@@ -14,73 +14,73 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex SpecialDateRegex =
-            new Regex(DateTimeDefinitions.SpecialDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDateRegex, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -89,37 +89,37 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         };
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonthRegex, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEndRegex, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -148,39 +148,39 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             UtilityConfiguration = new PortugueseDatetimeUtilityConfiguration();
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // no|em 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // no|em 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // 7/23
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, RegexFlags);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, RegexFlags);
 
             // 23/7
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, RegexFlags);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, RegexFlags);
 
             // 2015-12-23
-            var dateRegex10 = new Regex(DateTimeDefinitions.DateExtractor10, RegexFlags);
+            var dateRegex10 = RegexCache.Get(DateTimeDefinitions.DateExtractor10, RegexFlags);
 
             // dia 15
-            var dateRegex11 = new Regex(DateTimeDefinitions.DateExtractor11, RegexFlags);
+            var dateRegex11 = RegexCache.Get(DateTimeDefinitions.DateExtractor11, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (domingo,)? 5 de Abril
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (domingo,)? 5 de Abril 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor2, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor2, RegexFlags),
 
                 // (domingo,)? 6 de Abril
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -12,166 +12,166 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     {
         // base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PastRegex =
-            new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
         public static readonly Regex FutureRegex =
-            new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex DayBetweenRegex =
-            new Regex(DateTimeDefinitions.DayBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayBetweenRegex, RegexFlags);
 
         // TODO: modify it according to the related regex in English
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthWithYearRegex =
-            new Regex(DateTimeDefinitions.MonthWithYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYearRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYearRegex =
-            new Regex(DateTimeDefinitions.MonthNumWithYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYearRegex, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         // TODO: add this regex, let it correspond to the one in English
         public static readonly Regex RestOfDateRegex =
-            new Regex(@"^[.]", RegexFlags);
+            RegexCache.Get(@"^[.]", RegexFlags);
 
         // TODO: add this regex, let it correspond to the one in English
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PastPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public PortugueseDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimeExtractorConfiguration.cs
@@ -10,60 +10,60 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         // TODO: modify it according to the corresponding English regex
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         // TODO: add this for Portuguese
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -130,8 +130,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             text = text.Trim();
             return string.IsNullOrEmpty(text)
-                    || PrepositionRegex.IsMatch(text)
-                    || ConnectorRegex.IsMatch(text);
+                    || PrepositionRegexCache.IsMatch(text)
+                    || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDateTimePeriodExtractorConfiguration.cs
@@ -10,63 +10,63 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseDateTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public PortugueseDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDurationExtractorConfiguration.cs
@@ -8,56 +8,56 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
         // TODO: improve Portuguese the SuffixAndRegex
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex FollowedUnit =
-            new Regex(DateTimeDefinitions.FollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.DurationNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationNumberCombinedWithUnit, RegexFlags);
 
         // TODO: add half in AnUnitRegex
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseHolidayExtractorConfiguration.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     {
         public static readonly Regex[] HolidayRegexList =
         {
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags),
         };
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseMergedExtractorConfiguration.cs
@@ -12,41 +12,41 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     public class PortugueseMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         // TODO: change the following three regexes to Portuguese if there are the same requirement of splitting from A to B as two time points
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseSetExtractorConfiguration.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex BeforeEachDayRegex =
-            new Regex(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
@@ -10,47 +10,47 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... en punto"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... tarde"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... de la mañana"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "y media ..." "menos cuarto ..."
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         public static readonly Regex TensTimeRegex =
-            new Regex(DateTimeDefinitions.TensTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TensTimeRegex, RegexFlags);
 
         // handle "seis treinta", "seis veintiuno", "seis menos diez"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
@@ -58,50 +58,50 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         // TODO: add some new regex which have used in AtRegex
         // TODO: modify according to corresponding English regex
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (tres min pasadas las)? siete|7|(siete treinta) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (tres min pasadas las)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (tres min pasadas las)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (En la noche) a las (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (En la noche) (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
             // once (y)? veinticinco
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // (tres menos veinte) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // (tres min pasadas las)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex12, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex12, RegexFlags),
 
             WrittenTimeRegex,
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimePeriodExtractorConfiguration.cs
@@ -14,49 +14,49 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.TimeHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeHourNumRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex FollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         // TODO: add this according to corresponding English regex
         public static readonly Regex TimeOfDayRegex =
-            new Regex(string.Empty, RegexFlags);
+            RegexCache.Get(string.Empty, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public PortugueseTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             RelativeWeekDayRegex = PortugueseDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = PortugueseDateExtractorConfiguration.BeforeAfterRegex;
 
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -160,12 +160,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -176,7 +176,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim();
-            return PreviousPrefixRegex.IsMatch(trimmedText);
+            return PreviousPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -12,19 +12,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
     {
         // TODO: config this according to English
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             CenturySuffixRegex = PortugueseDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = PortugueseDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = PortugueseDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
             DayOfMonth = config.DayOfMonth;
@@ -228,12 +228,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -245,16 +245,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             var trimmedText = text.Trim();
             var swift = -10;
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -265,13 +265,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public bool IsFuture(string text)
         {
             var trimmedText = text.Trim();
-            return ThisPrefixRegex.IsMatch(trimmedText) || NextPrefixRegex.IsMatch(trimmedText);
+            return ThisPrefixRegexCache.IsMatch(trimmedText) || NextPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public bool IsLastCardinal(string text)
         {
             var trimmedText = text.Trim();
-            return PreviousPrefixRegex.IsMatch(trimmedText);
+            return PreviousPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public bool IsMonthOnly(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimeParserConfiguration.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             TimeParser = config.TimeParser;
 
             NowRegex = PortugueseDateTimeExtractorConfiguration.NowRegex;
-            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexFlags);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexFlags);
+            AMTimeRegex = RegexCache.Get(DateTimeDefinitions.AmTimeRegex, RegexFlags);
+            PMTimeRegex = RegexCache.Get(DateTimeDefinitions.PmTimeRegex, RegexFlags);
             SimpleTimeOfTodayAfterRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
             SimpleTimeOfTodayBeforeRegex = PortugueseDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
             SpecificTimeOfDayRegex = PortugueseDateTimeExtractorConfiguration.SpecificTimeOfDayRegex;
@@ -153,11 +153,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (PortugueseDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            else if (PortugueseDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateTimePeriodParserConfiguration.cs
@@ -181,12 +181,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var swift = 0;
 
             // @TODO move hardcoded values to resources file
-            if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText) ||
+            if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText) ||
                 trimmedText.Equals("anoche", StringComparison.Ordinal))
             {
                 swift = -1;
             }
-            else if (PortugueseDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            else if (PortugueseDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseHolidayParserConfiguration.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             var trimmedText = text.Trim();
             var swift = -10;
 
-            if (PortugueseDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            if (PortugueseDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PortugueseDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (PortugueseDatePeriodParserConfiguration.ThisPrefixRegex.IsMatch(trimmedText))
+            else if (PortugueseDatePeriodParserConfiguration.ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Utilities/PortugueseDatetimeUtilityConfiguration.cs
@@ -8,43 +8,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese.Utilities
     public class PortugueseDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateExtractorConfiguration.cs
@@ -14,73 +14,73 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishDateExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateExtractorConfiguration
     {
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex SpecialDateRegex =
-            new Regex(DateTimeDefinitions.SpecialDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDateRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly Regex[] ImplicitDateList =
         {
@@ -89,37 +89,37 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         };
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonthRegex, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEndRegex, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek = DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
 
@@ -148,36 +148,36 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             UtilityConfiguration = new SpanishDatetimeUtilityConfiguration();
 
             // 3-23-2017
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // el 1.3
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // el 24-12
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // 7/23
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, RegexFlags);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, RegexFlags);
 
             // 23/7
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, RegexFlags);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, RegexFlags);
 
             // 2015-12-23
-            var dateRegex10 = new Regex(DateTimeDefinitions.DateExtractor10, RegexFlags);
+            var dateRegex10 = RegexCache.Get(DateTimeDefinitions.DateExtractor10, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // (domingo,)? 5 de Abril
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // (domingo,)? 5 de Abril 5, 2016
-                new Regex(DateTimeDefinitions.DateExtractor2, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor2, RegexFlags),
 
                 // (domingo,)? 6 de Abril
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -12,166 +12,166 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     {
         // base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PastRegex =
-            new Regex(DateTimeDefinitions.PastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PastRegex, RegexFlags);
 
         public static readonly Regex FutureRegex =
-            new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex DayBetweenRegex =
-            new Regex(DateTimeDefinitions.DayBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayBetweenRegex, RegexFlags);
 
         // TODO: modify it according to the related regex in English
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthWithYearRegex =
-            new Regex(DateTimeDefinitions.MonthWithYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYearRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYearRegex =
-            new Regex(DateTimeDefinitions.MonthNumWithYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYearRegex, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         // TODO: add this regex, let it correspond to the one in English
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         // TODO: add this regex, let it correspond to the one in English
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public SpanishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimeExtractorConfiguration.cs
@@ -10,60 +10,60 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         // TODO: modify it according to the corresponding English regex
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         // TODO: add this for Spanish
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -130,8 +130,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             text = text.Trim();
             return string.IsNullOrEmpty(text) ||
-                   PrepositionRegex.IsMatch(text) ||
-                   ConnectorRegex.IsMatch(text);
+                   PrepositionRegexCache.IsMatch(text) ||
+                   ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDateTimePeriodExtractorConfiguration.cs
@@ -11,69 +11,69 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateTimePeriodNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodSpecificTimeOfDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public SpanishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDurationExtractorConfiguration.cs
@@ -8,56 +8,56 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.UnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnitRegex, RegexFlags);
 
         // TODO: improve Spanish the SuffixAndRegex
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex FollowedUnit =
-            new Regex(DateTimeDefinitions.FollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.DurationNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationNumberCombinedWithUnit, RegexFlags);
 
         // TODO: add half in AnUnitRegex
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishHolidayExtractorConfiguration.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     {
         public static readonly Regex[] HolidayRegexList =
         {
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags),
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags),
         };
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishMergedExtractorConfiguration.cs
@@ -11,38 +11,38 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class SpanishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         // TODO: change the following three regexes to Spanish if there is same requirement of split from A to B as two time points
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex[] TermFilterRegexes = System.Array.Empty<Regex>();
 
@@ -84,10 +84,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         }
 
         // Used in Standard mode
-        public static Regex SinceRegex { get; set; } = new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+        public static Regex SinceRegex { get; set; } = RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         // used in Experimental mode
-        public static Regex SinceRegexExp { get; } = new Regex(DateTimeDefinitions.SinceRegexExp, RegexFlags);
+        public static Regex SinceRegexExp { get; } = RegexCache.Get(DateTimeDefinitions.SinceRegexExp, RegexFlags);
 
         public IDateExtractor DateExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishSetExtractorConfiguration.cs
@@ -11,25 +11,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly string ExtractorName = Constants.SYS_DATETIME_SET;
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex BeforeEachDayRegex =
-            new Regex(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -10,47 +10,47 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... en punto"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... tarde"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... de la mañana"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "y media ..." "menos cuarto ..."
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         public static readonly Regex TensTimeRegex =
-            new Regex(DateTimeDefinitions.TensTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TensTimeRegex, RegexFlags);
 
         // handle "seis treinta", "seis veintiuno", "seis menos diez"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
@@ -58,50 +58,50 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         // TODO: add some new regex which have used in AtRegex
         // TODO: modify according to corresponding English regex
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (tres min pasadas las)? siete|7|(siete treinta) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (tres min pasadas las)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (tres min pasadas las)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (En la noche) a las (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
             // (En la noche) (cinco treinta|siete|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex8, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex8, RegexFlags),
 
             // once (y)? veinticinco
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // (tres menos veinte) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // (tres min pasadas las)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex12, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex12, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimePeriodExtractorConfiguration.cs
@@ -15,48 +15,48 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly string ExtractorName = Constants.SYS_DATETIME_TIMEPERIOD; // "TimePeriod";
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.TimeHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeHourNumRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex FollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         private static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public SpanishTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     public class DateTimePeriodParser : BaseDateTimePeriodParser
     {
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -94,7 +94,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
                 // Check if Date and TimeOfDay are contiguous
                 var middleStr = beforeStr.Substring((int)ers[0].Start + (int)ers[0].Length).Trim();
-                if (!(string.IsNullOrWhiteSpace(middleStr) || ConnectorRegex.IsMatch(middleStr)))
+                if (!(string.IsNullOrWhiteSpace(middleStr) || ConnectorRegexCache.IsMatch(middleStr)))
                 {
                     return ret;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             RelativeWeekDayRegex = SpanishDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = SpanishDateExtractorConfiguration.BeforeAfterRegex;
 
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -160,12 +160,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimmedText = text.Trim().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -176,7 +176,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public bool IsCardinalLast(string text)
         {
             var trimmedText = text.Trim().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
-            return PreviousPrefixRegex.IsMatch(trimmedText);
+            return PreviousPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public string Normalize(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -11,31 +11,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
     {
         // TODO: config this according to English
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex NextSuffixRegex =
-            new Regex(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextSuffixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousSuffixRegex =
-            new Regex(DateTimeDefinitions.PreviousSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousSuffixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeSuffixRegex =
-            new Regex(DateTimeDefinitions.RelativeSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -91,7 +91,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             CenturySuffixRegex = SpanishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = SpanishDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = SpanishDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -241,15 +241,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText) || PreviousSuffixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText) || PreviousSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -261,19 +261,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             var trimmedText = text.Trim();
             var swift = -10;
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText) || NextSuffixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText) || NextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText) || PreviousSuffixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText) || PreviousSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -284,20 +284,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public bool IsFuture(string text)
         {
             var trimmedText = text.Trim();
-            return ThisPrefixRegex.IsMatch(trimmedText) || NextPrefixRegex.IsMatch(trimmedText);
+            return ThisPrefixRegexCache.IsMatch(trimmedText) || NextPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public bool IsLastCardinal(string text)
         {
             var trimmedText = text.Trim();
-            return PreviousPrefixRegex.IsMatch(trimmedText);
+            return PreviousPrefixRegexCache.IsMatch(trimmedText);
         }
 
         public bool IsMonthOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.MonthTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegex.IsMatch(trimmedText));
+                   (DateTimeDefinitions.MonthTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsMonthToDate(string text)
@@ -310,14 +310,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegex.IsMatch(trimmedText));
+                   (DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegex.IsMatch(trimmedText))) &&
+                   (DateTimeDefinitions.WeekTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegexCache.IsMatch(trimmedText))) &&
                    !DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.Contains(o));
         }
 
@@ -325,7 +325,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegex.IsMatch(trimmedText));
+                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimeParserConfiguration.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
             NowRegex = SpanishDateTimeExtractorConfiguration.NowRegex;
 
-            AMTimeRegex = new Regex(DateTimeDefinitions.AmTimeRegex, RegexFlags);
-            PMTimeRegex = new Regex(DateTimeDefinitions.PmTimeRegex, RegexFlags);
+            AMTimeRegex = RegexCache.Get(DateTimeDefinitions.AmTimeRegex, RegexFlags);
+            PMTimeRegex = RegexCache.Get(DateTimeDefinitions.PmTimeRegex, RegexFlags);
 
             SimpleTimeOfTodayAfterRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayAfterRegex;
             SimpleTimeOfTodayBeforeRegex = SpanishDateTimeExtractorConfiguration.SimpleTimeOfTodayBeforeRegex;
@@ -153,11 +153,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText))
+            if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (SpanishDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            else if (SpanishDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -180,12 +180,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var swift = 0;
 
             // @TODO move hardcoded values to resources file
-            if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText) ||
+            if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText) ||
                 trimmedText.Equals("anoche", StringComparison.Ordinal))
             {
                 swift = -1;
             }
-            else if (SpanishDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            else if (SpanishDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             var trimmedText = text.Trim();
             var swift = -10;
 
-            if (SpanishDatePeriodParserConfiguration.NextPrefixRegex.IsMatch(trimmedText))
+            if (SpanishDatePeriodParserConfiguration.NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (SpanishDatePeriodParserConfiguration.PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (SpanishDatePeriodParserConfiguration.ThisPrefixRegex.IsMatch(trimmedText))
+            else if (SpanishDatePeriodParserConfiguration.ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Utilities/SpanishDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish.Utilities
     public class SpanishDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateExtractorConfiguration.cs
@@ -14,103 +14,103 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     {
 
         public static readonly Regex MonthRegex =
-            new Regex(DateTimeDefinitions.MonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex SingleWeekDayRegex =
-            new Regex(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleWeekDayRegex, RegexFlags);
 
         public static readonly Regex OnRegex =
-            new Regex(DateTimeDefinitions.OnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OnRegex, RegexFlags);
 
         public static readonly Regex RelaxedOnRegex =
-            new Regex(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelaxedOnRegex, RegexFlags);
 
         public static readonly Regex ThisRegex =
-            new Regex(DateTimeDefinitions.ThisRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisRegex, RegexFlags);
 
         public static readonly Regex LastDateRegex =
-            new Regex(DateTimeDefinitions.LastDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastDateRegex, RegexFlags);
 
         public static readonly Regex NextDateRegex =
-            new Regex(DateTimeDefinitions.NextDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextDateRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex SpecialDayRegex =
-            new Regex(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayRegex, RegexFlags);
 
         public static readonly Regex WeekDayOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex RelativeWeekDayRegex =
-            new Regex(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeWeekDayRegex, RegexFlags);
 
         public static readonly Regex SpecialDate =
-            new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDate, RegexFlags);
 
         public static readonly Regex SpecialDayWithNumRegex =
-            new Regex(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecialDayWithNumRegex, RegexFlags);
 
         public static readonly Regex ForTheRegex =
-            new Regex(DateTimeDefinitions.ForTheRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ForTheRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayOfMothRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekDayAndDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayAndDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex StrictRelativeRegex =
-            new Regex(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.StrictRelativeRegex, RegexFlags);
 
         public static readonly Regex PrefixArticleRegex =
-            new Regex(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrefixArticleRegex, RegexFlags);
 
         public static readonly Regex OfMonth =
-            new Regex(DateTimeDefinitions.OfMonth, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OfMonth, RegexFlags);
 
         public static readonly Regex MonthEnd =
-            new Regex(DateTimeDefinitions.MonthEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthEnd, RegexFlags);
 
         public static readonly Regex WeekDayEnd =
-            new Regex(DateTimeDefinitions.WeekDayEnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayEnd, RegexFlags);
 
         public static readonly Regex WeekDayStart =
-            new Regex(DateTimeDefinitions.WeekDayStart, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayStart, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorSymbolRegex =
-            new Regex(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
+            RegexCache.Get(Definitions.BaseDateTime.RangeConnectorSymbolRegex, RegexFlags);
 
         public static readonly ImmutableDictionary<string, int> DayOfWeek =
             DateTimeDefinitions.DayOfWeek.ToImmutableDictionary();
@@ -119,12 +119,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             DateTimeDefinitions.MonthOfYear.ToImmutableDictionary();
 
         public static readonly Regex BeforeAfterRegex =
-            new Regex(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ImplicitDayRegex, RegexFlags);
 
         public TurkishDateExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -188,45 +188,45 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             }
 
             // Gelecek Pazar (1 Nisan 2016)
-            var dateRegex4 = new Regex(DateTimeDefinitions.DateExtractor4, RegexFlags);
+            var dateRegex4 = RegexCache.Get(DateTimeDefinitions.DateExtractor4, RegexFlags);
 
             // 23-3-2015 (,Pazar|(Pazar))?
-            var dateRegex5 = new Regex(DateTimeDefinitions.DateExtractor5, RegexFlags);
+            var dateRegex5 = RegexCache.Get(DateTimeDefinitions.DateExtractor5, RegexFlags);
 
             // Gelecek Pazar (1-1-2016)
-            var dateRegex6 = new Regex(DateTimeDefinitions.DateExtractor6, RegexFlags);
+            var dateRegex6 = RegexCache.Get(DateTimeDefinitions.DateExtractor6, RegexFlags);
 
             // 6 Nisan'da or Altı Nisan'da
-            var dateRegex7 = new Regex(DateTimeDefinitions.DateExtractor7, RegexFlags);
+            var dateRegex7 = RegexCache.Get(DateTimeDefinitions.DateExtractor7, RegexFlags);
 
             // 2015 yılı Nisan'ın 6'sı(nda)? (Pazar)?
-            var dateRegex8 = new Regex(DateTimeDefinitions.DateExtractor8, RegexFlags);
+            var dateRegex8 = RegexCache.Get(DateTimeDefinitions.DateExtractor8, RegexFlags);
 
             // 6'ncı Çarşamba or Altıncı Çarşamba
-            var dateRegex9 = new Regex(DateTimeDefinitions.DateExtractor9, RegexFlags);
+            var dateRegex9 = RegexCache.Get(DateTimeDefinitions.DateExtractor9, RegexFlags);
 
             // "(Sunday,)? 7/23, 2018", year part is required
-            var dateRegex7L = new Regex(DateTimeDefinitions.DateExtractor7L, RegexFlags);
+            var dateRegex7L = RegexCache.Get(DateTimeDefinitions.DateExtractor7L, RegexFlags);
 
             // "(Sunday,)? 7/23", year part is not required
-            var dateRegex7S = new Regex(DateTimeDefinitions.DateExtractor7S, RegexFlags);
+            var dateRegex7S = RegexCache.Get(DateTimeDefinitions.DateExtractor7S, RegexFlags);
 
             // "(Sunday,)? 23/7, 2018", year part is required
-            var dateRegex9L = new Regex(DateTimeDefinitions.DateExtractor9L, RegexFlags);
+            var dateRegex9L = RegexCache.Get(DateTimeDefinitions.DateExtractor9L, RegexFlags);
 
             // "(Sunday,)? 23/7", year part is not required
-            var dateRegex9S = new Regex(DateTimeDefinitions.DateExtractor9S, RegexFlags);
+            var dateRegex9S = RegexCache.Get(DateTimeDefinitions.DateExtractor9S, RegexFlags);
 
             // (Sunday,)? 2015-12-23
-            var dateRegexA = new Regex(DateTimeDefinitions.DateExtractorA, RegexFlags);
+            var dateRegexA = RegexCache.Get(DateTimeDefinitions.DateExtractorA, RegexFlags);
 
             DateRegexList = new List<Regex>
             {
                 // 5 Nisan (Pazar|(Pazar)|,Pazar)? or 5 Nisan 2016 (Pazar|(Pazar)|,Pazar)?
-                new Regex(DateTimeDefinitions.DateExtractor1, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor1, RegexFlags),
 
                 // Gelecek ayın 6'sı(nda)? (Pazar)? or Gelecek ayın altısı(nda)? (Pazar)?
-                new Regex(DateTimeDefinitions.DateExtractor3, RegexFlags),
+                RegexCache.Get(DateTimeDefinitions.DateExtractor3, RegexFlags),
             };
 
             var enableDmy = DmyDateFormat ||

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDatePeriodExtractorConfiguration.cs
@@ -13,169 +13,169 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     {
         // Base regexes
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public static readonly Regex MonthNumRegex =
-            new Regex(DateTimeDefinitions.MonthNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumRegex, RegexFlags);
 
         public static readonly Regex IllegalYearRegex =
-            new Regex(BaseDateTime.IllegalYearRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.IllegalYearRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex WeekDayRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         public static readonly Regex RelativeMonthRegex =
-            new Regex(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeMonthRegex, RegexFlags);
 
         public static readonly Regex WrittenMonthRegex =
-            new Regex(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenMonthRegex, RegexFlags);
 
         public static readonly Regex MonthSuffixRegex =
-            new Regex(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthSuffixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex FutureSuffixRegex =
-            new Regex(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FutureSuffixRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-             new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         // composite regexes
         public static readonly Regex SimpleCasesRegex =
-            new Regex(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontSimpleCasesRegex =
-            new Regex(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontSimpleCasesRegex, RegexFlags);
 
         public static readonly Regex MonthFrontBetweenRegex =
-            new Regex(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthFrontBetweenRegex, RegexFlags);
 
         public static readonly Regex BetweenRegex =
-            new Regex(DateTimeDefinitions.BetweenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BetweenRegex, RegexFlags);
 
         public static readonly Regex MonthWithYear =
-            new Regex(DateTimeDefinitions.MonthWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthWithYear, RegexFlags);
 
         public static readonly Regex OneWordPeriodRegex =
-            new Regex(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OneWordPeriodRegex, RegexFlags);
 
         public static readonly Regex MonthNumWithYear =
-            new Regex(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthNumWithYear, RegexFlags);
 
         public static readonly Regex WeekOfMonthRegex =
-            new Regex(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfMonthRegex, RegexFlags);
 
         public static readonly Regex WeekOfYearRegex =
-            new Regex(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfYearRegex, RegexFlags);
 
         public static readonly Regex FollowedDateUnit =
-            new Regex(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FollowedDateUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDateUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDateUnit, RegexFlags);
 
         public static readonly Regex QuarterRegex =
-            new Regex(DateTimeDefinitions.QuarterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegex, RegexFlags);
 
         public static readonly Regex QuarterRegexYearFront =
-            new Regex(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterRegexYearFront, RegexFlags);
 
         public static readonly Regex AllHalfYearRegex =
-            new Regex(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllHalfYearRegex, RegexFlags);
 
         public static readonly Regex SeasonRegex =
-            new Regex(DateTimeDefinitions.SeasonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SeasonRegex, RegexFlags);
 
         public static readonly Regex WhichWeekRegex =
-            new Regex(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WhichWeekRegex, RegexFlags);
 
         public static readonly Regex WeekOfRegex =
-            new Regex(DateTimeDefinitions.WeekOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekOfRegex, RegexFlags);
 
         public static readonly Regex MonthOfRegex =
-            new Regex(DateTimeDefinitions.MonthOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MonthOfRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex RestOfDateRegex =
-            new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
 
         public static readonly Regex LaterEarlyPeriodRegex =
-            new Regex(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterEarlyPeriodRegex, RegexFlags);
 
         public static readonly Regex WeekWithWeekDayRangeRegex =
-            new Regex(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekWithWeekDayRangeRegex, RegexFlags);
 
         public static readonly Regex YearPlusNumberRegex =
-            new Regex(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPlusNumberRegex, RegexFlags);
 
         public static readonly Regex DecadeWithCenturyRegex =
-            new Regex(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DecadeWithCenturyRegex, RegexFlags);
 
         public static readonly Regex YearPeriodRegex =
-            new Regex(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearPeriodRegex, RegexFlags);
 
         public static readonly Regex ComplexDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ComplexDatePeriodRegex, RegexFlags);
 
         public static readonly Regex RelativeDecadeRegex =
-            new Regex(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDecadeRegex, RegexFlags);
 
         public static readonly Regex ReferenceDatePeriodRegex =
-            new Regex(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ReferenceDatePeriodRegex, RegexFlags);
 
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags);
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags);
 
         public static readonly Regex CenturySuffixRegex =
-            new Regex(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CenturySuffixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex ExcludeSuffixRegex =
-            new Regex(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCasesRegexes =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeAltExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeAltExtractorConfiguration.cs
@@ -7,22 +7,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDateTimeAltExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeAltExtractorConfiguration
     {
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         public static readonly Regex[] RelativePrefixList =
         {
@@ -37,10 +37,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex OrRegex =
-            new Regex(DateTimeDefinitions.OrRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OrRegex, RegexFlags);
 
         private static readonly Regex DayRegex =
-            new Regex(DateTimeDefinitions.DayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DayRegex, RegexFlags);
 
         public TurkishDateTimeAltExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimeExtractorConfiguration.cs
@@ -8,63 +8,63 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDateTimeExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeExtractorConfiguration
     {
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex NowRegex =
-            new Regex(DateTimeDefinitions.NowRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowRegex, RegexFlags);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayAfterRegex =
-             new Regex(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.TimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex TimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayAfterRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayAfterRegex, RegexFlags);
 
         public static readonly Regex SimpleTimeOfTodayBeforeRegex =
-            new Regex(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SimpleTimeOfTodayBeforeRegex, RegexFlags);
 
         public static readonly Regex SpecificEndOfRegex =
-            new Regex(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRegex, RegexFlags);
 
         public static readonly Regex UnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectorRegex =
-            new Regex(DateTimeDefinitions.ConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectorRegex, RegexFlags);
 
         public static readonly Regex NumberAsTimeRegex =
-            new Regex(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberAsTimeRegex, RegexFlags);
 
         public static readonly Regex DateNumberConnectorRegex =
-            new Regex(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateNumberConnectorRegex, RegexFlags);
 
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex YearSuffix =
-            new Regex(DateTimeDefinitions.YearSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearSuffix, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex ExcludeSuffixRegex =
-            new Regex(DateTimeDefinitions.ExcludeSuffixDateTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ExcludeSuffixDateTime, RegexFlags);
 
         public TurkishDateTimeExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
@@ -126,7 +126,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             }
 
             text = text.Trim();
-            return string.IsNullOrEmpty(text) || PrepositionRegex.IsMatch(text) || ConnectorRegex.IsMatch(text);
+            return string.IsNullOrEmpty(text) || PrepositionRegexCache.IsMatch(text) || ConnectorRegexCache.IsMatch(text);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDateTimePeriodExtractorConfiguration.cs
@@ -11,57 +11,57 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         IDateTimePeriodExtractorConfiguration
     {
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex HyphenDateRegex =
-            new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.HyphenDateRegex, RegexFlags);
 
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
 
         public static readonly Regex RestOfDateTimeRegex =
-            new Regex(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RestOfDateTimeRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex PrefixDayRegex =
-            new Regex(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.PrefixDayRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex SuffixRegex =
-            new Regex(DateTimeDefinitions.SuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixRegex, RegexFlags);
 
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex WeekDaysRegex =
-            new Regex(DateTimeDefinitions.WeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WeekDayRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex ExcludeSuffixRegex =
-            new Regex(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex[] SimpleCases =
         {
@@ -70,25 +70,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         };
 
         private static readonly Regex PeriodTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex PeriodSpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         private static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         private static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         private static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private static readonly Regex MiddlePauseRegex =
-            new Regex(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddlePauseRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public TurkishDateTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDurationExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishDurationExtractorConfiguration.cs
@@ -8,51 +8,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDurationExtractorConfiguration : BaseDateTimeOptionsConfiguration, IDurationExtractorConfiguration
     {
         public static readonly Regex DurationUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex SuffixAndRegex =
-            new Regex(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAndRegex, RegexFlags);
 
         public static readonly Regex DurationFollowedUnit =
-            new Regex(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationFollowedUnit, RegexFlags);
 
         public static readonly Regex NumberCombinedWithDurationUnit =
-            new Regex(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberCombinedWithDurationUnit, RegexFlags);
 
         public static readonly Regex AnUnitRegex =
-            new Regex(DateTimeDefinitions.AnUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AnUnitRegex, RegexFlags);
 
         public static readonly Regex DuringRegex =
-            new Regex(DateTimeDefinitions.DuringRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DuringRegex, RegexFlags);
 
         public static readonly Regex AllRegex =
-            new Regex(DateTimeDefinitions.AllRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AllRegex, RegexFlags);
 
         public static readonly Regex HalfRegex =
-            new Regex(DateTimeDefinitions.HalfRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfRegex, RegexFlags);
 
         public static readonly Regex ConjunctionRegex =
-            new Regex(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConjunctionRegex, RegexFlags);
 
         public static readonly Regex InexactNumberRegex =
-            new Regex(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberRegex, RegexFlags);
 
         public static readonly Regex InexactNumberUnitRegex =
-            new Regex(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InexactNumberUnitRegex, RegexFlags);
 
         public static readonly Regex RelativeDurationUnitRegex =
-            new Regex(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeDurationUnitRegex, RegexFlags);
 
         public static readonly Regex DurationConnectorRegex =
-            new Regex(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationConnectorRegex, RegexFlags);
 
         public static readonly Regex SpecialNumberUnitRegex = null;
 
         public static readonly Regex MoreThanRegex =
-            new Regex(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.MoreThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         public static readonly Regex LessThanRegex =
-            new Regex(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
+            RegexCache.Get(DateTimeDefinitions.LessThanRegex, RegexFlags | RegexOptions.RightToLeft);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishHolidayExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishHolidayExtractorConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishHolidayExtractorConfiguration : BaseDateTimeOptionsConfiguration, IHolidayExtractorConfiguration
     {
         public static readonly Regex YearRegex =
-            new Regex(DateTimeDefinitions.YearRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.YearRegex, RegexFlags);
 
         public static readonly Regex H1 =
-            new Regex(DateTimeDefinitions.HolidayRegex1, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex1, RegexFlags);
 
         public static readonly Regex H2 =
-            new Regex(DateTimeDefinitions.HolidayRegex2, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex2, RegexFlags);
 
         public static readonly Regex H3 =
-            new Regex(DateTimeDefinitions.HolidayRegex3, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HolidayRegex3, RegexFlags);
 
         public static readonly Regex[] HolidayRegexList =
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishMergedExtractorConfiguration.cs
@@ -10,51 +10,51 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishMergedExtractorConfiguration : BaseDateTimeOptionsConfiguration, IMergedExtractorConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegexWithAnchor, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegexWithAnchor, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegexWithAnchor, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegexWithAnchor, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegexWithAnchor, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegexWithAnchor, RegexFlags);
 
         public static readonly Regex AroundRegex =
-            new Regex(DateTimeDefinitions.AroundRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AroundRegex, RegexFlags);
 
         public static readonly Regex EqualRegex =
-            new Regex(BaseDateTime.EqualRegex, RegexFlags);
+            RegexCache.Get(BaseDateTime.EqualRegex, RegexFlags);
 
         public static readonly Regex FromToRegex =
-            new Regex(DateTimeDefinitions.FromToRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromToRegex, RegexFlags);
 
         public static readonly Regex SingleAmbiguousMonthRegex =
-            new Regex(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousMonthRegex, RegexFlags);
 
         public static readonly Regex PrepositionSuffixRegex =
-            new Regex(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionSuffixRegex, RegexFlags);
 
         public static readonly Regex AmbiguousRangeModifierPrefix =
-            new Regex(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmbiguousRangeModifierPrefix, RegexFlags);
 
         public static readonly Regex NumberEndingPattern =
-            new Regex(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NumberEndingPattern, RegexFlags);
 
         public static readonly Regex SuffixAfterRegex =
-            new Regex(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SuffixAfterRegex, RegexFlags);
 
         public static readonly Regex UnspecificDatePeriodRegex =
-            new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
         public static readonly Regex FailFastRegex =
-            new Regex(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
+            RegexCache.Get(DateTimeDefinitions.FailFastRegex, RegexFlags | RegexOptions.Compiled);
 
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
-            new Regex(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.OneOnOneRegex, RegexFlags),
 
             // (the)? (day|week|month|year)
-            new Regex(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.SingleAmbiguousTermsRegex, RegexFlags),
         };
 
         public static readonly StringMatcher SuperfluousWordMatcher = new StringMatcher();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishSetExtractorConfiguration.cs
@@ -9,28 +9,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishSetExtractorConfiguration : BaseDateTimeOptionsConfiguration, ISetExtractorConfiguration
     {
         public static readonly Regex SetUnitRegex =
-            new Regex(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DurationUnitRegex, RegexFlags);
 
         public static readonly Regex PeriodicRegex =
-            new Regex(DateTimeDefinitions.PeriodicRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodicRegex, RegexFlags);
 
         public static readonly Regex EachUnitRegex =
-            new Regex(DateTimeDefinitions.EachUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachUnitRegex, RegexFlags);
 
         public static readonly Regex EachPrefixRegex =
-            new Regex(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachPrefixRegex, RegexFlags);
 
         public static readonly Regex SetLastRegex =
-            new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex =
-            new Regex(DateTimeDefinitions.EachDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EachDayRegex, RegexFlags);
 
         public static readonly Regex SetWeekDayRegex =
-            new Regex(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetWeekDayRegex, RegexFlags);
 
         public static readonly Regex SetEachRegex =
-            new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimeExtractorConfiguration.cs
@@ -10,114 +10,114 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         // part 1: smallest component
         // --------------------------------------
         public static readonly Regex DescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex HourNumRegex =
-            new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourNumRegex, RegexFlags);
 
         public static readonly Regex MinuteNumRegex =
-            new Regex(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MinuteNumRegex, RegexFlags);
 
         // part 2: middle level component
         // --------------------------------------
         // handle "... o'clock"
         public static readonly Regex OclockRegex =
-            new Regex(DateTimeDefinitions.OclockRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.OclockRegex, RegexFlags);
 
         // handle "... afternoon"
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         // handle "... in the morning"
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         // handle "half past ..." "a quarter to ..."
         // rename 'min' group to 'deltamin'
         public static readonly Regex LessThanOneHour =
-            new Regex(DateTimeDefinitions.LessThanOneHour, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LessThanOneHour, RegexFlags);
 
         // handle "six thirty", "six twenty one"
         public static readonly Regex WrittenTimeRegex =
-            new Regex(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WrittenTimeRegex, RegexFlags);
 
         public static readonly Regex TimePrefix =
-            new Regex(DateTimeDefinitions.TimePrefix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimePrefix, RegexFlags);
 
         public static readonly Regex TimeSuffix =
-            new Regex(DateTimeDefinitions.TimeSuffix, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffix, RegexFlags);
 
         public static readonly Regex BasicTime =
-            new Regex(DateTimeDefinitions.BasicTime, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BasicTime, RegexFlags);
 
         // handle special time such as 'at midnight', 'midnight', 'midday'
         public static readonly Regex MidnightRegex =
-            new Regex(DateTimeDefinitions.MidnightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidnightRegex, RegexFlags);
 
         public static readonly Regex MidmorningRegex =
-            new Regex(DateTimeDefinitions.MidmorningRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidmorningRegex, RegexFlags);
 
         public static readonly Regex MidafternoonRegex =
-            new Regex(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidafternoonRegex, RegexFlags);
 
         public static readonly Regex MiddayRegex =
-            new Regex(DateTimeDefinitions.MiddayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MiddayRegex, RegexFlags);
 
         public static readonly Regex MidTimeRegex =
-            new Regex(DateTimeDefinitions.MidTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MidTimeRegex, RegexFlags);
 
         // part 3: regex for time
         // --------------------------------------
         // handle "at four" "at 3"
         public static readonly Regex AtRegex =
-            new Regex(DateTimeDefinitions.AtRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AtRegex, RegexFlags);
 
         public static readonly Regex IshRegex =
-            new Regex(DateTimeDefinitions.IshRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.IshRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex ConnectNumRegex =
-            new Regex(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ConnectNumRegex, RegexFlags);
 
         public static readonly Regex TimeBeforeAfterRegex =
-            new Regex(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeBeforeAfterRegex, RegexFlags);
 
         public static readonly Regex[] TimeRegexList =
         {
             // (three min past)? seven|7|(seven thirty) pm
-            new Regex(DateTimeDefinitions.TimeRegex1, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex1, RegexFlags),
 
             // (three min past)? 3:00(:00)? (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex2, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex2, RegexFlags),
 
             // (three min past)? 3.00 (pm)
-            new Regex(DateTimeDefinitions.TimeRegex3, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex3, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex4, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex4, RegexFlags),
 
             // (three min past) (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex5, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex5, RegexFlags),
 
             // (five thirty|seven|7|7:00(:00)?) (pm)? (in the night)
-            new Regex(DateTimeDefinitions.TimeRegex6, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex6, RegexFlags),
 
             // (in the night) at? (five thirty|seven|7|7:00(:00)?) (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex7, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex7, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
             // (three min past)? 3h00 (pm)?
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // at 2.30, "at" prefix is required here
             // 3.30pm, "am/pm" suffix is required here
-            new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex11, RegexFlags),
 
             // saat 12'de öğleden sonra
-            new Regex(DateTimeDefinitions.TimeRegex12, RegexFlags),
+            RegexCache.Get(DateTimeDefinitions.TimeRegex12, RegexFlags),
 
             // 340pm
             ConnectNumRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Extractors/TurkishTimePeriodExtractorConfiguration.cs
@@ -11,69 +11,69 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishTimePeriodExtractorConfiguration : BaseDateTimeOptionsConfiguration, ITimePeriodExtractorConfiguration
     {
         public static readonly Regex TillRegex =
-            new Regex(DateTimeDefinitions.TillRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TillRegex, RegexFlags);
 
         public static readonly Regex HourRegex =
-            new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HourRegex, RegexFlags);
 
         public static readonly Regex PeriodHourNumRegex =
-            new Regex(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PeriodHourNumRegex, RegexFlags);
 
         public static readonly Regex PeriodDescRegex =
-            new Regex(DateTimeDefinitions.DescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DescRegex, RegexFlags);
 
         public static readonly Regex PmRegex =
-            new Regex(DateTimeDefinitions.PmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmRegex, RegexFlags);
 
         public static readonly Regex AmRegex =
-            new Regex(DateTimeDefinitions.AmRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmRegex, RegexFlags);
 
         public static readonly Regex PureNumFromTo =
-            new Regex(DateTimeDefinitions.PureNumFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumFromTo, RegexFlags);
 
         public static readonly Regex PureNumBetweenAnd =
-            new Regex(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PureNumBetweenAnd, RegexFlags);
 
         public static readonly Regex SpecificTimeFromTo =
-            new Regex(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeFromTo, RegexFlags);
 
         public static readonly Regex SpecificTimeBetweenAnd =
-            new Regex(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeBetweenAnd, RegexFlags);
 
         public static readonly Regex PrepositionRegex =
-            new Regex(DateTimeDefinitions.PrepositionRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PrepositionRegex, RegexFlags);
 
         public static readonly Regex TimeOfDayRegex =
-            new Regex(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeOfDayRegex, RegexFlags);
 
         public static readonly Regex SpecificTimeOfDayRegex =
-            new Regex(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SpecificTimeOfDayRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeFollowedUnit =
-            new Regex(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeFollowedUnit, RegexFlags);
 
         public static readonly Regex TimeNumberCombinedWithUnit =
-            new Regex(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeNumberCombinedWithUnit, RegexFlags);
 
         public static readonly Regex GeneralEndingRegex =
-            new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FromRegex =
-            new Regex(DateTimeDefinitions.FromRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.FromRegex, RegexFlags);
 
         private static readonly Regex ExcludeSuffixRegex =
-            new Regex(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ExcludeSuffixRegex, RegexFlags);
 
         private static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private static readonly Regex RangeConnectorRegex =
-            new Regex(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeConnectorRegex, RegexFlags);
 
         public TurkishTimePeriodExtractorConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
         public static readonly Regex LastTokenRegex =
-            new Regex(DateTimeDefinitions.LastRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LastRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -46,11 +46,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             RelativeWeekDayRegex = TurkishDateExtractorConfiguration.RelativeWeekDayRegex;
             BeforeAfterRegex = TurkishDateExtractorConfiguration.BeforeAfterRegex;
 
-            RelativeDayRegex = new Regex(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
-            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
-            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
-            UpcomingPrefixRegex = new Regex(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
-            PastPrefixRegex = new Regex(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
+            RelativeDayRegex = RegexCache.Get(DateTimeDefinitions.RelativeDayRegex, RegexFlags);
+            NextPrefixRegex = RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            UpcomingPrefixRegex = RegexCache.Get(DateTimeDefinitions.UpcomingPrefixRegex, RegexFlags);
+            PastPrefixRegex = RegexCache.Get(DateTimeDefinitions.PastPrefixRegex, RegexFlags);
 
             DayOfMonth = config.DayOfMonth;
             DayOfWeek = config.DayOfWeek;
@@ -161,12 +161,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             var trimmedText = text.Trim();
             var swift = 0;
 
-            if (NextPrefixRegex.IsMatch(trimmedText))
+            if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
 
-            if (PreviousPrefixRegex.IsMatch(trimmedText))
+            if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDatePeriodParserConfiguration.cs
@@ -10,19 +10,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDatePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDatePeriodParserConfiguration
     {
         public static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public static readonly Regex ThisPrefixRegex =
-            new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
 
         public static readonly Regex AfterNextSuffixRegex =
-            new Regex(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterNextSuffixRegex, RegexFlags);
 
         public static readonly Regex RelativeRegex =
-            new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RelativeRegex, RegexFlags);
 
         public static readonly Regex UnspecificEndOfRangeRegex =
-            new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             DateTimeDefinitions.YearTerms.Select(str => $" {str} ").ToList();
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         public TurkishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             CenturySuffixRegex = TurkishDatePeriodExtractorConfiguration.CenturySuffixRegex;
             NowRegex = TurkishDatePeriodExtractorConfiguration.NowRegex;
             SpecialDayRegex = TurkishDateExtractorConfiguration.SpecialDayRegex;
-            TodayNowRegex = new Regex(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
+            TodayNowRegex = RegexCache.Get(DateTimeDefinitions.TodayNowRegex, RegexOptions.Singleline);
 
             UnitMap = config.UnitMap;
             CardinalMap = config.CardinalMap;
@@ -246,15 +246,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
@@ -268,19 +268,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
             var trimmedText = text.Trim();
 
-            if (AfterNextSuffixRegex.IsMatch(trimmedText))
+            if (AfterNextSuffixRegexCache.IsMatch(trimmedText))
             {
                 swift = 2;
             }
-            else if (NextPrefixRegex.IsMatch(trimmedText))
+            else if (NextPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (ThisPrefixRegex.IsMatch(trimmedText))
+            else if (ThisPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = 0;
             }
@@ -304,7 +304,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.MonthTerms.Any(o => trimmedText.EndsWith(o)) ||
-                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (monthTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsMonthToDate(string text)
@@ -317,22 +317,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekendTerms.Any(o => trimmedText.EndsWith(o)) ||
-                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText));
+                   (weekendTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsWeekOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.WeekTerms.Any(o => trimmedText.EndsWith(o)) ||
-                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText) && !weekendTermsPadded.Any(o => trimmedText.Contains(o)));
+                   (weekTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText) && !weekendTermsPadded.Any(o => trimmedText.Contains(o)));
         }
 
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o)) ||
-                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegex.IsMatch(trimmedText)) ||
-                   (DateTimeDefinitions.GenericYearTerms.Any(o => trimmedText.EndsWith(o)) && UnspecificEndOfRangeRegex.IsMatch(trimmedText));
+                   (yearTermsPadded.Any(o => trimmedText.Contains(o)) && AfterNextSuffixRegexCache.IsMatch(trimmedText)) ||
+                   (DateTimeDefinitions.GenericYearTerms.Any(o => trimmedText.EndsWith(o)) && UnspecificEndOfRangeRegexCache.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimeParserConfiguration.cs
@@ -9,27 +9,27 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDateTimeParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimeParserConfiguration
     {
         public static readonly Regex AmTimeRegex =
-             new Regex(DateTimeDefinitions.AMTimeRegex, RegexFlags);
+             RegexCache.Get(DateTimeDefinitions.AMTimeRegex, RegexFlags);
 
         public static readonly Regex PmTimeRegex =
-            new Regex(DateTimeDefinitions.PMTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PMTimeRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex NowTimeRegex =
-            new Regex(DateTimeDefinitions.NowTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NowTimeRegex, RegexFlags);
 
         private static readonly Regex RecentlyTimeRegex =
-            new Regex(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RecentlyTimeRegex, RegexFlags);
 
         private static readonly Regex AsapTimeRegex =
-            new Regex(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AsapTimeRegex, RegexFlags);
 
         private static readonly Regex NextPrefixRegex =
-            new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
 
         private static readonly Regex PreviousPrefixRegex =
-            new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
 
         public TurkishDateTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateTimePeriodParserConfiguration.cs
@@ -8,16 +8,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public class TurkishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
         public static readonly Regex MorningStartEndRegex =
-            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
 
         public static readonly Regex AfternoonStartEndRegex =
-            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
 
         public static readonly Regex EveningStartEndRegex =
-            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
 
         public static readonly Regex NightStartEndRegex =
-            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -146,25 +146,25 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-            if (MorningStartEndRegex.IsMatch(trimmedText))
+            if (MorningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TMO";
                 beginHour = 8;
                 endHour = Constants.HalfDayHourCount;
             }
-            else if (AfternoonStartEndRegex.IsMatch(trimmedText))
+            else if (AfternoonStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TAF";
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (EveningStartEndRegex.IsMatch(trimmedText))
+            else if (EveningStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TEV";
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (NightStartEndRegex.IsMatch(trimmedText))
+            else if (NightStartEndRegexCache.IsMatch(trimmedText))
             {
                 timeStr = "TNI";
                 beginHour = 20;
@@ -185,11 +185,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
             var trimmedText = text.Trim();
 
             var swift = 0;
-            if (FutureRegex.IsMatch(trimmedText))
+            if (FutureRegexCache.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (PreviousPrefixRegex.IsMatch(trimmedText))
+            else if (PreviousPrefixRegexCache.IsMatch(trimmedText))
             {
                 swift = -1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishMergedParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishMergedParserConfiguration.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
     public sealed class TurkishMergedParserConfiguration : TurkishCommonDateTimeParserConfiguration, IMergedParserConfiguration
     {
         public static readonly Regex BeforeRegex =
-            new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex =
-            new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AfterRegex, RegexFlags);
 
         public static readonly Regex SinceRegex =
-            new Regex(DateTimeDefinitions.SinceRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishSetParserConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public TurkishSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimeParserConfiguration.cs
@@ -12,22 +12,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex TimeSuffixFull =
-            new Regex(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeSuffixFull, RegexFlags);
 
         private static readonly Regex LunchRegex =
-            new Regex(DateTimeDefinitions.LunchRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LunchRegex, RegexFlags);
 
         private static readonly Regex NightRegex =
-            new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.NightRegex, RegexFlags);
 
         private static readonly Regex HalfTokenRegex =
-            new Regex(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
 
         private static readonly Regex QuarterTokenRegex =
-            new Regex(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
 
         private static readonly Regex ToTokenRegex =
-            new Regex(DateTimeDefinitions.ToTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.ToTokenRegex, RegexFlags);
 
         public TurkishTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)
@@ -60,11 +60,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
             var trimedPrefix = prefix.Trim();
 
-            if (HalfTokenRegex.IsMatch(trimedPrefix))
+            if (HalfTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = 30;
             }
-            else if (QuarterTokenRegex.IsMatch(trimedPrefix))
+            else if (QuarterTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = 15;
             }
@@ -91,7 +91,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
                 }
             }
 
-            if (ToTokenRegex.IsMatch(trimedPrefix))
+            if (ToTokenRegexCache.IsMatch(trimedPrefix))
             {
                 deltaMin = -deltaMin;
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
                         deltaHour = Constants.HalfDayHourCount;
                     }
 
-                    if (LunchRegex.IsMatch(matchPmStr))
+                    if (LunchRegexCache.IsMatch(matchPmStr))
                     {
                         if (hour >= 10 && hour <= Constants.HalfDayHourCount)
                         {
@@ -153,7 +153,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
                             hasPm = true;
                         }
                     }
-                    else if (NightRegex.IsMatch(matchPmStr))
+                    else if (NightRegexCache.IsMatch(matchPmStr))
                     {
                         if (hour <= 3 || hour == Constants.HalfDayHourCount)
                         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishTimePeriodParserConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex PluralTokenRegex =
-            new Regex(DateTimeDefinitions.PluralTokenRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PluralTokenRegex, RegexFlags);
 
         public TurkishTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
         public bool GetMatchedTimexRange(string text, out string timex, out int beginHour, out int endHour, out int endMin)
         {
             var trimmedText = text.Trim();
-            if (PluralTokenRegex.IsMatch(trimmedText))
+            if (PluralTokenRegexCache.IsMatch(trimmedText))
             {
                 trimmedText = trimmedText.Substring(0, trimmedText.Length - 4);
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Utilities/TurkishDatetimeUtilityConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Utilities/TurkishDatetimeUtilityConfiguration.cs
@@ -7,43 +7,43 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish.Utilities
     public class TurkishDatetimeUtilityConfiguration : IDateTimeUtilityConfiguration
     {
         public static readonly Regex AgoRegex =
-            new Regex(DateTimeDefinitions.AgoRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AgoRegex, RegexFlags);
 
         public static readonly Regex LaterRegex =
-            new Regex(DateTimeDefinitions.LaterRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.LaterRegex, RegexFlags);
 
         public static readonly Regex InConnectorRegex =
-            new Regex(DateTimeDefinitions.InConnectorRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.InConnectorRegex, RegexFlags);
 
         public static readonly Regex SinceYearSuffixRegex =
-            new Regex(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.SinceYearSuffixRegex, RegexFlags);
 
         public static readonly Regex WithinNextPrefixRegex =
-            new Regex(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.WithinNextPrefixRegex, RegexFlags);
 
         public static readonly Regex AmDescRegex =
-            new Regex(DateTimeDefinitions.AmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmDescRegex, RegexFlags);
 
         public static readonly Regex PmDescRegex =
-            new Regex(DateTimeDefinitions.PmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.PmDescRegex, RegexFlags);
 
         public static readonly Regex AmPmDescRegex =
-            new Regex(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.AmPmDescRegex, RegexFlags);
 
         public static readonly Regex RangeUnitRegex =
-            new Regex(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangeUnitRegex, RegexFlags);
 
         public static readonly Regex TimeUnitRegex =
-            new Regex(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.TimeUnitRegex, RegexFlags);
 
         public static readonly Regex DateUnitRegex =
-            new Regex(DateTimeDefinitions.DateUnitRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.DateUnitRegex, RegexFlags);
 
         public static readonly Regex CommonDatePrefixRegex =
-            new Regex(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.CommonDatePrefixRegex, RegexFlags);
 
         public static readonly Regex RangePrefixRegex =
-            new Regex(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
+            RegexCache.Get(DateTimeDefinitions.RangePrefixRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/AgoLaterUtil.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             bool isUnitMatch = false;
                             foreach (var unitRegex in regex.Item2)
                             {
-                                isUnitMatch = isUnitMatch || unitRegex.IsMatch(er.Text);
+                                isUnitMatch = isUnitMatch || unitRegexCache.IsMatch(er.Text);
                             }
 
                             if (!isUnitMatch)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateTimeFormatUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateTimeFormatUtil.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public static class DateTimeFormatUtil
     {
-        private static readonly Regex HourTimexRegex = new Regex(@"(?<!P)T(\d{2})");
-        private static readonly Regex WeekDayTimexRegex = new Regex(@"XXXX-WXX-(\d)");
+        private static readonly Regex HourTimexRegex = RegexCache.Get(@"(?<!P)T(\d{2})");
+        private static readonly Regex WeekDayTimexRegex = RegexCache.Get(@"XXXX-WXX-(\d)");
 
         public static int ParseChineseDynastyYear(string yearStr, Regex dynastyYearRegex, string dynastyStartYear, ImmutableDictionary<string, int> dynastyYearMap, IExtractor integerExtractor, IParser numberParser)
         {
@@ -216,7 +216,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             for (int i = 0; i < splits.Count; i += 1)
             {
-                if (HourTimexRegex.IsMatch(splits[i]))
+                if (HourTimexRegexCache.IsMatch(splits[i]))
                 {
                     splits[i] = ToPm(splits[i]);
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeFunctions.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
                 return -1;
             }
 
-            if (Regex.IsMatch(text, @"\d+"))
+            if (RegexCache.IsMatch(text, @"\d+"))
             {
                 return int.Parse(text, CultureInfo.InvariantCulture);
             }
@@ -181,7 +181,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
         public TimeResult GetShortLeft(string text)
         {
             string des = null;
-            if (Regex.IsMatch(text, DayDescRegex))
+            if (RegexCache.IsMatch(text, DayDescRegex))
             {
                 des = text.Substring(0, text.Length - 1);
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/DoubleExtractor.cs
@@ -21,31 +21,31 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/FractionExtractor.cs
@@ -22,31 +22,31 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex2, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionWithOrdinalPrefix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionWithOrdinalPrefix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionWithPartOfPrefix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionWithPartOfPrefix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC)
                 },
             };
@@ -57,13 +57,13 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
                 if ((Options & NumberOptions.PercentageMode) != 0)
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC));
                 }
                 else
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ARABIC));
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/IntegerExtractor.cs
@@ -25,27 +25,27 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ARABIC)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/NumberExtractor.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
@@ -68,7 +68,7 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/NumberRangeExtractor.cs
@@ -34,62 +34,62 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // فيه خمس مائة وأكثر منتجات
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Extractors/OrdinalExtractor.cs
@@ -23,22 +23,22 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options.ToString() + "_" + config.Culture);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.ARABIC)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.ARABIC)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Parsers/ArabicNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Parsers/ArabicNumberParserConfiguration.cs
@@ -48,10 +48,10 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Arabic/Parsers/ArabicNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Arabic/Parsers/ArabicNumberRangeParserConfiguration.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Recognizers.Text.Number.Arabic
             OrdinalExtractor = Arabic.OrdinalExtractor.GetInstance(numConfig);
             NumberParser = new BaseNumberParser(new ArabicNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/DoubleExtractor.cs
@@ -16,42 +16,42 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-)2.5, can avoid cases like ip address xx.xx.xx.xx
-                    new Regex(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-).2
-                    new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1.0 K
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // １５.２万
-                    new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 四十五点三三
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 2e6, 21.2e0
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
                     // 2^5
-                    new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/FractionExtractor.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 {
                     // -4 5/2,       ４ ６／３
-                    new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 8/3
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 四分之六十五
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllFractionNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.CHINESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/IntegerExtractor.cs
@@ -17,32 +17,32 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 {
                     // 123456,  －１２３４５６
-                    new Regex(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15k,  16 G
-                    new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1,234,  ２，３３２，１１１
-                    new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 半百  半打
-                    new Regex(NumbersDefinitions.NumbersWithHalfDozen, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithHalfDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 半
-                    new Regex(NumbersDefinitions.HalfUnitRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.HalfUnitRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 一打  五十打
-                    new Regex(NumbersDefinitions.NumbersWithDozen, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE)
                 },
             };
@@ -53,7 +53,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "四" from "四川"
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE));
                     break;
 
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
                     // 一百五十五, 负一亿三百二十二, "四" from "四川".
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.CHINESE));
                     break;
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberExtractor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/NumberRangeExtractor.cs
@@ -17,57 +17,57 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 {
                     // 在...和...之间
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexOptions.Singleline),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // 大于...小于...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexOptions.Singleline),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // 小于...大于...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexOptions.Singleline),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // ...到/至..., 20~30
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexOptions.Singleline),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // 大于/多于/高于...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexOptions.Singleline),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 比...大/高/多
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexOptions.Singleline),
                     NumberRangeConstants.MORE
                 },
                 {
                     // ...多/以上/之上
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexOptions.Singleline),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 小于/少于/低于...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexOptions.Singleline),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 比...小/低/少
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexOptions.Singleline),
                     NumberRangeConstants.LESS
                 },
                 {
                     // .../以下/之下
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex3, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex3, RegexOptions.Singleline),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 等于...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexOptions.Singleline),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexOptions.Singleline),
                     NumberRangeConstants.EQUAL
                 },
             };
@@ -75,7 +75,7 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexOptions.Singleline);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/OrdinalExtractor.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 {
                     // 第一百五十四
-                    new Regex(NumbersDefinitions.OrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 第２５６５,  第1234
-                    new Regex(NumbersDefinitions.OrdinalNumbersRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumbersRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.CHINESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Extractors/PercentageExtractor.cs
@@ -17,112 +17,112 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             {
                 {
                     // 二十个百分点,  四点五个百分点
-                    new Regex(NumbersDefinitions.PercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.PercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 百分之五十  百分之一点五
-                    new Regex(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.CHINESE)
                 },
                 {
                     // 百分之５６.２　百分之１２
-                    new Regex(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 百分之3,000  百分之１，１２３
-                    new Regex(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 百分之3.2 k
-                    new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 12.56个百分点  ０.４个百分点
-                    new Regex(NumbersDefinitions.FractionPercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15,123个百分点  １１１，１１１个百分点
-                    new Regex(NumbersDefinitions.FractionPercentageWithSeparatorRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPercentageWithSeparatorRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 12.1k个百分点  １５.1k个百分点
-                    new Regex(NumbersDefinitions.FractionPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 百分之22  百分之１２０
-                    new Regex(NumbersDefinitions.SimpleNumbersPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleNumbersPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 百分之15k
-                    new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 百分之1,111  百分之９，９９９
-                    new Regex(NumbersDefinitions.SimpleNumbersPercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleNumbersPercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 12个百分点
-                    new Regex(NumbersDefinitions.IntegerPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.IntegerPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 12k个百分点
-                    new Regex(NumbersDefinitions.IntegerPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.IntegerPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 2,123个百分点
-                    new Regex(NumbersDefinitions.NumbersFractionPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersFractionPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 32.5%
-                    new Regex(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 2折 ２.５折
-                    new Regex(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 三折 六点五折 七五折
-                    new Regex(NumbersDefinitions.FoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 5成 6成半 6成4
-                    new Regex(NumbersDefinitions.SimpleFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 七成半 七成五
-                    new Regex(NumbersDefinitions.SpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 2成 ２.５成
-                    new Regex(NumbersDefinitions.NumbersSpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 三成 六点五成
-                    new Regex(NumbersDefinitions.SimpleSpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleSpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 打对折 半成
-                    new Regex(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberParserConfiguration.cs
@@ -52,18 +52,18 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             this.HalfADozenRegex = null;
 
             // @TODO Change init to follow design in other languages
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
-            this.PercentageNumRegex = new Regex(NumbersDefinitions.PercentageNumRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DigitNumRegex = RegexCache.Get(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DozenRegex = RegexCache.Get(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PercentageRegex = RegexCache.Get(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.DoubleAndRoundRegex = RegexCache.Get(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = RegexCache.Get(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.PointRegex = RegexCache.Get(NumbersDefinitions.PointRegex, RegexFlags);
+            this.SpeGetNumberRegex = RegexCache.Get(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PairRegex = RegexCache.Get(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.PercentageNumRegex = RegexCache.Get(NumbersDefinitions.PercentageNumRegex, RegexFlags);
             this.FractionPrepositionRegex = null;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Chinese/Parsers/ChineseNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.Chinese
             OrdinalExtractor = new OrdinalExtractor(numConfig);
             NumberParser = new BaseCJKNumberParser(new ChineseNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/DoubleExtractor.cs
@@ -19,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.DUTCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/FractionExtractor.cs
@@ -21,20 +21,20 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(
+                    RegexCache.Get(
                         NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH)
                 },
             };
@@ -45,13 +45,13 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
                 if ((Options & NumberOptions.PercentageMode) != 0)
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH));
                 }
                 else
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.DUTCH));
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/IntegerExtractor.cs
@@ -24,27 +24,27 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.DUTCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.DUTCH)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberExtractor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/NumberRangeExtractor.cs
@@ -22,62 +22,62 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex5, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex5, RegexFlags),
                     NumberRangeConstants.TWONUMCLOSED
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -85,7 +85,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Extractors/OrdinalExtractor.cs
@@ -25,19 +25,19 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalDutchRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalDutchRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.DUTCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.DUTCH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberParserConfiguration.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FractionHalfRegex =
-            new Regex(NumbersDefinitions.FractionHalfRegex, RegexFlags);
+            RegexCache.Get(NumbersDefinitions.FractionHalfRegex, RegexFlags);
 
         private static readonly Regex FractionUnitsRegex =
-            new Regex(NumbersDefinitions.FractionUnitsRegex, RegexFlags);
+            RegexCache.Get(NumbersDefinitions.FractionUnitsRegex, RegexFlags);
 
         private static readonly string[] OneHalfTokens = NumbersDefinitions.OneHalfTokens;
 
@@ -47,10 +47,10 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
             // @TODO Change init to follow design in other languages
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }
@@ -103,7 +103,7 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             fracWords.RemoveAll(item => item == "/");
             for (int i = fracWords.Count - 1; i >= 0; i--)
             {
-                if (FractionHalfRegex.IsMatch(fracWords[i]))
+                if (FractionHalfRegexCache.IsMatch(fracWords[i]))
                 {
                     fracWords[i] = fracWords[i].Substring(0, fracWords[i].Length - 6);
                     fracWords.Insert(i + 1, this.WrittenFractionSeparatorTexts.ElementAt(3));

--- a/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Dutch/Parsers/DutchNumberRangeParserConfiguration.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Recognizers.Text.Number.Dutch
             // @TODO Change init to follow design in other languages
             NumberParser = new BaseNumberParser(new DutchNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/DoubleExtractor.cs
@@ -21,35 +21,35 @@ namespace Microsoft.Recognizers.Text.Number.English
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleIndianDecimalPointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleIndianDecimalPointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.ENGLISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/FractionExtractor.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Recognizers.Text.Number.English
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH)
                 },
             };
@@ -45,13 +45,13 @@ namespace Microsoft.Recognizers.Text.Number.English
                 if ((Options & NumberOptions.PercentageMode) != 0)
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH));
                 }
                 else
                 {
                     regexes.Add(
-                        new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ENGLISH));
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/IntegerExtractor.cs
@@ -25,31 +25,31 @@ namespace Microsoft.Recognizers.Text.Number.English
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.IndianNumberingSystemRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.IndianNumberingSystemRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ENGLISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ENGLISH)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/MergedNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/MergedNumberExtractor.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Recognizers.Text.Number.English
         public MergedNumberExtractor(BaseNumberOptionsConfiguration config)
         {
             NumberExtractor = English.NumberExtractor.GetInstance(config);
-            RoundNumberIntegerRegexWithLocks = new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
-            ConnectorRegex = new Regex(NumbersDefinitions.ConnectorRegex, RegexFlags);
+            RoundNumberIntegerRegexWithLocks = RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
+            ConnectorRegex = RegexCache.Get(NumbersDefinitions.ConnectorRegex, RegexFlags);
         }
 
         public sealed override BaseNumberExtractor NumberExtractor { get; set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberExtractor.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Recognizers.Text.Number.English
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(config));
 
@@ -70,7 +70,7 @@ namespace Microsoft.Recognizers.Text.Number.English
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/NumberRangeExtractor.cs
@@ -22,57 +22,57 @@ namespace Microsoft.Recognizers.Text.Number.English
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1LB, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1LB, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1LB, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1LB, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number.English
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Extractors/OrdinalExtractor.cs
@@ -23,26 +23,26 @@ namespace Microsoft.Recognizers.Text.Number.English
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options.ToString() + "_" + config.Culture);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.ENGLISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.ENGLISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberParserConfiguration.cs
@@ -46,11 +46,11 @@ namespace Microsoft.Recognizers.Text.Number.English
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
-            this.RoundMultiplierRegex = new Regex(NumbersDefinitions.RoundMultiplierRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.RoundMultiplierRegex = RegexCache.Get(NumbersDefinitions.RoundMultiplierRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/English/Parsers/EnglishNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.English
             OrdinalExtractor = English.OrdinalExtractor.GetInstance(numConfig);
             NumberParser = new BaseNumberParser(new EnglishNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberExtractor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Number
     public abstract class BaseNumberExtractor : IExtractor
     {
         public static readonly Regex CurrencyRegex =
-            new Regex(BaseNumbers.CurrencyRegex, RegexOptions.Singleline | RegexOptions.ExplicitCapture);
+            RegexCache.Get(BaseNumbers.CurrencyRegex, RegexOptions.Singleline | RegexOptions.ExplicitCapture);
 
         protected static readonly ResultsCache<ExtractResult> ResultsCache = new ResultsCache<ExtractResult>(4);
 
@@ -163,7 +163,7 @@ namespace Microsoft.Recognizers.Text.Number
                 BaseNumbers.IntegerRegexDefinition(placeholder, thousandsMark) :
                 BaseNumbers.DoubleRegexDefinition(placeholder, thousandsMark, decimalsMark);
 
-            return new Regex(regexDefinition, flags);
+            return RegexCache.Get(regexDefinition, flags);
         }
 
         private List<ExtractResult> FilterAmbiguity(List<ExtractResult> extractResults, string text)

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BasePercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BasePercentageExtractor.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Recognizers.Text.Number
                     regexOptions |= RegexOptions.IgnoreCase;
                 }
 
-                Regex regex = new Regex(regexString, regexOptions);
+                Regex regex = RegexCache.Get(regexString, regexOptions);
 
                 regexes.Add(regex);
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/DoubleExtractor.cs
@@ -20,31 +20,31 @@ namespace Microsoft.Recognizers.Text.Number.French
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.FRENCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/FractionExtractor.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Recognizers.Text.Number.French
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.FRENCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.FRENCH)
                 },
             };
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.Number.French
             if (mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.FRENCH));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/IntegerExtractor.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Recognizers.Text.Number.French
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -32,19 +32,19 @@ namespace Microsoft.Recognizers.Text.Number.French
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.FRENCH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.FRENCH)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/NumberExtractor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.Number.French
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Extractors/OrdinalExtractor.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Recognizers.Text.Number.French
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalFrenchRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalFrenchRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.FRENCH)
                 },
             }.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/French/Parsers/FrenchNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/French/Parsers/FrenchNumberParserConfiguration.cs
@@ -41,10 +41,10 @@ namespace Microsoft.Recognizers.Text.Number.French
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
             // @TODO Change init to follow design in other languages
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/DoubleExtractor.cs
@@ -20,31 +20,31 @@ namespace Microsoft.Recognizers.Text.Number.German
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.GERMAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/FractionExtractor.cs
@@ -20,19 +20,19 @@ namespace Microsoft.Recognizers.Text.Number.German
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.GERMAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.GERMAN)
                 },
             };
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Text.Number.German
             if (mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.GERMAN));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/IntegerExtractor.cs
@@ -20,27 +20,27 @@ namespace Microsoft.Recognizers.Text.Number.German
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.GERMAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.GERMAN)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/NumberExtractor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Recognizers.Text.Number.German
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Extractors/OrdinalExtractor.cs
@@ -20,19 +20,19 @@ namespace Microsoft.Recognizers.Text.Number.German
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalGermanRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalGermanRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.GERMAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.GERMAN)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/German/Parsers/GermanNumberParserConfiguration.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Recognizers.Text.Number.German
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex FractionHalfRegex =
-            new Regex(NumbersDefinitions.FractionHalfRegex, RegexFlags);
+            RegexCache.Get(NumbersDefinitions.FractionHalfRegex, RegexFlags);
 
         private static readonly Regex FractionUnitsRegex =
-            new Regex(NumbersDefinitions.FractionUnitsRegex, RegexFlags);
+            RegexCache.Get(NumbersDefinitions.FractionUnitsRegex, RegexFlags);
 
         private static readonly string[] OneHalfTokens = NumbersDefinitions.OneHalfTokens;
 
@@ -48,10 +48,10 @@ namespace Microsoft.Recognizers.Text.Number.German
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number.German
             fracWords.RemoveAll(item => item == "/");
             for (int i = fracWords.Count - 1; i >= 0; i--)
             {
-                if (FractionHalfRegex.IsMatch(fracWords[i]))
+                if (FractionHalfRegexCache.IsMatch(fracWords[i]))
                 {
                     fracWords[i] = fracWords[i].Substring(0, fracWords[i].Length - 7);
                     fracWords.Insert(i + 1, this.WrittenFractionSeparatorTexts.ElementAt(0));

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/DoubleExtractor.cs
@@ -18,31 +18,31 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/FractionExtractor.cs
@@ -20,23 +20,23 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.NegativeCompoundNumberOrdinals, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NegativeCompoundNumberOrdinals, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI)
                 },
             };
@@ -44,16 +44,16 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             if ((Options & NumberOptions.PercentageMode) != 0)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionWithinPercentModeRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI));
             }
             else
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI));
                 regexes.Add(
-                   new Regex(NumbersDefinitions.FractionPrepositionInverseRegex, RegexFlags),
+                   RegexCache.Get(NumbersDefinitions.FractionPrepositionInverseRegex, RegexFlags),
                    RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.HINDI));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/IntegerExtractor.cs
@@ -19,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.IndianNumberingSystemRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.IndianNumberingSystemRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.HINDI)
                 },
                 {
@@ -59,15 +59,15 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NegativeHinglishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NegativeHinglishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.CompoundEnglishNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.CompoundEnglishNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.DecimalUnitsWithRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DecimalUnitsWithRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.HINDI)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/MergedNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/MergedNumberExtractor.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
         public MergedNumberExtractor(NumberMode mode, NumberOptions options)
         {
             NumberExtractor = Hindi.NumberExtractor.GetInstance(mode, options);
-            RoundNumberIntegerRegexWithLocks = new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
-            ConnectorRegex = new Regex(NumbersDefinitions.ConnectorRegex, RegexFlags);
+            RoundNumberIntegerRegexWithLocks = RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
+            ConnectorRegex = RegexCache.Get(NumbersDefinitions.ConnectorRegex, RegexFlags);
         }
 
         public sealed override BaseNumberExtractor NumberExtractor { get; set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/NumberExtractor.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
 
         private NumberExtractor(NumberMode mode, NumberOptions options)
         {
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             Options = options;
 
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/NumberRangeExtractor.cs
@@ -20,67 +20,67 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex0, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex0, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex0, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex0, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -88,7 +88,7 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Extractors/OrdinalExtractor.cs
@@ -17,34 +17,34 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             : base(options)
         {
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.HinglishOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.HinglishOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.CompoundHindiOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.CompoundHindiOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.CompoundNumberOrdinals, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.CompoundNumberOrdinals, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.CompoundEnglishOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.CompoundEnglishOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.HINDI)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Parsers/HindiNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Parsers/HindiNumberParserConfiguration.cs
@@ -40,12 +40,12 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
             this.ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
 
-            this.AdditionTermsRegex = new Regex(NumbersDefinitions.AdditionTermsRegex, RegexFlags);
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
-            this.FractionPrepositionInverseRegex = new Regex(NumbersDefinitions.FractionPrepositionInverseRegex, RegexFlags);
+            this.AdditionTermsRegex = RegexCache.Get(NumbersDefinitions.AdditionTermsRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.FractionPrepositionInverseRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionInverseRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Hindi/Parsers/HindiNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Hindi/Parsers/HindiNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.Hindi
             OrdinalExtractor = Hindi.OrdinalExtractor.GetInstance();
             NumberParser = new BaseIndianNumberParser(new HindiNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/DoubleExtractor.cs
@@ -20,31 +20,31 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.ITALIAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/FractionExtractor.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ITALIAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ITALIAN)
                 },
             };
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             if (mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.ITALIAN));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/IntegerExtractor.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -32,19 +32,19 @@ namespace Microsoft.Recognizers.Text.Number.Italian
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ITALIAN)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.ITALIAN)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberExtractor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/NumberRangeExtractor.cs
@@ -22,57 +22,57 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             {
                  {
                      // between...and...
-                     new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                      NumberRangeConstants.TWONUMBETWEEN
                  },
                  {
                      // more than ... less than ...
-                     new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                      NumberRangeConstants.TWONUM
                  },
                  {
                      // less than ... more than ...
-                     new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                      NumberRangeConstants.TWONUM
                  },
                  {
                      // from ... to/~/- ...
-                     new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                      NumberRangeConstants.TWONUMTILL
                  },
                  {
                      // more/greater/higher than ...
-                     new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                      NumberRangeConstants.MORE
                  },
                  {
                      // 30 and/or greater/higher
-                     new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                      NumberRangeConstants.MORE
                  },
                  {
                      // less/smaller/lower than ...
-                     new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                      NumberRangeConstants.LESS
                  },
                  {
                      // 30 and/or less/smaller/lower
-                     new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                      NumberRangeConstants.LESS
                  },
                  {
                      // equal to ...
-                     new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                      NumberRangeConstants.EQUAL
                  },
                  {
                      // equal to 30 or more than, larger than 30 or equal to ...
-                     new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                      NumberRangeConstants.MORE
                  },
                  {
                      // equal to 30 or less, smaller than 30 or equal ...
-                     new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                     RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                      NumberRangeConstants.LESS
                  },
             };
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Extractors/OrdinalExtractor.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             this.Regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalItalianRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalItalianRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.ITALIAN)
                 },
             }.ToImmutableDictionary();

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberParserConfiguration.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Recognizers.Text.Number.Italian
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
-            this.OneToNineOrdinalRegex = new Regex(NumbersDefinitions.OneToNineOrdinalRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.OneToNineOrdinalRegex = RegexCache.Get(NumbersDefinitions.OneToNineOrdinalRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Italian/Parsers/ItalianNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.Italian
 
             NumberParser = new BaseNumberParser(new ItalianNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/DoubleExtractor.cs
@@ -16,46 +16,46 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-)2.5, can avoid cases like ip address xx.xx.xx.xx
-                    new Regex(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-).2
-                    new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // えは九・二三二一三一二
-                    new Regex(NumbersDefinitions.DoubleRoundNumberSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleRoundNumberSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1.0 K
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // １５.２万
-                    new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.JAPANESE)
                 },
                 {
                     // 2e6, 21.2e0
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationKanjiRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationKanjiRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
                     // 2^5
-                    new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/FractionExtractor.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             {
                 {
                     // -4 5/2,       ４ ６／３
-                    new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 8/3
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 五分の二   七分の三
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllFractionNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.JAPANESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
@@ -18,27 +18,27 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             {
                 {
                     // 123456,  －１２３４５６
-                    new Regex(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15k,  16 G
-                    new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1,234,  ２，３３２，１１１
-                    new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 半百  半ダース
-                    new Regex(NumbersDefinitions.NumbersWithHalfDozen, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithHalfDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
                 },
                 {
                     // 一ダース  五十ダース
-                    new Regex(NumbersDefinitions.NumbersWithDozen, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
                 },
             };
@@ -49,7 +49,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     // 一百五十五, 负一亿三百二十二.
                     // Uses an allow list to avoid extracting "西九条" from "九"
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
                     break;
 
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     // 一百五十五, 负一亿三百二十二, "西九条" from "九"
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE));
                     break;
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberRangeExtractor.cs
@@ -21,67 +21,67 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             {
                 {
                     // ...と...の間
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // より大きい...より小さい...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // より小さい...より大きい...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // ...と/から..., 20~30
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // 大なり|大きい|高い|大きく...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // ...以上
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 少なくとも|多くて|最大...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // ...以上
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex5, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex5, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // ...以上
-                    new Regex(NumbersDefinitions.TwoNumberRangeMoreSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeMoreSuffix, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 小なり|小さい|低い...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // ...以下
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex3, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // ...以下
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex4, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // イコール...　｜　...等しい|
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
             };
@@ -89,7 +89,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/OrdinalExtractor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             {
                 {
                     // だい一百五十四
-                    new Regex(NumbersDefinitions.AllOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.JAPANESE)
                 },
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/PercentageExtractor.cs
@@ -17,67 +17,67 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             {
                 {
                     // 百パーセント 十五パーセント
-                    new Regex(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.JAPANESE)
                 },
                 {
                     // 19パーセント　１パーセント
-                    new Regex(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 3,000パーセント  １，１２３パーセント
-                    new Regex(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 3.2 k パーセント
-                    new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15kパーセント
-                    new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // @TODO Example missing
-                    new Regex(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 2割引 ２.５割引
-                    new Regex(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 三割引 六点五折 七五折
-                    new Regex(NumbersDefinitions.FoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 5割 7割半
-                    new Regex(NumbersDefinitions.SimpleFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 七割半
-                    new Regex(NumbersDefinitions.SpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 2割 ２.５割
-                    new Regex(NumbersDefinitions.NumbersSpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // 三割
-                    new Regex(NumbersDefinitions.SimpleSpecialsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleSpecialsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
                 {
                     // @TODO Example missing
-                    new Regex(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SpecialsFoldsPercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.SPECIAL_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
@@ -51,17 +51,17 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             this.HalfADozenRegex = null;
 
             // @TODO Change init to follow design in other languages
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DozenRegex = RegexCache.Get(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PointRegex = RegexCache.Get(NumbersDefinitions.PointRegex, RegexFlags);
+            this.DigitNumRegex = RegexCache.Get(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DoubleAndRoundRegex = RegexCache.Get(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = RegexCache.Get(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.SpeGetNumberRegex = RegexCache.Get(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PercentageRegex = RegexCache.Get(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.PairRegex = RegexCache.Get(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
             this.PercentageNumRegex = null;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberRangeParserConfiguration.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
 
             NumberParser = new BaseCJKNumberParser(new JapaneseNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
@@ -16,41 +16,41 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-)2.5, can avoid cases like ip address xx.xx.xx.xx
-                    new Regex(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleSpecialsCharsWithNegatives, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleRoundNumberSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleRoundNumberSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // (-).2
-                    new Regex(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleDoubleSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1.0 K
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // １５.２만
-                    new Regex(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithThousandsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.KOREAN)
                 },
                 {
                     // 2e6, 21.2e0
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
                     // 2^5
-                    new Regex(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleScientificNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/FractionExtractor.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             {
                 {
                     // -4 5/2,       ４ ６／３
-                    new Regex(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationSpecialsCharsRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 8/3
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 오분의 이   칠분의 삼
-                    new Regex(NumbersDefinitions.AllFractionNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllFractionNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.KOREAN)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/IntegerExtractor.cs
@@ -17,42 +17,42 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             {
                 {
                     // 123456,  －１２３４５６
-                    new Regex(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15k,  16 G
-                    new Regex(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsCharsWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 1,234,  ２，３３２，１１１
-                    new Regex(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DottedNumbersSpecialsChar, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 마이너스 일, 마이너스 오
-                    new Regex(NumbersDefinitions.ZeroToNineIntegerSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.ZeroToNineIntegerSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN)
                 },
                 {
                     // 마이너스 일, 마이너스 오
-                    new Regex(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersSpecialsChars, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN)
                 },
                 {
                     // 다스
-                    new Regex(NumbersDefinitions.NumbersWithDozen, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN)
                 },
                 {
                     // 3백21
-                    new Regex(NumbersDefinitions.NativeCumKoreanRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NativeCumKoreanRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 스물여섯
-                    new Regex(NumbersDefinitions.NativeSingleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NativeSingleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN)
                 },
             };
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                 case KoreanNumberExtractorMode.Default:
                     // 일백오십오
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersWithAllowListRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
                     break;
 
@@ -70,7 +70,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     // 일백오십오, 사직구장, "사직구장" from "사(it is homonym, seems like four(4) or other chinese character)"
                     // Uses no allow lists and extracts all potential integers (useful in Units, for example).
                     regexes.Add(
-                        new Regex(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
+                        RegexCache.Get(NumbersDefinitions.NumbersAggressiveRegex, RegexFlags),
                         RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.KOREAN));
                     break;
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
@@ -21,91 +21,91 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             {
                 {
                     // ...과...사이
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // 이상...이하...
 
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // 이하...이상...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // 이십보다 크고 삼십오보다 작다
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex7, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex7, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // ...에서..., 20~30
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex5, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex5, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex6, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex6, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // ...이상|초과|많|높|크|더많|더높|더크|>
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                      // ...이상|초과|많|높|크|더많|더높|더크|>
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // >|≥...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex3, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex5, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex5, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                    // >|≥...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegexFraction, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegexFraction, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 까지최소|<|≤...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex3, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // >|≥...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex2, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // 700에 달하는
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex4, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/OrdinalExtractor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalKoreanRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalKoreanRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/PercentageExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/PercentageExtractor.cs
@@ -18,32 +18,32 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             {
                 {
                     // 백퍼센트 십오퍼센트
-                    new Regex(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimplePercentageRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.KOREAN)
                 },
                 {
                     // 19퍼센트　１퍼센트
-                    new Regex(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentagePointRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 3,000퍼센트  １，１２３퍼센트
-                    new Regex(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithSeparatorRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 3.2 k 퍼센트
-                    new Regex(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                     // 15k퍼센트
-                    new Regex(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.SimpleNumbersPercentageWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
                 // 마이너스십삼퍼센트
-                new Regex(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
+                RegexCache.Get(NumbersDefinitions.SimpleIntegerPercentageRegex, RegexFlags),
                 RegexTagGenerator.GenerateRegexTag(Constants.PERCENT_PREFIX, Constants.NUMBER_SUFFIX)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberParserConfiguration.cs
@@ -49,18 +49,18 @@ namespace Microsoft.Recognizers.Text.Number.Korean
 
             // @TODO Change init to follow design in other languages
             this.HalfADozenRegex = null;
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.DigitNumRegex = new Regex(NumbersDefinitions.DigitNumRegex, RegexFlags);
-            this.DozenRegex = new Regex(NumbersDefinitions.DozenRegex, RegexFlags);
-            this.PercentageRegex = new Regex(NumbersDefinitions.PercentageRegex, RegexFlags);
-            this.DoubleAndRoundRegex = new Regex(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
-            this.FracSplitRegex = new Regex(NumbersDefinitions.FracSplitRegex, RegexFlags);
-            this.NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.PointRegex = new Regex(NumbersDefinitions.PointRegex, RegexFlags);
-            this.SpeGetNumberRegex = new Regex(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
-            this.PairRegex = new Regex(NumbersDefinitions.PairRegex, RegexFlags);
-            this.RoundNumberIntegerRegex = new Regex(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.DigitNumRegex = RegexCache.Get(NumbersDefinitions.DigitNumRegex, RegexFlags);
+            this.DozenRegex = RegexCache.Get(NumbersDefinitions.DozenRegex, RegexFlags);
+            this.PercentageRegex = RegexCache.Get(NumbersDefinitions.PercentageRegex, RegexFlags);
+            this.DoubleAndRoundRegex = RegexCache.Get(NumbersDefinitions.DoubleAndRoundRegex, RegexFlags);
+            this.FracSplitRegex = RegexCache.Get(NumbersDefinitions.FracSplitRegex, RegexFlags);
+            this.NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.PointRegex = RegexCache.Get(NumbersDefinitions.PointRegex, RegexFlags);
+            this.SpeGetNumberRegex = RegexCache.Get(NumbersDefinitions.SpeGetNumberRegex, RegexFlags);
+            this.PairRegex = RegexCache.Get(NumbersDefinitions.PairRegex, RegexFlags);
+            this.RoundNumberIntegerRegex = RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegex, RegexFlags);
             this.FractionPrepositionRegex = null;
             this.PercentageNumRegex = null;
         }

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Parsers/KoreanNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.Korean
             OrdinalExtractor = new OrdinalExtractor();
             NumberParser = new BaseCJKNumberParser(new KoreanNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Recognizers.Text.Number
             {
                 getExtResult.Text = NormalizeCharWidth(getExtResult.Text);
                 ret = DigitNumberParse(getExtResult);
-                if (Config.NegativeNumberSignRegex.IsMatch(getExtResult.Text) && (double)ret.Value > 0)
+                if (Config.NegativeNumberSignRegexCache.IsMatch(getExtResult.Text) && (double)ret.Value > 0)
                 {
                     ret.Value = -(double)ret.Value;
                 }
@@ -151,21 +151,21 @@ namespace Microsoft.Recognizers.Text.Number
                 numPart = splitResult[1];
             }
 
-            var intValue = Config.DigitNumRegex.IsMatch(intPart)
+            var intValue = Config.DigitNumRegexCache.IsMatch(intPart)
                 ? GetDigitValue(intPart, 1.0)
                 : GetIntValue(intPart);
 
-            var numValue = Config.DigitNumRegex.IsMatch(numPart)
+            var numValue = Config.DigitNumRegexCache.IsMatch(numPart)
                 ? GetDigitValue(numPart, 1.0)
-                : (Config.PointRegex.IsMatch(numPart)
+                : (Config.PointRegexCache.IsMatch(numPart)
                 ? GetIntValue(Config.PointRegex.Split(numPart)[0]) + GetPointValue(Config.PointRegex.Split(numPart)[1])
                 : GetIntValue(numPart));
 
-            var demoValue = Config.DigitNumRegex.IsMatch(demoPart)
+            var demoValue = Config.DigitNumRegexCache.IsMatch(demoPart)
                 ? GetDigitValue(demoPart, 1.0)
                 : GetIntValue(demoPart);
 
-            if (Config.NegativeNumberSignRegex.IsMatch(intPart))
+            if (Config.NegativeNumberSignRegexCache.IsMatch(intPart))
             {
                 result.Value = intValue - (numValue / demoValue);
             }
@@ -317,7 +317,7 @@ namespace Microsoft.Recognizers.Text.Number
                 var doubleValue = GetIntValue(splitResult[0]);
                 if (splitResult.Length == 2)
                 {
-                    if (Config.NegativeNumberSignRegex.IsMatch(splitResult[0]))
+                    if (Config.NegativeNumberSignRegexCache.IsMatch(splitResult[0]))
                     {
                         doubleValue -= GetPointValue(splitResult[1]);
                     }
@@ -338,7 +338,7 @@ namespace Microsoft.Recognizers.Text.Number
                     string demoPart = percentageNumSearch.Value;
                     var splitResult = Config.FracSplitRegex.Split(demoPart);
                     demoPart = splitResult[0];
-                    var demoValue = Config.DigitNumRegex.IsMatch(demoPart)
+                    var demoValue = Config.DigitNumRegexCache.IsMatch(demoPart)
                         ? GetDigitValue(demoPart, 1.0)
                         : GetIntValue(demoPart);
 
@@ -372,7 +372,7 @@ namespace Microsoft.Recognizers.Text.Number
             var resultText = extResult.Text;
             resultText = resultText.Substring(1);
 
-            result.Value = (Config.DigitNumRegex.IsMatch(resultText) && !Config.RoundNumberIntegerRegex.IsMatch(resultText))
+            result.Value = (Config.DigitNumRegexCache.IsMatch(resultText) && !Config.RoundNumberIntegerRegexCache.IsMatch(resultText))
                 ? GetDigitValue(resultText, 1)
                 : GetIntValue(resultText);
 
@@ -394,7 +394,7 @@ namespace Microsoft.Recognizers.Text.Number
 
             var resultText = extResult.Text;
 
-            if (Config.DoubleAndRoundRegex.IsMatch(resultText))
+            if (Config.DoubleAndRoundRegexCache.IsMatch(resultText))
             {
                 resultText = ReplaceUnit(resultText);
                 result.Value = GetDigitValue(
@@ -411,7 +411,7 @@ namespace Microsoft.Recognizers.Text.Number
                     splitResult[0] = Config.ZeroChar.ToString(CultureInfo.InvariantCulture);
                 }
 
-                if (Config.NegativeNumberSignRegex.IsMatch(splitResult[0]))
+                if (Config.NegativeNumberSignRegexCache.IsMatch(splitResult[0]))
                 {
                     result.Value = GetIntValue(splitResult[0]) - GetPointValue(splitResult[1]);
                 }
@@ -462,7 +462,7 @@ namespace Microsoft.Recognizers.Text.Number
         {
             var isNegative = false;
 
-            if (Config.NegativeNumberSignRegex.IsMatch(intStr))
+            if (Config.NegativeNumberSignRegexCache.IsMatch(intStr))
             {
                 isNegative = true;
                 intStr = intStr.Substring(1);
@@ -518,7 +518,7 @@ namespace Microsoft.Recognizers.Text.Number
             var isDozen = false;
             var isPair = false;
 
-            if (Config.DozenRegex.IsMatch(intStr))
+            if (Config.DozenRegexCache.IsMatch(intStr))
             {
                 isDozen = true;
                 if (Config.CultureInfo.Name == "zh-CN")
@@ -530,13 +530,13 @@ namespace Microsoft.Recognizers.Text.Number
                     intStr = intStr.Substring(0, intStr.Length - 3);
                 }
             }
-            else if (Config.PairRegex.IsMatch(intStr))
+            else if (Config.PairRegexCache.IsMatch(intStr))
             {
                 isPair = true;
                 intStr = intStr.Substring(0, intStr.Length - 1);
             }
 
-            if (Config.NegativeNumberSignRegex.IsMatch(intStr))
+            if (Config.NegativeNumberSignRegexCache.IsMatch(intStr))
             {
                 isNegative = true;
                 if (Config.CultureInfo.Name == "ko-KR")

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseIndianNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseIndianNumberParser.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.Number
             };
 
             var resultText = extResult.Text;
-            if (Config.FractionPrepositionRegex.IsMatch(resultText) && !Config.AdditionTermsRegex.IsMatch(resultText))
+            if (Config.FractionPrepositionRegexCache.IsMatch(resultText) && !Config.AdditionTermsRegexCache.IsMatch(resultText))
             {
                 // condition inncludes AdditionTermsRegex in combination with FractionPrepositionRegex
                 // to account for Behaviour changes of और - In fraction cases where और is used to connect two words and may not be used as addition of two words from its left and right.
@@ -55,7 +55,7 @@ namespace Microsoft.Recognizers.Text.Number
 
                 result.Value = smallValue / bigValue;
             }
-            else if (Config.FractionPrepositionInverseRegex.IsMatch(resultText))
+            else if (Config.FractionPrepositionInverseRegexCache.IsMatch(resultText))
             {
                 // condition  to use FractionPrepositionInverseRegex where denominator and nominator are switched to account for
                 // में से (out of) - These type of cases are very common in Hindi. It belongs to fraction unit type. Here any word/char
@@ -546,7 +546,7 @@ namespace Microsoft.Recognizers.Text.Number
                 textNumberPattern = @"(?<=\b)(" + singleIntFrac + @")(?=\b)";
             }
 
-            return new Regex(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
+            return RegexCache.Get(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseNumberParser.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Number
     public class BaseNumberParser : IParser
     {
         private static readonly Regex LongFormRegex =
-            new Regex(@"\d+", RegexOptions.Singleline);
+            RegexCache.Get(@"\d+", RegexOptions.Singleline);
 
         private readonly bool isMultiDecimalSeparatorCulture = false;
 
@@ -345,7 +345,7 @@ namespace Microsoft.Recognizers.Text.Number
             };
 
             var resultText = extResult.Text;
-            if (Config.FractionPrepositionRegex.IsMatch(resultText))
+            if (Config.FractionPrepositionRegexCache.IsMatch(resultText))
             {
                 var match = Config.FractionPrepositionRegex.Match(resultText);
                 var numerator = match.Groups["numerator"].Value;
@@ -932,7 +932,7 @@ namespace Microsoft.Recognizers.Text.Number
                 textNumberPattern = @"(?<=\b)(" + singleIntFrac + @")(?=\b)";
             }
 
-            return new Regex(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
+            return RegexCache.Get(textNumberPattern, RegexOptions.Singleline | RegexOptions.Compiled);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/DoubleExtractor.cs
@@ -22,31 +22,31 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.PORTUGUESE)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/FractionExtractor.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.PORTUGUESE)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.PORTUGUESE)
                 },
             };
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             if (config.Mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.PORTUGUESE));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/IntegerExtractor.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -46,23 +46,23 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozen2Suffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozen2Suffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.PORTUGUESE)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.PORTUGUESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/NumberExtractor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Extractors/OrdinalExtractor.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalEnglishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.PORTUGUESE)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Portuguese/Parsers/PortugueseNumberParserConfiguration.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Recognizers.Text.Number.Portuguese
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/DoubleExtractor.cs
@@ -22,31 +22,31 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.SPANISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/FractionExtractor.cs
@@ -22,19 +22,19 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SPANISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SPANISH)
                 },
             };
@@ -43,7 +43,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             if (config.Mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SPANISH));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/IntegerExtractor.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
@@ -46,19 +46,19 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SPANISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SPANISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberExtractor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
@@ -64,7 +64,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/NumberRangeExtractor.cs
@@ -22,57 +22,57 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             {
                 {
                     // entre ...y ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // más que ... monos que ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // monos que ... más que ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // de ... a ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // más/mayor que ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1LB, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1LB, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1LB, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1LB, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 y/o mas/más/mayor/mayores
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // igual a ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // igual a 30 o más, más que 30 o igual ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // igual a 30 o menos, menos que 30 o igual ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Extractors/OrdinalExtractor.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.SPANISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberParserConfiguration.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Spanish/Parsers/SpanishNumberRangeParserConfiguration.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Recognizers.Text.Number.Spanish
 
             NumberParser = new BaseNumberParser(new SpanishNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/DoubleExtractor.cs
@@ -21,31 +21,31 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.SWEDISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                /* {

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/FractionExtractor.cs
@@ -24,19 +24,19 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SWEDISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SWEDISH)
                 },
             };
@@ -45,7 +45,7 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             if (config.Mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.SWEDISH));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/IntegerExtractor.cs
@@ -24,27 +24,27 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(config.Placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SWEDISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.SWEDISH)
                 },
                 /*{

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberExtractor.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options + "_" + config.Mode + "_" + config.Culture);
 
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var builder = ImmutableDictionary.CreateBuilder<Regex, TypeTag>();
 
@@ -67,7 +67,7 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/NumberRangeExtractor.cs
@@ -22,57 +22,57 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             Regexes = regexes.ToImmutableDictionary();
 
             AmbiguousFractionConnectorsRegex =
-                new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
         }
 
         internal sealed override ImmutableDictionary<Regex, string> Regexes { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Extractors/OrdinalExtractor.cs
@@ -23,26 +23,26 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
 
             keyPrefix = string.Intern(ExtractType + "_" + config.Options.ToString() + "_" + config.Culture);
 
-            AmbiguousFractionConnectorsRegex = new Regex(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
+            AmbiguousFractionConnectorsRegex = RegexCache.Get(NumbersDefinitions.AmbiguousFractionConnectorsRegex, RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalSwedishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSwedishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.SWEDISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalRoundNumberRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.SWEDISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Parsers/SwedishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Parsers/SwedishNumberParserConfiguration.cs
@@ -40,10 +40,10 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
 
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Swedish/Parsers/SwedishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Swedish/Parsers/SwedishNumberRangeParserConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.Number.Swedish
             OrdinalExtractor = Swedish.OrdinalExtractor.GetInstance(numConfig);
             NumberParser = new BaseNumberParser(new SwedishNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/DoubleExtractor.cs
@@ -19,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleDecimalPointRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithoutIntegralRegex(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithMultiplierRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleWithRoundNumber, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleAllFloatRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.DoubleCaretExponentialNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.POWER_SUFFIX)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/FractionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/FractionExtractor.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationWithSpacesRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNotationRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNotationRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionNounWithArticleRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.TURKISH)
                 },
             };
@@ -38,7 +38,7 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             if (mode != NumberMode.Unit)
             {
                 regexes.Add(
-                    new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.FRACTION_PREFIX, Constants.TURKISH));
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/IntegerExtractor.cs
@@ -19,31 +19,31 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithPlaceHolder(placeholder), RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NumbersWithDozenSuffix, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.NegativeAllIntRegexWithLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.NegativeAllIntRegexWithLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.AllIntRegexWithDozenSuffixLocks, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.TURKISH)
                 },
                 {

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/MergedNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/MergedNumberExtractor.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
         {
             NumberExtractor = Turkish.NumberExtractor.GetInstance(mode, options);
             RoundNumberIntegerRegexWithLocks =
-                new Regex(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.RoundNumberIntegerRegexWithLocks, RegexFlags);
             ConnectorRegex =
-                new Regex(NumbersDefinitions.ConnectorRegex, RegexFlags);
+                RegexCache.Get(NumbersDefinitions.ConnectorRegex, RegexFlags);
         }
 
         public sealed override BaseNumberExtractor NumberExtractor { get; set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberExtractor.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
 
         private NumberExtractor(NumberMode mode, NumberOptions options)
         {
-            NegativeNumberTermsRegex = new Regex(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
+            NegativeNumberTermsRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberTermsRegex + '$', RegexFlags);
 
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             Options = options;
 
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             {
                 foreach (var item in NumbersDefinitions.AmbiguityFiltersDict)
                 {
-                    ambiguityBuilder.Add(new Regex(item.Key, RegexFlags), new Regex(item.Value, RegexFlags));
+                    ambiguityBuilder.Add(RegexCache.Get(item.Key, RegexFlags), RegexCache.Get(item.Value, RegexFlags));
                 }
             }
 

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/NumberRangeExtractor.cs
@@ -22,57 +22,57 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             {
                 {
                     // between...and...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex1, RegexFlags),
                     NumberRangeConstants.TWONUMBETWEEN
                 },
                 {
                     // more than ... less than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex2, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // less than ... more than ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex3, RegexFlags),
                     NumberRangeConstants.TWONUM
                 },
                 {
                     // from ... to/~/- ...
-                    new Regex(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.TwoNumberRangeRegex4, RegexFlags),
                     NumberRangeConstants.TWONUMTILL
                 },
                 {
                     // more/greater/higher than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex1, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // 30 and/or greater/higher
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreRegex2, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // less/smaller/lower than ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex1, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // 30 and/or less/smaller/lower
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
                     NumberRangeConstants.LESS
                 },
                 {
                     // equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeEqualRegex, RegexFlags),
                     NumberRangeConstants.EQUAL
                 },
                 {
                     // equal to 30 or more than, larger than 30 or equal to ...
-                    new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags),
                     NumberRangeConstants.MORE
                 },
                 {
                     // equal to 30 or less, smaller than 30 or equal ...
-                    new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags),
                     NumberRangeConstants.LESS
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/OrdinalExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Extractors/OrdinalExtractor.cs
@@ -17,24 +17,24 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
         private OrdinalExtractor(NumberOptions options)
             : base(options)
         {
-            RelativeReferenceRegex = new Regex(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
+            RelativeReferenceRegex = RegexCache.Get(NumbersDefinitions.RelativeOrdinalRegex, RegexFlags);
 
             var regexes = new Dictionary<Regex, TypeTag>
             {
                 {
-                    new Regex(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalSuffixRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalNumericRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.NUMBER_SUFFIX)
                 },
                 {
-                    new Regex(NumbersDefinitions.OrdinalTurkishRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.OrdinalTurkishRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.TURKISH)
                 },
                 {
-                    new Regex(NumbersDefinitions.RoundNumberOrdinalRegex, RegexFlags),
+                    RegexCache.Get(NumbersDefinitions.RoundNumberOrdinalRegex, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.ORDINAL_PREFIX, Constants.TURKISH)
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberParserConfiguration.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             this.RelativeReferenceOffsetMap = NumbersDefinitions.RelativeReferenceOffsetMap.ToImmutableDictionary();
             this.RelativeReferenceRelativeToMap = NumbersDefinitions.RelativeReferenceRelativeToMap.ToImmutableDictionary();
             this.RoundNumberMap = NumbersDefinitions.RoundNumberMap.ToImmutableDictionary();
-            this.HalfADozenRegex = new Regex(NumbersDefinitions.HalfADozenRegex, RegexFlags);
-            this.DigitalNumberRegex = new Regex(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
-            this.NegativeNumberSignRegex = new Regex(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
-            this.FractionPrepositionRegex = new Regex(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
+            this.HalfADozenRegex = RegexCache.Get(NumbersDefinitions.HalfADozenRegex, RegexFlags);
+            this.DigitalNumberRegex = RegexCache.Get(NumbersDefinitions.DigitalNumberRegex, RegexFlags);
+            this.NegativeNumberSignRegex = RegexCache.Get(NumbersDefinitions.NegativeNumberSignRegex, RegexFlags);
+            this.FractionPrepositionRegex = RegexCache.Get(NumbersDefinitions.FractionPrepositionRegex, RegexFlags);
         }
 
         public string NonDecimalSeparatorText { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Turkish/Parsers/TurkishNumberRangeParserConfiguration.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Recognizers.Text.Number.Turkish
             OrdinalExtractor = Turkish.OrdinalExtractor.GetInstance(config.Options);
             NumberParser = new BaseNumberParser(new TurkishNumberParserConfiguration(config));
 
-            MoreOrEqual = new Regex(NumbersDefinitions.MoreOrEqual, RegexFlags);
-            LessOrEqual = new Regex(NumbersDefinitions.LessOrEqual, RegexFlags);
-            MoreOrEqualSuffix = new Regex(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
-            LessOrEqualSuffix = new Regex(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
-            MoreOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
-            LessOrEqualSeparate = new Regex(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
+            MoreOrEqual = RegexCache.Get(NumbersDefinitions.MoreOrEqual, RegexFlags);
+            LessOrEqual = RegexCache.Get(NumbersDefinitions.LessOrEqual, RegexFlags);
+            MoreOrEqualSuffix = RegexCache.Get(NumbersDefinitions.MoreOrEqualSuffix, RegexFlags);
+            LessOrEqualSuffix = RegexCache.Get(NumbersDefinitions.LessOrEqualSuffix, RegexFlags);
+            MoreOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeMoreSeparateRegex, RegexFlags);
+            LessOrEqualSeparate = RegexCache.Get(NumbersDefinitions.OneNumberRangeLessSeparateRegex, RegexFlags);
         }
 
         public CultureInfo CultureInfo { get; private set; }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
-        private static readonly Regex HalfUnitRegex = new Regex(NumbersWithUnitDefinitions.HalfUnitRegex, RegexFlags);
+        private static readonly Regex HalfUnitRegex = RegexCache.Get(NumbersWithUnitDefinitions.HalfUnitRegex, RegexFlags);
 
         protected ChineseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/TemperatureExtractorConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Chinese))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected DutchNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/TemperatureExtractorConfiguration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Dutch))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected EnglishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/TemperatureExtractorConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.English))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/NumberWithUnitExtractor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
         private readonly StringMatcher prefixMatcher = new StringMatcher(MatchStrategy.TrieTree, new NumberWithUnitTokenizer());
 
         private readonly Regex separateRegex;
-        private readonly Regex singleCharUnitRegex = new Regex(BaseUnits.SingleCharUnitRegex,
+        private readonly Regex singleCharUnitRegex = RegexCache.Get(BaseUnits.SingleCharUnitRegex,
                                                                RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly int maxPrefixMatchLen;
@@ -424,7 +424,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
                 var pattern = $@"{this.config.BuildPrefix}({string.Join("|", regexTokens)}){this.config.BuildSuffix}";
                 var options = RegexOptions.Singleline | RegexOptions.ExplicitCapture | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
 
-                var regex = new Regex(pattern, options);
+                var regex = RegexCache.Get(pattern, options);
                 regexes.Add(regex);
             }
 
@@ -485,7 +485,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             var pattern = $@"{this.config.BuildPrefix}({string.Join("|", regexTokens)}){this.config.BuildSuffix}";
             var options = RegexOptions.Singleline | RegexOptions.ExplicitCapture | (ignoreCase ? RegexOptions.IgnoreCase : RegexOptions.None);
 
-            var regex = new Regex(pattern, options);
+            var regex = RegexCache.Get(pattern, options);
             return regex;
         }
 
@@ -521,7 +521,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
             }
 
             // Filter single-char units if not exact match
-            extractResults = extractResults.Where(er => !(er.Length != text.Length && singleCharUnitRegex.IsMatch(er.Text))).ToList();
+            extractResults = extractResults.Where(er => !(er.Length != text.Length && singleCharUnitRegexCache.IsMatch(er.Text))).ToList();
 
             return extractResults;
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected FrenchNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.French))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected GermanNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/TemperatureExtractorConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.German))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/HindiNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/HindiNumberWithUnitExtractorConfiguration.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Hindi
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected HindiNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/TemperatureExtractorConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Hindi
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.Hindi))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected ItalianNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Italian))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected JapaneseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected PortugueseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.Portuguese))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected SpanishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/TemperatureExtractorConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Spanish))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/SwedishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/SwedishNumberWithUnitExtractorConfiguration.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Swedish
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexFlags);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexFlags);
 
         protected SwedishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/TemperatureExtractorConfiguration.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Swedish
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexFlags);
 
         public TemperatureExtractorConfiguration()
             : this(new CultureInfo(Culture.Swedish))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TemperatureExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TemperatureExtractorConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
             NumbersWithUnitDefinitions.AmbiguousTemperatureUnitList.ToImmutableList();
 
         private static readonly Regex AmbiguousUnitMultiplierRegex =
-            new Regex(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
+            RegexCache.Get(BaseUnits.AmbiguousUnitNumberMultiplierRegex, RegexOptions.None);
 
         public TemperatureExtractorConfiguration()
                : this(new CultureInfo(Culture.Turkish))

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
     public abstract class TurkishNumberWithUnitExtractorConfiguration : INumberWithUnitExtractorConfiguration
     {
         private static readonly Regex CompoundUnitConnRegex =
-            new Regex(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
+            RegexCache.Get(NumbersWithUnitDefinitions.CompoundUnitConnectorRegex, RegexOptions.None);
 
         private static readonly Regex NonUnitsRegex =
-            new Regex(BaseUnits.PmNonUnitRegex, RegexOptions.None);
+            RegexCache.Get(BaseUnits.PmNonUnitRegex, RegexOptions.None);
 
         protected TurkishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChineseIpExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChineseIpExtractorConfiguration.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Recognizers.Text.Sequence.Chinese
         public ChineseIpExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            Ipv4Regex = new Regex(IpDefinitions.Ipv4Regex, RegexOptions.Compiled);
-            Ipv6Regex = new Regex(IpDefinitions.Ipv6Regex, RegexOptions.Compiled);
+            Ipv4Regex = RegexCache.Get(IpDefinitions.Ipv4Regex, RegexOptions.Compiled);
+            Ipv6Regex = RegexCache.Get(IpDefinitions.Ipv6Regex, RegexOptions.Compiled);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChinesePhoneNumberExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChinesePhoneNumberExtractorConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Sequence.Chinese
             WordBoundariesRegex = PhoneNumbersDefinitions.WordBoundariesRegex;
             NonWordBoundariesRegex = PhoneNumbersDefinitions.NonWordBoundariesRegex;
             EndWordBoundariesRegex = PhoneNumbersDefinitions.EndWordBoundariesRegex;
-            ColonPrefixCheckRegex = new Regex(PhoneNumbersDefinitions.ColonPrefixCheckRegex);
+            ColonPrefixCheckRegex = RegexCache.Get(PhoneNumbersDefinitions.ColonPrefixCheckRegex);
             ForbiddenPrefixMarkers = (List<char>)PhoneNumbersDefinitions.ForbiddenPrefixMarkers;
         }
     }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChineseURLExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Chinese/Extractors/ChineseURLExtractorConfiguration.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Recognizers.Text.Sequence.Chinese
         public ChineseURLExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            UrlRegex = new Regex(URLDefinitions.UrlRegex, RegexOptions.Compiled);
-            IpUrlRegex = new Regex(URLDefinitions.IpUrlRegex, RegexOptions.Compiled);
+            UrlRegex = RegexCache.Get(URLDefinitions.UrlRegex, RegexOptions.Compiled);
+            IpUrlRegex = RegexCache.Get(URLDefinitions.IpUrlRegex, RegexOptions.Compiled);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishIpExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishIpExtractorConfiguration.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Recognizers.Text.Sequence.English
         public EnglishIpExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            Ipv4Regex = new Regex(BaseIp.Ipv4Regex, RegexOptions.Compiled);
-            Ipv6Regex = new Regex(BaseIp.Ipv6Regex, RegexOptions.Compiled);
+            Ipv4Regex = RegexCache.Get(BaseIp.Ipv4Regex, RegexOptions.Compiled);
+            Ipv6Regex = RegexCache.Get(BaseIp.Ipv6Regex, RegexOptions.Compiled);
         }
 
     }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishPhoneNumberExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishPhoneNumberExtractorConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
         public EnglishPhoneNumberExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            FalsePositivePrefixRegex = new Regex(PhoneNumbersDefinitions.FalsePositivePrefixRegex);
+            FalsePositivePrefixRegex = RegexCache.Get(PhoneNumbersDefinitions.FalsePositivePrefixRegex);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishURLExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Extractors/EnglishURLExtractorConfiguration.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Recognizers.Text.Sequence.English
         public EnglishURLExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            IpUrlRegex = new Regex(BaseURL.IpUrlRegex, RegexOptions.Compiled);
-            UrlRegex = new Regex(BaseURL.UrlRegex, RegexOptions.Compiled);
+            IpUrlRegex = RegexCache.Get(BaseURL.IpUrlRegex, RegexOptions.Compiled);
+            UrlRegex = RegexCache.Get(BaseURL.UrlRegex, RegexOptions.Compiled);
         }
 
     }

--- a/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/GUIDParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/English/Parsers/GUIDParser.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Recognizers.Text.Sequence.English
         private static string pureDigitRegex = @"^\d*$";
         private static string formatRegex = @"-";
 
-        private static readonly Regex GuidElementRegex = new Regex(BaseGUID.GUIDRegexElement, RegexOptions.Compiled);
+        private static readonly Regex GuidElementRegex = RegexCache.Get(BaseGUID.GUIDRegexElement, RegexOptions.Compiled);
 
         public static double ScoreGUID(string textGUID)
         {
@@ -27,8 +27,8 @@ namespace Microsoft.Recognizers.Text.Sequence.English
                 int startIndex = elementMatch.Groups[1].Index;
                 string guidElement = elementMatch.Groups[1].Value;
                 score -= startIndex == 0 ? noBoundaryPenalty : 0;
-                score -= Regex.IsMatch(guidElement, formatRegex) ? 0 : noFormatPenalty;
-                score -= Regex.IsMatch(textGUID, pureDigitRegex) ? pureDigitPenalty : 0;
+                score -= RegexCache.IsMatch(guidElement, formatRegex) ? 0 : noFormatPenalty;
+                score -= RegexCache.IsMatch(textGUID, pureDigitRegex) ? pureDigitPenalty : 0;
             }
 
             return Math.Max(Math.Min(score, scoreUpperLimit), scoreLowerLimit) / (scoreUpperLimit - scoreLowerLimit);

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseEmailExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseEmailExtractor.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Recognizers.Text.Sequence
 {
     public class BaseEmailExtractor : BaseSequenceExtractor
     {
-        private static readonly Regex Rfc5322ValidationRegex = new Regex(BaseEmail.RFC5322Regex, RegexOptions.Compiled);
+        private static readonly Regex Rfc5322ValidationRegex = RegexCache.Get(BaseEmail.RFC5322Regex, RegexOptions.Compiled);
 
         private static readonly char[] TrimmableChars = { '.' };
 
@@ -22,11 +22,11 @@ namespace Microsoft.Recognizers.Text.Sequence
             var regexes = new Dictionary<Regex, string>
             {
                 {
-                    new Regex(BaseEmail.EmailRegex, RegexOptions.Compiled),
+                    RegexCache.Get(BaseEmail.EmailRegex, RegexOptions.Compiled),
                     Constants.EMAIL_REGEX
                 },
                 {
-                    new Regex(BaseEmail.EmailRegex2, RegexOptions.Compiled),
+                    RegexCache.Get(BaseEmail.EmailRegex2, RegexOptions.Compiled),
                     Constants.EMAIL_REGEX
                 },
             };
@@ -57,7 +57,7 @@ namespace Microsoft.Recognizers.Text.Sequence
                     }
                 }
 
-                return results.Where(r => Rfc5322ValidationRegex.IsMatch(r.Text)).ToList();
+                return results.Where(r => Rfc5322ValidationRegexCache.IsMatch(r.Text)).ToList();
             }
         }
 

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseGUIDExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseGUIDExtractor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Recognizers.Text.Sequence
             var regexes = new Dictionary<Regex, string>
             {
                 {
-                    new Regex(BaseGUID.GUIDRegex),
+                    RegexCache.Get(BaseGUID.GUIDRegex),
                     Constants.GUID_REGEX
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseHashTagExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseHashTagExtractor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Sequence
             var regexes = new Dictionary<Regex, string>
             {
                 {
-                    new Regex(BaseHashtag.HashtagRegex),
+                    RegexCache.Get(BaseHashtag.HashtagRegex),
                     Constants.HASHTAG_REGEX
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseMentionExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseMentionExtractor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Sequence
             var regexes = new Dictionary<Regex, string>
             {
                 {
-                    new Regex(BaseMention.MentionRegex),
+                    RegexCache.Get(BaseMention.MentionRegex),
                     Constants.MENTION_REGEX
                 },
             };

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BasePhoneNumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BasePhoneNumberExtractor.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Recognizers.Text.Sequence
 {
     public class BasePhoneNumberExtractor : BaseSequenceExtractor
     {
-        private static readonly Regex InternationalDialingPrefixRegex = new Regex(BasePhoneNumbers.InternationDialingPrefixRegex);
+        private static readonly Regex InternationalDialingPrefixRegex = RegexCache.Get(BasePhoneNumbers.InternationDialingPrefixRegex);
 
-        private static readonly Regex PreCheckPhoneNumberRegex = new Regex(BasePhoneNumbers.PreCheckPhoneNumberRegex, RegexOptions.Compiled);
+        private static readonly Regex PreCheckPhoneNumberRegex = RegexCache.Get(BasePhoneNumbers.PreCheckPhoneNumberRegex, RegexOptions.Compiled);
 
-        private static readonly Regex SSNFilterRegex = new Regex(BasePhoneNumbers.SSNFilterRegex, RegexOptions.Compiled);
+        private static readonly Regex SSNFilterRegex = RegexCache.Get(BasePhoneNumbers.SSNFilterRegex, RegexOptions.Compiled);
 
         private PhoneNumberConfiguration config;
 
@@ -28,43 +28,43 @@ namespace Microsoft.Recognizers.Text.Sequence
             var regexes = new Dictionary<Regex, string>
             {
                 {
-                    new Regex(BasePhoneNumbers.GeneralPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.GeneralPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_GENERAL
                 },
                 {
-                    new Regex(BasePhoneNumbers.BRPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.BRPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_BR
                 },
                 {
-                    new Regex(BasePhoneNumbers.UKPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.UKPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_UK
                 },
                 {
-                    new Regex(BasePhoneNumbers.DEPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.DEPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_DE
                 },
                 {
-                    new Regex(BasePhoneNumbers.USPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.USPhoneNumberRegex(wordBoundariesRegex, nonWordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_US
                 },
                 {
-                    new Regex(BasePhoneNumbers.CNPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.CNPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_CN
                 },
                 {
-                    new Regex(BasePhoneNumbers.DKPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.DKPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_DK
                 },
                 {
-                    new Regex(BasePhoneNumbers.ITPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.ITPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_IT
                 },
                 {
-                    new Regex(BasePhoneNumbers.NLPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.NLPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_NL
                 },
                 {
-                    new Regex(BasePhoneNumbers.SpecialPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
+                    RegexCache.Get(BasePhoneNumbers.SpecialPhoneNumberRegex(wordBoundariesRegex, endWordBoundariesRegex), RegexOptions.Compiled),
                     Constants.PHONE_NUMBER_REGEX_SPECIAL
                 },
             };
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.Sequence
 
         public override List<ExtractResult> Extract(string text)
         {
-            if (!PreCheckPhoneNumberRegex.IsMatch(text))
+            if (!PreCheckPhoneNumberRegexCache.IsMatch(text))
             {
                 return new List<ExtractResult>();
             }
@@ -90,7 +90,7 @@ namespace Microsoft.Recognizers.Text.Sequence
             for (var i = 0; i < ers.Count; i++)
             {
                 var er = ers[i];
-                if ((CountDigits(er.Text) < 7 && er.Data.ToString() != "ITPhoneNumber") || SSNFilterRegex.IsMatch(er.Text))
+                if ((CountDigits(er.Text) < 7 && er.Data.ToString() != "ITPhoneNumber") || SSNFilterRegexCache.IsMatch(er.Text))
                 {
                     ers.Remove(er);
                     i--;
@@ -145,7 +145,7 @@ namespace Microsoft.Recognizers.Text.Sequence
                     var front = text.Substring(0, (int)(er.Start - 1));
 
                     if (this.config.FalsePositivePrefixRegex != null &&
-                            this.config.FalsePositivePrefixRegex.IsMatch(front))
+                            this.config.FalsePositivePrefixRegexCache.IsMatch(front))
                     {
                         ers.Remove(er);
                         i--;
@@ -162,7 +162,7 @@ namespace Microsoft.Recognizers.Text.Sequence
                             if (!char.IsNumber(charGap) && !char.IsWhiteSpace(charGap))
                             {
                                 // check if the extracted string has a non-digit string before "-".
-                                var flag = Regex.IsMatch(text.Substring(0, (int)(er.Start - 2)), @"^[^0-9]+$");
+                                var flag = RegexCache.IsMatch(text.Substring(0, (int)(er.Start - 2)), @"^[^0-9]+$");
 
                                 // Handle cases like "91a-677-0060".
                                 if (char.IsLower(charGap) && !flag)
@@ -175,7 +175,7 @@ namespace Microsoft.Recognizers.Text.Sequence
                             }
 
                             // check the international dialing prefix
-                            if (InternationalDialingPrefixRegex.IsMatch(front))
+                            if (InternationalDialingPrefixRegexCache.IsMatch(front))
                             {
                                 var moveOffset = InternationalDialingPrefixRegex.Match(front).Length + 1;
                                 er.Start = er.Start - moveOffset;
@@ -195,7 +195,7 @@ namespace Microsoft.Recognizers.Text.Sequence
                         // Handle "tel:123456".
                         if (BasePhoneNumbers.ColonMarkers.Contains(ch))
                         {
-                            if (this.config.ColonPrefixCheckRegex.IsMatch(front))
+                            if (this.config.ColonPrefixCheckRegexCache.IsMatch(front))
                             {
                                 continue;
                             }
@@ -228,7 +228,7 @@ namespace Microsoft.Recognizers.Text.Sequence
 
         private static bool CheckFormattedPhoneNumber(string phoneNumberText)
         {
-            return Regex.IsMatch(phoneNumberText, BasePhoneNumbers.FormatIndicatorRegex);
+            return RegexCache.IsMatch(phoneNumberText, BasePhoneNumbers.FormatIndicatorRegex);
         }
 
         private static int CountDigits(string candidateString)

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BasePhoneNumberExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BasePhoneNumberExtractorConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Recognizers.Text.Sequence
             WordBoundariesRegex = BasePhoneNumbers.WordBoundariesRegex;
             NonWordBoundariesRegex = BasePhoneNumbers.NonWordBoundariesRegex;
             EndWordBoundariesRegex = BasePhoneNumbers.EndWordBoundariesRegex;
-            ColonPrefixCheckRegex = new Regex(BasePhoneNumbers.ColonPrefixCheckRegex);
+            ColonPrefixCheckRegex = RegexCache.Get(BasePhoneNumbers.ColonPrefixCheckRegex);
             ColonMarkers = (List<char>)BasePhoneNumbers.ColonMarkers;
             ForbiddenPrefixMarkers = (List<char>)BasePhoneNumbers.ForbiddenPrefixMarkers;
             ForbiddenSuffixMarkers = (List<char>)BasePhoneNumbers.ForbiddenSuffixMarkers;

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseURLExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Extractors/BaseURLExtractor.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Recognizers.Text.Sequence
                     Constants.URL_REGEX
                 },
                 {
-                    new Regex(BaseURL.UrlRegex2, RegexOptions.Compiled),
+                    RegexCache.Get(BaseURL.UrlRegex2, RegexOptions.Compiled),
                     Constants.URL_REGEX
                 },
             };
 
             Regexes = regexes.ToImmutableDictionary();
-            AmbiguousTimeTerm = new Regex(BaseURL.AmbiguousTimeTerm, RegexOptions.Compiled);
+            AmbiguousTimeTerm = RegexCache.Get(BaseURL.AmbiguousTimeTerm, RegexOptions.Compiled);
 
             TldMatcher = new StringMatcher();
             TldMatcher.Init(BaseURL.TldList);

--- a/.NET/Microsoft.Recognizers.Text.Sequence/Portuguese/PortuguesePhoneNumberExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Sequence/Portuguese/PortuguesePhoneNumberExtractorConfiguration.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Recognizers.Text.Sequence.Portuguese
         public PortuguesePhoneNumberExtractorConfiguration(SequenceOptions options)
             : base(options)
         {
-            FalsePositivePrefixRegex = new Regex(PhoneNumbersDefinitions.FalsePositivePrefixRegex);
+            FalsePositivePrefixRegex = RegexCache.Get(PhoneNumbersDefinitions.FalsePositivePrefixRegex);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Utilities/QueryProcessor.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/QueryProcessor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.Utilities
         // Must be in sync with Base-Numbers YAML due to inter-dependency issue with different .NET targets
         private const string CaseSensitiveTerms = @"(?<=(\s|\d))(kB|K[Bb]?|M[BbM]?|G[Bb]?|B)\b";
 
-        private static readonly Regex SpecialTokensRegex = new Regex(CaseSensitiveTerms, RegexOptions.Compiled);
+        private static readonly Regex SpecialTokensRegex = RegexCache.Get(CaseSensitiveTerms, RegexOptions.Compiled);
 
         public static string Preprocess(string query, bool caseSensitive = false, bool recode = true)
         {

--- a/.NET/Microsoft.Recognizers.Text/Utilities/RegExpUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/RegExpUtility.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Recognizers.Text.Utilities
 
         private static string SanitizeGroups(string source)
         {
-            Regex matchGroup = new Regex(@"\?< (?<name>\w +) >");
+            Regex matchGroup = RegexCache.Get(@"\?< (?<name>\w +) >");
 
             var result = Regex.Replace(source, matchGroup.ToString(), ReplaceMatchGroup);
             return result;

--- a/.NET/Microsoft.Recognizers.Text/Utilities/RegexCache.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/RegexCache.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text
@@ -22,5 +23,10 @@ namespace Microsoft.Recognizers.Text
         }
 
         public static Regex Get(string pattern) => Get(pattern, default);
+
+        public static bool IsMatch(string text, string pattern)
+        {
+            return Get(pattern).IsMatch(text);
+        }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text/Utilities/RegexCache.cs
+++ b/.NET/Microsoft.Recognizers.Text/Utilities/RegexCache.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Recognizers.Text
+{
+    public static class RegexCache
+    {
+        private static ConcurrentDictionary<(string pattern, RegexOptions options), Regex> _cache = new ConcurrentDictionary<(string pattern, RegexOptions options), Regex>();
+
+        public static bool Compiled { get; set; } = false;
+
+        public static Regex Get(string pattern, RegexOptions options)
+        {
+            if (Compiled)
+            {
+                return _cache.GetOrAdd((pattern, options), k => new Regex(k.pattern, k.options | RegexOptions.Compiled));
+            }
+            else
+            {
+                return _cache.GetOrAdd((pattern, options), k => new Regex(k.pattern, k.options));
+            }
+        }
+
+        public static Regex Get(string pattern) => Get(pattern, default);
+    }
+}


### PR DESCRIPTION
This change should reduce significantly the number of Regex objects required by the library, as there was a large number of duplicated Regex being built on the Parser/Extractors. 

As an extra benefit, it also adds the option to use compiled Regex by setting the flag before consuming any model:

`````cshasp
RegexCache.Compiled = true;`
`````
This should be useful for cases where startup time is not as important as parsing time.

Closes #2386 
