### PR TITLE
[.NET] Dutch DateTime Set support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)";
       public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
-      public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+))?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)s\b";
+      public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)(s|(?<suffix>e)n)\b";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(vanaf\s+nu|later))\b";
       public static readonly string SpecialDate = $@"(?=\b(op\s+)(de\s+)?){DayRegex}\b";
@@ -146,9 +146,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
       public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
-      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))";
+      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)";
       public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))";
-      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^ochtend))";
+      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))";
       public const string LunchRegex = @"\b(lunchtijd)\b";
       public static readonly string NightRegex = $@"\b((({ApostrofsRegex}|des)\s+)?nachts|(midder)?nacht)\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
@@ -160,7 +160,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HourDTRegEx = $@"({BaseDateTime.HourRegex})";
       public static readonly string MinuteDTRegEx = $@"({BaseDateTime.MinuteRegex})";
       public static readonly string SecondDTRegEx = $@"({BaseDateTime.SecondRegex})";
-      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))";
+      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}(:|\.){MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))";
       public static readonly string MidnightRegex = $@"(?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)";
       public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?(morgen|ochtend)|halverwege de ochtend|het midden van de ochtend)";
       public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)";
@@ -181,11 +181,11 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeRegex4 = $@"\b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
       public static readonly string TimeRegex5 = $@"\b({TimePrefix}\s+{BasicTime}|{BasicTime}\s+{TimePrefix})((\s*({DescRegex}|{TimeSuffix}))|\b)";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)|({WrittenTimeRegex}|{BasicTime})(\s*{DescRegex})(\s*{TimeSuffixFull})";
       public static readonly string TimeRegex8 = $@".^";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s+{FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?";
-      public static readonly string TimeRegex11 = $@"\b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%)))";
+      public static readonly string TimeRegex11 = $@"\b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%|{EachUnitRegex})))";
       public static readonly string TimeRegex12 = $@"({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))";
       public static readonly string FirstTimeRegexInTimeRange = $@"\b{TimeRegexWithDotConnector}(\s*{DescRegex})?";
       public static readonly string PureNumFromToPrefixExcluded = $@"({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
@@ -223,12 +223,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
       public const string SuffixAndRegex = @"(?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
-      public const string PeriodicRegex = @"\b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b";
-      public static readonly string EachUnitRegex = $@"(?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})";
-      public const string EachPrefixRegex = @"\b(?<each>(iedere|elke)\s*$)";
-      public const string SetEachRegex = @"\b(?<each>(iedere|elke)\s*)";
+      public const string PeriodicRegex = @"\b(?<periodic>dagelijks|(drie)?maandelijkse?|wekelijks|twee-?wekelijks|jaarlijks|kwartaal)\b";
+      public static readonly string EachUnitRegex = $@"(?<each>((iedere|elke|eenmaal per)(?<other>\s+andere)?\s*{DurationUnitRegex})|(({DurationUnitRegex}|{WeekDayRegex})\s+om(\s+de)?(?<other>\s+andere)?\s*(week|{DurationUnitRegex})))";
+      public const string EachPrefixRegex = @"\b(?<each>(iedere|elke|eenmaal per)\s*$)";
+      public const string SetEachRegex = @"\b(?<each>(iedere|elke|om de)\s*(?<other>\s+andere)?\s*(week)?)";
       public const string SetLastRegex = @"(?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorige?|verleden|laatste)";
-      public const string EachDayRegex = @"^\s*(elke)\s*dag\b";
+      public const string EachDayRegex = @"^\s*(iedere|elke)\s*dag\b";
+      public const string BeforeEachDayRegex = @"(iedere|elke)\s*dag\s*";
       public static readonly string DurationFollowedUnit = $@"^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}";
       public static readonly string AnUnitRegex = $@"\b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}";
@@ -272,7 +273,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-zë]+\s)?[A-Za-zë\d]+?(ste|de|e))";
       public static readonly string ForTheRegex = $@"\b((((?<=voor\s+)de\s+{FlexibleDayRegex})|((?<=op\s+)de\s+{FlexibleDayRegex}(?<=(ste|de|e))))(?<end>(\s+(tussen|binnen|terug|tegen|aan|uit|mee|bij|vol|uit|aan|op|in|na|af)\s*)?(\s+(ge\w\w\w+|\w\w\w+en)\s*)?(,|\.|!|\?|$)))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b";
-      public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
+      public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+{DayRegex}(?!([-]|:\d+|\.\d+|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
       public const string RestOfDateTimeRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<unit>vandaag|dag)\b";
       public const string MealTimeRegex = @"\b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b";
@@ -932,5 +933,11 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             @"jaar tot op heden",
             @"vanaf vorig jaareinde"
         };
+      public const string DayTypeRegex = @"^(dag(elijks)?)$";
+      public const string WeekTypeRegex = @"^(wekelijks|week)$";
+      public const string BiWeekTypeRegex = @"^(tweewekelijks)$";
+      public const string MonthTypeRegex = @"^(maand(elijks)?)$";
+      public const string QuarterTypeRegex = @"^(kwartaal|driemaandelijkse)$";
+      public const string YearTypeRegex = @"^(elk\s+jaar|jaar(lijks)?)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string MoreThanRegex = @"\b(meer\s+dan)\b";
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
       public const string SuffixAndRegex = @"(?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
-      public const string PeriodicRegex = @"\b(?<periodic>dagelijks|(drie)?maandelijkse?|wekelijks|twee-?wekelijks|jaarlijks|kwartaal)\b";
+      public const string PeriodicRegex = @"\b(?<periodic>dagelijkse?|(drie)?maandelijkse?|wekelijkse?|twee-?wekelijkse?|jaarlijkse?|kwartaal)\b";
       public static readonly string EachUnitRegex = $@"(?<each>((iedere|elke|eenmaal per)(?<other>\s+andere)?\s*{DurationUnitRegex})|(({DurationUnitRegex}|{WeekDayRegex})\s+om(\s+de)?(?<other>\s+andere)?\s*(week|{DurationUnitRegex})))";
       public const string EachPrefixRegex = @"\b(?<each>(iedere|elke|eenmaal per)\s*$)";
       public const string SetEachRegex = @"\b(?<each>(iedere|elke|om de)\s*(?<other>\s+andere)?\s*(week)?)";
@@ -933,11 +933,11 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             @"jaar tot op heden",
             @"vanaf vorig jaareinde"
         };
-      public const string DayTypeRegex = @"^(dag(elijks)?)$";
-      public const string WeekTypeRegex = @"^(wekelijks|week)$";
-      public const string BiWeekTypeRegex = @"^(tweewekelijks)$";
-      public const string MonthTypeRegex = @"^(maand(elijks)?)$";
-      public const string QuarterTypeRegex = @"^(kwartaal|driemaandelijkse)$";
-      public const string YearTypeRegex = @"^(elk\s+jaar|jaar(lijks)?)$";
+      public const string DayTypeRegex = @"^(dag(elijkse?)?)$";
+      public const string WeekTypeRegex = @"^(wekelijkse?|week)$";
+      public const string BiWeekTypeRegex = @"^(tweewekelijkse?)$";
+      public const string MonthTypeRegex = @"^(maand(elijkse?)?)$";
+      public const string QuarterTypeRegex = @"^(kwartaal|driemaandelijkse?)$";
+      public const string YearTypeRegex = @"^(elk\s+jaar|jaar(lijkse?)?)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex SetEachRegex =
             new Regex(DateTimeDefinitions.SetEachRegex, RegexFlags);
 
+        public static readonly Regex BeforeEachDayRegex =
+           new Regex(DateTimeDefinitions.BeforeEachDayRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public DutchSetExtractorConfiguration(IDateTimeOptionsConfiguration config)
@@ -60,7 +63,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public IDateTimeExtractor DateTimePeriodExtractor { get; }
 
-        bool ISetExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+        bool ISetExtractorConfiguration.CheckBothBeforeAfter => true;
 
         Regex ISetExtractorConfiguration.LastRegex => SetLastRegex;
 
@@ -72,7 +75,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         Regex ISetExtractorConfiguration.EachDayRegex => EachDayRegex;
 
-        Regex ISetExtractorConfiguration.BeforeEachDayRegex => null;
+        Regex ISetExtractorConfiguration.BeforeEachDayRegex => BeforeEachDayRegex;
 
         Regex ISetExtractorConfiguration.SetWeekDayRegex => SetWeekDayRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchSetExtractorConfiguration.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public IDateTimeExtractor DateTimePeriodExtractor { get; }
 
+        // CheckBothBeforeAfter normally gets its value from DateTimeDefinitions.CheckBothBeforeAfter which however for Dutch is false.
+        // It only needs to be true in SetExtractor.
         bool ISetExtractorConfiguration.CheckBothBeforeAfter => true;
 
         Regex ISetExtractorConfiguration.LastRegex => SetLastRegex;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchSetParserConfiguration.cs
@@ -1,12 +1,33 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Dutch;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.Dutch
 {
     public class DutchSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+        private static readonly Regex DayTypeRegex =
+            new Regex(DateTimeDefinitions.DayTypeRegex, RegexFlags);
+
+        private static readonly Regex WeekTypeRegex =
+            new Regex(DateTimeDefinitions.WeekTypeRegex, RegexFlags);
+
+        private static readonly Regex BiWeekTypeRegex =
+            new Regex(DateTimeDefinitions.BiWeekTypeRegex, RegexFlags);
+
+        private static readonly Regex MonthTypeRegex =
+            new Regex(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
+
+        private static readonly Regex QuarterTypeRegex =
+            new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
+
+        private static readonly Regex YearTypeRegex =
+            new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
+
         public DutchSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
@@ -81,28 +102,29 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         {
             var trimmedText = text.Trim();
 
-            // @TODO move hardcoded values to resources file
-
-            if (trimmedText.Equals("dagelijks", StringComparison.Ordinal))
+            if (DayTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1D";
             }
-            else if (trimmedText.Equals("wekelijks", StringComparison.Ordinal))
+            else if (WeekTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1W";
             }
-            else if (trimmedText.Equals("tweewekelijks", StringComparison.Ordinal))
+            else if (BiWeekTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P2W";
             }
-            else if (trimmedText.Equals("maandelijks", StringComparison.Ordinal))
+            else if (MonthTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1M";
             }
-            else if (trimmedText.Equals("elk jaar", StringComparison.Ordinal) ||
-                     trimmedText.Equals("jaarlijks", StringComparison.Ordinal))
+            else if (YearTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1Y";
+            }
+            else if (QuarterTypeRegex.IsMatch(trimmedText))
+            {
+                timex = "P3M";
             }
             else
             {
@@ -115,33 +137,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public bool GetMatchedUnitTimex(string text, out string timex)
         {
-            var trimmedText = text.Trim();
-
-            // @TODO move hardcoded values to resources file
-
-            if (trimmedText.Equals("dag", StringComparison.Ordinal))
-            {
-                timex = "P1D";
-            }
-            else if (trimmedText.Equals("week", StringComparison.Ordinal))
-            {
-                timex = "P1W";
-            }
-            else if (trimmedText.Equals("maand", StringComparison.Ordinal))
-            {
-                timex = "P1M";
-            }
-            else if (trimmedText.Equals("jaar", StringComparison.Ordinal))
-            {
-                timex = "P1Y";
-            }
-            else
-            {
-                timex = null;
-                return false;
-            }
-
-            return true;
+            return GetMatchedDailyTimex(text, out timex);
         }
 
         public string WeekDayGroupMatchString(Match match) => SetHandler.WeekDayGroupMatchString(match);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseSetExtractor.cs
@@ -160,6 +160,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 len += match.Groups[Constants.PrefixGroupName].ToString().Length;
                             }
 
+                            if (match.Groups[Constants.SuffixGroupName].ToString().Length > 0)
+                            {
+                                len += match.Groups[Constants.SuffixGroupName].ToString().Length;
+                            }
+
                             ret.Add(new Token(er.Start ?? 0, er.Start + len ?? 0));
                         }
                     }

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -249,7 +249,7 @@ RelativeDayRegex: !nestedRegex
   def: \b(((de\s+)?{RelativeRegex}\s+dag))\b
   references: [ RelativeRegex ]
 SetWeekDayRegex: !simpleRegex
-  def: \b(?<prefix>op\s+({ArticleRegex}\s+))?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)s\b
+  def: \b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)(s|(?<suffix>e)n)\b
 WeekDayOfMonthRegex: !nestedRegex
   def: (?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))
   references: [ WeekDayRegex, MonthSuffixRegex ]
@@ -326,13 +326,13 @@ MinuteNumRegex: !simpleRegex
 DeltaMinuteNumRegex: !simpleRegex
   def: (?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
 PmRegex: !nestedRegex
-  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht))
+  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)
   references: [ ApostrofsRegex ]
 PmRegexFull: !nestedRegex
   def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))
   references: [ ApostrofsRegex ]
 AmRegex: !nestedRegex
-  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^ochtend))
+  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))
   references: [ ApostrofsRegex ]
 LunchRegex: !simpleRegex
   def: \b(lunchtijd)\b
@@ -366,7 +366,7 @@ SecondDTRegEx: !nestedRegex
   def: ({BaseDateTime.SecondRegex})
   references: [ BaseDateTime.SecondRegex, BaseUnits.SecondRegex]
 BasicTime: !nestedRegex
-  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}:{MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))
+  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{HourDTRegEx}(:|\.){MinuteDTRegEx}(:{SecondDTRegEx})?|((?<prefix>half)\s+)?{HourDTRegEx}(?![.,:]?[%\d]))
   references: [ WrittenTimeRegex, HourNumRegex, HourDTRegEx, MinuteDTRegEx, SecondDTRegEx ]
 MidnightRegex: !nestedRegex
   def: (?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)
@@ -423,7 +423,7 @@ TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
 TimeRegex7: !nestedRegex
-  def: ({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)
+  def: ({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)|({WrittenTimeRegex}|{BasicTime})(\s*{DescRegex})(\s*{TimeSuffixFull})
   references: [ TimeSuffixFull, BasicTime, DescRegex, WrittenTimeRegex, TimePrefix ]
 TimeRegex8: !nestedRegex
   def: .^
@@ -435,8 +435,8 @@ TimeRegex10: !nestedRegex
   def: \b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?
   references: [ TimePrefix, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, DescRegex ]
 TimeRegex11: !nestedRegex
-  def: \b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%)))
-  references: [ TimeTokenPrefix, TimeRegexWithDotConnector, DescRegex, TimeSuffix ]
+  def: \b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%|{EachUnitRegex})))
+  references: [ TimeTokenPrefix, TimeRegexWithDotConnector, DescRegex, TimeSuffix, EachUnitRegex ]
 TimeRegex12: !nestedRegex
   def: ({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))
   references: [ BaseDateTime.HourRegex ]
@@ -534,18 +534,20 @@ DurationUnitRegex: !nestedRegex
 SuffixAndRegex: !simpleRegex
   def: (?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
 PeriodicRegex: !simpleRegex
-  def: \b(?<periodic>dagelijks|maandelijks|wekelijks|twee-wekelijks|jaarlijks)\b
+  def: \b(?<periodic>dagelijks|(drie)?maandelijkse?|wekelijks|twee-?wekelijks|jaarlijks|kwartaal)\b
 EachUnitRegex: !nestedRegex
-  def: (?<each>(iedere|elke)(?<other>\s+andere)?\s*{DurationUnitRegex})
-  references: [ DurationUnitRegex ]
+  def: (?<each>((iedere|elke|eenmaal per)(?<other>\s+andere)?\s*{DurationUnitRegex})|(({DurationUnitRegex}|{WeekDayRegex})\s+om(\s+de)?(?<other>\s+andere)?\s*(week|{DurationUnitRegex})))
+  references: [ DurationUnitRegex, WeekDayRegex ]
 EachPrefixRegex: !simpleRegex
-  def: \b(?<each>(iedere|elke)\s*$)
+  def: \b(?<each>(iedere|elke|eenmaal per)\s*$)
 SetEachRegex: !simpleRegex
-  def: \b(?<each>(iedere|elke)\s*)
+  def: \b(?<each>(iedere|elke|om de)\s*(?<other>\s+andere)?\s*(week)?)
 SetLastRegex: !simpleRegex
   def: (?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorige?|verleden|laatste)
 EachDayRegex: !simpleRegex
-  def: ^\s*(elke)\s*dag\b
+  def: ^\s*(iedere|elke)\s*dag\b
+BeforeEachDayRegex: !simpleRegex
+  def: (iedere|elke)\s*dag\s*
 DurationFollowedUnit: !nestedRegex
   def: ^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})
   references: [ SuffixAndRegex, DurationUnitRegex ]
@@ -659,7 +661,7 @@ WeekDayAndDayOfMonthRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+(de\s+{FlexibleDayRegex})\b
   references: [WeekDayRegex, FlexibleDayRegex]
 WeekDayAndDayRegex: !nestedRegex
-  def: \b{WeekDayRegex}\s+{DayRegex}(?!([-]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
+  def: \b{WeekDayRegex}\s+{DayRegex}(?!([-]|:\d+|\.\d+|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, AmDescRegex, PmDescRegex, OclockRegex]
 RestOfDateRegex: !simpleRegex
   def: \brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b
@@ -1364,4 +1366,16 @@ YearToDateTerms: !list
     - jaar tot heden
     - jaar tot op heden
     - vanaf vorig jaareinde
+DayTypeRegex: !simpleRegex
+  def: ^(dag(elijks)?)$
+WeekTypeRegex: !simpleRegex
+  def: ^(wekelijks|week)$
+BiWeekTypeRegex: !simpleRegex
+  def: ^(tweewekelijks)$
+MonthTypeRegex: !simpleRegex
+  def: ^(maand(elijks)?)$
+QuarterTypeRegex: !simpleRegex
+  def: ^(kwartaal|driemaandelijkse)$
+YearTypeRegex: !simpleRegex
+  def: ^(elk\s+jaar|jaar(lijks)?)$
 ...

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -1,6 +1,7 @@
 ---
 #ISO 639-2 Code
 LangMarker: Dut
+# Note: CheckBothBeforeAfter is set to true in DutchSetExtractorConfiguration
 CheckBothBeforeAfter: !bool false
 TillRegex: !nestedRegex
   def: (?<till>\b(tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van)\b|{BaseDateTime.RangeConnectorSymbolRegex})
@@ -534,7 +535,7 @@ DurationUnitRegex: !nestedRegex
 SuffixAndRegex: !simpleRegex
   def: (?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
 PeriodicRegex: !simpleRegex
-  def: \b(?<periodic>dagelijks|(drie)?maandelijkse?|wekelijks|twee-?wekelijks|jaarlijks|kwartaal)\b
+  def: \b(?<periodic>dagelijkse?|(drie)?maandelijkse?|wekelijkse?|twee-?wekelijkse?|jaarlijkse?|kwartaal)\b
 EachUnitRegex: !nestedRegex
   def: (?<each>((iedere|elke|eenmaal per)(?<other>\s+andere)?\s*{DurationUnitRegex})|(({DurationUnitRegex}|{WeekDayRegex})\s+om(\s+de)?(?<other>\s+andere)?\s*(week|{DurationUnitRegex})))
   references: [ DurationUnitRegex, WeekDayRegex ]
@@ -544,8 +545,10 @@ SetEachRegex: !simpleRegex
   def: \b(?<each>(iedere|elke|om de)\s*(?<other>\s+andere)?\s*(week)?)
 SetLastRegex: !simpleRegex
   def: (?<last>volgende?|komende|aankomende|aanstaande|deze|huidige|aanstaande|vorige?|verleden|laatste)
+# This regex is used to extract Set patterns like "3pm every day" where "every day" follows the time.
 EachDayRegex: !simpleRegex
   def: ^\s*(iedere|elke)\s*dag\b
+# This regex is used to extract Set patterns like "every day at 3pm" where "every day" preceeds the time.
 BeforeEachDayRegex: !simpleRegex
   def: (iedere|elke)\s*dag\s*
 DurationFollowedUnit: !nestedRegex
@@ -1367,15 +1370,15 @@ YearToDateTerms: !list
     - jaar tot op heden
     - vanaf vorig jaareinde
 DayTypeRegex: !simpleRegex
-  def: ^(dag(elijks)?)$
+  def: ^(dag(elijkse?)?)$
 WeekTypeRegex: !simpleRegex
-  def: ^(wekelijks|week)$
+  def: ^(wekelijkse?|week)$
 BiWeekTypeRegex: !simpleRegex
-  def: ^(tweewekelijks)$
+  def: ^(tweewekelijkse?)$
 MonthTypeRegex: !simpleRegex
-  def: ^(maand(elijks)?)$
+  def: ^(maand(elijkse?)?)$
 QuarterTypeRegex: !simpleRegex
-  def: ^(kwartaal|driemaandelijkse)$
+  def: ^(kwartaal|driemaandelijkse?)$
 YearTypeRegex: !simpleRegex
-  def: ^(elk\s+jaar|jaar(lijks)?)$
+  def: ^(elk\s+jaar|jaar(lijkse?)?)$
 ...

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -10025,5 +10025,101 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Ik zal vertrekken om 09:00 's ochtends",
+    "Context": {
+      "ReferenceDateTime": "2020-08-17T00:00:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "09:00 's ochtends",
+        "Start": 21,
+        "End": 37,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T09:00",
+              "type": "time",
+              "value": "09:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal vertrekken 's ochtends om 9",
+    "Context": {
+      "ReferenceDateTime": "2020-08-17T00:00:00"
+    },
+    "NotSupported": "dotNet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "'s ochtends om 9",
+        "Start": 18,
+        "End": 33,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T09",
+              "type": "time",
+              "value": "09:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal elke maandag vertrekken om 09:00",
+    "Context": {
+      "ReferenceDateTime": "2020-08-17T00:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke maandag",
+        "Type": "set",
+        "Start": 7,
+        "End": 18,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "09:00",
+        "Start": 34,
+        "End": 38,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T09:00",
+              "type": "time",
+              "value": "09:00:00"
+            },
+            {
+              "timex": "T21:00",
+              "type": "time",
+              "value": "21:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Dutch/SetExtractor.json
+++ b/Specs/DateTime/Dutch/SetExtractor.json
@@ -9,7 +9,6 @@
         "Length": 9
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -22,7 +21,6 @@
         "Length": 9
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -35,7 +33,6 @@
         "Length": 8
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -48,7 +45,6 @@
         "Length": 10
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -61,7 +57,6 @@
         "Length": 9
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -74,7 +69,6 @@
         "Length": 15
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -87,7 +81,6 @@
         "Length": 15
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -100,7 +93,6 @@
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -113,7 +105,6 @@
         "Length": 19
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -126,7 +117,6 @@
         "Length": 9
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -139,7 +129,6 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -152,7 +141,6 @@
         "Length": 21
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -165,7 +153,6 @@
         "Length": 12
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -178,7 +165,6 @@
         "Length": 21
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -191,7 +177,6 @@
         "Length": 20
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -204,7 +189,6 @@
         "Length": 17
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -217,33 +201,30 @@
         "Length": 19
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik zal vertrekken om 09:00 's ochtends",
+    "Input": "Ik ga weg iedere ochtend om 9 uur",
     "Results": [
       {
-        "Text": "09:00 's ochtends",
+        "Text": "iedere ochtend om 9 uur",
         "Type": "set",
-        "Start": 21,
-        "Length": 17
+        "Start": 10,
+        "Length": 23
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik zal vertrekken 's ochtends om 9",
+    "Input": "Ik ga weg om 9 uur iedere ochtend",
     "Results": [
       {
-        "Text": "'s ochtends om 9",
+        "Text": "9 uur iedere ochtend",
         "Type": "set",
-        "Start": 18,
-        "Length": 16
+        "Start": 13,
+        "Length": 20
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -256,20 +237,18 @@
         "Length": 28
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik zal elke maandag vertrekken om 09:00",
+    "Input": "Ik zal elke maandag om 09:00 vertrekken",
     "Results": [
       {
-        "Text": "maandag vertrekken om 09:00",
+        "Text": "elke maandag om 09:00",
         "Type": "set",
-        "Start": 12,
-        "Length": 27
+        "Start": 7,
+        "Length": 21
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -282,7 +261,6 @@
         "Length": 30
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
@@ -295,42 +273,14 @@
         "Length": 11
       }
     ],
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
     "Input": "Ik vertrek wekelijks",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "wekelijks",
-        "Type": "set",
-        "Start": 11,
-        "Length": 6
-      }
-    ]
-  },
-  {
-    "Input": "Ik vertrek dagelijks",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "dagelijks",
-        "Type": "set",
-        "Start": 11,
-        "Length": 5
-      }
-    ]
-  },
-  {
-    "Input": "Ik vertrek elke dag",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "elke dag",
         "Type": "set",
         "Start": 11,
         "Length": 9
@@ -338,8 +288,31 @@
     ]
   },
   {
+    "Input": "Ik vertrek dagelijks",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "dagelijks",
+        "Type": "set",
+        "Start": 11,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "Ik vertrek elke dag",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "elke dag",
+        "Type": "set",
+        "Start": 11,
+        "Length": 8
+      }
+    ]
+  },
+  {
     "Input": "Ik vertrek elke maand",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -352,124 +325,114 @@
   },
   {
     "Input": "Ik vertrek jaarlijks",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "jaarlijks",
         "Type": "set",
         "Start": 11,
-        "Length": 8
+        "Length": 9
       }
     ]
   },
   {
     "Input": "Ik vertek elke twee dagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "elke twee dagen",
         "Type": "set",
         "Start": 10,
-        "Length": 13
+        "Length": 15
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere dag 15:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere dag 15:00",
         "Type": "set",
         "Start": 11,
-        "Length": 13
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Ik vertrek elke dag 15:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "elke dag 15:00",
         "Type": "set",
         "Start": 11,
-        "Length": 12
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik vertrek elke 15-4",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15-4",
+        "Text": "elke 15-4",
         "Type": "set",
-        "Start": 16,
+        "Start": 11,
         "Length": 9
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere maandag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere maandag",
         "Type": "set",
         "Start": 11,
-        "Length": 12
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik vertrek elke maandag 16:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "elke maandag 16:00",
         "Type": "set",
         "Start": 11,
-        "Length": 15
+        "Length": 18
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere ochtend",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere ochtend",
         "Type": "set",
         "Start": 11,
-        "Length": 13
+        "Length": 14
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere ochtend om 9:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere ochtend om 9:00",
         "Type": "set",
         "Start": 11,
-        "Length": 20
+        "Length": 22
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere middag om 16:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -482,89 +445,106 @@
   },
   {
     "Input": "Ik vertrek iedere avond om 21:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere avond om 21:00",
         "Type": "set",
         "Start": 11,
-        "Length": 18
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik vertrek iedere avond om 9 uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere avond om 9 uur",
         "Type": "set",
         "Start": 11,
-        "Length": 16
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik vertrek de ochtenden om 9:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de ochtenden om 9:00",
         "Type": "set",
         "Start": 11,
-        "Length": 15
+        "Length": 20
       }
     ]
   },
   {
     "Input": "Ik vertrek op ochtenden om 9 uur",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "op ochtenden om 9 uur",
         "Type": "set",
         "Start": 11,
-        "Length": 16
+        "Length": 21
       }
     ]
   },
   {
     "Input": "Ik vertrek om 9 uur 's ochtends iedere zondag",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9 uur 's ochtends iedere zondag",
         "Type": "set",
         "Start": 14,
-        "Length": 16
+        "Length": 31
       }
     ]
   },
   {
     "Input": "Ik vertrek om 9 uur 's ochtends op maandagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9 uur 's ochtends op maandagen",
         "Type": "set",
         "Start": 14,
-        "Length": 14
+        "Length": 30
       }
     ]
   },
   {
     "Input": "Ik vertrek om 9:00 op maandagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "om 9:00 op maandagen",
+        "Text": "9:00 op maandagen",
+        "Type": "set",
+        "Start": 14,
+        "Length": 17
+      }
+    ]
+  },
+  {
+    "Input": "Ik vertrek op maandagen",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op maandagen",
+        "Type": "set",
+        "Start": 11,
+        "Length": 12
+      }
+    ]
+  },
+  {
+    "Input": "Ik vertrek op zondagen",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "op zondagen",
         "Type": "set",
         "Start": 11,
         "Length": 11
@@ -572,54 +552,26 @@
     ]
   },
   {
-    "Input": "Ik vertrek op maandagen",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "op maandagen",
-        "Type": "set",
-        "Start": 11,
-        "Length": 10
-      }
-    ]
-  },
-  {
-    "Input": "Ik vertrek op zondagen",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "op zondagen",
-        "Type": "set",
-        "Start": 11,
-        "Length": 10
-      }
-    ]
-  },
-  {
     "Input": "Ik vertrek zondagen",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zondagen",
         "Type": "set",
         "Start": 11,
-        "Length": 7
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Kan ik een boeking plaatsen voor de 9e van mei voor 2 nachten?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "nachten",
         "Type": "set",
         "Start": 54,
-        "Length": 6
+        "Length": 7
       }
     ]
   }

--- a/Specs/DateTime/Dutch/SetParser.json
+++ b/Specs/DateTime/Dutch/SetParser.json
@@ -1106,5 +1106,53 @@
         "Length": 8
       }
     ]
+  },
+  {
+    "Input": "Lees de beste artikelen op het gebied van Contoso via onze wekelijkse nieuwsbrief!",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "wekelijkse",
+        "Type": "set",
+        "Value": {
+          "Timex": "P1W",
+          "FutureResolution": {
+            "set": "Set: P1W"
+          },
+          "PastResolution": {
+            "set": "Set: P1W"
+          }
+        },
+        "Start": 59,
+        "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "Laten we een driemaandelijkse vergadering houden.",
+    "Context": {
+      "ReferenceDateTime": "2019-11-25T17:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "driemaandelijkse",
+        "Type": "set",
+        "Value": {
+          "Timex": "P3M",
+          "FutureResolution": {
+            "set": "Set: P3M"
+          },
+          "PastResolution": {
+            "set": "Set: P3M"
+          }
+        },
+        "Start": 13,
+        "Length": 16
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Dutch/SetParser.json
+++ b/Specs/DateTime/Dutch/SetParser.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2744475+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2754476+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -54,7 +52,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2779449+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2794445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -104,7 +100,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2829445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -129,7 +124,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2844439+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -154,11 +148,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2909444+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "elke twee dagen ",
+        "Text": "elke twee dagen",
         "Type": "set",
         "Value": {
           "Timex": "P2D",
@@ -170,7 +163,7 @@
           }
         },
         "Start": 7,
-        "Length": 16
+        "Length": 15
       }
     ]
   },
@@ -179,7 +172,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2959472+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -204,19 +196,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2989494+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15.00 elke dag",
         "Type": "set",
         "Value": {
-          "Timex": "T15",
+          "Timex": "T15:00",
           "FutureResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           },
           "PastResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           }
         },
         "Start": 7,
@@ -229,19 +220,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3039501+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15.00 iedere dag",
         "Type": "set",
         "Value": {
-          "Timex": "T15",
+          "Timex": "T15:00",
           "FutureResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           },
           "PastResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           }
         },
         "Start": 7,
@@ -254,7 +244,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3109498+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -279,7 +268,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3259514+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -304,19 +292,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3379507+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "elke maandag 16.00",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-1T16",
+          "Timex": "XXXX-WXX-1T16:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-1T16"
+            "set": "Set: XXXX-WXX-1T16:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-1T16"
+            "set": "Set: XXXX-WXX-1T16:00"
           }
         },
         "Start": 7,
@@ -329,7 +316,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3429518+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -354,23 +340,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3609535+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "iedere ochtend om 9.00 ",
+        "Text": "iedere ochtend om 9.00",
         "Type": "set",
         "Value": {
-          "Timex": "T09",
+          "Timex": "T09:00",
           "FutureResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           },
           "PastResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           }
         },
         "Start": 7,
-        "Length": 23
+        "Length": 22
       }
     ]
   },
@@ -379,23 +364,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3730732+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "iedere middag  om 16.00 ",
+        "Text": "iedere middag  om 16.00",
         "Type": "set",
         "Value": {
-          "Timex": "T16",
+          "Timex": "T16:00",
           "FutureResolution": {
-            "set": "Set: T16"
+            "set": "Set: T16:00"
           },
           "PastResolution": {
-            "set": "Set: T16"
+            "set": "Set: T16:00"
           }
         },
         "Start": 7,
-        "Length": 24
+        "Length": 23
       }
     ]
   },
@@ -404,23 +388,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3840706+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "iedere avond om 21.00 ",
+        "Text": "iedere avond om 21.00",
         "Type": "set",
         "Value": {
-          "Timex": "T21",
+          "Timex": "T21:00",
           "FutureResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           },
           "PastResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           }
         },
         "Start": 7,
-        "Length": 22
+        "Length": 21
       }
     ]
   },
@@ -429,23 +412,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3930718+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "iedere avond om 21.00 ",
+        "Text": "iedere avond om 21.00",
         "Type": "set",
         "Value": {
-          "Timex": "T21",
+          "Timex": "T21:00",
           "FutureResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           },
           "PastResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           }
         },
         "Start": 7,
-        "Length": 22
+        "Length": 21
       }
     ]
   },
@@ -454,19 +436,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4065719+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "ochtenden om 9.00",
         "Type": "set",
         "Value": {
-          "Timex": "T09",
+          "Timex": "T09:00",
           "FutureResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           },
           "PastResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           }
         },
         "Start": 7,
@@ -479,19 +460,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4170727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "op ochtenden om 9.00",
         "Type": "set",
         "Value": {
-          "Timex": "T09",
+          "Timex": "T09:00",
           "FutureResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           },
           "PastResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           }
         },
         "Start": 7,
@@ -504,23 +484,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4295727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 9.00 iedere zondag ",
+        "Text": "9.00 iedere zondag",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-7T09:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           }
         },
-        "Start": 9,
-        "Length": 20
+        "Start": 10,
+        "Length": 18
       }
     ]
   },
@@ -529,23 +508,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.438575+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "9.00 op zondagen ",
+        "Text": "9.00 op zondagen",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-7T09:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           }
         },
         "Start": 10,
-        "Length": 17
+        "Length": 16
       }
     ]
   },
@@ -554,19 +532,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4505726+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "zondagen 9.00",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-7T09:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           }
         },
         "Start": 7,
@@ -579,7 +556,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4570731+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -604,7 +580,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4635727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -629,7 +604,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4710739+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -654,7 +628,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -679,7 +652,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -701,6 +673,7 @@
   },
   {
     "Input": "Laten we vrijdag om de week afspreken",
+    "Comment": "The English counterpart is 'Every other Friday' and in Dutch the different structure (Friday every other week) prevents the case to be parsed.",
     "Context": {
       "ReferenceDateTime": "2019-11-25T17:00:00"
     },
@@ -729,7 +702,6 @@
     "Context": {
       "ReferenceDateTime": "2019-11-25T17:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -754,7 +726,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2794445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -779,7 +750,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2829445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -804,11 +774,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2909444+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "iedere twee dagen ",
+        "Text": "iedere twee dagen",
         "Type": "set",
         "Value": {
           "Timex": "P2D",
@@ -820,7 +789,7 @@
           }
         },
         "Start": 7,
-        "Length": 18
+        "Length": 17
       }
     ]
   },
@@ -829,19 +798,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2989494+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15.00 iedere dag",
         "Type": "set",
         "Value": {
-          "Timex": "T15",
+          "Timex": "T15:00",
           "FutureResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           },
           "PastResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           }
         },
         "Start": 7,
@@ -854,19 +822,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3039501+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15.00 elke dag",
         "Type": "set",
         "Value": {
-          "Timex": "T15",
+          "Timex": "T15:00",
           "FutureResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           },
           "PastResolution": {
-            "set": "Set: T15"
+            "set": "Set: T15:00"
           }
         },
         "Start": 7,
@@ -879,7 +846,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3109498+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -904,7 +870,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3259514+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -929,19 +894,18 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3379507+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "iedere maandag 16.00",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-1T16",
+          "Timex": "XXXX-WXX-1T16:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-1T16"
+            "set": "Set: XXXX-WXX-1T16:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-1T16"
+            "set": "Set: XXXX-WXX-1T16:00"
           }
         },
         "Start": 7,
@@ -954,7 +918,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3429518+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -979,23 +942,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3609535+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "elke ochtend om 9.00 ",
+        "Text": "elke ochtend om 9.00",
         "Type": "set",
         "Value": {
-          "Timex": "T09",
+          "Timex": "T09:00",
           "FutureResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           },
           "PastResolution": {
-            "set": "Set: T09"
+            "set": "Set: T09:00"
           }
         },
         "Start": 7,
-        "Length": 21
+        "Length": 20
       }
     ]
   },
@@ -1004,23 +966,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3730732+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "elke middag  om 16.00 ",
+        "Text": "elke middag  om 16.00",
         "Type": "set",
         "Value": {
-          "Timex": "T16",
+          "Timex": "T16:00",
           "FutureResolution": {
-            "set": "Set: T16"
+            "set": "Set: T16:00"
           },
           "PastResolution": {
-            "set": "Set: T16"
+            "set": "Set: T16:00"
           }
         },
         "Start": 7,
-        "Length": 22
+        "Length": 21
       }
     ]
   },
@@ -1029,23 +990,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3840706+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "elke avond om 21.00 ",
+        "Text": "elke avond om 21.00",
         "Type": "set",
         "Value": {
-          "Timex": "T21",
+          "Timex": "T21:00",
           "FutureResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           },
           "PastResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           }
         },
         "Start": 7,
-        "Length": 20
+        "Length": 19
       }
     ]
   },
@@ -1054,23 +1014,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3930718+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "elke avond om 21.00 ",
+        "Text": "elke avond om 21.00",
         "Type": "set",
         "Value": {
-          "Timex": "T21",
+          "Timex": "T21:00",
           "FutureResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           },
           "PastResolution": {
-            "set": "Set: T21"
+            "set": "Set: T21:00"
           }
         },
         "Start": 7,
-        "Length": 20
+        "Length": 19
       }
     ]
   },
@@ -1079,28 +1038,28 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4295727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 9.00 elke zondag ",
+        "Text": "9.00 elke zondag",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-7T09:00",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-7T09:00"
           }
         },
-        "Start": 9,
-        "Length": 18
+        "Start": 10,
+        "Length": 16
       }
     ]
   },
   {
     "Input": "Laten we vrijdag om de andere week afspreken",
+    "Comment": "The English counterpart is 'Every other Friday' and in Dutch the different structure (Friday every other week) prevents the case to be parsed.",
     "Context": {
       "ReferenceDateTime": "2019-11-25T17:00:00"
     },
@@ -1129,11 +1088,10 @@
     "Context": {
       "ReferenceDateTime": "2019-11-25T17:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " kwartaal",
+        "Text": "kwartaal",
         "Type": "set",
         "Value": {
           "Timex": "P3M",
@@ -1144,8 +1102,8 @@
             "set": "Set: P3M"
           }
         },
-        "Start": 12,
-        "Length": 9
+        "Start": 13,
+        "Length": 8
       }
     ]
   }


### PR DESCRIPTION
In SetExtractor, all test cases pass.
In SetParser, 2 cases fail: 
"Laten we vrijdag om de week afspreken" and "Laten we vrijdag om de andere week afspreken" which correspond to "Every other Friday" in English. The different structure of the Dutch expression (literally "Friday every other week") prevents these cases to be parsed in the current implementation.

A few cases have been modified in SetExtractor and the original spec moved to DateTimeModel:
- "Ik zal vertrekken om 09:00 's ochtends" -> "Ik ga weg iedere ochtend om 9 uur" (I leave every morning at 9am)
- "Ik zal vertrekken 's ochtends om 9" -> "Ik ga weg om 9 uur iedere ochtend" (I leave at 9am every morning)
In the above two cases, the original sentences do not represent Set entities but Time.
- "Ik zal elke maandag vertrekken om 09:00" -> "Ik zal elke maandag om 09:00 vertrekken" (I will leave every Monday at 9am)
In the original sentence the verb splits Set and Time that consequently cannot be extracted together as a single entity.

In DateTimeModel: 166 pass, 199 fail.