### PR TITLE
[DE Unit/Currency] Support for hyphen-connected unit expressions (#2494)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersWithUnitDefinitions.cs
@@ -439,6 +439,7 @@ namespace Microsoft.Recognizers.Definitions.German
         };
       public const string BuildPrefix = @"(?<=(\s|^))";
       public const string BuildSuffix = @"(?=(\s|\W|$))";
+      public const string ConnectorToken = @"-";
       public static readonly Dictionary<string, string> LengthSuffixList = new Dictionary<string, string>
         {
             { @"Kilometer", @"km|kilometer|kilometern" },

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             this.UnitNumExtractor = NumberExtractor.GetInstance(NumberMode.Unit);
             this.BuildPrefix = NumbersWithUnitDefinitions.BuildPrefix;
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
-            this.ConnectorToken = string.Empty;
+            this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
 
             AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.AmbiguityFiltersDict);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Parsers/GermanNumberWithUnitParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Parsers/GermanNumberWithUnitParserConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Recognizers.Definitions.German;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.German;
 
@@ -16,7 +17,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
             this.InternalNumberExtractor = NumberExtractor.GetInstance();
             this.InternalNumberParser = AgnosticNumberParserFactory.GetParser(AgnosticNumberParserType.Number,
                                                                               new GermanNumberParserConfiguration(numConfig));
-            this.ConnectorToken = string.Empty;
+            this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
 
             this.TypeList = DimensionExtractorConfiguration.DimensionTypeList;
         }

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/GermanNumberWithUnitExtractorConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/extractors/GermanNumberWithUnitExtractorConfiguration.java
@@ -46,7 +46,7 @@ public abstract class GermanNumberWithUnitExtractorConfiguration implements INum
     }
 
     public String getConnectorToken() {
-        return "";
+        return GermanNumericWithUnit.ConnectorToken;
     }
 
     public Pattern getCompoundUnitConnectorRegex() {

--- a/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/GermanNumberWithUnitParserConfiguration.java
+++ b/Java/libraries/recognizers-text-number-with-unit/src/main/java/com/microsoft/recognizers/text/numberwithunit/german/parsers/GermanNumberWithUnitParserConfiguration.java
@@ -8,6 +8,7 @@ import com.microsoft.recognizers.text.number.german.parsers.GermanNumberParserCo
 import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserFactory;
 import com.microsoft.recognizers.text.number.parsers.AgnosticNumberParserType;
 import com.microsoft.recognizers.text.numberwithunit.parsers.BaseNumberWithUnitParserConfiguration;
+import com.microsoft.recognizers.text.numberwithunit.resources.GermanNumericWithUnit;
 
 public abstract class GermanNumberWithUnitParserConfiguration extends BaseNumberWithUnitParserConfiguration {
 
@@ -26,7 +27,7 @@ public abstract class GermanNumberWithUnitParserConfiguration extends BaseNumber
 
     @Override
     public String getConnectorToken() {
-        return "";
+        return GermanNumericWithUnit.ConnectorToken;
     }
 
     public GermanNumberWithUnitParserConfiguration(CultureInfo ci) {

--- a/Patterns/German/German-NumbersWithUnit.yaml
+++ b/Patterns/German/German-NumbersWithUnit.yaml
@@ -524,6 +524,7 @@ BuildPrefix: !simpleRegex
   def: (?<=(\s|^))
 BuildSuffix: !simpleRegex
   def: (?=(\s|\W|$))
+ConnectorToken: '-'
 #LengthExtractorConfiguration
 LengthSuffixList: !dictionary
   types: [ string, string ]

--- a/Specs/NumberWithUnit/German/CurrencyModel.json
+++ b/Specs/NumberWithUnit/German/CurrencyModel.json
@@ -441,5 +441,20 @@
         }
       }
     ]
+  },
+  {
+    "Input": "siebenhundert-Euro",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "siebenhundert-euro",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "700",
+          "unit": "Euro"
+        }
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/German/DimensionModel.json
+++ b/Specs/NumberWithUnit/German/DimensionModel.json
@@ -363,5 +363,41 @@
     "Input": "2:00 pm",
     "NotSupported": "java",
     "Results": []
+  },
+  {
+    "Input": "12 Pfund Tasse Kaffee",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "12 pfund",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "12",
+          "unit": "Pound",
+          "subtype": "Weight"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "12-Pfund-Tasse Kaffee",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "java, javascript",
+    "Results": [
+      {
+        "Text": "12-pfund",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "12",
+          "unit": "Pound",
+          "subtype": "Weight"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/German/DimensionModel.json
+++ b/Specs/NumberWithUnit/German/DimensionModel.json
@@ -399,5 +399,23 @@
         "End": 7
       }
     ]
+  },
+  {
+    "Input": "12 - Pfund - Tasse Kaffee",
+    "NotSupportedByDesign": "python",
+    "NotSupported": "javascript",
+    "Results": [
+      {
+        "Text": "12 - pfund",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "12",
+          "unit": "Pound",
+          "subtype": "Weight"
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2494 in .NET. 
Solution applied also in Java, but an additional problem appears there with non-spaced connectors (i.e. "12 - Pfund" is recognized correctly but "12-Pfund" is not).
Test cases added to German DimensionModel and CurrencyModel.