### PR TITLE
[TimexExpression] Fix timex without specified year/month like "XXXX-XX-06"

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Resolver_DateTimeRange_Thanksgiving()
         {
+            // XXXX-11-WXX-4-4 -> 4th Thursday (4th ISO weekday) in unspecified week in November in unspecified year
             var today = new System.DateTime(2020, 10, 20);
             var resolution = TimexResolver.Resolve(new[] { "XXXX-11-WXX-4-4" }, today);
             Assert.AreEqual(2, resolution.Values.Count);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -65,6 +65,46 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_Date_6th()
+        {
+            var today = new System.DateTime(2019, 4, 23, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-XX-06" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-XX-06", resolution.Values[0].Timex);
+            Assert.AreEqual("date", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-06", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+
+            Assert.AreEqual("XXXX-XX-06", resolution.Values[1].Timex);
+            Assert.AreEqual("date", resolution.Values[1].Type);
+            Assert.AreEqual("2019-05-06", resolution.Values[1].Value);
+            Assert.IsNull(resolution.Values[1].Start);
+            Assert.IsNull(resolution.Values[1].End);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_Date_Feb_2nd()
+        {
+            var today = new System.DateTime(2020, 10, 20);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-02-02 " }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-02-02", resolution.Values[0].Timex);
+            Assert.AreEqual("date", resolution.Values[0].Type);
+            Assert.AreEqual("2020-02-02", resolution.Values[0].Value);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+
+            Assert.AreEqual("XXXX-02-02", resolution.Values[1].Timex);
+            Assert.AreEqual("date", resolution.Values[1].Type);
+            Assert.AreEqual("2021-02-02", resolution.Values[1].Value);
+            Assert.IsNull(resolution.Values[1].Start);
+            Assert.IsNull(resolution.Values[1].End);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_DateTime_Wednesday_4()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -105,6 +105,137 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_Oct_25th_Afternoon()
+        {
+            var today = new System.DateTime(2020, 10, 20);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-10-25TAF" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-10-25TAF", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-10-25 12:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2019-10-25 16:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-10-25TAF", resolution.Values[1].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[1].Type);
+            Assert.AreEqual("2020-10-25 12:00:00", resolution.Values[1].Start);
+            Assert.AreEqual("2020-10-25 16:00:00", resolution.Values[1].End);
+            Assert.IsNull(resolution.Values[1].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_Week11_Monday()
+        {
+            var today = new System.DateTime(2020, 10, 20);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-W11-1" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-W11-1", resolution.Values[0].Timex);
+            Assert.AreEqual("date", resolution.Values[0].Type);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+            Assert.AreEqual("2020-03-09", resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-W11-1", resolution.Values[1].Timex);
+            Assert.AreEqual("date", resolution.Values[1].Type);
+            Assert.IsNull(resolution.Values[1].Start);
+            Assert.IsNull(resolution.Values[1].End);
+            Assert.AreEqual("2021-03-15", resolution.Values[1].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_Thanksgiving()
+        {
+            var today = new System.DateTime(2020, 10, 20);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-11-WXX-4-4" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-11-WXX-4-4", resolution.Values[0].Timex);
+            Assert.AreEqual("date", resolution.Values[0].Type);
+            Assert.IsNull(resolution.Values[0].Start);
+            Assert.IsNull(resolution.Values[0].End);
+            Assert.AreEqual("2019-11-28", resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-11-WXX-4-4", resolution.Values[1].Timex);
+            Assert.AreEqual("date", resolution.Values[1].Type);
+            Assert.IsNull(resolution.Values[1].Start);
+            Assert.IsNull(resolution.Values[1].End);
+            Assert.AreEqual("2020-11-26", resolution.Values[1].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_Monday_Morning()
+        {
+            var today = new System.DateTime(2021, 1, 22, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-WXX-1TMO" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-WXX-1TMO", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2021-01-18 08:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2021-01-18 12:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+
+            Assert.AreEqual("XXXX-WXX-1TMO", resolution.Values[1].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[1].Type);
+            Assert.AreEqual("2021-01-25 08:00:00", resolution.Values[1].Start);
+            Assert.AreEqual("2021-01-25 12:00:00", resolution.Values[1].End);
+            Assert.IsNull(resolution.Values[1].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateTimeRange_April_5th_from_10am_to_11am()
+        {
+            var today = new System.DateTime(2021, 1, 22, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "(XXXX-04-05T10,XXXX-04-05T11,PT1H)" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("(XXXX-04-05T10,XXXX-04-05T11,PT1H)", resolution.Values[0].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[0].Type);
+            Assert.AreEqual("2020-04-05 10:00:00", resolution.Values[0].Start);
+            Assert.AreEqual("2020-04-05 11:00:00", resolution.Values[0].End);
+            Assert.IsNull(resolution.Values[0].Value);
+
+            Assert.AreEqual("(XXXX-04-05T10,XXXX-04-05T11,PT1H)", resolution.Values[1].Timex);
+            Assert.AreEqual("datetimerange", resolution.Values[1].Type);
+            Assert.AreEqual("2021-04-05 10:00:00", resolution.Values[1].Start);
+            Assert.AreEqual("2021-04-05 11:00:00", resolution.Values[1].End);
+            Assert.IsNull(resolution.Values[1].Value);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateRange_first_week_of_April_2019()
+        {
+            var today = new System.DateTime(2021, 1, 22, 15, 30, 0);
+            var resolution = TimexResolver.Resolve(new[] { "2019-04-W01" }, today);
+            Assert.AreEqual(1, resolution.Values.Count);
+
+            Assert.AreEqual("2019-04-W01", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2019-04-01", resolution.Values[0].Start);
+            Assert.AreEqual("2019-04-08", resolution.Values[0].End);
+        }
+
+        [TestMethod]
+        public void DataTypes_Resolver_DateRange_first_week_of_April()
+        {
+            var today = new System.DateTime(2021, 1, 22);
+            var resolution = TimexResolver.Resolve(new[] { "XXXX-04-W01" }, today);
+            Assert.AreEqual(2, resolution.Values.Count);
+
+            Assert.AreEqual("XXXX-04-W01", resolution.Values[0].Timex);
+            Assert.AreEqual("daterange", resolution.Values[0].Type);
+            Assert.AreEqual("2020-03-30", resolution.Values[0].Start);
+            Assert.AreEqual("2020-04-06", resolution.Values[0].End);
+
+            Assert.AreEqual("XXXX-04-W01", resolution.Values[1].Timex);
+            Assert.AreEqual("daterange", resolution.Values[1].Type);
+            Assert.AreEqual("2021-03-29", resolution.Values[1].Start);
+            Assert.AreEqual("2021-04-05", resolution.Values[1].End);
+        }
+
+        [TestMethod]
         public void DataTypes_Resolver_DateTime_Wednesday_4()
         {
             var today = new System.DateTime(2017, 9, 28, 15, 30, 0);
@@ -347,7 +478,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_Resolver_DateRange_Demaical_Period_PT()
+        public void DataTypes_Resolver_DateRange_Decimal_Period_PT()
         {
             var sourceLanguage = CultureInfo.CurrentCulture;
             var testLanguage = new CultureInfo("pt-PT", false);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string TimexHour = "H";
         public const string TimexMinute = "M";
         public const string TimexSecond = "S";
+        public const string TimexNight = "NI";
         public const char TimexFuzzy = 'X';
         public const string TimexFuzzyYear = "XXXX";
         public const string TimexFuzzyMonth = "XX";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -33,6 +33,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string HourUnit = "hour";
         public const string MinuteUnit = "minute";
         public const string SecondUnit = "second";
+        public const string TimeDurationUnit = "s";
+
+        public const string AM = "AM";
+        public const string PM = "PM";
+
+        public const int InvalidValue = -1;
 
         public static class TimexTypes
         {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -5,6 +5,35 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     public static class Constants
     {
+        // Timex
+        public const string TimexYear = "Y";
+        public const string TimexMonth = "M";
+        public const string TimexMonthFull = "MON";
+        public const string TimexWeek = "W";
+        public const string TimexDay = "D";
+        public const string TimexBusinessDay = "BD";
+        public const string TimexWeekend = "WE";
+        public const string TimexHour = "H";
+        public const string TimexMinute = "M";
+        public const string TimexSecond = "S";
+        public const char TimexFuzzy = 'X';
+        public const string TimexFuzzyYear = "XXXX";
+        public const string TimexFuzzyMonth = "XX";
+        public const string TimexFuzzyWeek = "WXX";
+        public const string TimexFuzzyDay = "XX";
+        public const string DateTimexConnector = "-";
+        public const string TimeTimexConnector = ":";
+        public const string GeneralPeriodPrefix = "P";
+        public const string TimeTimexPrefix = "T";
+
+        public const string YearUnit = "year";
+        public const string MonthUnit = "month";
+        public const string WeekUnit = "week";
+        public const string DayUnit = "day";
+        public const string HourUnit = "hour";
+        public const string MinuteUnit = "minute";
+        public const string SecondUnit = "second";
+
         public static class TimexTypes
         {
             public static readonly string Present = "present";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
@@ -7,6 +7,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     internal static class TimexConstantsEnglish
     {
+        public const string Every = "every";
+        public const string Now = "now";
+        public const string Midnight = "midnight";
+        public const string Midday = "midday";
+        public const string Today = "today";
+        public const string Tomorrow = "tomorrow";
+        public const string Yesterday = "yesterday";
+        public const string Weekend = "weekend";
+        public const string Tonight = "tonight";
+        public const string TimexNight = "NI";
+        public const string This = "this";
+        public const string Last = "last";
+        public const string Next = "next";
         public static readonly string[] Days =
         {
             "Monday",

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string Yesterday = "yesterday";
         public const string Weekend = "weekend";
         public const string Tonight = "tonight";
-        public const string TimexNight = "NI";
         public const string This = "this";
         public const string Last = "last";
         public const string Next = "next";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -95,16 +95,21 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 return TimexConstantsEnglish.Days[timex.DayOfWeek.Value - 1];
             }
 
-            var month = TimexConstantsEnglish.Months[timex.Month.Value - 1];
             var date = timex.DayOfMonth.ToString();
             var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString())];
 
-            if (timex.Year != null)
+            if (timex.Month != null)
             {
-                return $"{date}{abbreviation} {month} {timex.Year}".Trim();
+                var month = TimexConstantsEnglish.Months[timex.Month.Value - 1];
+                if (timex.Year != null)
+                {
+                    return $"{date}{abbreviation} {month} {timex.Year}".Trim();
+                }
+
+                return $"{date}{abbreviation} {month}";
             }
 
-            return $"{date}{abbreviation} {month}";
+            return $"{date}{abbreviation}";
         }
 
         private static string ConvertDurationPropertyToString(decimal value, string property, bool includeSingleCount)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexRelativeConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexRelativeConvertEnglish.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     if (TimexDateHelpers.DatePartEquals(timexDate, date))
                     {
-                        if (timex.PartOfDay == TimexConstantsEnglish.TimexNight)
+                        if (timex.PartOfDay == Constants.TimexNight)
                         {
                             return TimexConstantsEnglish.Tonight;
                         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexRelativeConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexRelativeConvertEnglish.cs
@@ -49,34 +49,34 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
                 if (TimexDateHelpers.DatePartEquals(timexDate, date))
                 {
-                    return "today";
+                    return TimexConstantsEnglish.Today;
                 }
 
                 var tomorrow = TimexDateHelpers.Tomorrow(date);
                 if (TimexDateHelpers.DatePartEquals(timexDate, tomorrow))
                 {
-                    return "tomorrow";
+                    return TimexConstantsEnglish.Tomorrow;
                 }
 
                 var yesterday = TimexDateHelpers.Yesterday(date);
                 if (TimexDateHelpers.DatePartEquals(timexDate, yesterday))
                 {
-                    return "yesterday";
+                    return TimexConstantsEnglish.Yesterday;
                 }
 
                 if (TimexDateHelpers.IsThisWeek(timexDate, date))
                 {
-                    return $"this {GetDateDay(timexDate.DayOfWeek)}";
+                    return $"{TimexConstantsEnglish.This} {GetDateDay(timexDate.DayOfWeek)}";
                 }
 
                 if (TimexDateHelpers.IsNextWeek(timexDate, date))
                 {
-                    return $"next {GetDateDay(timexDate.DayOfWeek)}";
+                    return $"{TimexConstantsEnglish.Next} {GetDateDay(timexDate.DayOfWeek)}";
                 }
 
                 if (TimexDateHelpers.IsLastWeek(timexDate, date))
                 {
-                    return $"last {GetDateDay(timexDate.DayOfWeek)}";
+                    return $"{TimexConstantsEnglish.Last} {GetDateDay(timexDate.DayOfWeek)}";
                 }
             }
 
@@ -100,17 +100,17 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         var thisWeek = TimexDateHelpers.WeekOfYear(date);
                         if (thisWeek == timex.WeekOfYear)
                         {
-                            return timex.Weekend != null ? "this weekend" : "this week";
+                            return timex.Weekend != null ? $"{TimexConstantsEnglish.This} {TimexConstantsEnglish.Weekend}" : $"{TimexConstantsEnglish.This} {Constants.WeekUnit}";
                         }
 
                         if (thisWeek == timex.WeekOfYear + 1)
                         {
-                            return timex.Weekend != null ? "last weekend" : "last week";
+                            return timex.Weekend != null ? $"{TimexConstantsEnglish.Last} {TimexConstantsEnglish.Weekend}" : $"{TimexConstantsEnglish.Last} {Constants.WeekUnit}";
                         }
 
                         if (thisWeek == timex.WeekOfYear - 1)
                         {
-                            return timex.Weekend != null ? "next weekend" : "next week";
+                            return timex.Weekend != null ? $"{TimexConstantsEnglish.Next} {TimexConstantsEnglish.Weekend}" : $"{TimexConstantsEnglish.Next} {Constants.WeekUnit}";
                         }
                     }
 
@@ -118,31 +118,31 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     {
                         if (timex.Month == date.Month)
                         {
-                            return "this month";
+                            return $"{TimexConstantsEnglish.This} {Constants.MonthUnit}";
                         }
 
                         if (timex.Month == date.Month + 1)
                         {
-                            return "next month";
+                            return $"{TimexConstantsEnglish.Next} {Constants.MonthUnit}";
                         }
 
                         if (timex.Month == date.Month - 1)
                         {
-                            return "last month";
+                            return $"{TimexConstantsEnglish.Last} {Constants.MonthUnit}";
                         }
                     }
 
-                    return (timex.Season != null) ? $"this {TimexConstantsEnglish.Seasons[timex.Season]}" : "this year";
+                    return (timex.Season != null) ? $"{TimexConstantsEnglish.This} {TimexConstantsEnglish.Seasons[timex.Season]}" : $"{TimexConstantsEnglish.This} {Constants.YearUnit}";
                 }
 
                 if (timex.Year == year + 1)
                 {
-                    return (timex.Season != null) ? $"next {TimexConstantsEnglish.Seasons[timex.Season]}" : "next year";
+                    return (timex.Season != null) ? $"{TimexConstantsEnglish.Next} {TimexConstantsEnglish.Seasons[timex.Season]}" : $"{TimexConstantsEnglish.Next} {Constants.YearUnit}";
                 }
 
                 if (timex.Year == year - 1)
                 {
-                    return (timex.Season != null) ? $"last {TimexConstantsEnglish.Seasons[timex.Season]}" : "last year";
+                    return (timex.Season != null) ? $"{TimexConstantsEnglish.Last} {TimexConstantsEnglish.Seasons[timex.Season]}" : $"{TimexConstantsEnglish.Last} {Constants.YearUnit}";
                 }
             }
 
@@ -159,36 +159,36 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     if (TimexDateHelpers.DatePartEquals(timexDate, date))
                     {
-                        if (timex.PartOfDay == "NI")
+                        if (timex.PartOfDay == TimexConstantsEnglish.TimexNight)
                         {
-                            return "tonight";
+                            return TimexConstantsEnglish.Tonight;
                         }
                         else
                         {
-                            return $"this {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
+                            return $"{TimexConstantsEnglish.This} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                         }
                     }
 
                     var tomorrow = TimexDateHelpers.Tomorrow(date);
                     if (TimexDateHelpers.DatePartEquals(timexDate, tomorrow))
                     {
-                        return $"tomorrow {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
+                        return $"{TimexConstantsEnglish.Tomorrow} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
 
                     var yesterday = TimexDateHelpers.Yesterday(date);
                     if (TimexDateHelpers.DatePartEquals(timexDate, yesterday))
                     {
-                        return $"yesterday {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
+                        return $"{TimexConstantsEnglish.Yesterday} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
 
                     if (TimexDateHelpers.IsNextWeek(timexDate, date))
                     {
-                        return $"next {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
+                        return $"{TimexConstantsEnglish.Next} {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
 
                     if (TimexDateHelpers.IsLastWeek(timexDate, date))
                     {
-                        return $"last {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
+                        return $"{TimexConstantsEnglish.Last} {GetDateDay(timexDate.DayOfWeek)} {TimexConstantsEnglish.DayParts[timex.PartOfDay]}";
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -128,6 +128,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
             }
 
+            if (timex.DayOfMonth != null)
+            {
+                return $"{Constants.TimexFuzzyYear}-{Constants.TimexFuzzyMonth}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
+            }
+
             if (timex.DayOfWeek != null)
             {
                 return $"XXXX-WXX-{timex.DayOfWeek}";

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -118,27 +118,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string FormatDate(TimexProperty timex)
         {
-            if (timex.Year != null && timex.Month != null && timex.DayOfMonth != null)
-            {
-                return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
-            }
-
-            if (timex.Month != null && timex.DayOfMonth != null)
-            {
-                return $"XXXX-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
-            }
-
-            if (timex.DayOfMonth != null)
-            {
-                return $"{Constants.TimexFuzzyYear}-{Constants.TimexFuzzyMonth}-{TimexDateHelpers.FixedFormatNumber(timex.DayOfMonth, 2)}";
-            }
-
-            if (timex.DayOfWeek != null)
-            {
-                return $"XXXX-WXX-{timex.DayOfWeek}";
-            }
-
-            return string.Empty;
+            return TimexHelpers.GenerateDateTimex(timex.Year ?? Constants.InvalidValue, timex.WeekOfYear ?? (timex.Month ?? Constants.InvalidValue), timex.DayOfWeek != null ? timex.DayOfWeek.Value : timex.DayOfMonth ?? Constants.InvalidValue, timex.WeekOfMonth ?? Constants.InvalidValue, timex.DayOfWeek != null);
         }
 
         private static string FormatDateRange(TimexProperty timex)
@@ -151,6 +131,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             if (timex.Year != null && timex.WeekOfYear != null)
             {
                 return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-W{TimexDateHelpers.FixedFormatNumber(timex.WeekOfYear, 2)}";
+            }
+
+            if (timex.Year != null && timex.Month != null && timex.WeekOfMonth != null)
+            {
+                return $"{TimexDateHelpers.FixedFormatNumber(timex.Year, 4)}-{TimexDateHelpers.FixedFormatNumber(timex.Month, 2)}-W{TimexDateHelpers.FixedFormatNumber(timex.WeekOfMonth, 2)}";
             }
 
             if (timex.Year != null && timex.Season != null)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -391,6 +391,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return timexBuilder.ToString();
         }
 
+        public static string FormatResolvedDateValue(string dateValue, string timeValue)
+        {
+            return $"{dateValue} {timeValue}";
+        }
+
         private static TimexProperty TimeAdd(TimexProperty start, TimexProperty duration)
         {
             int second = (int)(start.Second + (duration.Seconds ?? 0));

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -171,6 +172,31 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
 
             return start;
+        }
+
+        public static string GenerateDateTimex(int year, int monthOrWeekOfYear, int day, int weekOfMonth, bool byWeek)
+        {
+            var yearString = year == Constants.InvalidValue ? Constants.TimexFuzzyYear : TimexDateHelpers.FixedFormatNumber(year, 4);
+            var monthWeekString = monthOrWeekOfYear == Constants.InvalidValue ? Constants.TimexFuzzyMonth : TimexDateHelpers.FixedFormatNumber(monthOrWeekOfYear, 2);
+            string dayString;
+            if (byWeek)
+            {
+                dayString = day.ToString(CultureInfo.InvariantCulture);
+                if (weekOfMonth != Constants.InvalidValue)
+                {
+                    monthWeekString = monthWeekString + $"-{Constants.TimexFuzzyWeek}-" + weekOfMonth.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    monthWeekString = Constants.TimexWeek + monthWeekString;
+                }
+            }
+            else
+            {
+                dayString = day == Constants.InvalidValue ? Constants.TimexFuzzyDay : TimexDateHelpers.FixedFormatNumber(day, 2);
+            }
+
+            return $"{yearString}-{monthWeekString}-{dayString}";
         }
 
         public static TimexProperty TimexTimeAdd(TimexProperty start, TimexProperty duration)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexInference.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexInference.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static bool IsDate(TimexProperty timexProperty)
         {
-            return (timexProperty.Month != null && timexProperty.DayOfMonth != null) || timexProperty.DayOfWeek != null;
+            return timexProperty.DayOfMonth != null || timexProperty.DayOfWeek != null;
         }
 
         private static bool IsTimeRange(TimexProperty timexProperty)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexInference.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexInference.cs
@@ -108,10 +108,10 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static bool IsDateRange(TimexProperty timexProperty)
         {
-            return (timexProperty.Year != null && timexProperty.DayOfMonth == null) ||
-                   (timexProperty.Year != null && timexProperty.Month != null && timexProperty.DayOfMonth == null) ||
-                   (timexProperty.Month != null && timexProperty.DayOfMonth == null) ||
-                   timexProperty.Season != null || timexProperty.WeekOfYear != null || timexProperty.WeekOfMonth != null;
+            return (timexProperty.DayOfMonth == null && timexProperty.DayOfWeek == null) &&
+                (timexProperty.Year != null || timexProperty.Month != null ||
+                timexProperty.Season != null || timexProperty.WeekOfYear != null ||
+                timexProperty.WeekOfMonth != null);
         }
 
         private static bool IsDefinite(TimexProperty timexProperty)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -199,6 +199,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             foreach (var item in source)
             {
+                if (item.Value.Equals(string.Empty))
+                {
+                    continue;
+                }
+
                 switch (item.Key)
                 {
                     case "year":

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -18,23 +18,18 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             {
                 DateCollectionName, new Regex[]
                 {
-                    // date
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
+                   // date
+                    new Regex(@"^(XXXX|(?<year>\d\d\d\d))-(?<month>\d\d)(-(?<dayOfMonth>\d\d))?"),
                     new Regex(@"^XXXX-WXX-(?<dayOfWeek>\d)"),
                     new Regex(@"^XXXX-XX-(?<dayOfMonth>\d\d)"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
 
                     // daterange
                     new Regex(@"^(?<year>\d\d\d\d)"),
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)"),
+                    new Regex(@"^(XXXX|(?<year>\d\d\d\d))-(?<month>\d\d)-W(?<weekOfMonth>\d\d)"),
+                    new Regex(@"^(XXXX|(?<year>\d\d\d\d))-(?<month>\d\d)-WXX-(?<weekOfMonth>\d{1,2})(-(?<dayOfWeek>\d))?"),
                     new Regex(@"^(?<season>SP|SU|FA|WI)"),
-                    new Regex(@"^(?<year>\d\d\d\d)-(?<season>SP|SU|FA|WI)"),
-                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)"),
-                    new Regex(@"^(?<year>\d\d\d\d)-W(?<weekOfYear>\d\d)-(?<weekend>WE)"),
-                    new Regex(@"^XXXX-(?<month>\d\d)"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-W(?<weekOfMonth>\d\d)"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d{1,2})"),
-                    new Regex(@"^XXXX-(?<month>\d\d)-WXX-(?<weekOfMonth>\d)-(?<dayOfWeek>\d)"),
+                    new Regex(@"^(XXXX|(?<year>\d\d\d\d))-(?<season>SP|SU|FA|WI)"),
+                    new Regex(@"^(XXXX|(?<year>\d\d\d\d))-W(?<weekOfYear>\d\d)(-(?<dayOfWeek>\d)|-(?<weekend>WE))?"),
                 }
             },
             {

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRegex.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     // date
                     new Regex(@"^(?<year>\d\d\d\d)-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
                     new Regex(@"^XXXX-WXX-(?<dayOfWeek>\d)"),
+                    new Regex(@"^XXXX-XX-(?<dayOfMonth>\d\d)"),
                     new Regex(@"^XXXX-(?<month>\d\d)-(?<dayOfMonth>\d\d)"),
 
                     // daterange

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -142,12 +142,35 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string LastDateValue(TimexProperty timex, DateObject date)
         {
-            if (timex.Month != null && timex.DayOfMonth != null)
+            if (timex.DayOfMonth != null)
             {
+                var year = date.Year;
+                var month = date.Month;
+                if (timex.Month != null)
+                {
+                    month = timex.Month.Value;
+                    if (date.Month <= month || (date.Month == month && date.Day <= timex.DayOfMonth))
+                    {
+                        year--;
+                    }
+                }
+                else
+                {
+                    if (date.Day <= timex.DayOfMonth)
+                    {
+                        month--;
+                        if (month < 1)
+                        {
+                            month = (month + 12) % 12;
+                            year--;
+                        }
+                    }
+                }
+
                 return TimexValue.DateValue(new TimexProperty
                 {
-                    Year = date.Year - 1,
-                    Month = timex.Month,
+                    Year = year,
+                    Month = month,
                     DayOfMonth = timex.DayOfMonth,
                 });
             }
@@ -169,12 +192,35 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string NextDateValue(TimexProperty timex, DateObject date)
         {
-            if (timex.Month != null && timex.DayOfMonth != null)
+            if (timex.DayOfMonth != null)
             {
+                var year = date.Year;
+                var month = date.Month;
+                if (timex.Month != null)
+                {
+                    month = timex.Month.Value;
+                    if (date.Month > month || (date.Month == month && date.Day > timex.DayOfMonth))
+                    {
+                        year++;
+                    }
+                }
+                else
+                {
+                    if (date.Day > timex.DayOfMonth)
+                    {
+                        month++;
+                        if (month > 12)
+                        {
+                            month = month % 12;
+                            year--;
+                        }
+                    }
+                }
+
                 return TimexValue.DateValue(new TimexProperty
                 {
-                    Year = date.Year,
-                    Month = timex.Month,
+                    Year = year,
+                    Month = month,
                     DayOfMonth = timex.DayOfMonth,
                 });
             }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -609,8 +609,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         {
                             Timex = timex.TimexValue,
                             Type = "datetimerange",
-                            Start = $"{dateValue} {timeRange.Item1}",
-                            End = $"{dateValue} {timeRange.Item2}",
+                            Start = TimexHelpers.FormatResolvedDateValue(dateValue, timeRange.Item1),
+                            End = TimexHelpers.FormatResolvedDateValue(dateValue, timeRange.Item2),
                         });
                 }
 
@@ -629,8 +629,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                         {
                             Timex = timex.TimexValue,
                             Type = "datetimerange",
-                            Start = $"{dateRange.start} {TimexValue.TimeValue(range.Start, date)}",
-                            End = $"{dateRange.end} {TimexValue.TimeValue(range.End, date)}",
+                            Start = TimexHelpers.FormatResolvedDateValue(dateRange.start, TimexValue.TimeValue(range.Start, date)),
+                            End = TimexHelpers.FormatResolvedDateValue(dateRange.end, TimexValue.TimeValue(range.End, date)),
                         });
                 }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -123,21 +125,19 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static List<Resolution.Entry> ResolveDate(TimexProperty timex, DateObject date)
         {
-            return new List<Resolution.Entry>
+            var dateValueList = GetDateValues(timex, date);
+            var result = new List<Resolution.Entry> { };
+            foreach (string dateValue in dateValueList)
             {
-                new Resolution.Entry
+                result.Add(new Resolution.Entry
                 {
                     Timex = timex.TimexValue,
                     Type = "date",
-                    Value = LastDateValue(timex, date),
-                },
-                new Resolution.Entry
-                {
-                    Timex = timex.TimexValue,
-                    Type = "date",
-                    Value = NextDateValue(timex, date),
-                },
-            };
+                    Value = dateValue,
+                });
+            }
+
+            return result;
         }
 
         private static string LastDateValue(TimexProperty timex, DateObject date)
@@ -177,13 +177,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
-                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
-                var result = TimexDateHelpers.DateOfLastDay(day, date);
+                var start = GenerateWeekDate(timex, date, true);
                 return TimexValue.DateValue(new TimexProperty
                 {
-                    Year = result.Year,
-                    Month = result.Month,
-                    DayOfMonth = result.Day,
+                    Year = start.Year,
+                    Month = start.Month,
+                    DayOfMonth = start.Day,
                 });
             }
 
@@ -227,13 +226,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
             if (timex.DayOfWeek != null)
             {
-                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
-                var result = TimexDateHelpers.DateOfNextDay(day, date);
+                var start = GenerateWeekDate(timex, date, false);
                 return TimexValue.DateValue(new TimexProperty
                 {
-                    Year = result.Year,
-                    Month = result.Month,
-                    DayOfMonth = result.Day,
+                    Year = start.Year,
+                    Month = start.Month,
+                    DayOfMonth = start.Day,
                 });
             }
 
@@ -311,24 +309,88 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return firstWeekDay.AddDays(weekOfYear * 7);
         }
 
-        private static Tuple<string, string> MonthWeekDateRange(int year, int month, int weekOfYear)
+        private static Tuple<string, string> MonthWeekDateRange(int year, int month, int weekOfMonth)
         {
-            var dateInWeek = new DateObject(year, month, 1 + ((weekOfYear - 1) * 7));
-            if (dateInWeek.DayOfWeek == DayOfWeek.Sunday)
-            {
-                dateInWeek = dateInWeek.AddDays(1);
-            }
-            else if (dateInWeek.DayOfWeek > DayOfWeek.Monday)
-            {
-                dateInWeek = dateInWeek.AddDays(1 - (int)dateInWeek.DayOfWeek);
-            }
-
-            var start = dateInWeek;
-            var end = dateInWeek.AddDays(7);
+            var start = GenerateMonthWeekDateStart(year, month, weekOfMonth);
+            var end = start.AddDays(7);
 
             return new Tuple<string, string>(
                 TimexValue.DateValue(new TimexProperty { Year = start.Year, Month = start.Month, DayOfMonth = start.Day }),
                 TimexValue.DateValue(new TimexProperty { Year = end.Year, Month = end.Month, DayOfMonth = end.Day }));
+        }
+
+        private static DateObject GenerateMonthWeekDateStart(int year, int month, int weekOfMonth)
+        {
+            var dateInWeek = new DateObject(year, month, 1 + ((weekOfMonth - 1) * 7));
+
+            // Align the date of the week according to Thursday, base on ISO 8601, https://en.wikipedia.org/wiki/ISO_8601
+            if (dateInWeek.DayOfWeek > DayOfWeek.Thursday)
+            {
+                dateInWeek = dateInWeek.AddDays(7 - (int)dateInWeek.DayOfWeek + 1);
+            }
+            else
+            {
+                dateInWeek = dateInWeek.AddDays(1 - (int)dateInWeek.DayOfWeek);
+            }
+
+            return dateInWeek;
+        }
+
+        private static DateObject GenerateWeekDate(TimexProperty timex, DateObject date, bool isBefore)
+        {
+            DateObject start;
+            if (timex.WeekOfMonth == null && timex.WeekOfYear == null)
+            {
+                var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
+                if (isBefore)
+                {
+                    start = TimexDateHelpers.DateOfLastDay(day, date);
+                }
+                else
+                {
+                    start = TimexDateHelpers.DateOfNextDay(day, date);
+                }
+            }
+            else
+            {
+                int dayOfWeek = timex.DayOfWeek.Value - 1;
+                int year = timex.Year ?? date.Year;
+                if (timex.WeekOfYear != null)
+                {
+                    int weekOfYear = timex.WeekOfYear.Value;
+                    start = FirstDateOfWeek(year, weekOfYear, CultureInfo.InvariantCulture).AddDays(dayOfWeek);
+                    if (timex.Year == null)
+                    {
+                        if (isBefore && start > date)
+                        {
+                            start = FirstDateOfWeek(year - 1, weekOfYear, CultureInfo.InvariantCulture).AddDays(dayOfWeek);
+                        }
+                        else if (!isBefore && start < date)
+                        {
+                            start = FirstDateOfWeek(year + 1, weekOfYear, CultureInfo.InvariantCulture).AddDays(dayOfWeek);
+                        }
+                    }
+                }
+                else
+                {
+                    int month = timex.Month ?? date.Month;
+                    int weekOfMonth = timex.WeekOfMonth.Value;
+                    start = GenerateMonthWeekDateStart(year, month, weekOfMonth).AddDays(dayOfWeek);
+                    if (timex.Year == null || timex.Month == null)
+                    {
+                        if (isBefore && start > date)
+                        {
+                            start = GenerateMonthWeekDateStart(timex.Month != null ? year - 1 : year, timex.Month == null ? month - 1 : month, weekOfMonth).AddDays(dayOfWeek);
+                        }
+                        else if (!isBefore && start < date)
+                        {
+                            start = GenerateMonthWeekDateStart(timex.Month != null ? year + 1 : year, timex.Month == null ? month + 1 : month, weekOfMonth).AddDays(dayOfWeek);
+                        }
+                    }
+                }
+            }
+
+            return start;
         }
 
         private static List<Resolution.Entry> ResolveDateRange(TimexProperty timex, DateObject date)
@@ -347,6 +409,24 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
             else
             {
+                if (timex.Month != null && timex.WeekOfMonth != null)
+                {
+                    var yearDateRangeList = GetMonthWeekDateRange(timex.Year ?? Constants.InvalidValue, timex.Month.Value, timex.WeekOfMonth.Value, date.Year);
+                    var result = new List<Resolution.Entry> { };
+                    foreach (Tuple<string, string> yearDateRange in yearDateRangeList)
+                    {
+                        result.Add(new Resolution.Entry
+                        {
+                            Timex = timex.TimexValue,
+                            Type = "daterange",
+                            Start = yearDateRange.Item1,
+                            End = yearDateRange.Item2,
+                        });
+                    }
+
+                    return result;
+                }
+
                 if (timex.Year != null && timex.Month != null)
                 {
                     var dateRange = MonthDateRange(timex.Year.Value, timex.Month.Value);
@@ -374,30 +454,6 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                             Type = "daterange",
                             Start = dateRange.Item1,
                             End = dateRange.Item2,
-                        },
-                    };
-                }
-
-                if (timex.Month != null && timex.WeekOfMonth != null)
-                {
-                    var lastYearDateRange = MonthWeekDateRange(date.Year - 1, timex.Month.Value, timex.WeekOfMonth.Value);
-                    var thisYearDateRange = MonthWeekDateRange(date.Year, timex.Month.Value, timex.WeekOfMonth.Value);
-
-                    return new List<Resolution.Entry>
-                    {
-                        new Resolution.Entry
-                        {
-                            Timex = timex.TimexValue,
-                            Type = "daterange",
-                            Start = lastYearDateRange.Item1,
-                            End = lastYearDateRange.Item2,
-                        },
-                        new Resolution.Entry
-                        {
-                            Timex = timex.TimexValue,
-                            Type = "daterange",
-                            Start = thisYearDateRange.Item1,
-                            End = thisYearDateRange.Item2,
                         },
                     };
                 }
@@ -504,36 +560,81 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return resolvedDates;
         }
 
+        private static List<string> GetDateValues(TimexProperty timex, DateObject date)
+        {
+            List<string> result = new List<string> { };
+            if (timex.Year != null && timex.Month != null && timex.DayOfMonth != null)
+            {
+                result.Add(TimexValue.DateValue(timex));
+            }
+            else
+            {
+                result.Add(LastDateValue(timex, date));
+                if (timex.Year == null)
+                {
+                    result.Add(NextDateValue(timex, date));
+                }
+            }
+
+            return result;
+        }
+
+        private static List<Tuple<string, string>> GetMonthWeekDateRange(int year, int month, int weekOfMonth, int referYear)
+        {
+            var result = new List<Tuple<string, string>> { };
+            if (year == Constants.InvalidValue)
+            {
+                result.Add(MonthWeekDateRange(referYear - 1, month, weekOfMonth));
+                result.Add(MonthWeekDateRange(referYear, month, weekOfMonth));
+            }
+            else
+            {
+                result.Add(MonthWeekDateRange(year, month, weekOfMonth));
+            }
+
+            return result;
+        }
+
         private static List<Resolution.Entry> ResolveDateTimeRange(TimexProperty timex, DateObject date)
         {
             if (timex.PartOfDay != null)
             {
-                var dateValue = TimexValue.DateValue(timex);
+                var dateValues = GetDateValues(timex, date);
                 var timeRange = PartOfDayTimeRange(timex);
-                return new List<Resolution.Entry>
+                var result = new List<Resolution.Entry> { };
+                foreach (string dateValue in dateValues)
                 {
-                    new Resolution.Entry
-                    {
-                        Timex = timex.TimexValue,
-                        Type = "datetimerange",
-                        Start = $"{dateValue} {timeRange.Item1}",
-                        End = $"{dateValue} {timeRange.Item2}",
-                    },
-                };
+                    result.Add(
+                        new Resolution.Entry
+                        {
+                            Timex = timex.TimexValue,
+                            Type = "datetimerange",
+                            Start = $"{dateValue} {timeRange.Item1}",
+                            End = $"{dateValue} {timeRange.Item2}",
+                        });
+                }
+
+                return result;
             }
             else
             {
                 var range = TimexHelpers.ExpandDateTimeRange(timex);
-                return new List<Resolution.Entry>
+                var startDateValues = GetDateValues(range.Start, date);
+                var endDateValues = GetDateValues(range.End, date);
+                var result = new List<Resolution.Entry> { };
+                foreach (var dateRange in startDateValues.Zip(endDateValues, (n, w) => new { start = n, end = w }))
                 {
-                    new Resolution.Entry
-                    {
-                        Timex = timex.TimexValue,
-                        Type = "datetimerange",
-                        Start = $"{TimexValue.DateValue(range.Start)} {TimexValue.TimeValue(range.Start, date)}",
-                        End = $"{TimexValue.DateValue(range.End)} {TimexValue.TimeValue(range.End, date)}",
-                    },
-                };
+                    result.Add(
+                        new Resolution.Entry
+                        {
+                            Timex = timex.TimexValue,
+                            Type = "datetimerange",
+                            Start = $"{dateRange.start} {TimexValue.TimeValue(range.Start, date)}",
+                            End = $"{dateRange.end} {TimexValue.TimeValue(range.End, date)}",
+                        });
+                }
+
+                return result;
             }
         }
     }


### PR DESCRIPTION
Fix timex without specified year/month like "XXXX-XX-06", "XXXX-02-02".
Return future/past resolutions according to reference date.
Add test cases.

Support week related timex like "XXXX-WXX-1", "XXXX-11-WXX-4-4"(#2456).
Support datetimerange with fuzzy timex like "XXXX-10-25TAF"(#2318), "(XXXX-04-05T10,XXXX-04-05T11,PT1H)"(#1513), "XXXX-WXX-1TMO"(#1560)