### PR TITLE
[TimexExpression] Support merged timex of duration/datetimerange like "PT1H30M" (#1515, #1530, #1923, #2110)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -366,6 +366,20 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_TimeRange_11_30_to_12()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T11:30,T12,PT30M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T11:30,T12,PT30M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("11:30:00", resolution.Values[0].Start);
+            Assert.AreEqual("12:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_TimeRange_11_to_11_30()
         {
             var today = System.DateTime.Now;

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -221,6 +221,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(resolution.Values[0].End);
         }
 
+        public void DataTypes_Resolver_Duration_1hour30minutes()
+        {
+            var resolution = TimexResolver.Resolve(new[] { "PT1H30M" });
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("PT1H30M", resolution.Values[0].Timex);
+            Assert.AreEqual("duration", resolution.Values[0].Type);
+            Assert.AreEqual("5400", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+        }
+
         [TestMethod]
         public void DataTypes_Resolver_DateRange_September()
         {
@@ -353,6 +365,20 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_TimeRange_15_15_to_16_20()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T15:15,T16:20,PT1H5M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T15:15,T16:20,PT1H5M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("15:15:00", resolution.Values[0].Start);
+            Assert.AreEqual("16:20:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_TimeRange_Morning()
         {
             var today = System.DateTime.Now;
@@ -431,6 +457,48 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("datetimerange", resolution.Values[0].Type);
             Assert.AreEqual("2017-10-09 04:00:00", resolution.Values[0].Start);
             Assert.AreEqual("2017-10-12 15:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_20200604_15_00_to_20200604_17_30()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(2020-06-04T15,2020-06-04T17:30,PT2H30M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(2020-06-04T15,2020-06-04T17:30,PT2H30M)", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2020-06-04 15:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2020-06-04 17:30:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_20190325_10_to_20190325_11()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(2019-03-25T10,2019-03-25T11,PT1H)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(2019-03-25T10,2019-03-25T11,PT1H)", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-03-25 10:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2019-03-25 11:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateRange_20190427_20190511_2weeks()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(2019-04-27,2019-05-11,P2W)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(2019-04-27,2019-05-11,P2W)", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-27", resolution.Values[0].Start);
+            Assert.AreEqual("2019-05-11", resolution.Values[0].End);
             Assert.IsNull(resolution.Values[0].Value);
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -352,6 +352,62 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_TimeRange_11_30_to_12_00()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T11:30,T12:00,PT30M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T11:30,T12,PT30M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("11:30:00", resolution.Values[0].Start);
+            Assert.AreEqual("12:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_TimeRange_11_to_11_30()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T11:00,T11:30,PT30M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T11,T11:30,PT30M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("11:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("11:30:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_TimeRange_23_45_to_00_30()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T23:45,T00:30,PT45M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T23:45,T00:30,PT45M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("23:45:00", resolution.Values[0].Start);
+            Assert.AreEqual("00:30:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_20190401_09_30_to_20190401_11()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(2019-04-01T09:30,2019-04-01T11,PT1H30M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(2019-04-01T09:30,2019-04-01T11,PT1H30M)", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-01 09:30:00", resolution.Values[0].Start);
+            Assert.AreEqual("2019-04-01 11:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_TimeRange_4am_to_8pm()
         {
             var today = System.DateTime.Now;
@@ -362,6 +418,20 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("timerange", resolution.Values[0].Type);
             Assert.AreEqual("04:00:00", resolution.Values[0].Start);
             Assert.AreEqual("20:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_TimeRange_23_45_to_00_20()
+        {
+            var today = System.DateTime.Now;
+            var resolution = TimexResolver.Resolve(new[] { "(T23:45,T01:20,PT1H35M)" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("(T23:45,T01:20,PT1H35M)", resolution.Values[0].Timex);
+            Assert.AreEqual("timerange", resolution.Values[0].Type);
+            Assert.AreEqual("23:45:00", resolution.Values[0].Start);
+            Assert.AreEqual("01:20:00", resolution.Values[0].End);
             Assert.IsNull(resolution.Values[0].Value);
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(resolution.Values[0].End);
         }
 
+        [TestMethod]
         public void DataTypes_Resolver_Duration_1hour30minutes()
         {
             var resolution = TimexResolver.Resolve(new[] { "PT1H30M" });

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             var today = new System.DateTime(2019, 4, 30);
             var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);
             Assert.AreEqual(1, resolution.Values.Count);
-            Assert.AreEqual("(2019-04-05,2019-04-10,P5,54701493625231D)", resolution.Values[0].Timex);
+            Assert.AreEqual("(2019-04-05,2019-04-10,P5.54701493625231D)", resolution.Values[0].Timex);
             Assert.AreEqual("daterange", resolution.Values[0].Type);
             Assert.AreEqual("2019-04-05", resolution.Values[0].Start);
             Assert.AreEqual("2019-04-10", resolution.Values[0].End);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_Resolver_TimeRange_23_45_to_00_20()
+        public void DataTypes_Resolver_TimeRange_23_45_to_01_20()
         {
             var today = System.DateTime.Now;
             var resolution = TimexResolver.Resolve(new[] { "(T23:45,T01:20,PT1H35M)" }, today);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -33,6 +33,14 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string HourUnit = "hour";
         public const string MinuteUnit = "minute";
         public const string SecondUnit = "second";
+        public const string TimeDurationUnit = "s";
+
+        public const string Now = "now";
+        public const string Midnight = "midnight";
+        public const string Midday = "midday";
+        public const string AM = "AM";
+        public const string PM = "PM";
+        public const string Every = "every";
 
         public static class TimexTypes
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -5,6 +5,35 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     public static class Constants
     {
+        // Timex
+        public const string TimexYear = "Y";
+        public const string TimexMonth = "M";
+        public const string TimexMonthFull = "MON";
+        public const string TimexWeek = "W";
+        public const string TimexDay = "D";
+        public const string TimexBusinessDay = "BD";
+        public const string TimexWeekend = "WE";
+        public const string TimexHour = "H";
+        public const string TimexMinute = "M";
+        public const string TimexSecond = "S";
+        public const char TimexFuzzy = 'X';
+        public const string TimexFuzzyYear = "XXXX";
+        public const string TimexFuzzyMonth = "XX";
+        public const string TimexFuzzyWeek = "WXX";
+        public const string TimexFuzzyDay = "XX";
+        public const string DateTimexConnector = "-";
+        public const string TimeTimexConnector = ":";
+        public const string GeneralPeriodPrefix = "P";
+        public const string TimeTimexPrefix = "T";
+
+        public const string YearUnit = "year";
+        public const string MonthUnit = "month";
+        public const string WeekUnit = "week";
+        public const string DayUnit = "day";
+        public const string HourUnit = "hour";
+        public const string MinuteUnit = "minute";
+        public const string SecondUnit = "second";
+
         public static class TimexTypes
         {
             public static readonly string Present = "present";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -35,12 +35,10 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string SecondUnit = "second";
         public const string TimeDurationUnit = "s";
 
-        public const string Now = "now";
-        public const string Midnight = "midnight";
-        public const string Midday = "midday";
         public const string AM = "AM";
         public const string PM = "PM";
-        public const string Every = "every";
+
+        public const int InvalidValue = -1;
 
         public static class TimexTypes
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
@@ -7,6 +7,10 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     internal static class TimexConstantsEnglish
     {
+        public const string Every = "every";
+        public const string Now = "now";
+        public const string Midnight = "midnight";
+        public const string Midday = "midday";
         public static readonly string[] Days =
         {
             "Monday",

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (types.Contains(Constants.TimexTypes.Present))
             {
-                return Constants.Now;
+                return TimexConstantsEnglish.Now;
             }
 
             if (types.Contains(Constants.TimexTypes.DateTimeRange))
@@ -61,11 +61,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var timex = timexSet.Timex;
             if (timex.Types.Contains(Constants.TimexTypes.Duration))
             {
-                return $"{Constants.Every} {ConvertTimexDurationToString(timex, false)}";
+                return $"{TimexConstantsEnglish.Every} {ConvertTimexDurationToString(timex, false)}";
             }
             else
             {
-                return $"{Constants.Every} {ConvertTimexToString(timex)}";
+                return $"{TimexConstantsEnglish.Every} {ConvertTimexToString(timex)}";
             }
         }
 
@@ -73,12 +73,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             if (timex.Hour == 0 && timex.Minute == 0 && timex.Second == 0)
             {
-                return Constants.Midnight;
+                return TimexConstantsEnglish.Midnight;
             }
 
             if (timex.Hour == 12 && timex.Minute == 0 && timex.Second == 0)
             {
-                return Constants.Midday;
+                return TimexConstantsEnglish.Midday;
             }
 
             var hour = (timex.Hour == 0) ? "12" : (timex.Hour > 12) ? (timex.Hour - 12).Value.ToString(CultureInfo.InvariantCulture) : timex.Hour.Value.ToString(CultureInfo.InvariantCulture);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             var month = TimexConstantsEnglish.Months[timex.Month.Value - 1];
             var date = timex.DayOfMonth.ToString();
-            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString())];
+            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString(), System.Globalization.CultureInfo.InvariantCulture)];
 
             if (timex.Year != null)
             {
@@ -121,42 +121,43 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string ConvertTimexDurationToString(TimexProperty timex, bool includeSingleCount)
         {
+            string result = string.Empty;
             if (timex.Years != null)
             {
-                return ConvertDurationPropertyToString(timex.Years.Value, "year", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Years.Value, Constants.YearUnit, includeSingleCount);
             }
 
             if (timex.Months != null)
             {
-                return ConvertDurationPropertyToString(timex.Months.Value, "month", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Months.Value, Constants.MonthUnit, includeSingleCount);
             }
 
             if (timex.Weeks != null)
             {
-                return ConvertDurationPropertyToString(timex.Weeks.Value, "week", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Weeks.Value, Constants.WeekUnit, includeSingleCount);
             }
 
             if (timex.Days != null)
             {
-                return ConvertDurationPropertyToString(timex.Days.Value, "day", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Days.Value, Constants.DayUnit, includeSingleCount);
             }
 
             if (timex.Hours != null)
             {
-                return ConvertDurationPropertyToString(timex.Hours.Value, "hour", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Hours.Value, Constants.HourUnit, includeSingleCount);
             }
 
             if (timex.Minutes != null)
             {
-                return ConvertDurationPropertyToString(timex.Minutes.Value, "minute", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Minutes.Value, Constants.MinuteUnit, includeSingleCount);
             }
 
             if (timex.Seconds != null)
             {
-                return ConvertDurationPropertyToString(timex.Seconds.Value, "second", includeSingleCount);
+                result += ConvertDurationPropertyToString(timex.Seconds.Value, Constants.SecondUnit, includeSingleCount);
             }
 
-            return string.Empty;
+            return result;
         }
 
         private static string ConvertDuration(TimexProperty timex)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
@@ -13,7 +14,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (types.Contains(Constants.TimexTypes.Present))
             {
-                return "now";
+                return Constants.Now;
             }
 
             if (types.Contains(Constants.TimexTypes.DateTimeRange))
@@ -60,11 +61,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var timex = timexSet.Timex;
             if (timex.Types.Contains(Constants.TimexTypes.Duration))
             {
-                return $"every {ConvertTimexDurationToString(timex, false)}";
+                return $"{Constants.Every} {ConvertTimexDurationToString(timex, false)}";
             }
             else
             {
-                return $"every {ConvertTimexToString(timex)}";
+                return $"{Constants.Every} {ConvertTimexToString(timex)}";
             }
         }
 
@@ -72,18 +73,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             if (timex.Hour == 0 && timex.Minute == 0 && timex.Second == 0)
             {
-                return "midnight";
+                return Constants.Midnight;
             }
 
             if (timex.Hour == 12 && timex.Minute == 0 && timex.Second == 0)
             {
-                return "midday";
+                return Constants.Midday;
             }
 
-            var hour = (timex.Hour == 0) ? "12" : (timex.Hour > 12) ? (timex.Hour - 12).ToString() : timex.Hour.ToString();
-            var minute = (timex.Minute == 0 && timex.Second == 0) ? string.Empty : ":" + timex.Minute.ToString().PadLeft(2, '0');
-            var second = (timex.Second == 0) ? string.Empty : ":" + timex.Second.ToString().PadLeft(2, '0');
-            var period = timex.Hour < 12 ? "AM" : "PM";
+            var hour = (timex.Hour == 0) ? "12" : (timex.Hour > 12) ? (timex.Hour - 12).Value.ToString(CultureInfo.InvariantCulture) : timex.Hour.Value.ToString(CultureInfo.InvariantCulture);
+            var minute = (timex.Minute == 0 && timex.Second == 0) ? string.Empty : Constants.TimeTimexConnector + timex.Minute.Value.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0');
+            var second = (timex.Second == 0) ? string.Empty : Constants.TimeTimexConnector + timex.Second.Value.ToString(CultureInfo.InvariantCulture).PadLeft(2, '0');
+            var period = timex.Hour < 12 ? Constants.AM : Constants.PM;
 
             return $"{hour}{minute}{second}{period}";
         }
@@ -96,8 +97,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
 
             var month = TimexConstantsEnglish.Months[timex.Month.Value - 1];
-            var date = timex.DayOfMonth.ToString();
-            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString(), System.Globalization.CultureInfo.InvariantCulture)];
+            var date = timex.DayOfMonth.Value.ToString(CultureInfo.InvariantCulture);
+            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture)];
 
             if (timex.Year != null)
             {
@@ -115,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
             else
             {
-                return $"{value} {property}s";
+                return $"{value} {property}{Constants.TimeDurationUnit}";
             }
         }
 
@@ -169,7 +170,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             var season = (timex.Season != null) ? TimexConstantsEnglish.Seasons[timex.Season] : string.Empty;
 
-            var year = (timex.Year != null) ? timex.Year.ToString() : string.Empty;
+            var year = (timex.Year != null) ? timex.Year.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
 
             if (timex.WeekOfYear != null)
             {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.xml
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.xml
@@ -4,5 +4,40 @@
         <name>Microsoft.Recognizers.Text.DataTypes.TimexExpression</name>
     </assembly>
     <members>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Year">
+            <summary>
+            Year
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Month">
+            <summary>
+            Month
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Week">
+            <summary>
+            Week
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Day">
+            <summary>
+            Day
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Hour">
+            <summary>
+            Hour
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Minute">
+            <summary>
+            Minute
+            </summary>
+        </member>
+        <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Second">
+            <summary>
+            Second
+            </summary>
+        </member>
     </members>
 </doc>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static string FixedFormatNumber(int? n, int size)
         {
-            return n.Value.ToString().PadLeft(size, '0');
+            return n.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).PadLeft(size, '0');
         }
 
         public static DateObject DateOfLastDay(DayOfWeek day, DateObject referenceDate)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -68,37 +68,37 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var timexList = new List<string> { };
             if (timex.Years != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Years}{Constants.TimexYear}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Year, timex.Years ?? Constants.InvalidValue));
             }
 
             if (timex.Months != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Months}{Constants.TimexMonth}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Month, timex.Months ?? Constants.InvalidValue));
             }
 
             if (timex.Weeks != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Weeks}{Constants.TimexWeek}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Week, timex.Weeks ?? Constants.InvalidValue));
             }
 
             if (timex.Days != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Days}{Constants.TimexDay}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Day, timex.Days ?? Constants.InvalidValue));
             }
 
             if (timex.Hours != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Hours}{Constants.TimexHour}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Hour, timex.Hours ?? Constants.InvalidValue));
             }
 
             if (timex.Minutes != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Minutes}{Constants.TimexMinute}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Minute, timex.Minutes ?? Constants.InvalidValue));
             }
 
             if (timex.Seconds != null)
             {
-                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Seconds}{Constants.TimexSecond}");
+                timexList.Add(TimexHelpers.GenerateDurationTimex(TimexUnit.Second, timex.Seconds ?? Constants.InvalidValue));
             }
 
             return TimexHelpers.GenerateCompoundDurationTimex(timexList);
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string FormatDate(TimexProperty timex)
         {
-            return TimexHelpers.GenerateDateTimex(timex.Year ?? -1, timex.Month ?? -1, timex.DayOfWeek != null ? timex.DayOfWeek.Value : timex.DayOfMonth ?? -1, timex.DayOfWeek != null);
+            return TimexHelpers.GenerateDateTimex(timex.Year ?? Constants.InvalidValue, timex.Month ?? Constants.InvalidValue, timex.DayOfWeek != null ? timex.DayOfWeek.Value : timex.DayOfMonth ?? Constants.InvalidValue, timex.DayOfWeek != null);
         }
 
         private static string FormatDateRange(TimexProperty timex)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Globalization;
+using System.Text;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
@@ -63,42 +64,47 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string FormatDuration(TimexProperty timex)
         {
+            var isTimeDurationAlreadyExist = false;
+            var timexBuilder = new StringBuilder(Constants.GeneralPeriodPrefix);
             if (timex.Years != null)
             {
-                return $"P{timex.Years}Y";
+                timexBuilder.Append($"{timex.Years}Y");
             }
 
             if (timex.Months != null)
             {
-                return $"P{timex.Months}M";
+                timexBuilder.Append($"{timex.Months}M");
             }
 
             if (timex.Weeks != null)
             {
-                return $"P{timex.Weeks}W";
+                timexBuilder.Append($"{timex.Weeks}W");
             }
 
             if (timex.Days != null)
             {
-                return $"P{timex.Days}D";
+                timexBuilder.Append($"{timex.Days}D");
             }
 
             if (timex.Hours != null)
             {
-                return $"PT{timex.Hours}H";
+                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Hours}D" : $"{Constants.TimeTimexPrefix}{timex.Hours}H");
+                isTimeDurationAlreadyExist = true;
             }
 
             if (timex.Minutes != null)
             {
-                return $"PT{timex.Minutes}M";
+                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Minutes}M" : $"{Constants.TimeTimexPrefix}{timex.Minutes}M");
+                isTimeDurationAlreadyExist = true;
             }
 
             if (timex.Seconds != null)
             {
-                return $"PT{timex.Seconds}S";
+                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Seconds}D" : $"{Constants.TimeTimexPrefix}{timex.Seconds}S");
+                isTimeDurationAlreadyExist = true;
             }
 
-            return string.Empty;
+            return timexBuilder.ToString();
         }
 
         private static string FormatTime(TimexProperty timex)
@@ -125,12 +131,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.Month != null && timex.DayOfMonth != null)
             {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
+                return $"{Constants.TimexFuzzyYear}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
             }
 
             if (timex.DayOfWeek != null)
             {
-                return $"XXXX-WXX-{timex.DayOfWeek}";
+                return $"{Constants.TimexFuzzyYear}-{Constants.TimexFuzzyWeek}-{timex.DayOfWeek}";
             }
 
             return string.Empty;
@@ -170,17 +176,17 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.Month != null && timex.WeekOfMonth != null && timex.DayOfWeek != null)
             {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-WXX-{timex.WeekOfMonth}-{timex.DayOfWeek}";
+                return $"{Constants.TimexFuzzyYear}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{Constants.TimexFuzzyWeek}-{timex.WeekOfMonth}-{timex.DayOfWeek}";
             }
 
             if (timex.Month != null && timex.WeekOfMonth != null)
             {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-W{timex.WeekOfMonth?.ToString("D2", CultureInfo.InvariantCulture)}";
+                return $"{Constants.TimexFuzzyYear}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-W{timex.WeekOfMonth?.ToString("D2", CultureInfo.InvariantCulture)}";
             }
 
             if (timex.Month != null)
             {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}";
+                return $"{Constants.TimexFuzzyYear}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}";
             }
 
             return string.Empty;

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -64,47 +65,43 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string FormatDuration(TimexProperty timex)
         {
-            var isTimeDurationAlreadyExist = false;
-            var timexBuilder = new StringBuilder(Constants.GeneralPeriodPrefix);
+            var timexList = new List<string> { };
             if (timex.Years != null)
             {
-                timexBuilder.Append($"{timex.Years}Y");
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Years}{Constants.TimexYear}");
             }
 
             if (timex.Months != null)
             {
-                timexBuilder.Append($"{timex.Months}M");
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Months}{Constants.TimexMonth}");
             }
 
             if (timex.Weeks != null)
             {
-                timexBuilder.Append($"{timex.Weeks}W");
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Weeks}{Constants.TimexWeek}");
             }
 
             if (timex.Days != null)
             {
-                timexBuilder.Append($"{timex.Days}D");
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{timex.Days}{Constants.TimexDay}");
             }
 
             if (timex.Hours != null)
             {
-                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Hours}D" : $"{Constants.TimeTimexPrefix}{timex.Hours}H");
-                isTimeDurationAlreadyExist = true;
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Hours}{Constants.TimexHour}");
             }
 
             if (timex.Minutes != null)
             {
-                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Minutes}M" : $"{Constants.TimeTimexPrefix}{timex.Minutes}M");
-                isTimeDurationAlreadyExist = true;
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Minutes}{Constants.TimexMinute}");
             }
 
             if (timex.Seconds != null)
             {
-                timexBuilder.Append(isTimeDurationAlreadyExist ? $"{timex.Seconds}D" : $"{Constants.TimeTimexPrefix}{timex.Seconds}S");
-                isTimeDurationAlreadyExist = true;
+                timexList.Add($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}{timex.Seconds}{Constants.TimexSecond}");
             }
 
-            return timexBuilder.ToString();
+            return TimexHelpers.GenerateCompoundDurationTimex(timexList);
         }
 
         private static string FormatTime(TimexProperty timex)
@@ -124,22 +121,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string FormatDate(TimexProperty timex)
         {
-            if (timex.Year != null && timex.Month != null && timex.DayOfMonth != null)
-            {
-                return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
-            }
-
-            if (timex.Month != null && timex.DayOfMonth != null)
-            {
-                return $"{Constants.TimexFuzzyYear}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
-            }
-
-            if (timex.DayOfWeek != null)
-            {
-                return $"{Constants.TimexFuzzyYear}-{Constants.TimexFuzzyWeek}-{timex.DayOfWeek}";
-            }
-
-            return string.Empty;
+            return TimexHelpers.GenerateDateTimex(timex.Year ?? -1, timex.Month ?? -1, timex.DayOfWeek != null ? timex.DayOfWeek.Value : timex.DayOfMonth ?? -1, timex.DayOfWeek != null);
         }
 
         private static string FormatDateRange(TimexProperty timex)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -175,9 +175,21 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static TimexProperty TimexTimeAdd(TimexProperty start, TimexProperty duration)
         {
+            var result = start.Clone();
+            if (duration.Minutes != null)
+            {
+                result.Minute += (int)duration.Minutes.Value;
+
+                if (result.Minute.Value > 59)
+                {
+                    result.Hour++;
+                    var minute = result.Minute % 60;
+                    result.Minute = minute;
+                }
+            }
+
             if (duration.Hours != null)
             {
-                var result = start.Clone();
                 result.Hour += (int)duration.Hours.Value;
                 if (result.Hour.Value > 23)
                 {
@@ -203,25 +215,9 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         return result;
                     }
                 }
-
-                return result;
             }
 
-            if (duration.Minutes != null)
-            {
-                var result = start.Clone();
-                result.Minute += (int)duration.Minutes.Value;
-
-                if (result.Minute.Value > 59)
-                {
-                    result.Hour++;
-                    result.Minute = 0;
-                }
-
-                return result;
-            }
-
-            return start;
+            return result;
         }
 
         public static TimexProperty TimexDateTimeAdd(TimexProperty start, TimexProperty duration)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -202,19 +203,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 switch (item.Key)
                 {
                     case "year":
-                        Year = int.Parse(item.Value);
+                        Year = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "month":
-                        Month = int.Parse(item.Value);
+                        Month = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "dayOfMonth":
-                        DayOfMonth = int.Parse(item.Value);
+                        DayOfMonth = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "dayOfWeek":
-                        DayOfWeek = int.Parse(item.Value);
+                        DayOfWeek = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "season":
@@ -222,7 +223,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         break;
 
                     case "weekOfYear":
-                        WeekOfYear = int.Parse(item.Value);
+                        WeekOfYear = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "weekend":
@@ -230,18 +231,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         break;
 
                     case "weekOfMonth":
-                        WeekOfMonth = int.Parse(item.Value);
+                        WeekOfMonth = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "hour":
-                        Hour = int.Parse(item.Value);
+                        Hour = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "minute":
-                        Minute = int.Parse(item.Value);
+                        Minute = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
                     case "second":
-                        Second = int.Parse(item.Value);
+                        Second = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case "partOfDay":
@@ -252,8 +253,16 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         AssignDateDuration(source);
                         break;
 
-                    case "timeUnit":
-                        AssignTimeDuration(source);
+                    case "hourAmount":
+                        Hours = int.Parse(item.Value, CultureInfo.InvariantCulture);
+                        break;
+
+                    case "minuteAmount":
+                        Minutes = int.Parse(item.Value, CultureInfo.InvariantCulture);
+                        break;
+
+                    case "secondAmount":
+                        Seconds = int.Parse(item.Value, CultureInfo.InvariantCulture);
                         break;
                 }
             }
@@ -264,37 +273,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             switch (source["dateUnit"])
             {
                 case "Y":
-                    Years = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
+                    Years = decimal.Parse(source["amount"], CultureInfo.InvariantCulture);
                     break;
 
                 case "M":
-                    Months = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
+                    Months = decimal.Parse(source["amount"], CultureInfo.InvariantCulture);
                     break;
 
                 case "W":
-                    Weeks = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
+                    Weeks = decimal.Parse(source["amount"], CultureInfo.InvariantCulture);
                     break;
 
                 case "D":
-                    Days = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
-                    break;
-            }
-        }
-
-        private void AssignTimeDuration(IDictionary<string, string> source)
-        {
-            switch (source["timeUnit"])
-            {
-                case "H":
-                    Hours = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
-                    break;
-
-                case "M":
-                    Minutes = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
-                    break;
-
-                case "S":
-                    Seconds = decimal.Parse(source["amount"], System.Globalization.CultureInfo.InvariantCulture);
+                    Days = decimal.Parse(source["amount"], CultureInfo.InvariantCulture);
                     break;
             }
         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -52,14 +53,16 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 PeriodCollectionName, new Regex[]
                 {
                     new Regex(@"^P(?<amount>\d*\.?\d+)(?<dateUnit>Y|M|W|D)$"),
-                    new Regex(@"^PT(?<amount>\d*\.?\d+)(?<timeUnit>H|M|S)$"),
+                    new Regex(@"^PT(?<hourAmount>\d*\.?\d+)H(\d*\.?\d+(M|S)){0,2}$"),
+                    new Regex(@"^PT(\d*\.?\d+H)?(?<minuteAmount>\d*\.?\d+)M(\d*\.?\d+S)?$"),
+                    new Regex(@"^PT(\d*\.?\d+(H|M)){0,2}(?<secondAmount>\d*\.?\d+)S$"),
                 }
             },
         };
 
         public static bool Extract(string name, string timex, IDictionary<string, string> result)
         {
-            var lowerName = name.ToLower();
+            var lowerName = name.ToLower(CultureInfo.InvariantCulture);
             var nameGroup = new string[lowerName == DateTimeCollectionName ? 2 : 1];
 
             if (lowerName == DateTimeCollectionName)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexValue.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
@@ -24,8 +25,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 if (date.Kind == DateTimeKind.Utc)
                 {
                     var timeString = $"{TimexDateHelpers.FixedFormatNumber(timexProperty.Hour, 2)}:{TimexDateHelpers.FixedFormatNumber(timexProperty.Minute, 2)}:{TimexDateHelpers.FixedFormatNumber(timexProperty.Second, 2)}";
-                    var tempDateTime = DateTime.Parse(timeString);
-                    return tempDateTime.ToUniversalTime().ToString("HH:mm:ss");
+                    var tempDateTime = DateTime.Parse(timeString, CultureInfo.InvariantCulture);
+                    return tempDateTime.ToUniversalTime().ToString("HH:mm:ss", CultureInfo.InvariantCulture);
                 }
                 else
                 {
@@ -43,42 +44,43 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static string DurationValue(TimexProperty timexProperty)
         {
+            decimal duration = 0;
             if (timexProperty.Years != null)
             {
-                return (31536000 * timexProperty.Years).ToString();
+                duration += 31536000 * timexProperty.Years ?? 0;
             }
 
             if (timexProperty.Months != null)
             {
-                return (2592000 * timexProperty.Months).ToString();
+                duration += 2592000 * timexProperty.Months ?? 0;
             }
 
             if (timexProperty.Weeks != null)
             {
-                return (604800 * timexProperty.Weeks).ToString();
+                duration += 604800 * timexProperty.Weeks ?? 0;
             }
 
             if (timexProperty.Days != null)
             {
-                return (86400 * timexProperty.Days).ToString();
+                duration += 86400 * timexProperty.Days ?? 0;
             }
 
             if (timexProperty.Hours != null)
             {
-                return (3600 * timexProperty.Hours).ToString();
+                duration += 3600 * timexProperty.Hours ?? 0;
             }
 
             if (timexProperty.Minutes != null)
             {
-                return (60 * timexProperty.Minutes).ToString();
+                duration += 60 * timexProperty.Minutes ?? 0;
             }
 
             if (timexProperty.Seconds != null)
             {
-                return timexProperty.Seconds.ToString();
+                duration += timexProperty.Seconds ?? 0;
             }
 
-            return string.Empty;
+            return duration.ToString(CultureInfo.InvariantCulture);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using System.Text;
+using Microsoft.Recognizers.Text.DataTypes.TimexExpression;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DateTime
@@ -52,27 +54,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         {
             var unitList = new List<string>(unitToTimexComponents.Keys);
             unitList.Sort((x, y) => (unitValueMap[x] < unitValueMap[y] ? 1 : -1));
-
-            var isTimeDurationAlreadyExist = false;
-            var timexBuilder = new StringBuilder(Constants.GeneralPeriodPrefix);
-
-            for (int i = 0; i < unitList.Count; i++)
-            {
-                var timexComponent = unitToTimexComponents[unitList[i]];
-
-                // The Time Duration component occurs first time,
-                if (!isTimeDurationAlreadyExist && IsTimeDurationTimex(timexComponent))
-                {
-                    timexBuilder.Append($"{Constants.TimeTimexPrefix}{GetDurationTimexWithoutPrefix(timexComponent)}");
-                    isTimeDurationAlreadyExist = true;
-                }
-                else
-                {
-                    timexBuilder.Append($"{GetDurationTimexWithoutPrefix(timexComponent)}");
-                }
-            }
-
-            return timexBuilder.ToString();
+            unitList = unitList.Select(t => unitToTimexComponents[t]).ToList();
+            return TimexHelpers.GenerateCompoundDurationTimex(unitList);
         }
 
         // TODO: Unify this two methods. This one here detect if "begin/end" have same year, month and day with "alter begin/end" and make them nonspecific.
@@ -427,12 +410,6 @@ namespace Microsoft.Recognizers.Text.DateTime
         private static bool IsTimeDurationTimex(string timex)
         {
             return timex.StartsWith($"{Constants.GeneralPeriodPrefix}{Constants.TimeTimexPrefix}", StringComparison.Ordinal);
-        }
-
-        private static string GetDurationTimexWithoutPrefix(string timex)
-        {
-            // Remove "PT" prefix for TimeDuration, Remove "P" prefix for DateDuration
-            return timex.Substring(IsTimeDurationTimex(timex) ? 2 : 1);
         }
 
         private static string GetDatePeriodTimexUnitCount(DateObject begin, DateObject end, DatePeriodTimexType timexType)


### PR DESCRIPTION
Support merged timex of duration/datetimerange like "PT1H30M", "(2020-06-04T15,2020-06-04T17:30,PT2H30M)".(#1515, #1923, #2110)
Fix time addition of start/end in duration/timerange. (#1530)
Add constants of TimexExpression.
Support Invariant Culture in parsing.
Add unit test.