### PR TITLE
[ZH DateTime V2] Fixed the output of invalid day like "2/29/2019" and "2/30"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -550,10 +550,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = DateTimeFormatUtil.LuisDate(year, month, day);
             }
 
-            var futurePastDateList = DateContext.GetFuturePastDate(noYear, referenceDate, year, month, day);
+            var futurePastDates = DateContext.GenerateDates(noYear, referenceDate, year, month, day);
 
-            ret.FutureValue = futurePastDateList[0];
-            ret.PastValue = futurePastDateList[1];
+            ret.FutureValue = futurePastDates.future;
+            ret.PastValue = futurePastDates.past;
             ret.Success = true;
 
             return ret;
@@ -615,7 +615,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             return DateObjectExtension.IsValidDate(year, month, day);
         }
 
-        // Judge the date is Feb 29th
         private static bool IsFeb29th(int year, int month, int day)
         {
             return month == 2 && day == 29;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -550,16 +550,33 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = DateTimeFormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            if (noYear && futureDate < referenceDate)
+            DateObject futureDate, pastDate;
+            if (IsNonleapYearFeb29th(year, month, day))
             {
-                futureDate = futureDate.AddYears(+1);
+                futureDate = DateObject.MinValue.SafeCreateFromValue(year + 1, month, day);
+                pastDate = DateObject.MinValue.SafeCreateFromValue(year - 1, month, day);
+                if (!futureDate.IsDefaultValue() && futureDate.AddYears(-1) >= referenceDate)
+                {
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                }
+                else if (!pastDate.IsDefaultValue() && pastDate.AddYears(+1) < referenceDate)
+                {
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                }
             }
-
-            if (noYear && pastDate >= referenceDate)
+            else
             {
-                pastDate = pastDate.AddYears(-1);
+                futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+                if (noYear && futureDate < referenceDate && !futureDate.IsDefaultValue())
+                {
+                    futureDate = DateObject.MinValue.SafeCreateFromValue(year + 1, month, day);
+                }
+
+                if (noYear && pastDate >= referenceDate && !pastDate.IsDefaultValue())
+                {
+                    pastDate = DateObject.MinValue.SafeCreateFromValue(year - 1, month, day);
+                }
             }
 
             ret.FutureValue = futureDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                             {
                                 pastDate = pastDate.AddMonths(-1);
                             }
-                            else if (!DateObject.IsLeapYear(year) && IsFeb29th(year, month - 1, day))
+                            else if (DateContext.IsFeb29th(year, month - 1, day))
                             {
                                 pastDate = pastDate.AddMonths(-2);
                             }
@@ -613,11 +613,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             }
 
             return DateObjectExtension.IsValidDate(year, month, day);
-        }
-
-        private static bool IsFeb29th(int year, int month, int day)
-        {
-            return month == 2 && day == 29;
         }
 
         // Handle cases like "三天前"

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateParserConfiguration.cs
@@ -550,54 +550,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 ret.Timex = DateTimeFormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            var futureYear = year;
-            var pastYear = year;
-            if (noYear)
-            {
-                if (IsFeb29th(year, month, day))
-                {
-                    if (DateObject.IsLeapYear(year))
-                    {
-                        if (futureDate < referenceDate)
-                        {
-                            futureDate = DateObject.MinValue.SafeCreateFromValue(futureYear + 4, month, day);
-                        }
-                        else
-                        {
-                            pastDate = DateObject.MinValue.SafeCreateFromValue(pastYear - 4, month, day);
-                        }
-                    }
-                    else
-                    {
-                        while (futureDate.IsDefaultValue() && futureYear - year <= 4)
-                        {
-                            futureDate = DateObject.MinValue.SafeCreateFromValue(++futureYear, month, day);
-                        }
+            var futurePastDateList = DateContext.GetFuturePastDate(noYear, referenceDate, year, month, day);
 
-                        while (pastDate.IsDefaultValue() && year - pastYear <= 4)
-                        {
-                            pastDate = DateObject.MinValue.SafeCreateFromValue(--pastYear, month, day);
-                        }
-                    }
-                }
-                else
-                {
-                    if (futureDate < referenceDate && !futureDate.IsDefaultValue())
-                    {
-                        futureDate = DateObject.MinValue.SafeCreateFromValue(year + 1, month, day);
-                    }
-
-                    if (pastDate >= referenceDate && !pastDate.IsDefaultValue())
-                    {
-                        pastDate = DateObject.MinValue.SafeCreateFromValue(year - 1, month, day);
-                    }
-                }
-            }
-
-            ret.FutureValue = futureDate;
-            ret.PastValue = pastDate;
+            ret.FutureValue = futurePastDateList[0];
+            ret.PastValue = futurePastDateList[1];
             ret.Success = true;
 
             return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -952,7 +952,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 pr1 = dateContext.ProcessDateEntityParsingResult(pr1);
                 pr2 = dateContext.ProcessDateEntityParsingResult(pr2);
 
-                // When the input is not the special year, we should sync the future/past year due to some invalid date(Feb 29th).
+                // When the case has no specified year, we should sync the future/past year due to invalid date Feb 29th.
                 if (dateContext.IsEmpty() && (DateContext.IsFeb29th((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue)
                                               || DateContext.IsFeb29th((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue)))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -979,9 +979,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
             if (pr1.TimexStr.StartsWith(Constants.TimexFuzzyYear) && futureBegin.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 2, 28)) <= 0 && futureEnd.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 3, 1)) >= 0)
             {
-                // due to only solve the noYear cases, we only have to judge the period in one year contains Feb 29th;
+                // Handle cases like "2月28日到3月1日".
+                // There may be different timexes for FutureValue and PastValue due to the different validity of Feb 29th.
                 ret.Comment = Constants.Comment_DoubleTimex;
-                ret.Timex += "|" + TimexUtility.GenerateDatePeriodTimex(pastBegin, pastEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
+                var pastTimex = TimexUtility.GenerateDatePeriodTimex(pastBegin, pastEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
+                ret.Timex = TimexUtility.MergeTimeAlternatives(ret.Timex, pastTimex);
             }
 
             ret.FutureValue = new Tuple<DateObject, DateObject>(futureBegin, futureEnd);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDatePeriodParserConfiguration.cs
@@ -983,7 +983,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
                 // There may be different timexes for FutureValue and PastValue due to the different validity of Feb 29th.
                 ret.Comment = Constants.Comment_DoubleTimex;
                 var pastTimex = TimexUtility.GenerateDatePeriodTimex(pastBegin, pastEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
-                ret.Timex = TimexUtility.MergeTimeAlternatives(ret.Timex, pastTimex);
+                ret.Timex = TimexUtility.MergeTimexAlternatives(ret.Timex, pastTimex);
             }
 
             ret.FutureValue = new Tuple<DateObject, DateObject>(futureBegin, futureEnd);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string Comment_WeekOf = "WeekOf";
         public const string Comment_MonthOf = "MonthOf";
 
-        public const string Comment_ContainFeb29th = "ContainFeb29th";
+        public const string Comment_DoubleTimex = "DoubleTimex";
 
         // MOD Value
         // "before" -> To mean "preceding in time". I.e. Does not include the extracted datetime entity in the resolution's ending point. Equivalent to "<"

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string Comment_WeekOf = "WeekOf";
         public const string Comment_MonthOf = "MonthOf";
 
+        public const string Comment_ContainFeb29th = "ContainFeb29th";
+
         // MOD Value
         // "before" -> To mean "preceding in time". I.e. Does not include the extracted datetime entity in the resolution's ending point. Equivalent to "<"
         public const string BEFORE_MOD = "before";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public const string InvalidDateString = "0001-01-01";
 
-        public const char TimexDelimiter = '|';
+        public const char CompositeTimexDelimiter = '|';
 
         // Invalid year
         public const int InvalidYear = int.MinValue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string Comment_WeekOf = "WeekOf";
         public const string Comment_MonthOf = "MonthOf";
 
+        // Tag to mark cases where the specifc resolution timex depends on future or past values.
         public const string Comment_DoubleTimex = "DoubleTimex";
 
         // MOD Value
@@ -190,6 +191,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string MealtimeDinner = "TMED";
 
         public const string InvalidDateString = "0001-01-01";
+
+        public const char TimexDelimiter = '|';
 
         // Invalid year
         public const int InvalidYear = int.MinValue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -187,6 +187,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string MealtimeLunch = "TMEL";
         public const string MealtimeDinner = "TMED";
 
+        public const string InvalidDateString = "0001-01-01";
+
         // Invalid year
         public const int InvalidYear = int.MinValue;
         public const int InvalidMonth = int.MinValue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -417,10 +417,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_ContainFeb29th, StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_DoubleTimex, StringComparison.Ordinal))
             {
-                ResolveFeb29th(res, Constants.ResolveToFuture, futureResolutionStr);
-                ResolveFeb29th(res, Constants.ResolveToPast, pastResolutionStr);
+                UpdateTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
             }
 
             if (isLunar)
@@ -489,15 +488,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             return candidateResults;
         }
 
-        internal static void ResolveFeb29th(Dictionary<string, object> resolutionDic, string keyName, Dictionary<string, string> resolutionStr)
+        internal static void UpdateTimex(Dictionary<string, object> resolutionDic, string futureKey, string pastKey, string originTimex)
         {
-            if (!resolutionDic.ContainsKey(keyName) || !resolutionStr.ContainsKey(DateTimeResolutionKey.Timex))
+            string[] timexs = originTimex.Split('|');
+
+            if (!resolutionDic.ContainsKey(futureKey) || !resolutionDic.ContainsKey(pastKey) || timexs.Length != 2)
             {
                 return;
             }
 
-            var resolution = (Dictionary<string, string>)resolutionDic[keyName];
-            resolution[DateTimeResolutionKey.Timex] = resolutionStr[DateTimeResolutionKey.Timex];
+            var futureResolution = (Dictionary<string, string>)resolutionDic[futureKey];
+            var pastResolution = (Dictionary<string, string>)resolutionDic[pastKey];
+            futureResolution[DateTimeResolutionKey.Timex] = timexs[0];
+            pastResolution[DateTimeResolutionKey.Timex] = timexs[1];
         }
 
         internal static void ResolveAmpm(Dictionary<string, object> resolutionDic, string keyName)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         public const string ParserTypeName = "datetimeV2";
 
+        public static readonly string DateMinString = DateTimeFormatUtil.FormatDate(DateObject.MinValue);
+
         private readonly IFullDateTimeParserConfiguration config;
 
         public FullDateTimeParser(IFullDateTimeParserConfiguration configuration)
@@ -20,7 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         public static void AddSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type,
                                                          string mod, Dictionary<string, string> res)
         {
-            if (resolutionDic.ContainsKey(type))
+            if (resolutionDic.ContainsKey(type) &&
+                !resolutionDic[type].StartsWith(DateMinString, StringComparison.Ordinal))
             {
                 if (!string.IsNullOrEmpty(mod))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -51,11 +51,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (resolutionDic.ContainsKey(startType))
             {
                 start = resolutionDic[startType];
+                if (start.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
 
             if (resolutionDic.ContainsKey(endType))
             {
                 end = resolutionDic[endType];
+                if (end.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
 
             if (!string.IsNullOrEmpty(mod))
@@ -409,6 +417,12 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
+            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_ContainFeb29th, StringComparison.Ordinal))
+            {
+                ResolveFeb29th(res, Constants.ResolveToFuture, futureResolutionStr);
+                ResolveFeb29th(res, Constants.ResolveToPast, pastResolutionStr);
+            }
+
             if (isLunar)
             {
                 res.Add(DateTimeResolutionKey.IsLunar, isLunar);
@@ -473,6 +487,17 @@ namespace Microsoft.Recognizers.Text.DateTime
         public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
         {
             return candidateResults;
+        }
+
+        internal static void ResolveFeb29th(Dictionary<string, object> resolutionDic, string keyName, Dictionary<string, string> resolutionStr)
+        {
+            if (!resolutionDic.ContainsKey(keyName) || !resolutionStr.ContainsKey(DateTimeResolutionKey.Timex))
+            {
+                return;
+            }
+
+            var resolution = (Dictionary<string, string>)resolutionDic[keyName];
+            resolution[DateTimeResolutionKey.Timex] = resolutionStr[DateTimeResolutionKey.Timex];
         }
 
         internal static void ResolveAmpm(Dictionary<string, object> resolutionDic, string keyName)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         public const string ParserTypeName = "datetimeV2";
 
-        public static readonly string DateMinString = DateTimeFormatUtil.FormatDate(DateObject.MinValue);
-
         private readonly IFullDateTimeParserConfiguration config;
 
         public FullDateTimeParser(IFullDateTimeParserConfiguration configuration)
@@ -23,7 +21,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                                                          string mod, Dictionary<string, string> res)
         {
             if (resolutionDic.ContainsKey(type) &&
-                !resolutionDic[type].StartsWith(DateMinString, StringComparison.Ordinal))
+                !resolutionDic[type].Equals(Constants.InvalidDateString, StringComparison.Ordinal))
             {
                 if (!string.IsNullOrEmpty(mod))
                 {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -490,7 +490,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         internal static void ProcessDoubleTimex(Dictionary<string, object> resolutionDic, string futureKey, string pastKey, string originTimex)
         {
-            string[] timexes = originTimex.Split(Constants.TimexDelimiter);
+            string[] timexes = originTimex.Split(Constants.CompositeTimexDelimiter);
 
             if (!resolutionDic.ContainsKey(futureKey) || !resolutionDic.ContainsKey(pastKey) || timexes.Length != 2)
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -417,9 +417,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_DoubleTimex, StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(comment) && HasDoubleTimex(comment))
             {
-                UpdateTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
+                ProcessDoubleTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
             }
 
             if (isLunar)
@@ -488,19 +488,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             return candidateResults;
         }
 
-        internal static void UpdateTimex(Dictionary<string, object> resolutionDic, string futureKey, string pastKey, string originTimex)
+        internal static void ProcessDoubleTimex(Dictionary<string, object> resolutionDic, string futureKey, string pastKey, string originTimex)
         {
-            string[] timexs = originTimex.Split('|');
+            string[] timexes = originTimex.Split(Constants.TimexDelimiter);
 
-            if (!resolutionDic.ContainsKey(futureKey) || !resolutionDic.ContainsKey(pastKey) || timexs.Length != 2)
+            if (!resolutionDic.ContainsKey(futureKey) || !resolutionDic.ContainsKey(pastKey) || timexes.Length != 2)
             {
                 return;
             }
 
             var futureResolution = (Dictionary<string, string>)resolutionDic[futureKey];
             var pastResolution = (Dictionary<string, string>)resolutionDic[pastKey];
-            futureResolution[DateTimeResolutionKey.Timex] = timexs[0];
-            pastResolution[DateTimeResolutionKey.Timex] = timexs[1];
+            futureResolution[DateTimeResolutionKey.Timex] = timexes[0];
+            pastResolution[DateTimeResolutionKey.Timex] = timexes[1];
         }
 
         internal static void ResolveAmpm(Dictionary<string, object> resolutionDic, string keyName)
@@ -618,6 +618,11 @@ namespace Microsoft.Recognizers.Text.DateTime
         private bool IsDurationWithAgoAndLater(ExtractResult er)
         {
             return er.Metadata != null && er.Metadata.IsDurationWithAgoAndLater;
+        }
+
+        private bool HasDoubleTimex(string comment)
+        {
+            return comment.Equals(Constants.Comment_DoubleTimex, StringComparison.Ordinal);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
@@ -7,6 +8,63 @@ namespace Microsoft.Recognizers.Text.DateTime
     public class DateContext
     {
         public int Year { get; set; } = Constants.InvalidYear;
+
+        public static List<DateObject> GetFuturePastDate(bool noYear, DateObject referenceDate, int year, int month, int day)
+        {
+            // Get future/past date, especially for Feb 29.
+            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
+            var futureYear = year;
+            var pastYear = year;
+            if (noYear)
+            {
+                if (IsFeb29th(year, month, day))
+                {
+                    if (DateObject.IsLeapYear(year))
+                    {
+                        if (futureDate < referenceDate)
+                        {
+                            futureDate = DateObject.MinValue.SafeCreateFromValue(futureYear + 4, month, day);
+                        }
+                        else
+                        {
+                            pastDate = DateObject.MinValue.SafeCreateFromValue(pastYear - 4, month, day);
+                        }
+                    }
+                    else
+                    {
+                        pastYear = pastYear >> 2 << 2;
+                        if (!DateObject.IsLeapYear(pastYear))
+                        {
+                            pastYear -= 4;
+                        }
+
+                        futureYear = pastYear + 4;
+                        if (!DateObject.IsLeapYear(futureYear))
+                        {
+                            futureYear += 4;
+                        }
+
+                        futureDate = DateObject.MinValue.SafeCreateFromValue(futureYear, month, day);
+                        pastDate = DateObject.MinValue.SafeCreateFromValue(pastYear, month, day);
+                    }
+                }
+                else
+                {
+                    if (futureDate < referenceDate && !futureDate.IsDefaultValue())
+                    {
+                        futureDate = DateObject.MinValue.SafeCreateFromValue(year + 1, month, day);
+                    }
+
+                    if (pastDate >= referenceDate && !pastDate.IsDefaultValue())
+                    {
+                        pastDate = DateObject.MinValue.SafeCreateFromValue(year - 1, month, day);
+                    }
+                }
+            }
+
+            return new List<DateObject> { futureDate, pastDate };
+        }
 
         // This method is to ensure the begin date is less than the end date.
         // As DateContext only supports common Year as context, so it subtracts one year from beginDate. @TODO problematic in other usages.
@@ -58,6 +116,12 @@ namespace Microsoft.Recognizers.Text.DateTime
         public bool IsEmpty()
         {
             return this.Year == Constants.InvalidYear;
+        }
+
+        // Judge the date is Feb 29th
+        private static bool IsFeb29th(int year, int month, int day)
+        {
+            return month == 2 && day == 29;
         }
 
         private DateObject SetDateWithContext(DateObject originalDate)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Recognizers.Text.DateTime
     {
         public int Year { get; set; } = Constants.InvalidYear;
 
-        public static List<DateObject> GetFuturePastDate(bool noYear, DateObject referenceDate, int year, int month, int day)
+        // Generate future/past date for cases without specific year like "Feb 29th"
+        public static (DateObject future, DateObject past) GenerateDates(bool noYear, DateObject referenceDate, int year, int month, int day)
         {
-            // Get future/past date, especially for Feb 29.
             var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
             var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
             var futureYear = year;
@@ -63,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            return new List<DateObject> { futureDate, pastDate };
+            return (futureDate, pastDate);
         }
 
         // This method is to ensure the begin date is less than the end date.
@@ -118,7 +118,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             return this.Year == Constants.InvalidYear;
         }
 
-        // Judge the date is Feb 29th
         private static bool IsFeb29th(int year, int month, int day)
         {
             return month == 2 && day == 29;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -78,6 +78,38 @@ namespace Microsoft.Recognizers.Text.DateTime
             return beginDate;
         }
 
+        public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncDateEntityInFeb29th(DateTimeParseResult pr1, DateTimeParseResult pr2)
+        {
+            if (IsEmpty() && (IsFeb29th((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue) || IsFeb29th((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue)))
+            {
+                int futureYear;
+                int pastYear;
+                if (IsFeb29th((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue))
+                {
+                    futureYear = ((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue).Year;
+                    pastYear = ((DateObject)((DateTimeResolutionResult)pr1.Value).PastValue).Year;
+                }
+                else
+                {
+                    futureYear = ((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue).Year;
+                    pastYear = ((DateObject)((DateTimeResolutionResult)pr2.Value).PastValue).Year;
+                }
+
+                pr1.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr1.Value, futureYear, pastYear);
+                pr2.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr2.Value, futureYear, pastYear);
+            }
+
+            return (pr1, pr2);
+        }
+
+        public DateTimeResolutionResult SyncDateEntityResolutionInFeb29th(DateTimeResolutionResult resolutionResult, int futureYear, int pastYear)
+        {
+            resolutionResult.FutureValue = SetDateWithContext((DateObject)resolutionResult.FutureValue, futureYear);
+            resolutionResult.PastValue = SetDateWithContext((DateObject)resolutionResult.PastValue, pastYear);
+
+            return resolutionResult;
+        }
+
         public DateTimeParseResult ProcessDateEntityParsingResult(DateTimeParseResult originalResult)
         {
             if (!IsEmpty())
@@ -123,9 +155,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             return month == 2 && day == 29;
         }
 
-        private DateObject SetDateWithContext(DateObject originalDate)
+        private static bool IsFeb29th(DateObject date)
         {
-            return new DateObject(Year, originalDate.Month, originalDate.Day);
+            return date.Month == 2 && date.Day == 29;
+        }
+
+        private DateObject SetDateWithContext(DateObject originalDate, int year = -1)
+        {
+            if (!originalDate.IsDefaultValue())
+            {
+                return new DateObject(year == -1 ? Year : year, originalDate.Month, originalDate.Day);
+            }
+
+            return originalDate;
         }
 
         private Tuple<DateObject, DateObject> SetDateRangeWithContext(Tuple<DateObject, DateObject> originalDateRange)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -78,9 +78,20 @@ namespace Microsoft.Recognizers.Text.DateTime
             return beginDate;
         }
 
-        public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncDateEntityInFeb29th(DateTimeParseResult pr1, DateTimeParseResult pr2)
+        public static bool IsFeb29th(DateObject date)
         {
-            if (IsEmpty() && (IsFeb29th((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue) || IsFeb29th((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue)))
+            return date.Month == 2 && date.Day == 29;
+        }
+
+        public static bool IsFeb29th(int year, int month, int day)
+        {
+            return month == 2 && day == 29;
+        }
+
+        // This method is to ensure the year of begin date is same with the end date in no year situation.
+        public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncYear(DateTimeParseResult pr1, DateTimeParseResult pr2)
+        {
+            if (IsEmpty())
             {
                 int futureYear;
                 int pastYear;
@@ -88,15 +99,14 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     futureYear = ((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue).Year;
                     pastYear = ((DateObject)((DateTimeResolutionResult)pr1.Value).PastValue).Year;
+                    pr2.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr2.Value, futureYear, pastYear);
                 }
-                else
+                else if (IsFeb29th((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue))
                 {
                     futureYear = ((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue).Year;
                     pastYear = ((DateObject)((DateTimeResolutionResult)pr2.Value).PastValue).Year;
+                    pr1.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr1.Value, futureYear, pastYear);
                 }
-
-                pr1.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr1.Value, futureYear, pastYear);
-                pr2.Value = SyncDateEntityResolutionInFeb29th((DateTimeResolutionResult)pr2.Value, futureYear, pastYear);
             }
 
             return (pr1, pr2);
@@ -148,16 +158,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         public bool IsEmpty()
         {
             return this.Year == Constants.InvalidYear;
-        }
-
-        private static bool IsFeb29th(int year, int month, int day)
-        {
-            return month == 2 && day == 29;
-        }
-
-        private static bool IsFeb29th(DateObject date)
-        {
-            return date.Month == 2 && date.Day == 29;
         }
 
         private DateObject SetDateWithContext(DateObject originalDate, int year = -1)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -258,6 +258,11 @@ namespace Microsoft.Recognizers.Text.DateTime
             return result;
         }
 
+        public static string MergeTimeAlternatives(string timex1, string timex2)
+        {
+            return $"{timex1}{Constants.TimexDelimiter}{timex2}";
+        }
+
         public static TimeOfDayResolutionResult ParseTimeOfDay(string tod)
         {
             var result = new TimeOfDayResolutionResult();

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -258,9 +258,9 @@ namespace Microsoft.Recognizers.Text.DateTime
             return result;
         }
 
-        public static string MergeTimeAlternatives(string timex1, string timex2)
+        public static string MergeTimexAlternatives(string timex1, string timex2)
         {
-            return $"{timex1}{Constants.TimexDelimiter}{timex2}";
+            return $"{timex1}{Constants.CompositeTimexDelimiter}{timex2}";
         }
 
         public static TimeOfDayResolutionResult ParseTimeOfDay(string tod)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -123,6 +123,14 @@ namespace Microsoft.Recognizers.Text.DateTime
             return $"({DateTimeFormatUtil.LuisDate(beginYear, beginMonth, beginDay)},{DateTimeFormatUtil.LuisDate(endYear, endMonth, endDay)},{datePeriodTimex})";
         }
 
+        public static string GenerateDatePeriodTimex(DateObject begin, DateObject end, DatePeriodTimexType timexType, string timex1, string timex2)
+        {
+            var boundaryValid = !begin.IsDefaultValue() && !end.IsDefaultValue();
+            var unitCount = boundaryValid ? GetDatePeriodTimexUnitCount(begin, end, timexType) : "X";
+            var datePeriodTimex = $"P{unitCount}{DatePeriodTimexTypeToTimexSuffix[timexType]}";
+            return $"({timex1},{timex2},{datePeriodTimex})";
+        }
+
         public static string GenerateWeekTimex(DateObject monday = default(DateObject))
         {
             if (monday.IsDefaultValue())

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -386,7 +386,7 @@ export class ChineseDateParser extends BaseDateParser {
                         if (this.isValidDate(year, month - 1, day)) {
                             pastDate = DateUtils.addMonths(pastDate, -1);
                         }
-                        else if (this.isNonleapYearFeb29th(year, month - 1, day)) {
+                        else if (!DateUtils.isLeapYear(year) && this.isFeb29th(year, month - 1, day)) {
                             pastDate = DateUtils.addMonths(pastDate, -2);
                         }
                     }
@@ -529,25 +529,37 @@ export class ChineseDateParser extends BaseDateParser {
         else {
             result.timex = DateTimeFormatUtil.luisDate(year, month, day);
         }
-        let futureDate, pastDate;
-        if (this.isNonleapYearFeb29th(year, month, day)) {
-            futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
-            pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
-            if (DateUtils.isValidDate(year + 1, month, day) && DateUtils.safeCreateFromMinValue(year, month, day - 1) >= referenceDate) {
-                futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
+        let futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
+        let pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
+        let futureYear = year;
+        let pastYear = year;
+        if (noYear){
+            if (this.isFeb29th(year, month, day)) {
+                if (DateUtils.isLeapYear(year)) {
+                    if (futureDate < referenceDate) {
+                        futureDate = DateUtils.safeCreateFromMinValue(futureYear + 4, month, day);
+                    }
+                    else {
+                        pastDate = DateUtils.safeCreateFromMinValue(pastYear - 4, month, day);
+                    }
+                }
+                else {
+                    while (!DateUtils.isValidDate(futureYear, month, day) && futureYear - year <= 4) {
+                        futureDate = DateUtils.safeCreateFromMinValue(++futureYear, month, day);
+                    }
+
+                    while (!DateUtils.isValidDate(pastYear, month, day) && year - pastYear <= 4) {
+                        pastDate = DateUtils.safeCreateFromMinValue(--pastYear, month, day);
+                    }
+                }
             }
-            else if (DateUtils.isValidDate(year - 1, month, day) && DateUtils.safeCreateFromMinValue(year, month, day - 1) < referenceDate) {
-                pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
-            }
-        }
-        else  {
-            futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
-            pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
-            if (noYear && futureDate < referenceDate && DateUtils.isValidDate(year, month, day)) {
-                futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
-            }
-            if (noYear && pastDate >= referenceDate && DateUtils.isValidDate(year, month, day)) {
-                pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
+            else {
+                if (futureDate < referenceDate && DateUtils.isValidDate(year, month, day)) {
+                    futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
+                }
+                if (pastDate >= referenceDate && DateUtils.isValidDate(year, month, day)) {
+                    pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
+                }
             }
         }
 
@@ -632,6 +644,10 @@ export class ChineseDateParser extends BaseDateParser {
 
     private isNonleapYearFeb29th(year: number, month: number, day: number): boolean {
         return !DateUtils.isLeapYear(year) && month === 1 && day === 29;
+    }
+
+    private isFeb29th(year: number, month: number, day: number): boolean {
+        return month === 1 && day === 29;
     }
     
     // Handle cases like "三天前"

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -529,14 +529,28 @@ export class ChineseDateParser extends BaseDateParser {
         else {
             result.timex = DateTimeFormatUtil.luisDate(year, month, day);
         }
-        let futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
-        let pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
-        if (noYear && futureDate < referenceDate) {
+        let futureDate, pastDate;
+        if (this.isNonleapYearFeb29th(year, month, day)) {
             futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
-        }
-        if (noYear && pastDate >= referenceDate) {
             pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
+            if (DateUtils.isValidDate(year + 1, month, day) && DateUtils.safeCreateFromMinValue(year, month, day - 1) >= referenceDate) {
+                futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
+            }
+            else if (DateUtils.isValidDate(year - 1, month, day) && DateUtils.safeCreateFromMinValue(year, month, day - 1) < referenceDate) {
+                pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
+            }
         }
+        else  {
+            futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
+            pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
+            if (noYear && futureDate < referenceDate && DateUtils.isValidDate(year, month, day)) {
+                futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
+            }
+            if (noYear && pastDate >= referenceDate && DateUtils.isValidDate(year, month, day)) {
+                pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
+            }
+        }
+
         result.futureValue = futureDate;
         result.pastValue = pastDate;
         result.success = true;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -386,7 +386,7 @@ export class ChineseDateParser extends BaseDateParser {
                         if (this.isValidDate(year, month - 1, day)) {
                             pastDate = DateUtils.addMonths(pastDate, -1);
                         }
-                        else if (!DateUtils.isLeapYear(year) && this.isFeb29th(year, month - 1, day)) {
+                        else if (!DateUtils.isLeapYear(year) && DateUtils.isFeb29th(year, month - 1, day)) {
                             pastDate = DateUtils.addMonths(pastDate, -2);
                         }
                     }
@@ -529,42 +529,11 @@ export class ChineseDateParser extends BaseDateParser {
         else {
             result.timex = DateTimeFormatUtil.luisDate(year, month, day);
         }
-        let futureDate = DateUtils.safeCreateFromMinValue(year, month, day);
-        let pastDate = DateUtils.safeCreateFromMinValue(year, month, day);
-        let futureYear = year;
-        let pastYear = year;
-        if (noYear){
-            if (this.isFeb29th(year, month, day)) {
-                if (DateUtils.isLeapYear(year)) {
-                    if (futureDate < referenceDate) {
-                        futureDate = DateUtils.safeCreateFromMinValue(futureYear + 4, month, day);
-                    }
-                    else {
-                        pastDate = DateUtils.safeCreateFromMinValue(pastYear - 4, month, day);
-                    }
-                }
-                else {
-                    while (!DateUtils.isValidDate(futureYear, month, day) && futureYear - year <= 4) {
-                        futureDate = DateUtils.safeCreateFromMinValue(++futureYear, month, day);
-                    }
 
-                    while (!DateUtils.isValidDate(pastYear, month, day) && year - pastYear <= 4) {
-                        pastDate = DateUtils.safeCreateFromMinValue(--pastYear, month, day);
-                    }
-                }
-            }
-            else {
-                if (futureDate < referenceDate && DateUtils.isValidDate(year, month, day)) {
-                    futureDate = DateUtils.safeCreateFromMinValue(year + 1, month, day);
-                }
-                if (pastDate >= referenceDate && DateUtils.isValidDate(year, month, day)) {
-                    pastDate = DateUtils.safeCreateFromMinValue(year - 1, month, day);
-                }
-            }
-        }
+        let futurePastDateList = DateUtils.getFuturePastDate(noYear, referenceDate, year, month, day);
 
-        result.futureValue = futureDate;
-        result.pastValue = pastDate;
+        result.futureValue = futurePastDateList[0];
+        result.pastValue = futurePastDateList[1];
         result.success = true;
         return result;
     }
@@ -644,10 +613,6 @@ export class ChineseDateParser extends BaseDateParser {
 
     private isNonleapYearFeb29th(year: number, month: number, day: number): boolean {
         return !DateUtils.isLeapYear(year) && month === 1 && day === 29;
-    }
-
-    private isFeb29th(year: number, month: number, day: number): boolean {
-        return month === 1 && day === 29;
     }
     
     // Handle cases like "三天前"

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateConfiguration.ts
@@ -530,10 +530,10 @@ export class ChineseDateParser extends BaseDateParser {
             result.timex = DateTimeFormatUtil.luisDate(year, month, day);
         }
 
-        let futurePastDateList = DateUtils.getFuturePastDate(noYear, referenceDate, year, month, day);
+        let futurePastDates = DateUtils.generateDates(noYear, referenceDate, year, month, day);
 
-        result.futureValue = futurePastDateList[0];
-        result.pastValue = futurePastDateList[1];
+        result.futureValue = futurePastDates.future;
+        result.pastValue = futurePastDates.past;
         result.success = true;
         return result;
     }

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -387,6 +387,49 @@ export class DateUtils {
     private static readonly oneMinute = 60 * 1000;
     private static readonly oneSecond = 1000;
 
+    static getFuturePastDate(noYear: boolean, referenceDate: Date, year: number, month: number, day: number): Date[] {
+        let futureDate = this.safeCreateFromMinValue(year, month, day);
+        let pastDate = this.safeCreateFromMinValue(year, month, day);
+        let futureYear = year;
+        let pastYear = year;
+        if (noYear){
+            if (this.isFeb29th(year, month, day)) {
+                if (this.isLeapYear(year)) {
+                    if (futureDate < referenceDate) {
+                        futureDate = this.safeCreateFromMinValue(futureYear + 4, month, day);
+                    }
+                    else {
+                        pastDate = this.safeCreateFromMinValue(pastYear - 4, month, day);
+                    }
+                }
+                else {
+                    pastYear = pastYear >> 2 << 2;
+                    if (!this.isLeapYear(pastYear)) {
+                        pastYear -= 4;
+                    }
+
+                    futureYear = pastYear + 4;
+                    if (!this.isLeapYear(futureYear)) {
+                        futureYear += 4;
+                    }
+
+                    futureDate = this.safeCreateFromMinValue(futureYear, month, day);
+                    pastDate = this.safeCreateFromMinValue(pastYear, month, day);
+                }
+            }
+            else {
+                if (futureDate < referenceDate && this.isValidDate(year, month, day)) {
+                    futureDate = this.safeCreateFromMinValue(year + 1, month, day);
+                }
+                if (pastDate >= referenceDate && this.isValidDate(year, month, day)) {
+                    pastDate = this.safeCreateFromMinValue(year - 1, month, day);
+                }
+            }
+        }
+
+        return new Array<Date>().concat(futureDate).concat(pastDate);
+    }
+
     static parseChineseDynastyYear(yearStr: string, dynastyYearRegex: RegExp, dynastyYearMap: ReadonlyMap<string, number>, dynastyStartYear: string, integerExtractor: IExtractor, numberParser: IParser): number {
         let year = -1;
         let regionTitleMatch = RegExpUtility.getMatches(dynastyYearRegex, yearStr).pop();
@@ -607,14 +650,18 @@ export class DateUtils {
         return Math.floor(diffDays / DateUtils.oneDay);
     }
 
-    private static validDays(year: number) {
-        return [31, this.isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    static isFeb29th(year: number, month: number, day: number): boolean {
+        return month === 1 && day === 29;
     }
 
     static isValidDate(year: number, month: number, day: number): boolean {
         return year > 0 && year <= 9999
             && month >= 0 && month < 12
             && day > 0 && day <= this.validDays(year)[month];
+    }
+
+    private static validDays(year: number) {
+        return [31, this.isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
     }
 
     private static isValidTime(hour: number, minute: number, second: number) {

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/utilities.ts
@@ -387,7 +387,8 @@ export class DateUtils {
     private static readonly oneMinute = 60 * 1000;
     private static readonly oneSecond = 1000;
 
-    static getFuturePastDate(noYear: boolean, referenceDate: Date, year: number, month: number, day: number): Date[] {
+    // Generate future/past date for cases without specific year like "Feb 29th"
+    static generateDates(noYear: boolean, referenceDate: Date, year: number, month: number, day: number): { future: Date, past: Date} {
         let futureDate = this.safeCreateFromMinValue(year, month, day);
         let pastDate = this.safeCreateFromMinValue(year, month, day);
         let futureYear = year;
@@ -427,7 +428,7 @@ export class DateUtils {
             }
         }
 
-        return new Array<Date>().concat(futureDate).concat(pastDate);
+        return { future: futureDate, past: pastDate };
     }
 
     static parseChineseDynastyYear(yearStr: string, dynastyYearRegex: RegExp, dynastyYearMap: ReadonlyMap<string, number>, dynastyStartYear: string, integerExtractor: IExtractor, numberParser: IParser): number {

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
@@ -298,7 +298,7 @@ class ChineseDateParser(BaseDateParser):
         else:
             result.timex = DateTimeFormatUtil.luis_date(year, month, day)
 
-        future_date, past_date = DateUtils.get_future_past_date(no_year, reference, year, month, day)
+        future_date, past_date = DateUtils.generate_dates(no_year, reference, year, month, day)
 
         result.future_value = future_date
         result.past_value = past_date

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
@@ -169,7 +169,7 @@ class ChineseDateParser(BaseDateParser):
                     if past_date >= reference:
                         if self.is_valid_date(year, month - 1, day):
                             past_date += datedelta(months=-1)
-                        elif self.is_non_leap_year_Feb_29th(year, month - 1, day):
+                        elif not self.is_leap_year(year) and self.is_Feb_29th(year, month - 1, day):
                             past_date += datedelta(months=-2)
                 elif not has_year:
                     if future_date < reference:
@@ -297,23 +297,31 @@ class ChineseDateParser(BaseDateParser):
             no_year = True
         else:
             result.timex = DateTimeFormatUtil.luis_date(year, month, day)
-        if self.is_non_leap_year_Feb_29th(year, month, day):
-            future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
-            past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
 
-            if self.is_valid_date(year + 1, month, day) and DateUtils.safe_create_from_min_value(year, month, day - 1) >= reference:
-                future_date = future_date = DateUtils.safe_create_from_min_value(year, month, day)
-            elif self.is_valid_date(year - 1, month, day) and DateUtils.safe_create_from_min_value(year, month, day - 1) < reference:
-                past_date = DateUtils.safe_create_from_min_value(year, month, day)
-        else:
-            future_date = DateUtils.safe_create_from_min_value(year, month, day)
-            past_date = DateUtils.safe_create_from_min_value(year, month, day)
+        future_date = DateUtils.safe_create_from_min_value(year, month, day)
+        past_date = DateUtils.safe_create_from_min_value(year, month, day)
+        future_year = year
+        past_year = year
+        if no_year:
+            if self.is_Feb_29th(year, month, day):
+                if self.is_leap_year(year):
+                    if future_date < reference:
+                        future_date = DateUtils.safe_create_from_min_value(future_year + 4, month, day)
+                    else:
+                        past_date = DateUtils.safe_create_from_min_value(past_year - 4, month, day)
+                else:
+                    while not self.is_valid_date(future_year, month, day) and future_year - year <= 4:
+                        future_year += 1
+                        future_date = DateUtils.safe_create_from_min_value(future_year, month, day)
+                    while not self.is_valid_date(past_year, month, day) and year - past_year <= 4:
+                        past_year -= 1
+                        past_date = DateUtils.safe_create_from_min_value(past_year, month, day)
+            else:
+                if no_year and future_date < reference and self.is_valid_date(year, month, day):
+                    future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
 
-            if no_year and future_date < reference and self.is_valid_date(year, month, day):
-                future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
-
-            if no_year and past_date >= reference and self.is_valid_date(year, month, day):
-                past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
+                if no_year and past_date >= reference and self.is_valid_date(year, month, day):
+                    past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
 
         result.future_value = future_date
         result.past_value = past_date
@@ -384,8 +392,8 @@ class ChineseDateParser(BaseDateParser):
 
         return DateUtils.is_valid_date(year, month, day)
 
-    def is_non_leap_year_Feb_29th(self, year, month, day):
-        return not self.is_leap_year(year) and month == 2 and day == 29
+    def is_Feb_29th(self, year, month, day):
+        return month == 2 and day == 29
 
     # Handle cases like "三天前"
     def parser_duration_with_ago_and_later(self, source: str, reference: datetime) -> DateTimeResolutionResult:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/date_parser.py
@@ -297,17 +297,23 @@ class ChineseDateParser(BaseDateParser):
             no_year = True
         else:
             result.timex = DateTimeFormatUtil.luis_date(year, month, day)
+        if self.is_non_leap_year_Feb_29th(year, month, day):
+            future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
+            past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
 
-        future_date = DateUtils.safe_create_from_min_value(year, month, day)
-        past_date = DateUtils.safe_create_from_min_value(year, month, day)
+            if self.is_valid_date(year + 1, month, day) and DateUtils.safe_create_from_min_value(year, month, day - 1) >= reference:
+                future_date = future_date = DateUtils.safe_create_from_min_value(year, month, day)
+            elif self.is_valid_date(year - 1, month, day) and DateUtils.safe_create_from_min_value(year, month, day - 1) < reference:
+                past_date = DateUtils.safe_create_from_min_value(year, month, day)
+        else:
+            future_date = DateUtils.safe_create_from_min_value(year, month, day)
+            past_date = DateUtils.safe_create_from_min_value(year, month, day)
 
-        if no_year and future_date < reference:
-            future_date = DateUtils.safe_create_from_min_value(
-                year + 1, month, day)
+            if no_year and future_date < reference and self.is_valid_date(year, month, day):
+                future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
 
-        if no_year and past_date >= reference:
-            past_date = DateUtils.safe_create_from_min_value(
-                year - 1, month, day)
+            if no_year and past_date >= reference and self.is_valid_date(year, month, day):
+                past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
 
         result.future_value = future_date
         result.past_value = past_date

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/merged_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/merged_parser.py
@@ -132,7 +132,7 @@ class ChineseMergedParser(BaseMergedParser):
             if past_values:
                 self._add_resolution_fields_any(
                     result, Constants.RESOLVE_TO_PAST_KEY, past)
-            if future_resolution:
+            if future_values:
                 self._add_resolution_fields_any(
                     result, Constants.RESOLVE_TO_FUTURE_KEY, future)
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -375,6 +375,38 @@ class DateUtils:
     min_value = datetime(1, 1, 1, 0, 0, 0, 0)
 
     @staticmethod
+    def get_future_past_date(no_year: bool, reference: datetime, year: int, month: int, day: int) -> list:
+        future_date = DateUtils.safe_create_from_min_value(year, month, day)
+        past_date = DateUtils.safe_create_from_min_value(year, month, day)
+        future_year = year
+        past_year = year
+        if no_year:
+            if DateUtils.is_Feb_29th(year, month, day):
+                if DateUtils.is_leap_year(year):
+                    if future_date < reference:
+                        future_date = DateUtils.safe_create_from_min_value(future_year + 4, month, day)
+                    else:
+                        past_date = DateUtils.safe_create_from_min_value(past_year - 4, month, day)
+                else:
+                    past_year = past_year >> 2 << 2
+                    if not DateUtils.is_leap_year(past_year):
+                        past_year -= 4
+
+                    future_year = past_year + 4
+                    if not DateUtils.is_leap_year(future_year):
+                        future_year += 4
+
+                    future_date = DateUtils.safe_create_from_min_value(future_year, month, day)
+                    past_date = DateUtils.safe_create_from_min_value(past_year, month, day)
+            else:
+                if future_date < reference and DateUtils.is_valid_date(year, month, day):
+                    future_date = DateUtils.safe_create_from_min_value(year + 1, month, day)
+
+                if past_date >= reference and DateUtils.is_valid_date(year, month, day):
+                    past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
+        return [future_date, past_date]
+
+    @staticmethod
     def int_try_parse(value):
         try:
             return int(value), True
@@ -450,6 +482,14 @@ class DateUtils:
     @staticmethod
     def week_of_year(date: datetime) -> int:
         return date.isocalendar()[1]
+
+    @staticmethod
+    def is_leap_year(year) -> bool:
+        return (year % 4 == 0) and (year % 100 != 0) or (year % 400 == 0)
+
+    @staticmethod
+    def is_Feb_29th(year, month, day):
+        return month == 2 and day == 29
 
 
 class HolidayFunctions:

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/utilities.py
@@ -374,8 +374,9 @@ class DayOfWeek(IntEnum):
 class DateUtils:
     min_value = datetime(1, 1, 1, 0, 0, 0, 0)
 
+    # Generate future/past date for cases without specific year like "Feb 29th"
     @staticmethod
-    def get_future_past_date(no_year: bool, reference: datetime, year: int, month: int, day: int) -> list:
+    def generate_dates(no_year: bool, reference: datetime, year: int, month: int, day: int) -> list:
         future_date = DateUtils.safe_create_from_min_value(year, month, day)
         past_date = DateUtils.safe_create_from_min_value(year, month, day)
         future_year = year
@@ -404,7 +405,7 @@ class DateUtils:
 
                 if past_date >= reference and DateUtils.is_valid_date(year, month, day):
                     past_date = DateUtils.safe_create_from_min_value(year - 1, month, day)
-        return [future_date, past_date]
+        return future_date, past_date
 
     @staticmethod
     def int_try_parse(value):

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -1302,10 +1302,10 @@
         "Value": {
           "Timex": "XXXX-02-29",
           "FutureResolution": {
-            "date": "0001-01-01"
+            "date": "2020-02-29"
           },
           "PastResolution": {
-            "date": "0001-01-01"
+            "date": "2016-02-29"
           }
         },
         "Start": 0,
@@ -1328,7 +1328,7 @@
             "date": "2020-02-29"
           },
           "PastResolution": {
-            "date": "0001-01-01"
+            "date": "2016-02-29"
           }
         },
         "Start": 0,
@@ -1348,7 +1348,7 @@
         "Value": {
           "Timex": "XXXX-02-29",
           "FutureResolution": {
-            "date": "0001-01-01"
+            "date": "2024-02-29"
           },
           "PastResolution": {
             "date": "2020-02-29"
@@ -1379,6 +1379,52 @@
         },
         "Start": 0,
         "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "2019年2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019年2月29日",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-02-29",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "2020年2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2020年2月29日",
+        "Type": "date",
+        "Value": {
+          "Timex": "2020-02-29",
+          "FutureResolution": {
+            "date": "2020-02-29"
+          },
+          "PastResolution": {
+            "date": "2020-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   }

--- a/Specs/DateTime/Chinese/DateParser.json
+++ b/Specs/DateTime/Chinese/DateParser.json
@@ -1289,5 +1289,97 @@
         "Length": 8
       }
     ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "2020-02-29"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "2020-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "2月30日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月30日",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-30",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 5
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -6283,5 +6283,152 @@
         "End": 3
       }
     ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "2月30日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月30日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "2月28日-3月1日",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "dotnet,javascript,python,java",
+    "Results": [
+      {
+        "Text": "2月28日-3月1日",
+        "Start": 0,
+        "End": 9,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2月29日-3月1日",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "dotnet,javascript,python,java",
+    "Results": [
+      {
+        "Text": "2月29日-3月1日",
+        "Start": 0,
+        "End": 9,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -6470,7 +6470,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet,javascript,python,java",
+    "NotSupported": "javascript,python,java",
     "Results": [
       {
         "Text": "2月28日-3月1日",
@@ -6501,7 +6501,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet,javascript,python,java",
+    "NotSupported": "javascript,python,java",
     "Results": [
       {
         "Text": "2月29日-3月1日",
@@ -6511,13 +6511,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
               "type": "daterange",
               "start": "2016-02-29",
               "end": "2016-03-01"
             },
             {
-              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
               "type": "daterange",
               "start": "2020-02-29",
               "end": "2020-03-01"
@@ -6532,7 +6532,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "dotnet,javascript,python,java",
+    "NotSupported": "javascript,python,java",
     "Results": [
       {
         "Text": "2019年2月29日-3月1日",
@@ -6542,7 +6542,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2019-02-29,2019-03-01,P1D)",
+              "timex": "(2019-02-29,2019-03-01,P737118D)",
               "type": "daterange",
               "value": "not resolved"
             }

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -6298,7 +6298,12 @@
             {
               "timex": "XXXX-02-29",
               "type": "date",
-              "value": "not resolved"
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
             }
           ]
         },
@@ -6318,6 +6323,11 @@
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
             {
               "timex": "XXXX-02-29",
               "type": "date",
@@ -6341,6 +6351,39 @@
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-01-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
             {
               "timex": "XXXX-02-29",
               "type": "date",
@@ -6377,6 +6420,52 @@
     ]
   },
   {
+    "Input": "2019年2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2019年2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "2020年2月29日",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2020年2月29日",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
+  },
+  {
     "Input": "2月28日-3月1日",
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
@@ -6397,7 +6486,7 @@
               "end": "2019-03-01"
             },
             {
-              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
               "type": "daterange",
               "start": "2020-02-28",
               "end": "2020-03-01"
@@ -6422,7 +6511,38 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2019年2月29日-3月1日",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "dotnet,javascript,python,java",
+    "Results": [
+      {
+        "Text": "2019年2月29日-3月1日",
+        "Start": 0,
+        "End": 14,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,P1D)",
               "type": "daterange",
               "value": "not resolved"
             }

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -6542,7 +6542,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2019-02-29,2019-03-01,P737118D)",
+              "timex": "(2019-02-29,2019-03-01,PXD)",
               "type": "daterange",
               "value": "not resolved"
             }


### PR DESCRIPTION
1. Modify the output of Feb 29th according to the reference date. 
2. Filter invalid futureresolution or pastresolution.
3. If they are both invalid, output "not resolved".
4. Added test cases.