### PR TITLE
[ES DateTimeV2] Fix date periods/ranges inconsistently recognized (#2400)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
       public const string QuarterTermRegex = @"\b(((?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th)[ -]+quarter)|(q(?<number>[1-4])))\b";
       public static readonly string RelativeQuarterTermRegex = $@"\b(?<orderQuarter>{StrictRelativeRegex})\s+quarter\b";
-      public static readonly string QuarterRegex = $@"((the\s+)?{QuarterTermRegex}(?:(\s+of|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}";
+      public static readonly string QuarterRegex = $@"((the\s+)?{QuarterTermRegex}(?:((\s+of)?\s+|\s*[,-]\s*)({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}";
       public static readonly string QuarterRegexYearFront = $@"(?:{YearRegex}|{RelativeRegex}\s+year)('s)?(?:\s*-\s*|\s+(the\s+)?)?{QuarterTermRegex}";
       public const string HalfYearTermRegex = @"(?<cardinal>first|1st|second|2nd)\s+half";
       public static readonly string HalfYearFrontRegex = $@"(?<year>((1[5-9]|20)\d{{2}})|2100)(\s*-\s*|\s+(the\s+)?)?h(?<number>[1-2])";
@@ -214,7 +214,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string PeriodicRegex = @"\b(?<periodic>((?<multiplier>semi|bi|tri)(\s*|-))?(daily|monthly|weekly|quarterly|yearly|annual(ly)?))\b";
       public static readonly string EachUnitRegex = $@"\b(?<each>(each|every|any|once an?)(?<other>\s+other)?\s+({DurationUnitRegex}|(?<specialUnit>quarters?|weekends?)|{WeekDayRegex})|(?<specialUnit>weekends))";
       public const string EachPrefixRegex = @"\b(?<each>(each|every|once an?)\s*$)";
-      public const string SetEachRegex = @"\b(?<each>(each|every)(?<other>\s+other)?\s*)\b";
+      public const string SetEachRegex = @"\b(?<each>(each|every)(?<other>\s+other)?\s*)(?!the|that)\b";
       public static readonly string SetLastRegex = $@"(?<last>following|next|upcoming|this|{LastNegPrefix}last|past|previous|current)";
       public const string EachDayRegex = @"^\s*(each|every)\s*day\b";
       public static readonly string DurationFollowedUnit = $@"(^\s*{DurationUnitRegex}\s+{SuffixAndRegex})|(^\s*{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+((el\s+(d[ií]a\s+)?){FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+({DayRegex}|{WrittenDayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
-      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[aoo|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))";
+      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[ao]|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))";
       public const string RelativeWeekDayRegex = @"^[.]";
       public const string AmbiguousRangeModifierPrefix = @"^[.]";
       public const string NumberEndingPattern = @"^[.]";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -565,9 +565,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string PreviousPrefixRegex = $@"\b({PastPrefixRegex}?pasad[oa](?!(\s+el)?\s+medio\s*d[ií]a)|[uú]ltim[oa]|anterior)\b";
       public const string ThisPrefixRegex = @"(est?[ea]|actual)\b";
       public const string PrefixWeekDayRegex = @"(\s*((,?\s*el)|[-—–]))";
-      public static readonly string ThisRegex = $@"\b((est[ae]\s*)(semana\s+(el\s+)?)?{WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b";
-      public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}\s+(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+([uú]ltimo|pasado|anterior))|({WeekDayRegex}(\s+((de\s+)?(esta|la)\s+([uú]ltima\s+)?semana)))\b";
-      public static readonly string NextDateRegex = $@"\b(({NextPrefixRegex}\s+)(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?(pr[oó]xima|siguiente)(\s*semana)))\b";
+      public static readonly string ThisRegex = $@"\b((est[ae]\s*)(semana{PrefixWeekDayRegex}?)?\s*{WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b";
+      public static readonly string LastDateRegex = $@"\b(({PreviousPrefixRegex}\s+(semana{PrefixWeekDayRegex}?)?|(la\s+)?semana\s+{PreviousPrefixRegex}{PrefixWeekDayRegex})\s*{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+([uú]ltimo|pasado|anterior))|({WeekDayRegex}(\s+((de\s+)?((esta|la)\s+([uú]ltima\s+)?semana)|(de\s+)?(la\s+)?semana\s+(pasada|anterior))))\b";
       public static readonly string NextDateRegex = $@"\b((({NextPrefixRegex}\s+)(semana{PrefixWeekDayRegex}?)?|(la\s+)?semana\s+{NextPrefixRegex}{PrefixWeekDayRegex})\s*{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?((pr[oó]xima|siguiente)\s+semana|semana\s+(pr[oó]xima|siguiente))))\b";
       public const string RelativeDayRegex = @"(?<relday>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+días)|(días\s+((que\s+viene)|pasado)))\b";
       public const string RestOfDateRegex = @"\bresto\s+((del|de)\s+)?((la|el|est?[ae])\s+)?(?<duration>semana|mes|año|decada)(\s+actual)?\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string LangMarker = @"Spa";
       public const bool CheckBothBeforeAfter = false;
       public static readonly string TillRegex = $@"(?<till>\b(hasta|hacia|al?)\b(\s+(el|la(s)?)\b)?|{BaseDateTime.RangeConnectorSymbolRegex})";
+      public static readonly string StrictTillRegex = $@"(?<till>\b(hasta|hacia|al?)(\s+(el|la(s)?))?\b|{BaseDateTime.RangeConnectorSymbolRegex}(?!\s*[qt][1-4](?!(\s+de|\s*,\s*))))";
       public static readonly string RangeConnectorRegex = $@"(?<and>\b(y\s*(el|(la(s)?)?))\b|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string WrittenDayRegex = @"(?<day>uno|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieciséis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintidós|veintitrés|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|treinta(\s+y\s+uno)?)";
       public const string DayRegex = @"\b(?<day>01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|1|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)(?:\.[º°])?(?=\b|t)";
@@ -40,8 +41,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string RelativeSuffixRegex = $@"({AfterNextSuffixRegex}|{NextSuffixRegex}|{PreviousSuffixRegex})";
       public const string RangePrefixRegex = @"((de(l|sde)?|entre)(\s+la(s)?)?)";
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-24-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d))|\.?[º°ª])\b";
-      public const string RelativeRegex = @"(?<rela>est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\b";
-      public const string StrictRelativeRegex = @"(?<rela>est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\b";
+      public const string RelativeRegex = @"(?<rela>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b";
+      public const string StrictRelativeRegex = @"(?<rela>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b";
       public const string WrittenOneToNineRegex = @"(un[ao]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)";
       public const string WrittenOneHundredToNineHundredRegex = @"(doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s|cien(to)?)";
       public static readonly string WrittenOneToNinetyNineRegex = $@"(((treinta|cuarenta|cincuenta|sesenta|setenta|ochenta|noventa)(\s+y\s+{WrittenOneToNineRegex})?)|diez|once|doce|trece|catorce|quince|dieciséis|dieciseis|diecisiete|dieciocho|diecinueve|veinte|veintiuno|veintiún|veintiun|veintiuna|veintidós|veintidos|veintitrés|veintitres|veinticuatro|veinticinco|veintiséis|veintisiete|veintiocho|veintinueve|un[ao]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)";
@@ -58,17 +59,18 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre(\s+el)?)\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*)((en|del?)\s+)?{YearRegex})?\b";
       public static readonly string DayBetweenRegex = $@"\b((entre(\s+el)?)\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)((en|del?)\s+)?{YearRegex})?\b";
       public const string SpecialYearPrefixes = @"((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))";
-      public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana))\b)";
+      public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)";
       public static readonly string MonthWithYearRegex = $@"\b(((pr[oó]xim[oa](s)?|est?[ae]|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de(l|\s+la)?|en)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b";
       public static readonly string MonthNumWithYearRegex = $@"\b(({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex}))\b";
-      public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|([12345](\.)?ª)|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
+      public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|([12345](\.)?ª)|[uú]ltima)\s+semana\s+{MonthSuffixRegex}((\s+de)?\s+({BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+año))?)\b";
       public static readonly string WeekOfYearRegex = $@"(?<woy>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima?|([12345]ª))\s+semana(\s+(del?|en))?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))";
       public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
       public const string QuarterTermRegex = @"\b((?<cardinal>primer|1er|segundo|2do|tercer|3ro|4to|([1234](\.)?º))\s+(trimestre|cuarto)|[tq](?<number>[1-4]))\b";
-      public static readonly string QuarterRegex = $@"(el\s+)?{QuarterTermRegex}((\s+(del?\s+)?|\s*[,-]\s*)({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o|a[ñn]o(\s+{RelativeSuffixRegex})))?";
+      public static readonly string RelativeQuarterTermRegex = $@"\b((?<orderQuarter>{StrictRelativeRegex})\s+(trimestre|cuarto)|(trimestre|cuarto)\s+(?<orderQuarter>(actual|pr[oó]ximo|siguiente|pasado|anterior)))\b";
+      public static readonly string QuarterRegex = $@"(el\s+)?{QuarterTermRegex}((\s+(del?\s+)?|\s*[,-]\s*)({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o|a[ñn]o(\s+{RelativeSuffixRegex}))|\s+del\s+a[ñn]o)?|{RelativeQuarterTermRegex}";
       public static readonly string QuarterRegexYearFront = $@"({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o)(?:\s*-\s*|\s+(el\s+)?)?{QuarterTermRegex}";
-      public const string AllHalfYearRegex = @"(?<cardinal>primer|1er|segundo|2do|[12](\.)?º)\s+semestre";
+      public static readonly string AllHalfYearRegex = $@"\b(?<cardinal>primer|1er|segundo|2do|[12](\.)?º)\s+semestre(\s+(de\s+)?({YearRegex}|{RelativeRegex}\s+año))?\b";
       public static readonly string EarlyPrefixRegex = $@"\b(?<EarlyPrefix>(?<RelEarly>m[aá]s\s+temprano(\s+(del?|en))?)|((comienzos?|inicios?|principios?|temprano)\s+({OfPrepositionRegex}(\s+d[ií]a)?)))(\s+(el|las?|los?))?\b";
       public static readonly string MidPrefixRegex = $@"\b(?<MidPrefix>(media[dn]os\s+({OfPrepositionRegex})))(\s+(el|las?|los?))?\b";
       public static readonly string LaterPrefixRegex = $@"\b(?<LatePrefix>((fin(al)?(es)?|[uú]ltimos)\s+({OfPrepositionRegex}))|(?<RelLate>m[aá]s\s+tarde(\s+(del?|en))?))(\s+(el|las?|los?))?\b";
@@ -77,7 +79,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string CenturySuffixRegex = @"(^siglo)\b";
       public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente)|{PrefixPeriodRegex})\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+(del?|en)|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
       public const string WhichWeekRegex = @"\b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
-      public static readonly string WeekOfRegex = $@"((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex})";
+      public static readonly string WeekOfRegex = $@"((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex}|que\s+(inicia|comienza)\s+el|(que\s+va|a\s+partir)\s+del)";
       public static readonly string MonthOfRegex = $@"(mes)(\s+)({OfPrepositionRegex})";
       public const string RangeUnitRegex = @"\b(?<unit>años?|mes(es)?|semanas?)\b";
       public const string BeforeAfterRegex = @"^[.]";
@@ -96,7 +98,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+((el\s+(d[ií]a\s+)?){FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+({DayRegex}|{WrittenDayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
-      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3er|cuarto|4to|quinto|5to|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
+      public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[aoo|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))";
       public const string RelativeWeekDayRegex = @"^[.]";
       public const string AmbiguousRangeModifierPrefix = @"^[.]";
       public const string NumberEndingPattern = @"^[.]";
@@ -115,8 +117,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string WeekDayStart = @"^[\.]";
       public static readonly string DateYearRegex = $@"(?<year>{YearRegex}|(?<!,\s?){TwoDigitYearRegex}|{TwoDigitYearRegex}(?=(\.(?!\d)|[?!;]|$)))";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}((\s*(d[eo])|[/\\\.\-])\s*)?{MonthRegex}\b";
-      public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|d[eo])\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b";
-      public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){DateYearRegex}\b)?";
+      public static readonly string DateExtractor2 = $@"\b((el\s+d[ií]a|{WeekDayRegex})(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|d[eo])\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b";
+      public static readonly string DateExtractor3 = $@"\b((el\s+d[ií]a|{WeekDayRegex})(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){DateYearRegex}\b)?";
       public static readonly string DateExtractor4 = $@"\b(?<!\d[.,]){MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
       public static readonly string DateExtractor5 = $@"\b(?<!\d[.,]){DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\.]\s*\d+)";
       public static readonly string DateExtractor6 = $@"(?<=\b(en|el)\s+){MonthNumRegex}[\-\.]{DayRegex}\b(?!\s*[/\\\.]\s*\d+)";
@@ -170,7 +172,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string DateTimeTimeOfDayRegex = @"\b(?<timeOfDay>mañana|madrugada|(?<pm>pasado\s+(el\s+)?medio\s?d[ií]a|tarde|noche))\b";
       public static readonly string PeriodTimeOfDayRegex = $@"\b((en\s+(el|la|lo)?\s+)?({LaterEarlyRegex}\s+)?(est[ae]\s+)?{DateTimeTimeOfDayRegex})\b";
       public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({LaterEarlyRegex}\s+)?est[ae]\s+{DateTimeTimeOfDayRegex}|({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})|anoche)\b";
-      public const string UnitRegex = @"(?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?)\b";
+      public const string UnitRegex = @"(?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|fin(es)?\s+de\s+semana|finde|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b";
       public const string ConnectorRegex = @"^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?(cerca|alrededor) de las?)$";
       public const string TimeHourNumRegex = @"(?<hour>veintiuno|veintidos|veintitres|veinticuatro|cero|uno|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|diecis([eé])is|diecisiete|dieciocho|diecinueve|veinte)";
       public static readonly string PureNumFromTo = $@"((\b(desde|de)\s+(la(s)?\s+)?)?({BaseDateTime.HourRegex}|{TimeHourNumRegex})(?!\s+al?\b)(\s*(?<leftDesc>{DescRegex}))?|(\b(desde|de)\s+(la(s)?\s+)?)({BaseDateTime.HourRegex}|{TimeHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?)\s*{TillRegex}\s*({BaseDateTime.HourRegex}|{TimeHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{DescRegex})?";
@@ -190,11 +192,11 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string DurationNumberCombinedWithUnit = $@"\b(?<num>\d+(\,\d*)?){UnitRegex}";
       public static readonly string AnUnitRegex = $@"\b(una?|otr[ao])\s+{UnitRegex}";
       public const string DuringRegex = @"^[.]";
-      public const string AllRegex = @"\b(?<all>tod[oa]?\s+(el|la)\s+(?<unit>año|mes|semana|d[ií]a))\b";
+      public const string AllRegex = @"\b(?<all>tod[oa]?\s+(el|la)\s+(?<unit>año|mes|semana|d[ií]a)|((una?|el|la)\s+)?(?<unit>año|mes|semana|d[ií]a)\s+enter[ao])\b";
       public const string HalfRegex = @"\b(?<half>medi[oa]\s+(?<unit>ano|mes|semana|d[íi]a|hora))\b";
       public const string ConjunctionRegex = @"^[.]";
-      public const string InexactNumberRegex = @"\b(pocos?|algo|vari[ao]s|algun[ao]s)\b";
-      public static readonly string InexactNumberUnitRegex = $@"\b(pocos?|algo|vari[ao]s|algun[ao]s)\s+{UnitRegex}";
+      public const string InexactNumberRegex = @"\b(pocos?|algo|vari[ao]s|algun[ao]s|un[ao]s)\b";
+      public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+{UnitRegex}";
       public static readonly string HolidayRegex1 = $@"\b(?<holiday>viernes santo|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public static readonly string HolidayRegex2 = $@"\b(?<holiday>(d[ií]a( del?( la)?)? )?(martin luther king|todos los santos|blanco|san patricio|san valent[ií]n|san jorge|cinco de mayo|independencia|raza|trabajador))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public static readonly string HolidayRegex3 = $@"\b(?<holiday>(d[ií]a( internacional)?( del?( l[ao]s?)?)? )(trabajador(es)?|madres?|padres?|[aá]rbol|mujer(es)?|solteros?|niños?|marmota|san valent[ií]n|maestro))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
@@ -204,8 +206,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string SinceRegexExp = $@"({SinceRegex}|\bde\b)";
       public const string AroundRegex = @"(?:\b(?:cerca|alrededor|aproximadamente)(\s+(de\s+(las?|el)|del?))?\s*\b)";
       public const string PeriodicRegex = @"\b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|semestral|anual)(es|mente)?)\b";
-      public const string EachExpression = @"cada|tod[oa]s\s*(l[oa]s)?";
-      public static readonly string EachUnitRegex = $@"(?<each>({EachExpression})\s*{UnitRegex})";
+      public const string EachExpression = @"\b(cada|tod[oa]s\s*(l[oa]s)?)\b\s*(?!\s*l[oa]\b)";
+      public static readonly string EachUnitRegex = $@"(?<each>({EachExpression})\s*({UnitRegex}|(?<specialUnit>fin(es)?\s+de\s+semana|finde)\b))";
       public static readonly string EachPrefixRegex = $@"(?<each>({EachExpression})\s*$)";
       public static readonly string EachDayRegex = $@"\s*({EachExpression})\s*d[ií]as\s*\b";
       public static readonly string BeforeEachDayRegex = $@"({EachExpression})\s*d[ií]as(\s+a\s+las?)?\s*\b";
@@ -226,7 +228,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string DecadeRegex = @"(?<decade>diez|veinte|treinta|cuarenta|cincuenta|se[st]enta|ochenta|noventa)";
       public static readonly string DecadeWithCenturyRegex = $@"(los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))";
       public static readonly string RelativeDecadeRegex = $@"\b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b";
-      public static readonly string ComplexDatePeriodRegex = $@"(?:((de(sde)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
+      public static readonly string ComplexDatePeriodRegex = $@"(?:((de(sde)?)\s+)?(?<start>.+)\s*({StrictTillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
       public const string AmbiguousPointRangeRegex = @"^(mar\.?)$";
       public static readonly string YearSuffix = $@"((,|\sde)?\s*({YearRegex}|{FullTextYearRegex}))";
       public const string AgoRegex = @"\b(antes\s+de\s+(?<day>hoy|ayer|mañana)|antes)\b";
@@ -248,11 +250,16 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"bimestres", @"2MON" },
             { @"semanas", @"W" },
             { @"semana", @"W" },
+            { @"fin de semana", @"WE" },
+            { @"fines de semana", @"WE" },
+            { @"finde", @"WE" },
             { @"dias", @"D" },
             { @"dia", @"D" },
             { @"días", @"D" },
             { @"día", @"D" },
             { @"jornada", @"D" },
+            { @"noche", @"D" },
+            { @"noches", @"D" },
             { @"horas", @"H" },
             { @"hora", @"H" },
             { @"hrs", @"H" },
@@ -277,10 +284,15 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"mes", 2592000 },
             { @"semanas", 604800 },
             { @"semana", 604800 },
+            { @"fin de semana", 172800 },
+            { @"fines de semana", 172800 },
+            { @"finde", 172800 },
             { @"dias", 86400 },
             { @"dia", 86400 },
             { @"días", 86400 },
             { @"día", 86400 },
+            { @"noche", 86400 },
+            { @"noches", 86400 },
             { @"horas", 3600 },
             { @"hora", 3600 },
             { @"hrs", 3600 },
@@ -550,21 +562,23 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string UpcomingPrefixRegex = @"((este\s+))";
       public static readonly string NextPrefixRegex = $@"\b({UpcomingPrefixRegex}?pr[oó]xim[oa]s?|siguiente|que\s+viene)\b";
       public const string PastPrefixRegex = @"((este\s+))";
-      public static readonly string PreviousPrefixRegex = $@"\b({PastPrefixRegex}?pasad[oa](?!(\s+el)?\s+medio\s*d[ií]a)|[uú]ltim[oa])\b";
-      public const string ThisPrefixRegex = @"(est?[ea])\b";
+      public static readonly string PreviousPrefixRegex = $@"\b({PastPrefixRegex}?pasad[oa](?!(\s+el)?\s+medio\s*d[ií]a)|[uú]ltim[oa]|anterior)\b";
+      public const string ThisPrefixRegex = @"(est?[ea]|actual)\b";
+      public const string PrefixWeekDayRegex = @"(\s*((,?\s*el)|[-—–]))";
       public static readonly string ThisRegex = $@"\b((est[ae]\s*)(semana\s+(el\s+)?)?{WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b";
       public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}\s+(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+([uú]ltimo|pasado|anterior))|({WeekDayRegex}(\s+((de\s+)?(esta|la)\s+([uú]ltima\s+)?semana)))\b";
       public static readonly string NextDateRegex = $@"\b(({NextPrefixRegex}\s+)(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?(pr[oó]xima|siguiente)(\s*semana)))\b";
+      public static readonly string NextDateRegex = $@"\b((({NextPrefixRegex}\s+)(semana{PrefixWeekDayRegex}?)?|(la\s+)?semana\s+{NextPrefixRegex}{PrefixWeekDayRegex})\s*{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?((pr[oó]xima|siguiente)\s+semana|semana\s+(pr[oó]xima|siguiente))))\b";
       public const string RelativeDayRegex = @"(?<relday>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+días)|(días\s+((que\s+viene)|pasado)))\b";
       public const string RestOfDateRegex = @"\bresto\s+((del|de)\s+)?((la|el|est?[ae])\s+)?(?<duration>semana|mes|año|decada)(\s+actual)?\b";
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?)\b";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b";
       public const string DurationConnectorRegex = @"^[.]";
       public static readonly string RelativeDurationUnitRegex = $@"(?:(?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))";
       public const string ReferencePrefixRegex = @"(mism[ao]|aquel|est?e)\b";
       public static readonly string ReferenceDatePeriodRegex = $@"\b{ReferencePrefixRegex}\s+({DateUnitRegex}|fin\s+de\s+semana)\b";
       public const string FromToRegex = @"\b(from).+(to)\b.+";
       public const string SingleAmbiguousMonthRegex = @"^(the\s+)?(may|march)$";
-      public const string UnspecificDatePeriodRegex = @"^(semana|mes)$";
+      public const string UnspecificDatePeriodRegex = @"^[\.]";
       public const string PrepositionSuffixRegex = @"\b(en|el|la|cerca|desde|durante|hasta|hacia)$";
       public const string RestOfDateTimeRegex = @"\bresto\s+((del?)\s+)?((la|el|est[ae])\s+)?(?<unit>(día|jornada))(\s+de\s+hoy)?\b";
       public const string SetWeekDayRegex = @"^[\.]";
@@ -586,7 +600,9 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"^mi$", @"\bmi\b" },
-            { @"^a[nñ]o$", @"(?<!el\s+)a[nñ]o" }
+            { @"^a[nñ]o$", @"(?<!el\s+)a[nñ]o" },
+            { @"^semana$", @"(?<!la\s+)semana" },
+            { @"^mes$", @"(?<!el\s+)mes" }
         };
       public static readonly IList<string> EarlyMorningTermList = new List<string>
         {
@@ -682,5 +698,12 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { 'ó', 'o' },
             { 'ú', 'u' }
         };
+      public const string DoubleMultiplierRegex = @"^(bi)(-|\s)?";
+      public const string DayTypeRegex = @"(d[ií]as?|diari(o|as|amente))$";
+      public const string WeekTypeRegex = @"(semanas?|semanalmente)$";
+      public const string BiWeekTypeRegex = @"(quincenalmente)$";
+      public const string WeekendTypeRegex = @"(fin(es)?\s+de\s+semana|finde)$";
+      public const string MonthTypeRegex = @"(mes(es)?|mensual(es|mente)?)$";
+      public const string YearTypeRegex = @"(años?|anualmente)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1895,7 +1895,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 var swift = this.config.GetSwiftYear(orderStr);
                 if (swift < -1)
                 {
-                    return ret;
+                    swift = 0;
                 }
 
                 year = referenceDate.Year + swift;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishDatePeriodExtractorConfiguration.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             MonthFrontSimpleCasesRegex,
             QuarterRegex,
             QuarterRegexYearFront,
+            AllHalfYearRegex,
             SeasonRegex,
             RestOfDateRegex,
             LaterEarlyPeriodRegex,

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -160,7 +160,7 @@ RelativeQuarterTermRegex: !nestedRegex
   def: \b(?<orderQuarter>{StrictRelativeRegex})\s+quarter\b
   references: [ StrictRelativeRegex ]
 QuarterRegex: !nestedRegex
-  def: ((the\s+)?{QuarterTermRegex}(?:(\s+of|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}
+  def: ((the\s+)?{QuarterTermRegex}(?:((\s+of)?\s+|\s*[,-]\s*)({YearRegex}|{RelativeRegex}\s+year))?)|{RelativeQuarterTermRegex}
   references: [ YearRegex, RelativeRegex, QuarterTermRegex, RelativeQuarterTermRegex ]
 QuarterRegexYearFront: !nestedRegex
   def: (?:{YearRegex}|{RelativeRegex}\s+year)('s)?(?:\s*-\s*|\s+(the\s+)?)?{QuarterTermRegex}
@@ -504,7 +504,7 @@ EachUnitRegex: !nestedRegex
 EachPrefixRegex: !simpleRegex
   def: \b(?<each>(each|every|once an?)\s*$)
 SetEachRegex: !simpleRegex
-  def: \b(?<each>(each|every)(?<other>\s+other)?\s*)\b
+  def: \b(?<each>(each|every)(?<other>\s+other)?\s*)(?!the|that)\b
 SetLastRegex: !nestedRegex
   def: (?<last>following|next|upcoming|this|{LastNegPrefix}last|past|previous|current)
   references: [ LastNegPrefix ]

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -198,7 +198,7 @@ WeekDayAndDayRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+({DayRegex}|{WrittenDayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, WrittenDayRegex, AmDescRegex, PmDescRegex, OclockRegex]
 WeekDayOfMonthRegex: !nestedRegex
-  def: (?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[aoo|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))
+  def: (?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[ao]|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))
   references: [ WeekDayRegex, MonthSuffixRegex ]
 RelativeWeekDayRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -5,6 +5,9 @@ CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
   def: (?<till>\b(hasta|hacia|al?)\b(\s+(el|la(s)?)\b)?|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
+StrictTillRegex: !nestedRegex
+  def: (?<till>\b(hasta|hacia|al?)(\s+(el|la(s)?))?\b|{BaseDateTime.RangeConnectorSymbolRegex}(?!\s*[qt][1-4](?!(\s+de|\s*,\s*))))
+  references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 RangeConnectorRegex: !nestedRegex
   def: (?<and>\b(y\s*(el|(la(s)?)?))\b|{BaseDateTime.RangeConnectorSymbolRegex})
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
@@ -46,9 +49,9 @@ TwoDigitYearRegex: !nestedRegex
   def: \b(?<![$])(?<year>([0-24-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d))|\.?[º°ª])\b
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
-  def: (?<rela>est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\b
+  def: (?<rela>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b
 StrictRelativeRegex: !simpleRegex
-  def: (?<rela>est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))\b
+  def: (?<rela>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b
 WrittenOneToNineRegex: !simpleRegex
   def: (un[ao]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)
 WrittenOneHundredToNineHundredRegex: !simpleRegex
@@ -90,7 +93,7 @@ DayBetweenRegex: !nestedRegex
 SpecialYearPrefixes: !simpleRegex
   def: ((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana))\b)
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)
   references: [MonthRegex, RelativeRegex, OfPrepositionRegex, RelativeSuffixRegex, DateUnitRegex]
 MonthWithYearRegex: !nestedRegex
   def: \b(((pr[oó]xim[oa](s)?|est?[ae]|[uú]ltim[oa]?)\s+)?({MonthRegex})(\s+|(\s*[,-]\s*))((de(l|\s+la)?|en)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año))\b
@@ -99,8 +102,8 @@ MonthNumWithYearRegex: !nestedRegex
   def: \b(({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex}))\b
   references: [ YearRegex, MonthNumRegex ]
 WeekOfMonthRegex: !nestedRegex
-  def: (?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|([12345](\.)?ª)|[uú]ltima)\s+semana\s+{MonthSuffixRegex})
-  references: [ MonthSuffixRegex ]
+  def: (?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|([12345](\.)?ª)|[uú]ltima)\s+semana\s+{MonthSuffixRegex}((\s+de)?\s+({BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+año))?)\b
+  references: [ MonthSuffixRegex, BaseDateTime.FourDigitYearRegex, RelativeRegex ]
 WeekOfYearRegex: !nestedRegex
   def: (?<woy>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|[uú]ltima?|([12345]ª))\s+semana(\s+(del?|en))?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))
   references: [ YearRegex ]
@@ -112,14 +115,18 @@ NumberCombinedWithDateUnit: !nestedRegex
   references: [ DateUnitRegex ]
 QuarterTermRegex: !simpleRegex
   def: \b((?<cardinal>primer|1er|segundo|2do|tercer|3ro|4to|([1234](\.)?º))\s+(trimestre|cuarto)|[tq](?<number>[1-4]))\b
+RelativeQuarterTermRegex: !nestedRegex
+  def: \b((?<orderQuarter>{StrictRelativeRegex})\s+(trimestre|cuarto)|(trimestre|cuarto)\s+(?<orderQuarter>(actual|pr[oó]ximo|siguiente|pasado|anterior)))\b
+  references: [ StrictRelativeRegex ]
 QuarterRegex: !nestedRegex
-  def: (el\s+)?{QuarterTermRegex}((\s+(del?\s+)?|\s*[,-]\s*)({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o|a[ñn]o(\s+{RelativeSuffixRegex})))?
-  references: [ YearRegex, QuarterTermRegex, RelativeRegex, RelativeSuffixRegex]
+  def: (el\s+)?{QuarterTermRegex}((\s+(del?\s+)?|\s*[,-]\s*)({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o|a[ñn]o(\s+{RelativeSuffixRegex}))|\s+del\s+a[ñn]o)?|{RelativeQuarterTermRegex}
+  references: [ YearRegex, QuarterTermRegex, RelativeRegex, RelativeSuffixRegex, RelativeQuarterTermRegex]
 QuarterRegexYearFront: !nestedRegex
   def: ({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+a[ñn]o)(?:\s*-\s*|\s+(el\s+)?)?{QuarterTermRegex}
   references: [ YearRegex, QuarterTermRegex ]
-AllHalfYearRegex: !simpleRegex
-  def: (?<cardinal>primer|1er|segundo|2do|[12](\.)?º)\s+semestre
+AllHalfYearRegex: !nestedRegex
+  def: \b(?<cardinal>primer|1er|segundo|2do|[12](\.)?º)\s+semestre(\s+(de\s+)?({YearRegex}|{RelativeRegex}\s+año))?\b
+  references: [ YearRegex, RelativeRegex ]
 EarlyPrefixRegex: !nestedRegex
   def: \b(?<EarlyPrefix>(?<RelEarly>m[aá]s\s+temprano(\s+(del?|en))?)|((comienzos?|inicios?|principios?|temprano)\s+({OfPrepositionRegex}(\s+d[ií]a)?)))(\s+(el|las?|los?))?\b
   references: [OfPrepositionRegex]
@@ -143,7 +150,7 @@ SeasonRegex: !nestedRegex
 WhichWeekRegex: !simpleRegex
   def: \b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b
 WeekOfRegex: !nestedRegex
-  def: ((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex})
+  def: ((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex}|que\s+(inicia|comienza)\s+el|(que\s+va|a\s+partir)\s+del)
   references: [ OfPrepositionRegex ]
 MonthOfRegex: !nestedRegex
   def: (mes)(\s+)({OfPrepositionRegex})
@@ -191,7 +198,7 @@ WeekDayAndDayRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+({DayRegex}|{WrittenDayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, WrittenDayRegex, AmDescRegex, PmDescRegex, OclockRegex]
 WeekDayOfMonthRegex: !nestedRegex
-  def: (?<wom>(el\s+)?(?<cardinal>primer|1er|segundo|2do|tercer|3er|cuarto|4to|quinto|5to|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+{WeekDayRegex}\s+{MonthSuffixRegex})
+  def: (?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[aoo|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))
   references: [ WeekDayRegex, MonthSuffixRegex ]
 RelativeWeekDayRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
@@ -237,11 +244,11 @@ DateExtractor1: !nestedRegex
   references: [ WeekDayRegex, DayRegex, MonthRegex ]
 DateExtractor2: !nestedRegex
   # (domingo,)? 5 de Abril 5, 2016
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|d[eo])\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b
+  def: \b((el\s+d[ií]a|{WeekDayRegex})(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}\s*([\.\-]|d[eo])\s*{MonthRegex}(\s*,\s*|\s*(del?)\s*){DateYearRegex}\b
   references: [ MonthRegex, DayRegex, DateYearRegex, WeekDayRegex ]
 DateExtractor3: !nestedRegex
   # (domingo,)? 6 de Abril
-  def: \b({WeekDayRegex}(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){DateYearRegex}\b)?
+  def: \b((el\s+d[ií]a|{WeekDayRegex})(\s+|\s*,\s*))?(?<!\d[.,]){DayRegex}(\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){MonthRegex}((\s+|\s*,\s*|\s+d[eo]\s+|\s*-\s*){DateYearRegex}\b)?
   references: [ DayRegex, MonthRegex, WeekDayRegex, DateYearRegex ]
 # The final lookahead in DateExtractor4|5|A avoids extracting as date "10/1-11" from an input like "10/1-11/2/2017" 
 DateExtractor4: !nestedRegex
@@ -412,7 +419,7 @@ PeriodSpecificTimeOfDayRegex: !nestedRegex
   def: \b(({LaterEarlyRegex}\s+)?est[ae]\s+{DateTimeTimeOfDayRegex}|({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})|anoche)\b
   references: [ PeriodTimeOfDayRegex, StrictRelativeRegex, DateTimeTimeOfDayRegex, LaterEarlyRegex ]
 UnitRegex: !simpleRegex
-  def: (?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?)\b
+  def: (?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|fin(es)?\s+de\s+semana|finde|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b
 ConnectorRegex: !simpleRegex
   def: ^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?(cerca|alrededor) de las?)$
 # SpanishTimePeriodExtractorConfiguration
@@ -468,17 +475,17 @@ DuringRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 AllRegex: !simpleRegex
-  def: \b(?<all>tod[oa]?\s+(el|la)\s+(?<unit>año|mes|semana|d[ií]a))\b
+  def: \b(?<all>tod[oa]?\s+(el|la)\s+(?<unit>año|mes|semana|d[ií]a)|((una?|el|la)\s+)?(?<unit>año|mes|semana|d[ií]a)\s+enter[ao])\b
 HalfRegex: !simpleRegex
   def: \b(?<half>medi[oa]\s+(?<unit>ano|mes|semana|d[íi]a|hora))\b
 ConjunctionRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 InexactNumberRegex: !simpleRegex
-  def: \b(pocos?|algo|vari[ao]s|algun[ao]s)\b
+  def: \b(pocos?|algo|vari[ao]s|algun[ao]s|un[ao]s)\b
 InexactNumberUnitRegex: !nestedRegex
-  def: \b(pocos?|algo|vari[ao]s|algun[ao]s)\s+{UnitRegex}
-  references: [ UnitRegex ]
+  def: ({InexactNumberRegex})\s+{UnitRegex}
+  references: [ InexactNumberRegex, UnitRegex ]
 # SpanishHolidayExtractorConfiguration
 HolidayRegex1: !nestedRegex
   def: \b(?<holiday>viernes santo|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
@@ -505,9 +512,9 @@ AroundRegex: !simpleRegex
 PeriodicRegex: !simpleRegex
   def: \b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|semestral|anual)(es|mente)?)\b
 EachExpression: !simpleRegex
-  def: cada|tod[oa]s\s*(l[oa]s)?
+  def: \b(cada|tod[oa]s\s*(l[oa]s)?)\b\s*(?!\s*l[oa]\b)
 EachUnitRegex: !nestedRegex
-  def: (?<each>({EachExpression})\s*{UnitRegex})
+  def: (?<each>({EachExpression})\s*({UnitRegex}|(?<specialUnit>fin(es)?\s+de\s+semana|finde)\b))
   references: [ EachExpression, UnitRegex ]
 EachPrefixRegex: !nestedRegex
   def: (?<each>({EachExpression})\s*$)
@@ -566,8 +573,8 @@ RelativeDecadeRegex: !nestedRegex
   def: \b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b
   references: [ RelativeRegex,WrittenOneToNineRegex ]
 ComplexDatePeriodRegex: !nestedRegex
-  def: (?:((de(sde)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
-  references: [ TillRegex, RangeConnectorRegex ]
+  def: (?:((de(sde)?)\s+)?(?<start>.+)\s*({StrictTillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
+  references: [ StrictTillRegex, RangeConnectorRegex ]
 AmbiguousPointRangeRegex: !simpleRegex
   def: ^(mar\.?)$
 YearSuffix: !nestedRegex
@@ -598,11 +605,16 @@ UnitMap: !dictionary
     bimestres: 2MON
     semanas: W
     semana: W
+    fin de semana: WE
+    fines de semana: WE
+    finde: WE
     dias: D
     dia: D
     días: D
     día: D
     jornada: D
+    noche: D
+    noches: D
     horas: H
     hora: H
     hrs: H
@@ -627,10 +639,15 @@ UnitValueMap: !dictionary
     mes: 2592000
     semanas: 604800
     semana: 604800
+    fin de semana: 172800
+    fines de semana: 172800
+    finde: 172800
     dias: 86400
     dia: 86400
     días: 86400
     día: 86400
+    noche: 86400
+    noches: 86400
     horas: 3600
     hora: 3600
     hrs: 3600
@@ -904,25 +921,27 @@ NextPrefixRegex: !nestedRegex
 PastPrefixRegex: !simpleRegex
   def: ((este\s+))
 PreviousPrefixRegex: !nestedRegex
-  def: \b({PastPrefixRegex}?pasad[oa](?!(\s+el)?\s+medio\s*d[ií]a)|[uú]ltim[oa])\b
+  def: \b({PastPrefixRegex}?pasad[oa](?!(\s+el)?\s+medio\s*d[ií]a)|[uú]ltim[oa]|anterior)\b
   references: [ PastPrefixRegex ]
 ThisPrefixRegex: !simpleRegex
-  def: (est?[ea])\b
+  def: (est?[ea]|actual)\b
+PrefixWeekDayRegex: !simpleRegex
+  def: (\s*((,?\s*el)|[-—–]))
 ThisRegex: !nestedRegex
-  def: \b((est[ae]\s*)(semana\s+(el\s+)?)?{WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b
-  references: [ WeekDayRegex ]
+  def: \b((est[ae]\s*)(semana{PrefixWeekDayRegex}?)?\s*{WeekDayRegex})|({WeekDayRegex}\s*((de\s+)?esta\s+semana))\b
+  references: [ WeekDayRegex, PrefixWeekDayRegex ]
 LastDateRegex: !nestedRegex
-  def: \b({PreviousPrefixRegex}\s+(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+([uú]ltimo|pasado|anterior))|({WeekDayRegex}(\s+((de\s+)?(esta|la)\s+([uú]ltima\s+)?semana)))\b
-  references: [ WeekDayRegex,PreviousPrefixRegex ]
+  def: \b(({PreviousPrefixRegex}\s+(semana{PrefixWeekDayRegex}?)?|(la\s+)?semana\s+{PreviousPrefixRegex}{PrefixWeekDayRegex})\s*{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+([uú]ltimo|pasado|anterior))|({WeekDayRegex}(\s+((de\s+)?((esta|la)\s+([uú]ltima\s+)?semana)|(de\s+)?(la\s+)?semana\s+(pasada|anterior))))\b
+  references: [ WeekDayRegex,PreviousPrefixRegex, PrefixWeekDayRegex ]
 NextDateRegex: !nestedRegex
-  def: \b(({NextPrefixRegex}\s+)(semana\s+(el\s+)?)?{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?(pr[oó]xima|siguiente)(\s*semana)))\b
-  references: [ WeekDayRegex, NextPrefixRegex ]
+  def: \b((({NextPrefixRegex}\s+)(semana{PrefixWeekDayRegex}?)?|(la\s+)?semana\s+{NextPrefixRegex}{PrefixWeekDayRegex})\s*{WeekDayRegex})|(este\s+)?({WeekDayRegex}\s+(pr[oó]ximo|siguiente|que\s+viene))|({WeekDayRegex}(\s+(de\s+)?(la\s+)?((pr[oó]xima|siguiente)\s+semana|semana\s+(pr[oó]xima|siguiente))))\b
+  references: [ WeekDayRegex, NextPrefixRegex, PrefixWeekDayRegex ]
 RelativeDayRegex: !simpleRegex
   def: (?<relday>((este|pr[oó]ximo|([uú]ltim(o|as|os)))\s+días)|(días\s+((que\s+viene)|pasado)))\b
 RestOfDateRegex: !simpleRegex
   def: \bresto\s+((del|de)\s+)?((la|el|est?[ae])\s+)?(?<duration>semana|mes|año|decada)(\s+actual)?\b
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?)\b
+  def: (?<unit>{DateUnitRegex}|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b
   references: [ DateUnitRegex ]
 DurationConnectorRegex: !simpleRegex
   # TODO: add this according to the related part in English
@@ -942,7 +961,7 @@ SingleAmbiguousMonthRegex: !simpleRegex
   # TODO: change to Spanish according to corresponding Regex
   def: ^(the\s+)?(may|march)$
 UnspecificDatePeriodRegex: !simpleRegex
-  def: ^(semana|mes)$
+  def: ^[\.]
 PrepositionSuffixRegex: !simpleRegex
   def: \b(en|el|la|cerca|desde|durante|hasta|hacia)$
 RestOfDateTimeRegex: !simpleRegex
@@ -978,6 +997,8 @@ AmbiguityFiltersDict: !dictionary
   entries:
     '^mi$': '\bmi\b'
     '^a[nñ]o$': '(?<!el\s+)a[nñ]o'
+    '^semana$': '(?<!la\s+)semana'
+    '^mes$': '(?<!el\s+)mes'
 # For TimeOfDay resolution
 EarlyMorningTermList: !list
   types: [ string ]
@@ -1074,4 +1095,19 @@ SpecialCharactersEquivalent: !dictionary
     í: i
     ó: o
     ú: u
+# For SetParserConfiguration
+DoubleMultiplierRegex: !simpleRegex
+  def: ^(bi)(-|\s)?
+DayTypeRegex: !simpleRegex
+  def: (d[ií]as?|diari(o|as|amente))$
+WeekTypeRegex: !simpleRegex
+  def: (semanas?|semanalmente)$
+BiWeekTypeRegex: !simpleRegex
+  def: (quincenalmente)$
+WeekendTypeRegex: !simpleRegex
+  def: (fin(es)?\s+de\s+semana|finde)$
+MonthTypeRegex: !simpleRegex
+  def: (mes(es)?|mensual(es|mente)?)$
+YearTypeRegex: !simpleRegex
+  def: (años?|anualmente)$
 ...

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -14910,10 +14910,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2019-01-01,2019-01-01,P0M)",
+              "timex": "(2019-01-01,2019-04-01,P3M)",
               "type": "daterange",
               "start": "2019-01-01",
-              "end": "2019-01-01"
+              "end": "2019-04-01"
             }
           ]
         }
@@ -19072,6 +19072,44 @@
     "Input": "end of the",
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "Results": []
+  },
+  {
+    "Input": "Show sales all week",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "all week",
+        "Start": 11,
+        "End": 18,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1W",
+              "type": "duration",
+              "value": "604800"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the first week",
+    "Context": {
+      "ReferenceDateTime": "2011-07-02T00:00:00"
+    },
+    "Results": []
+  },
+  {
+    "Input": "Show sales in the 1st week",
+    "Context": {
+      "ReferenceDateTime": "2011-07-02T00:00:00"
     },
     "Results": []
   }

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -2751,8 +2751,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "un mes entero",
@@ -2800,8 +2799,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "unas horas",
@@ -2849,8 +2847,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "unos días",
@@ -4751,12 +4748,11 @@
     "Context": {
       "ReferenceDateTime": "2018-05-22T16:12:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "el mes",
-        "Start": 16,
+        "Text": "mes",
+        "Start": 19,
         "End": 21,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -4853,12 +4849,11 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "del año",
-        "Start": 31,
+        "Text": "año",
+        "Start": 35,
         "End": 37,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -4879,12 +4874,11 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "del mes",
-        "Start": 22,
+        "Text": "mes",
+        "Start": 26,
         "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -4905,12 +4899,11 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "la semana",
-        "Start": 25,
+        "Text": "semana",
+        "Start": 28,
         "End": 33,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -6018,12 +6011,11 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "el 9º de mayo",
-        "Start": 30,
+        "Text": "9º de mayo",
+        "Start": 33,
         "End": 42,
         "TypeName": "datetimeV2.date",
         "Resolution": {
@@ -6063,11 +6055,10 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "el día 9 Mayo",
+        "Text": "el día 9 mayo",
         "Start": 25,
         "End": 37,
         "TypeName": "datetimeV2.date",
@@ -6612,12 +6603,11 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "el año",
-        "Start": 18,
+        "Text": "año",
+        "Start": 21,
         "End": 23,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -6638,21 +6628,19 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "toda la semana",
         "Start": 15,
         "End": 28,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-W27",
-              "type": "daterange",
-              "start": "2018-07-02",
-              "end": "2018-07-09"
+              "timex": "P1W",
+              "type": "duration",
+              "value": "604800"
             }
           ]
         }
@@ -6714,52 +6702,18 @@
     "Context": {
       "ReferenceDateTime": "2019-03-02T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
-    "Results": [
-      {
-        "Text": "primera semana",
-        "Start": 21,
-        "End": 34,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2019-W01",
-              "type": "daterange",
-              "start": "2018-12-31",
-              "end": "2019-01-07"
-            }
-          ]
-        }
-      }
-    ]
+    "Comment": "Also in English, 'first week' is not extracted ('4th week of month/year' and 'week 3' are the supported patterns).",
+    "NotSupported": "javascript, python, java",
+    "Results": []
   },
   {
     "Input": "Mostrar ventas en 1ª semana",
     "Context": {
       "ReferenceDateTime": "2011-07-02T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
-    "Results": [
-      {
-        "Text": "1ª semana",
-        "Start": 18,
-        "End": 26,
-        "TypeName": "datetimeV2.daterange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2011-W01",
-              "type": "daterange",
-              "start": "2011-01-03",
-              "end": "2011-01-10"
-            }
-          ]
-        }
-      }
-    ]
+    "Comment": "Also in English, '1st week' is not extracted ('4th week of month/year' and 'week 3' are the supported patterns).",
+    "NotSupported": "javascript, python, java",
+    "Results": []
   },
   {
     "Input": "No hay semana 00, ni W00",
@@ -7819,8 +7773,7 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "lunes de la semana siguiente",
@@ -10672,12 +10625,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "semana anterior - lunes",
-        "Start": 16,
+        "Text": "la semana anterior - lunes",
+        "Start": 13,
         "End": 38,
         "TypeName": "datetimeV2.date",
         "Resolution": {
@@ -11006,8 +10958,7 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "final de la semana",
@@ -11198,12 +11149,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "primera semana de enero de 2015",
-        "Start": 12,
+        "Text": "la primera semana de enero de 2015",
+        "Start": 9,
         "End": 42,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -11249,12 +11199,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "última semana de diciembre de 2016",
-        "Start": 12,
+        "Text": "la última semana de diciembre de 2016",
+        "Start": 9,
         "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -11325,13 +11274,12 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "3ª semana",
-        "Start": 12,
-        "End": 20,
+        "Text": "la 3ª semana de 2018",
+        "Start": 9,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -13925,8 +13873,7 @@
     "Context": {
       "ReferenceDateTime": "2019-06-11T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "segundo semestre de 2019",
@@ -13951,8 +13898,7 @@
     "Context": {
       "ReferenceDateTime": "2019-06-11T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2º semestre",
@@ -13977,8 +13923,7 @@
     "Context": {
       "ReferenceDateTime": "2019-06-11T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2017-t1 a 2018-t1",
@@ -14634,8 +14579,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "este trimestre",
@@ -14660,8 +14604,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "trimestre actual",
@@ -14686,8 +14629,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "último trimestre",
@@ -14712,8 +14654,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-28T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "último trimestre",
@@ -14738,8 +14679,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "próximo trimestre",
@@ -14764,8 +14704,7 @@
     "Context": {
       "ReferenceDateTime": "2019-12-28T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "trimestre siguiente",
@@ -14790,8 +14729,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "siguiente trimestre",
@@ -14816,8 +14754,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "trimestre anterior",
@@ -14842,8 +14779,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-04T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "trimestre pasado",
@@ -15752,8 +15688,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-30T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "martes de semana pasada",
@@ -15880,12 +15815,11 @@
     "Context": {
       "ReferenceDateTime": "2019-08-01T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "semana próxima",
-        "Start": 68,
+        "Text": "la semana próxima",
+        "Start": 65,
         "End": 81,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -16338,12 +16272,11 @@
     "Context": {
       "ReferenceDateTime": "2019-09-09T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "semana anterior",
-        "Start": 8,
+        "Text": "la semana anterior",
+        "Start": 5,
         "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -16865,8 +16798,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2019-t1",
@@ -16916,8 +16848,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1º trimestre-2019",
@@ -16927,10 +16858,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2019-01-01,2019-01-01,P0M)",
+              "timex": "(2019-01-01,2019-04-01,P3M)",
               "type": "daterange",
               "start": "2019-01-01",
-              "end": "2019-01-01"
+              "end": "2019-04-01"
             }
           ]
         }
@@ -16983,8 +16914,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "la semana que inicia el 4 de febrero",
@@ -17015,8 +16945,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "la semana que comienza el 4 de febrero",
@@ -17047,8 +16976,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "la semana que va del 4 de febrero",
@@ -17079,8 +17007,7 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "la semana a partir del 4 de febrero",
@@ -17770,11 +17697,10 @@
     "Context": {
       "ReferenceDateTime": "2019-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "Primera semana de octubre el viernes",
+        "Text": "primera semana de octubre el viernes",
         "Start": 0,
         "End": 35,
         "TypeName": "datetimeV2.date",
@@ -17854,8 +17780,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "dos noches",
@@ -17879,8 +17804,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "una noche",
@@ -18376,12 +18300,11 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "próxima semana",
-        "Start": 44,
+        "Text": "la próxima semana",
+        "Start": 41,
         "End": 57,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -18570,8 +18493,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "cada finde",
@@ -18581,7 +18503,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-WE",
+              "timex": "P1WE",
               "type": "set",
               "value": "not resolved"
             }
@@ -18595,8 +18517,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "cada dos fines de semana",
@@ -18620,8 +18541,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "tres fines de semana",
@@ -18645,8 +18565,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "el primer trimestre del año",
@@ -18677,12 +18596,11 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "invierno",
-        "Start": 3,
+        "Text": "el invierno",
+        "Start": 0,
         "End": 10,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -18718,8 +18636,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-15T00:00:00"
     },
-    "Comment": "PERIODREF. Refine support for quarter, half, week, weekend, etc. Including relatives.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "tres fines de semana",
@@ -20336,5 +20253,81 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Mostrar las ventas de la semana",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "semana",
+        "Start": 25,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-W27",
+              "type": "daterange",
+              "start": "2018-07-02",
+              "end": "2018-07-09"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar ventas en la semana 1",
+    "Context": {
+      "ReferenceDateTime": "2019-03-02T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "semana 1",
+        "Start": 21,
+        "End": 28,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-W01",
+              "type": "daterange",
+              "start": "2018-12-31",
+              "end": "2019-01-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar ventas en semana 1",
+    "Context": {
+      "ReferenceDateTime": "2011-07-02T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "semana 1",
+        "Start": 18,
+        "End": 25,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2011-W01",
+              "type": "daterange",
+              "start": "2011-01-03",
+              "end": "2011-01-10"
+            }
+          ]
+        }
+      }
+    ]
   }
+
 ]


### PR DESCRIPTION
Fix to issue #2400.

The pattern "primera semana" is not currently supported, also in English "first week" is not recognized (but instead "week 1"/"semana 1" is extracted). Should I add support for the pattern?

