### PR TITLE
[.NET DateTime V2] Fixed the output of invalid day like "2/29/2019" and "2/30" in all languages

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateParserConfiguration.cs
@@ -521,20 +521,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 ret.Timex = DateTimeFormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            if (noYear && futureDate < referenceDate)
-            {
-                futureDate = futureDate.AddYears(+1);
-            }
-
-            if (noYear && pastDate >= referenceDate)
-            {
-                pastDate = pastDate.AddYears(-1);
-            }
-
-            ret.FutureValue = futureDate;
-            ret.PastValue = pastDate;
+            var futurePastDates = DateContext.GenerateDates(noYear, referenceDate, year, month, day);
+            ret.FutureValue = futurePastDates.future;
+            ret.PastValue = futurePastDates.past;
             ret.Success = true;
 
             return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
@@ -922,11 +922,19 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
                 er[1].Start -= 3;
             }
 
+            var dateContext = BaseDatePeriodParser.GetYearContext(this.config, er[0].Text, er[1].Text, text);
             var pr1 = this.config.DateParser.Parse(er[0], referenceDate);
             var pr2 = this.config.DateParser.Parse(er[1], referenceDate);
             if (pr1.Value == null || pr2.Value == null)
             {
                 return ret;
+            }
+
+            // When the case has no specified year, we should sync the future/past year due to invalid date Feb 29th.
+            if (dateContext.IsEmpty() && (DateContext.IsFeb29th((DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue)
+                                            || DateContext.IsFeb29th((DateObject)((DateTimeResolutionResult)pr2.Value).FutureValue)))
+            {
+                (pr1, pr2) = dateContext.SyncYear(pr1, pr2);
             }
 
             DateObject futureBegin = (DateObject)((DateTimeResolutionResult)pr1.Value).FutureValue,
@@ -942,6 +950,17 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             if (pastEnd < pastBegin)
             {
                 pastEnd = futureEnd;
+            }
+
+            ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
+
+            if (pr1.TimexStr.StartsWith(Constants.TimexFuzzyYear) && futureBegin.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 2, 28)) <= 0 && futureEnd.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 3, 1)) >= 0)
+            {
+                // Handle cases like "Feb 28th - March 1st".
+                // There may be different timexes for FutureValue and PastValue due to the different validity of Feb 29th.
+                ret.Comment = Constants.Comment_DoubleTimex;
+                var pastTimex = TimexUtility.GenerateDatePeriodTimex(pastBegin, pastEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
+                ret.Timex = TimexUtility.MergeTimexAlternatives(ret.Timex, pastTimex);
             }
 
             if ((JapaneseDatePeriodExtractorConfiguration.YearAndMonth.IsMatch(pr1.Text) &&

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDatePeriodParserConfiguration.cs
@@ -905,6 +905,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             return ret;
         }
 
+        // @todo: Refactor to share common code with Chinese
         // parse entities that made up by two time points
         private DateTimeResolutionResult MergeTwoTimePoints(string text, DateObject referenceDate)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateParser.cs
@@ -888,21 +888,9 @@ namespace Microsoft.Recognizers.Text.DateTime
                 ret.Timex = DateTimeFormatUtil.LuisDate(year, month, day);
             }
 
-            var futureDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-            var pastDate = DateObject.MinValue.SafeCreateFromValue(year, month, day);
-
-            if (noYear && futureDate < referenceDate && !futureDate.IsDefaultValue())
-            {
-                futureDate = futureDate.AddYears(+1);
-            }
-
-            if (noYear && pastDate >= referenceDate && !pastDate.IsDefaultValue())
-            {
-                pastDate = pastDate.AddYears(-1);
-            }
-
-            ret.FutureValue = futureDate;
-            ret.PastValue = pastDate;
+            var futurePastDates = DateContext.GenerateDates(noYear, referenceDate, year, month, day);
+            ret.FutureValue = futurePastDates.future;
+            ret.PastValue = futurePastDates.past;
             ret.Success = true;
 
             return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -87,11 +87,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             if (resolutionDic.ContainsKey(startType))
             {
                 start = resolutionDic[startType];
+                if (start.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
 
             if (resolutionDic.ContainsKey(endType))
             {
                 end = resolutionDic[endType];
+                if (end.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
             }
 
             if (!string.IsNullOrEmpty(mod))
@@ -770,6 +778,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                 !string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_WeekOf, StringComparison.Ordinal))
             {
                 ResolveWeekOf(res, Constants.ResolveToPast);
+            }
+
+            if (!string.IsNullOrEmpty(comment) && TimexUtility.HasDoubleTimex(comment))
+            {
+                TimexUtility.ProcessDoubleTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
             }
 
             foreach (var p in res)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/FullDateTimeParser.cs
@@ -417,7 +417,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 }
             }
 
-            if (!string.IsNullOrEmpty(comment) && HasDoubleTimex(comment))
+            if (!string.IsNullOrEmpty(comment) && TimexUtility.HasDoubleTimex(comment))
             {
                 ProcessDoubleTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
             }
@@ -618,11 +618,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         private bool IsDurationWithAgoAndLater(ExtractResult er)
         {
             return er.Metadata != null && er.Metadata.IsDurationWithAgoAndLater;
-        }
-
-        private bool HasDoubleTimex(string comment)
-        {
-            return comment.Equals(Constants.Comment_DoubleTimex, StringComparison.Ordinal);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             if (!originalDate.IsDefaultValue())
             {
-                return new DateObject(year == -1 ? Year : year, originalDate.Month, originalDate.Day);
+                return DateObject.MinValue.SafeCreateFromValue(year == -1 ? Year : year, originalDate.Month, originalDate.Day);
             }
 
             return originalDate;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public static string MergeTimexAlternatives(string timex1, string timex2)
         {
-            if (timex1.Equals(timex2))
+            if (timex1.Equals(timex2, StringComparison.Ordinal))
             {
                 return timex1;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -260,7 +260,32 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public static string MergeTimexAlternatives(string timex1, string timex2)
         {
+            if (timex1.Equals(timex2))
+            {
+                return timex1;
+            }
+
             return $"{timex1}{Constants.CompositeTimexDelimiter}{timex2}";
+        }
+
+        public static void ProcessDoubleTimex(Dictionary<string, object> resolutionDic, string futureKey, string pastKey, string originTimex)
+        {
+            string[] timexes = originTimex.Split(Constants.CompositeTimexDelimiter);
+
+            if (!resolutionDic.ContainsKey(futureKey) || !resolutionDic.ContainsKey(pastKey) || timexes.Length != 2)
+            {
+                return;
+            }
+
+            var futureResolution = (Dictionary<string, string>)resolutionDic[futureKey];
+            var pastResolution = (Dictionary<string, string>)resolutionDic[pastKey];
+            futureResolution[DateTimeResolutionKey.Timex] = timexes[0];
+            pastResolution[DateTimeResolutionKey.Timex] = timexes[1];
+        }
+
+        public static bool HasDoubleTimex(string comment)
+        {
+            return comment.Equals(Constants.Comment_DoubleTimex, StringComparison.Ordinal);
         }
 
         public static TimeOfDayResolutionResult ParseTimeOfDay(string tod)

--- a/Specs/DateTime/Dutch/DatePeriodParser.json
+++ b/Specs/DateTime/Dutch/DatePeriodParser.json
@@ -3916,13 +3916,14 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "Compound timex represent value dependency and will be split at the model level",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "tussen 1 januari en 5 april",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)|(XXXX-01-01,XXXX-04-05,P95D)",
           "FutureResolution": {
             "startDate": "2017-01-01",
             "endDate": "2017-04-05"

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -2918,6 +2918,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "Feb 29",
@@ -2941,6 +2942,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -2964,6 +2966,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "Feb 29th",

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -2912,5 +2912,143 @@
         "Length": 11
       }
     ]
+  },
+  {
+    "Input": "Feb 29",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "Feb 29",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "2020-02-29"
+          },
+          "PastResolution": {
+            "date": "2016-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "2/29",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "2020-02-29"
+          },
+          "PastResolution": {
+            "date": "2016-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "Feb 29th",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "Feb 29th",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-29",
+          "FutureResolution": {
+            "date": "2024-02-29"
+          },
+          "PastResolution": {
+            "date": "2020-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "Feb 30",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "Feb 30",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-02-30",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 6
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2019",
+        "Type": "date",
+        "Value": {
+          "Timex": "2019-02-29",
+          "FutureResolution": {
+            "date": "0001-01-01"
+          },
+          "PastResolution": {
+            "date": "0001-01-01"
+          }
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2020",
+        "Type": "date",
+        "Value": {
+          "Timex": "2020-02-29",
+          "FutureResolution": {
+            "date": "2020-02-29"
+          },
+          "PastResolution": {
+            "date": "2020-02-29"
+          }
+        },
+        "Start": 0,
+        "Length": 9
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateParser.json
+++ b/Specs/DateTime/English/DateParser.json
@@ -2918,7 +2918,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "Feb 29",
@@ -2942,7 +2942,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -2966,7 +2966,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "Feb 29th",

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -4489,7 +4489,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "Comment": "Compound timex represent value dependency and will be split at the model level",
-    "NotSupported": "javascript",
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "between January 1st and April 5th",

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -4488,13 +4488,14 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "Compound timex represent value dependency and will be split at the model level",
     "NotSupported": "javascript",
     "Results": [
       {
         "Text": "between January 1st and April 5th",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)|(XXXX-01-01,XXXX-04-05,P95D)",
           "FutureResolution": {
             "startDate": "2017-01-01",
             "endDate": "2017-04-05"

--- a/Specs/DateTime/English/DatePeriodParser.json
+++ b/Specs/DateTime/English/DatePeriodParser.json
@@ -4489,7 +4489,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "Comment": "Compound timex represent value dependency and will be split at the model level",
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript,python,java",
     "Results": [
       {
         "Text": "between January 1st and April 5th",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -19118,6 +19118,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "feb 29",
@@ -19146,6 +19147,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -19174,6 +19176,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "feb 29th",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -19112,5 +19112,244 @@
       "ReferenceDateTime": "2011-07-02T00:00:00"
     },
     "Results": []
+  },
+  {
+    "Input": "Feb 29",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "feb 29",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "2/29",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "Feb 29th",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "feb 29th",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "Feb 30",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "feb 30",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "Feb 28th to March 1st",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "feb 28th to march 1st",
+        "Start": 0,
+        "End": 20,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2/29-3/1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2/29-3/1",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2/29-3/1/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2/29-3/1/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -19118,7 +19118,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "feb 29",
@@ -19147,7 +19147,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -19176,7 +19176,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "feb 29th",

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2967,7 +2967,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -2996,7 +2996,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -3025,7 +3025,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2967,6 +2967,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -2995,6 +2996,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -3023,6 +3025,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2961,5 +2961,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -3190,6 +3190,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -3218,6 +3219,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -3246,6 +3248,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -3184,5 +3184,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Hindi/DatePeriodParser.json
+++ b/Specs/DateTime/Hindi/DatePeriodParser.json
@@ -4090,13 +4090,14 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "Compound timex represent value dependency and will be split at the model level",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1ली जनवरी और 5 अप्रैल के बीच",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)|(XXXX-01-01,XXXX-04-05,P95D)",
           "FutureResolution": {
             "startDate": "2017-01-01",
             "endDate": "2017-04-05"

--- a/Specs/DateTime/Hindi/DateTimeModel.json
+++ b/Specs/DateTime/Hindi/DateTimeModel.json
@@ -13581,6 +13581,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -13609,6 +13610,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "2/29",
@@ -13637,6 +13639,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "2/29",

--- a/Specs/DateTime/Hindi/DateTimeModel.json
+++ b/Specs/DateTime/Hindi/DateTimeModel.json
@@ -13575,5 +13575,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "2/29",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "2/29",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "2/29",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "2/30",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/30",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "2/29/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "2/29/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "2/28-3/1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2/28-3/1",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2/29-3/1",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2/29-3/1",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "2/29-3/1/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2/29-3/1/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ] 

--- a/Specs/DateTime/Italian/DateTimeModel.json
+++ b/Specs/DateTime/Italian/DateTimeModel.json
@@ -2319,5 +2319,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Italian/DateTimeModel.json
+++ b/Specs/DateTime/Italian/DateTimeModel.json
@@ -2325,6 +2325,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -2353,6 +2354,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -2381,6 +2383,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -15141,5 +15141,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -15147,6 +15147,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -15175,6 +15176,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -15203,6 +15205,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/Japanese/DateTimeModel.json
+++ b/Specs/DateTime/Japanese/DateTimeModel.json
@@ -15147,7 +15147,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15176,7 +15176,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15205,7 +15205,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2",
@@ -15234,6 +15234,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "30/2",
@@ -15257,6 +15258,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2/2019",
@@ -15280,6 +15282,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2/2020",
@@ -15303,7 +15306,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "javascript,python,java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "28/2-1/3",
@@ -15334,7 +15337,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "javascript,python,java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2-1/3",
@@ -15365,7 +15368,7 @@
     "Context": {
       "ReferenceDateTime": "2019-09-18T18:00:00"
     },
-    "NotSupported": "javascript,python,java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "29/2-1/3/2019",

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1083,5 +1083,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1089,6 +1089,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -1117,6 +1118,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -1145,6 +1147,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -1173,6 +1176,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "30/2",
@@ -1196,6 +1200,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2/2019",
@@ -1219,6 +1224,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2/2020",

--- a/Specs/DateTime/Spanish/DatePeriodParser.json
+++ b/Specs/DateTime/Spanish/DatePeriodParser.json
@@ -5875,6 +5875,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "Compound timex represent value dependency and will be split at the model level",
     "NotSupported": "java, python",
     "NotSupportedByDesign": "javascript",
     "Results": [
@@ -5882,7 +5883,7 @@
         "Text": "entre 1 de enero y 5 de abril",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)|(XXXX-01-01,XXXX-04-05,P95D)",
           "FutureResolution": {
             "startDate": "2017-01-01",
             "endDate": "2017-04-05"

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -613,7 +613,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-02-02,XXXX-03-05,P32D)",
+              "timex": "(XXXX-02-02,XXXX-03-05,P31D)",
               "type": "daterange",
               "start": "2019-02-02",
               "end": "2019-03-05"
@@ -20328,6 +20328,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
-
 ]

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -20334,6 +20334,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -20362,6 +20363,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -20390,6 +20392,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -20334,7 +20334,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -20363,7 +20363,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -20392,7 +20392,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/Turkish/DatePeriodParser.json
+++ b/Specs/DateTime/Turkish/DatePeriodParser.json
@@ -3460,13 +3460,14 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
+    "Comment": "Compound timex represent value dependency and will be split at the model level",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1 Ocak ve 5 Nisan arası",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)",
+          "Timex": "(XXXX-01-01,XXXX-04-05,P94D)|(XXXX-01-01,XXXX-04-05,P95D)",
           "FutureResolution": {
             "startDate": "2017-01-01",
             "endDate": "2017-04-05"

--- a/Specs/DateTime/Turkish/DateTimeModel.json
+++ b/Specs/DateTime/Turkish/DateTimeModel.json
@@ -8726,6 +8726,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -8754,6 +8755,7 @@
     "Context": {
       "ReferenceDateTime": "2019-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",
@@ -8782,6 +8784,7 @@
     "Context": {
       "ReferenceDateTime": "2020-03-22T00:00:00"
     },
+    "NotSupported": "javascript, python",
     "Results": [
       {
         "Text": "29/2",

--- a/Specs/DateTime/Turkish/DateTimeModel.json
+++ b/Specs/DateTime/Turkish/DateTimeModel.json
@@ -8720,5 +8720,244 @@
         }
       }
     ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2019-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2016-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            },
+            {
+              "timex": "XXXX-02-29",
+              "type": "date",
+              "value": "2024-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "30/2",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "30/2",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-02-30",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2019",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2019",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-29",
+              "type": "date",
+              "value": "not resolved"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "29/2/2020",
+    "Context": {
+      "ReferenceDateTime": "2020-03-22T00:00:00"
+    },
+    "Results": [
+      {
+        "Text": "29/2/2020",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-02-29",
+              "type": "date",
+              "value": "2020-02-29"
+            }
+          ]
+        },
+        "Start": 0,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "28/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "28/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2019-02-28",
+              "end": "2019-03-01"
+            },
+            {
+              "timex": "(XXXX-02-28,XXXX-03-01,P2D)",
+              "type": "daterange",
+              "start": "2020-02-28",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3",
+        "Start": 0,
+        "End": 7,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2016-02-29",
+              "end": "2016-03-01"
+            },
+            {
+              "timex": "(XXXX-02-29,XXXX-03-01,P1D)",
+              "type": "daterange",
+              "start": "2020-02-29",
+              "end": "2020-03-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "29/2-1/3/2019",
+    "Context": {
+      "ReferenceDateTime": "2019-09-18T18:00:00"
+    },
+    "NotSupported": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "29/2-1/3/2019",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2019-02-29,2019-03-01,PXD)",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
In EN/FR/DE/HI/IT/JA/PT/ES/TR:
Modify the output of Feb 29th according to the reference date.
Support to recognize date period contains invalid date like 2/29 - 3/1.    
Generate future/past timexes separately if the case has no specific year. 
Added test cases.