### PR TITLE
[Java][DateTime] Fix arbitrary order in parsed elements

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java
@@ -438,7 +438,7 @@ public class BaseMergedDateTimeParser implements IDateTimeParser {
         }
 
         List<Map<String, String>> resolutions = new ArrayList<>();
-        Map<String, Object> res = new HashMap<>();
+        LinkedHashMap<String, Object> res = new LinkedHashMap<>();
 
         DateTimeResolutionResult val = (DateTimeResolutionResult)slot.getValue();
         if (val == null) {

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimexUtility.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimexUtility.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -281,7 +282,7 @@ public class TimexUtility {
         return timex1 + Constants.CompositeTimexDelimiter + timex2;
     }
 
-    public static Map<String, Object> processDoubleTimex(Map<String, Object> resolutionDic, String futureKey, String pastKey, String originTimex) {
+    public static LinkedHashMap<String, Object> processDoubleTimex(LinkedHashMap<String, Object> resolutionDic, String futureKey, String pastKey, String originTimex) {
         String[] timexes = originTimex.split(Constants.CompositeTimexSplit);
 
         if (!resolutionDic.containsKey(futureKey) || !resolutionDic.containsKey(pastKey) || timexes.length != 2) {


### PR DESCRIPTION
Fixes #2548

## Description
Fixes arbitrary differences in order found when retrieving elements from the output of [BaseMergedDateTimeParser::dateTimeResolution](https://github.com/microsoft/Recognizers-Text/blob/master/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java#L435), which created a disparity against the same output in C# and JavaScript.

## Specific Changes
We changed the type of the [res](https://github.com/microsoft/Recognizers-Text/blob/master/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseMergedDateTimeParser.java#L441) variable to [LinkedHashMap](http://docs.oracle.com/javase/6/docs/api/java/util/LinkedHashMap.html), since with the original type [HashMap](https://docs.oracle.com/javase/6/docs/api/java/util/HashMap.html), there's no certainty of the order the values will be retrieved in.

## Testing
_Successful Java `build.cmd` execution_
![image](https://user-images.githubusercontent.com/11904023/114215612-2c954680-993c-11eb-93b5-888c3aa17899.png)
