### PR TITLE
[Java | FR DateTimeV2] Correct regex definition and add ambiguity filter

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchDateExtractorConfiguration.java
@@ -58,10 +58,18 @@ public class FrenchDateExtractorConfiguration extends BaseOptionsConfiguration i
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor1));
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor2));
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor3));
-            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor5));
-            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor4));
-            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor6));
-            add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor7));
+            add(FrenchDateTime.DefaultLanguageFallback == "DMY" ?
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor5) :
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor4));
+            add(FrenchDateTime.DefaultLanguageFallback == "DMY" ?
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor4) :
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor5));
+            add(FrenchDateTime.DefaultLanguageFallback == "DMY" ?
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor7) :
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor6));
+            add(FrenchDateTime.DefaultLanguageFallback == "DMY" ?
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor6) :
+                    RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor7));
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor8));
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractor9));
             add(RegExpUtility.getSafeRegExp(FrenchDateTime.DateExtractorA));

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/french/extractors/FrenchMergedExtractorConfiguration.java
@@ -24,6 +24,8 @@ import com.microsoft.recognizers.text.matcher.StringMatcher;
 import com.microsoft.recognizers.text.number.french.extractors.IntegerExtractor;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.javatuples.Pair;
 
 public class FrenchMergedExtractorConfiguration extends BaseOptionsConfiguration implements IMergedExtractorConfiguration {
@@ -44,7 +46,11 @@ public class FrenchMergedExtractorConfiguration extends BaseOptionsConfiguration
     public static final Pattern UnspecificDatePeriodRegex = RegExpUtility
         .getSafeRegExp(FrenchDateTime.UnspecificDatePeriodRegex);
     public static final StringMatcher SuperfluousWordMatcher = new StringMatcher();
-    public final Iterable<Pair<Pattern, Pattern>> ambiguityFiltersDict = null;
+    public final Iterable<Pair<Pattern, Pattern>> ambiguityFiltersDict = FrenchDateTime.AmbiguityFiltersDict.entrySet().stream().map(pair -> {
+        Pattern key = RegExpUtility.getSafeRegExp(pair.getKey());
+        Pattern val = RegExpUtility.getSafeRegExp(pair.getValue());
+        return new Pair<Pattern, Pattern>(key, val);
+    }).collect(Collectors.toList());
     private final IDateExtractor dateExtractor;
     private final IDateTimeExtractor timeExtractor;
     private final IDateTimeExtractor dateTimeExtractor;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/FrenchDateTime.java
@@ -637,7 +637,8 @@ public class FrenchDateTime {
 
     public static final String PreviousPrefixRegex = ".^";
 
-    public static final String RelativeDayRegex = "\\b(((la\\s+)?{RelativeRegex}\\s+journ[ée]e))\\b";
+    public static final String RelativeDayRegex = "\\b(((la\\s+)?{RelativeRegex}\\s+journ[ée]e))\\b"
+            .replace("{RelativeRegex}", RelativeRegex);
 
     public static final String ConnectorRegex = "^(,|pour|t|vers)$";
 

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -491,8 +491,9 @@ PastPrefixRegex: !simpleRegex
 PreviousPrefixRegex: !simpleRegex
   # TODO: implement the relative day regex if needed. If yes, they should be abstracted
   def: .^
-RelativeDayRegex: !simpleRegex
+RelativeDayRegex: !nestedRegex
   def: \b(((la\s+)?{RelativeRegex}\s+journ[ée]e))\b
+  references: [RelativeRegex]
 ConnectorRegex: !simpleRegex
   def: ^(,|pour|t|vers)$
 ConnectorAndRegex: !simpleRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/french_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/french_date_time.py
@@ -207,7 +207,7 @@ class FrenchDateTime:
     NextPrefixRegex = f'.^'
     PastPrefixRegex = f'.^'
     PreviousPrefixRegex = f'.^'
-    RelativeDayRegex = f'\\b(((la\\s+)?{{RelativeRegex}}\\s+journ[ée]e))\\b'
+    RelativeDayRegex = f'\\b(((la\\s+)?{RelativeRegex}\\s+journ[ée]e))\\b'
     ConnectorRegex = f'^(,|pour|t|vers)$'
     ConnectorAndRegex = f'\\b(et\\s*(le|las?)?)\\b.+'
     FromRegex = f'((de|du)?)$'
@@ -242,6 +242,7 @@ class FrenchDateTime:
     YearPeriodRegex = f'^[.]'
     FutureSuffixRegex = f'^[.]'
     ComplexDatePeriodRegex = f'^[.]'
+    AmbiguousPointRangeRegex = f'^(mar\\.?)$'
     UnitMap = dict([("annees", "Y"),
                     ("annee", "Y"),
                     ("an", "Y"),

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2343,7 +2343,8 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "NotSupported": "python",
+    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "mercredi 10 juin 2020",
@@ -2383,7 +2384,8 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "NotSupported": "python",
+    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "mer. 10 juin 2020",
@@ -2423,7 +2425,8 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "NotSupported": "python",
+    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "mer. 24 juin 2020",
@@ -2846,8 +2849,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
-    "NotSupported": "python",
+    "Comment": "In python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "2 4 2009",
@@ -2894,8 +2897,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
-    "NotSupported": "python",
+    "Comment": "In python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "18 8 1978",
@@ -2942,8 +2945,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "In python, the full stop is included in the extracted text (even if the extractor returns the correct match)",
-    "NotSupported": "python",
+    "Comment": "In python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "18 8 78",

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2343,7 +2343,7 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "Comment": "In python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
     "NotSupported": "python, java",
     "Results": [
       {
@@ -2384,8 +2384,8 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
-    "NotSupported": "python, java",
+    "Comment": "In python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "mer. 10 juin 2020",
@@ -2425,7 +2425,7 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "Comment": "In  python and java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
     "NotSupported": "python, java",
     "Results": [
       {

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -2384,8 +2384,8 @@
     "Context": {
       "ReferenceDateTime": "2016-07-15T00:00:00"
     },
-    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
-    "NotSupported": "python, java",
+    "Comment": "In java, the full stop is included in the extracted text (even if the extractor returns the correct match)",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "mer. 10 juin 2020",


### PR DESCRIPTION
1. Filter ambiguity.
2. Correct "NotSupported" tags in French DateTimeModel since the full stop is included in the extracted text (even if the extractor returns the correct match).