### PR TITLE
[TimexExpression] Fix parsing Timex in different cultures in TimexResolover (#1528)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
@@ -303,6 +304,42 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("daterange", resolution.Values[0].Type);
             Assert.AreEqual("2019-04-10", resolution.Values[0].Start);
             Assert.AreEqual("2019-05-01", resolution.Values[0].End);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateRange_Demaical_Period_PT()
+        {
+            var sourceLanguage = CultureInfo.InstalledUICulture;
+            var testLanguage = new CultureInfo("pt-PT", false);
+            CultureInfo.CurrentUICulture = testLanguage;
+            CultureInfo.CurrentCulture = testLanguage;
+            var today = new System.DateTime(2019, 4, 30);
+            var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+            Assert.AreEqual("(2019-04-05,2019-04-10,P5,54701493625231D)", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-05", resolution.Values[0].Start);
+            Assert.AreEqual("2019-04-10", resolution.Values[0].End);
+            CultureInfo.CurrentUICulture = sourceLanguage;
+            CultureInfo.CurrentCulture = sourceLanguage;
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateRange_Demaical_Period_EN()
+        {
+            var sourceLanguage = CultureInfo.InstalledUICulture;
+            var testLanguage = new CultureInfo("en-En", false);
+            CultureInfo.CurrentUICulture = testLanguage;
+            CultureInfo.CurrentCulture = testLanguage;
+            var today = new System.DateTime(2019, 4, 30);
+            var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+            Assert.AreEqual("(2019-04-05,2019-04-10,P5.54701493625231D)", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-05", resolution.Values[0].Start);
+            Assert.AreEqual("2019-04-10", resolution.Values[0].End);
+            CultureInfo.CurrentUICulture = sourceLanguage;
+            CultureInfo.CurrentCulture = sourceLanguage;
         }
 
         [TestMethod]
@@ -612,6 +649,5 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("2021-01-01", resolution.Values[1].End);
             Assert.IsNull(resolution.Values[1].Value);
         }
-
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -309,9 +309,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_DateRange_Demaical_Period_PT()
         {
-            var sourceLanguage = CultureInfo.InstalledUICulture;
+            var sourceLanguage = CultureInfo.CurrentCulture;
             var testLanguage = new CultureInfo("pt-PT", false);
-            CultureInfo.CurrentUICulture = testLanguage;
             CultureInfo.CurrentCulture = testLanguage;
             var today = new System.DateTime(2019, 4, 30);
             var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);
@@ -320,16 +319,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("daterange", resolution.Values[0].Type);
             Assert.AreEqual("2019-04-05", resolution.Values[0].Start);
             Assert.AreEqual("2019-04-10", resolution.Values[0].End);
-            CultureInfo.CurrentUICulture = sourceLanguage;
             CultureInfo.CurrentCulture = sourceLanguage;
         }
 
         [TestMethod]
         public void DataTypes_Resolver_DateRange_Demaical_Period_EN()
         {
-            var sourceLanguage = CultureInfo.InstalledUICulture;
+            var sourceLanguage = CultureInfo.CurrentCulture;
             var testLanguage = new CultureInfo("en-En", false);
-            CultureInfo.CurrentUICulture = testLanguage;
             CultureInfo.CurrentCulture = testLanguage;
             var today = new System.DateTime(2019, 4, 30);
             var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);
@@ -338,7 +335,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("daterange", resolution.Values[0].Type);
             Assert.AreEqual("2019-04-05", resolution.Values[0].Start);
             Assert.AreEqual("2019-04-10", resolution.Values[0].End);
-            CultureInfo.CurrentUICulture = sourceLanguage;
             CultureInfo.CurrentCulture = sourceLanguage;
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -264,19 +264,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             switch (source["dateUnit"])
             {
                 case "Y":
-                    Years = decimal.Parse(source["amount"]);
+                    Years = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
 
                 case "M":
-                    Months = decimal.Parse(source["amount"]);
+                    Months = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
 
                 case "W":
-                    Weeks = decimal.Parse(source["amount"]);
+                    Weeks = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
 
                 case "D":
-                    Days = decimal.Parse(source["amount"]);
+                    Days = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
             }
         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -286,15 +286,15 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             switch (source["timeUnit"])
             {
                 case "H":
-                    Hours = decimal.Parse(source["amount"]);
+                    Hours = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
 
                 case "M":
-                    Minutes = decimal.Parse(source["amount"]);
+                    Minutes = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
 
                 case "S":
-                    Seconds = decimal.Parse(source["amount"]);
+                    Seconds = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
                     break;
             }
         }


### PR DESCRIPTION
Fix the culture problem of parsing Timex Durations with Decimal values. #1528
All timexes should use only '.' as canonical separator and parsing should work in any culture.
Add unit test to make sure it works in different culture settings.
