### PR TITLE
[* DateTimeV2] Support for context for establishing limits in DatePeriod and DateTimeperiod in ExperimentaMode (#640)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|last)\s+(week\s+{MonthSuffixRegex}[\.]?\s+(on\s+)?{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(from\s+now|later))\b";
       public static readonly string SpecialDate = $@"(?=\b(on|at)\s+the\s+){DayRegex}\b";
+      public const string PreciseDateTokens = @"\b(this|current|last|previous|past|yesterday|tomorrow|tmr|today|now|ago)\b";
       public const string DatePreposition = @"\b(on|in)";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*,\s*|\s+of\s+){DateYearRegex}";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}[\.]?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateParserConfiguration.cs
@@ -128,6 +128,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/English/Parsers/EnglishDateParserConfiguration.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime.English
 {
     public class EnglishDateParserConfiguration : BaseDateTimeOptionsConfiguration, IDateParserConfiguration
     {
+        public static readonly Regex PreciseDateTokens =
+            new Regex(DateTimeDefinitions.PreciseDateTokens, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public EnglishDateParserConfiguration(ICommonDateTimeParserConfiguration config)
@@ -132,6 +135,8 @@ namespace Microsoft.Recognizers.Text.DateTime.English
         public Regex PastPrefixRegex { get; }
 
         public Regex BeforeAfterRegex { get; }
+
+        Regex IDateParserConfiguration.PreciseDateTokens => PreciseDateTokens;
 
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Parsers/FrenchDateParserConfiguration.cs
@@ -132,6 +132,8 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanDateParserConfiguration.cs
@@ -131,6 +131,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Hindi/Parsers/HindiDateParserConfiguration.cs
@@ -133,6 +133,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Hindi
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Italian/Parsers/ItalianDateParserConfiguration.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Italian
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (!innerResult.Success)
                 {
                     innerResult = ParseImplicitDate(er.Text, referenceDate);
+                    if (innerResult.Success && this.config.PreciseDateTokens != null && !this.config.PreciseDateTokens.IsMatch(er.Text))
+                    {
+                        innerResult.Comment = "AmbiguousDate";
+                    }
                 }
 
                 if (!innerResult.Success)
@@ -48,6 +52,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                 if (!innerResult.Success)
                 {
                     innerResult = ParseDurationWithAgoAndLater(er.Text, referenceDate);
+                    if (innerResult.Success && this.config.PreciseDateTokens != null && !this.config.PreciseDateTokens.IsMatch(er.Text))
+                    {
+                        innerResult.Comment = "AmbiguousDate";
+                    }
                 }
 
                 if (!innerResult.Success)
@@ -734,9 +742,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         // Handle cases like "two days ago"
         private DateTimeResolutionResult ParseDurationWithAgoAndLater(string text, DateObject referenceDate)
         {
+            // Reference time should be ignored
+            DateObject refDate = new DateObject(referenceDate.Year, referenceDate.Month, referenceDate.Day);
             return AgoLaterUtil.ParseDurationWithAgoAndLater(
                 text,
-                referenceDate,
+                refDate,
                 config.DurationExtractor,
                 config.DurationParser,
                 config.NumberParser,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/IDateParserConfiguration.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex BeforeAfterRegex { get; }
 
+        Regex PreciseDateTokens { get; }
+
         IImmutableDictionary<string, string> UnitMap { get; }
 
         IImmutableDictionary<string, int> DayOfMonth { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDateParserConfiguration.cs
@@ -133,6 +133,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateParserConfiguration.cs
@@ -133,6 +133,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Turkish/Parsers/TurkishDateParserConfiguration.cs
@@ -134,6 +134,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Turkish
 
         public Regex BeforeAfterRegex { get; }
 
+        Regex IDateParserConfiguration.PreciseDateTokens => null;
+
         public IImmutableDictionary<string, int> DayOfMonth { get; }
 
         public IImmutableDictionary<string, int> DayOfWeek { get; }

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -247,6 +247,8 @@ RelativeWeekDayRegex: !nestedRegex
 SpecialDate: !nestedRegex
   def: (?=\b(on|at)\s+the\s+){DayRegex}\b
   references: [ DayRegex ]
+PreciseDateTokens: !simpleRegex
+  def: \b(this|current|last|previous|past|yesterday|tomorrow|tmr|today|now|ago)\b
 DatePreposition: !simpleRegex
   def: \b(on|in)
 DateExtractorYearTermRegex: !nestedRegex

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -19074,5 +19074,218 @@
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
     "Results": []
+  },
+  {
+    "Input": "I'll be out 2pm 1st jun 2000 until 2am on the next day",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2pm 1st jun 2000 until 2am on the next day",
+        "Start": 12,
+        "End": 53,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01T14,2016-11-08T02,PT144084H)",
+              "type": "datetimerange",
+              "start": "2000-06-01 14:00:00",
+              "end": "2016-11-08 02:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 2pm 1st jun 2000 until 2am on 2nd",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2pm 1st jun 2000 until 2am on 2nd",
+        "Start": 12,
+        "End": 44,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01T14,XXXX-XX-02T02,PT144660H)",
+              "type": "datetimerange",
+              "start": "2000-06-01 14:00:00",
+              "end": "2016-11-02 02:00:00"
+            },
+            {
+              "timex": "(2000-06-01T14,XXXX-XX-02T02,PT144660H)",
+              "type": "datetimerange",
+              "start": "2000-06-01 14:00:00",
+              "end": "2016-12-02 02:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 1st jun 2000 until the 2nd of june",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "1st jun 2000 until the 2nd of june",
+        "Start": 12,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01,XXXX-06-02,P6210D)",
+              "type": "daterange",
+              "start": "2000-06-01",
+              "end": "2016-06-02"
+            },
+            {
+              "timex": "(2000-06-01,XXXX-06-02,P6210D)",
+              "type": "daterange",
+              "start": "2000-06-01",
+              "end": "2017-06-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 1st jun 2000 until the 2nd of june 2000",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "1st jun 2000 until the 2nd of june 2000",
+        "Start": 12,
+        "End": 50,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01,2000-06-02,P1D)",
+              "type": "daterange",
+              "start": "2000-06-01",
+              "end": "2000-06-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till today",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till today",
+        "Start": 13,
+        "End": 36,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-24,P1272D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2018-10-24"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till the next Wednesday",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till the next wednesday",
+        "Start": 13,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-31,P1279D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2018-10-31"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till three days later",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "Comment": "dateContext.ProcessDateEntityParsingResult incorrectly modifies the end point in this case.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till three days later",
+        "Start": 13,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-27,P179D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2015-10-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till three days ago",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till three days ago",
+        "Start": 13,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-21,P1269D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2018-10-21"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -7915,5 +7915,205 @@
         }
       }
     ]
+  },
+  {
+    "Input": "I'll be out 2pm 1st jun 2000 until 2am on the next day",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2pm 1st jun 2000 until 2am on the next day",
+        "Start": 12,
+        "End": 53,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01T14,2000-06-02T02,PT12H)",
+              "type": "datetimerange",
+              "start": "2000-06-01 14:00:00",
+              "end": "2000-06-02 02:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 2pm 1st jun 2000 until 2am on 2nd",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2pm 1st jun 2000 until 2am on 2nd",
+        "Start": 12,
+        "End": 44,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01T14,XXXX-XX-02T02,PT12H)",
+              "type": "datetimerange",
+              "start": "2000-06-01 14:00:00",
+              "end": "2000-06-02 02:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 1st jun 2000 until the 2nd of june",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "1st jun 2000 until the 2nd of june",
+        "Start": 12,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01,XXXX-06-03,P2D)",
+              "type": "daterange",
+              "start": "2000-06-01",
+              "end": "2000-06-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out 1st jun 2000 until the 2nd of june 2000",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "1st jun 2000 until the 2nd of june 2000",
+        "Start": 12,
+        "End": 50,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-06-01,2000-06-03,P2D)",
+              "type": "daterange",
+              "start": "2000-06-01",
+              "end": "2000-06-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till today",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till today",
+        "Start": 13,
+        "End": 36,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-25,P1273D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2018-10-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till the next Wednesday",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till the next wednesday",
+        "Start": 13,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2015-05-07,P6D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2015-05-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till three days later",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till three days later",
+        "Start": 13,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2015-05-05,P4D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2015-05-05"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I will leave from 5/1/2015 till three days ago",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from 5/1/2015 till three days ago",
+        "Start": 13,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2015-05-01,2018-10-22,P1270D)",
+              "type": "daterange",
+              "start": "2015-05-01",
+              "end": "2018-10-22"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #640 where, in Experimental mode, ambiguous dates are recalculated using the other non-ambiguous date as reference (in DatePeriod and DateTimePeriod).
Test cases added to DateTimeModel and DateTimeModelExperimentalMode.

The use of context was already partially implemented in DatePeriod, but it needs to be improved because it produces inconsistent results in certain cases (e.g. "from 5/1/2015 till three days later").