### PR TITLE
[EN Age] Fix to Age in English should not require the word "old" to match (#2342)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Recognizers.Definitions.English
     {
       public static readonly Dictionary<string, string> AgePrefixList = new Dictionary<string, string>
         {
-            { @"Age", @"Age|age" }
+            { @"Age", @"Age|age|age of|i am" }
         };
       public static readonly Dictionary<string, string> AgeSuffixList = new Dictionary<string, string>
         {
-            { @"Year", @"years old|year old|year-old|years-old|-year-old|-years-old|years of age|year of age|yo" },
+            { @"Year", @"years old|year old|year-old|years-old|-year-old|-years-old|years of age|year of age|yo|years" },
             { @"Month", @"months old|month old|month-old|months-old|-month-old|-months-old|month of age|months of age|mo" },
             { @"Week", @"weeks old|week old|week-old|weeks-old|-week-old|-weeks-old|week of age|weeks of age" },
             { @"Day", @"days old|day old|day-old|days-old|-day-old|-days-old|day of age|days of age" }
@@ -813,7 +813,8 @@ namespace Microsoft.Recognizers.Definitions.English
         };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"\bm\b", @"((('|’)\s*m)|(m\s*('|’)))" }
+            { @"\bm\b", @"((('|’)\s*m)|(m\s*('|’)))" },
+            { @"\bi am\b", @"(i am(?!\s+\d{1,2}([.;,!](?!\d)|$)))" }
         };
     }
 }

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -3,11 +3,11 @@
 AgePrefixList: !dictionary
   types: [ string, string ]
   entries:
-    Age: Age|age
+    Age: Age|age|age of|i am
 AgeSuffixList: !dictionary
   types: [ string, string ]
   entries:
-    Year: years old|year old|year-old|years-old|-year-old|-years-old|years of age|year of age|yo
+    Year: years old|year old|year-old|years-old|-year-old|-years-old|years of age|year of age|yo|years
     Month: months old|month old|month-old|months-old|-month-old|-months-old|month of age|months of age|mo
     Week: weeks old|week old|week-old|weeks-old|-week-old|-weeks-old|week of age|weeks of age
     Day: days old|day old|day-old|days-old|-day-old|-days-old|day of age|days of age
@@ -905,4 +905,5 @@ AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     \bm\b: ((('|’)\s*m)|(m\s*('|’)))
+    \bi am\b: (i am(?!\s+\d{1,2}([.;,!](?!\d)|$)))
 ...

--- a/Specs/NumberWithUnit/English/AgeModel.json
+++ b/Specs/NumberWithUnit/English/AgeModel.json
@@ -275,5 +275,68 @@
         }
       }
     ]
+  },
+  {
+    "Input": "He died at the age of 74.",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "age of 74",
+        "Start": 15,
+        "End": 23,
+        "TypeName": "age",
+        "Resolution": {
+          "unit": "Age",
+          "value": "74"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How old are you? 25 years.",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "25 years",
+        "Start": 17,
+        "End": 24,
+        "TypeName": "age",
+        "Resolution": {
+          "unit": "Year",
+          "value": "25"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "How old are you? I am 25.",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "i am 25",
+        "Start": 17,
+        "End": 23,
+        "TypeName": "age",
+        "Resolution": {
+          "unit": "Age",
+          "value": "25"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I am 25m.",
+    "NotSupported": "javascript, java",
+    "Results": []
+  },
+  {
+    "Input": "I am 13 or 14 kg.",
+    "NotSupported": "javascript, java",
+    "Results": []
+  },
+  {
+    "Input": "I am 52,3 kg.",
+    "NotSupported": "javascript, java",
+    "Results": []
   }
 ]


### PR DESCRIPTION
Fix to issue #2342. 
Also added support for the pattern "I am 33." which is common and seems unambiguous when occurring at the end of sentence.
Test cases added to DateTimeModel.