### PR TITLE
[.NET] Arabic Time support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Arabic/DateTimeDefinitions.cs
@@ -50,11 +50,11 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s*مائة)?(\s*و)?)\b";
       public static readonly string LastTwoYearNumRegex = $@"(?:zero\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s*مائة(\s*و)?))\b";
-      public const string OclockRegex = @"(?<oclock>o\s*((’|‘|')\s*)?clock|sharp)";
+      public const string OclockRegex = @"(?<oclock>(ال)?ساعة|(ال)?ساعات)";
       public const string SpecialDescRegex = @"((?<ipm>)p\b)";
-      public static readonly string AmDescRegex = $@"(?:{BaseDateTime.BaseAmDescRegex})";
-      public static readonly string PmDescRegex = $@"(:?{BaseDateTime.BasePmDescRegex})";
-      public static readonly string AmPmDescRegex = $@"(:?{BaseDateTime.BaseAmPmDescRegex})";
+      public static readonly string AmDescRegex = $@"(في\s)?(صباح(ا)?|صباحًا|الصباح|{BaseDateTime.BaseAmDescRegex})";
+      public static readonly string PmDescRegex = $@"(في\s)?((ال)?مساء|مساءً|ليلًا|ليلا|(ال)?ليل(ة)?|بعد الظهر|الظهر|ظهرا|{BaseDateTime.BasePmDescRegex})";
+      public static readonly string AmPmDescRegex = $@"(في\s)?(صباح(ا)?|صباحًا|الصباح|(ال)?مساء|مساءً|{BaseDateTime.BaseAmPmDescRegex})";
       public static readonly string DescRegex = $@"(:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
       public const string OfPrepositionRegex = @"(\bof\b)";
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
@@ -70,6 +70,12 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public const string TimeTokenPrefix = @"عند ";
       public const string TokenBeforeDate = @"في ";
       public const string TokenBeforeTime = @"عند ";
+      public const string HalfTokenRegex = @"^(النصف|نصف|والنصف|ونصف)";
+      public const string QuarterTokenRegex = @"^(ربع|الربع|وربع|والربع|إلا ربع|إلا الربع)";
+      public const string ThreeQuarterTokenRegex = @"^(وثلاثة أرباع|ثلاثة أرباع|إلا الربع)";
+      public const string ToTokenRegex = @"\b(إلا)$";
+      public const string ToHalfTokenRegex = @"\b(إلا\s+(النصف|نصف))$";
+      public const string ForHalfTokenRegex = @"\b(ل(s+)?(نصف))$";
       public const string FromRegex = @"\b(from(\s+the)?)$";
       public const string BetweenTokenRegex = @"\b(between(\s+the)?)$";
       public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}\s+{MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
@@ -152,42 +158,42 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string WeekDayEnd = $@"(هذا\s+)?{WeekDayRegex}\s*[,،]?\s*$";
       public const string WeekDayStart = @"^[\.]";
       public const string RangeUnitRegex = @"\b(?<unit>years?|months?|weeks?)\b";
-      public const string HourNumRegex = @"\b(?<hournum>zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b";
-      public const string MinuteNumRegex = @"(?<minnum>ten|eleven|twelve|thirteen|fifteen|eighteen|(four|six|seven|nine)(teen)?|twenty|thirty|forty|fifty|one|two|three|five|eight)";
-      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>ten|eleven|twelve|thirteen|fifteen|eighteen|(four|six|seven|nine)(teen)?|twenty|thirty|forty|fifty|one|two|three|five|eight)";
-      public const string PmRegex = @"(?<pm>(((?:at|in|around|on|for)\s+(the\s+)?)?(afternoon|evening|midnight|lunchtime))|((at|in|around|on|for)\s+(the\s+)?night))";
-      public const string PmRegexFull = @"(?<pm>((?:at|in|around|on|for)\s+(the\s+)?)?(afternoon|evening|(mid)?night|lunchtime))";
-      public const string AmRegex = @"(?<am>((?:at|in|around|on|for)\s+(the\s+)?)?(morning))";
-      public const string LunchRegex = @"\blunchtime\b";
-      public const string NightRegex = @"\b(mid)?night\b";
+      public const string HourNumRegex = @"\b(?<hournum>الأولى|(ال)?واحدة|(ال)?ثانية|(ال)?ثالثة|(ال)?رابعة|(ال)?خامسة|(ال)?سادسة|(ال)?سابعة|(ال)?ثامنة|(ال)?تاسعة|(ال)?عاشرة|(ال)?حادية عشر(ة)?|(ال)?ثانية عشر(ة)?|خمسة عشر|أحد عشر)\b";
+      public const string MinuteNumRegex = @"\b(?<minnum>أربع|خمس|ست|سبع|ثمان|تسع|عشر|عشرة|أحد عشر|إثني عشر|إثنا عشر|ثلاثة عشر|خمسة عشر|ثمانية عشر|أربعة عشر|ستة عشر|سبعة عشر|(ال)?حادية عشر(ة)?|تسعة عشر|عشرون|ثلاثون|أربعون|خمسون|عشرين|ثلاث(ين)?|أربعين|خمسين|واحد|إثنان|ثلاثة|خمسة|ثمانية)\b";
+      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>عشرة|أحد عشر|اثنا عشر|ثلاثة عشر|خمسة عشر|ثمانية عشر|أربعة|ستة|سبعة|تسعة|عشرين|أربعة عشر|ستة عشر|سبعة عشر|تسعة عشر| ثلاثون|أربعون|خمسين|أربعين|خمسون|واحد|اثنان|ثلاثة|خمسة|ثمانية|ثلاث(ين)?|أربع|خمس|ست|سبع|ثمان|تسع|(ال)?واحدة|(ال)?ثانية|(ال)?ثالثة|(ال)?رابعة|(ال)?خامسة|(ال)?سادسة|(ال)?سابعة|(ال)?ثامنة|(ال)?تاسعة|(ال)?عاشرة|(ال)?حادية عشر(ة)?|(ال)?ثانية عشر(ة)?)";
+      public const string PmRegex = @"(?<pm>(?:(في|حول)\s|ل)?(وقت\s)?(بعد الظهر|بعد الظهيرة|(ال)?مساء|مساءً|منتصف(\s|-)الليل|الغداء|الليل|ليلا))";
+      public const string PmRegexFull = @"(?<pm>(?:(في|حول)\s|ل)?(وقت\s)?(بعد الظهر|بعد الظهيرة|(ال)?مساء|مساءً|منتصف(\s|-)الليل|الغداء|الليل|ليلا))";
+      public const string AmRegex = @"(?<am>(?:(في|حول)\s|ل)?(وقت\s)?((ال)?صباح|صباحا|صباحًا))";
+      public const string LunchRegex = @"\b(موعد الغذاء|وقت الغذاء)\b";
+      public const string NightRegex = @"\bمنتصف(\s|-)الليل\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
-      public static readonly string LessThanOneHour = $@"(?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)))";
-      public static readonly string WrittenTimeRegex = $@"(?<writtentime>{HourNumRegex}\s+({MinuteNumRegex}|(?<tens>twenty|thirty|fou?rty|fifty)\s+{MinuteNumRegex}))";
-      public static readonly string TimePrefix = $@"(?<prefix>{LessThanOneHour}\s+(past|to))";
+      public static readonly string LessThanOneHour = $@"(?<lth>((ال)?ربع|ثلاثة أرباع|(ال)?نصف)|({BaseDateTime.DeltaMinuteRegex}(\s(دقيقة|دقائق))?)|({DeltaMinuteNumRegex}(\s(دقيقة|دقائق))?))";
+      public static readonly string WrittenTimeRegex = $@"(?<writtentime>((ال)?ساعة\s)?{HourNumRegex}\s+(و(\s)?)?({MinuteNumRegex}|{{LessThanOneHour}}|({MinuteNumRegex}\s+(و(\s)?)?(?<tens>عشرون|ثلاثون|أربعون|خمسون|عشرين|ثلاثين|أربعين|خمسين))))";
+      public static readonly string TimePrefix = $@"(?<prefix>(إلا|حتى|و|قبل)?(\s)?{LessThanOneHour})";
       public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";
       public static readonly string TimeSuffixFull = $@"(?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})";
-      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex}(?![%\d]))";
-      public const string MidnightRegex = @"(?<midnight>mid\s*(-\s*)?night)";
-      public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?morning)";
-      public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?afternoon)";
-      public const string MiddayRegex = @"(?<midday>mid\s*(-\s*)?day|((12\s)?noon))";
+      public static readonly string BasicTime = $@"\b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|({MinuteNumRegex}(\s(دقيقة|دقائق))?)|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex}(?![%\d]))";
+      public const string MidnightRegex = @"(?<midnight>منتصف(\s|(\s?-\s?))الليل)";
+      public const string MidmorningRegex = @"(?<midmorning>منتصف(\s|(\s?-\s?))الصباح)";
+      public const string MidafternoonRegex = @"(?<midafternoon>منتصف(\s|(\s?-\s?))بعد الظهر)";
+      public const string MiddayRegex = @"(?<midday>(وقت الغداء\s)?(منتصف(\s|(\s?-\s?)))?(النهار|(الساعة\s)?((((12\s)?الظهر)|(12\s)?الظهيرة)|(12\s)?ظهرا))(\sوقت الغداء)?)";
       public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
-      public static readonly string AtRegex = $@"\b(?:(?:(?<=\bat\s+)(?:{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
-      public static readonly string IshRegex = $@"\b({BaseDateTime.HourRegex}(-|——)?ish|noon(ish)?)\b";
-      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>h(ou)?rs?|h|min(ute)?s?|sec(ond)?s?)\b";
+      public static readonly string AtRegex = $@"\b(?:(?:(?<=\bفي\s+)?(?:{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)|{MidTimeRegex}))|{MidTimeRegex})\b";
+      public static readonly string IshRegex = $@"\b((({BaseDateTime.HourRegex}|{WrittenTimeRegex})(\s|-))?(وقت\s)?((الظهيرة|الظهر|ظهر(ا|اً))))\b";
+      public const string TimeUnitRegex = @"([^A-Za-z]{1,}|\b)(?<unit>(ال)?ساعة|(ال)?ساعات|(ال)?دقائق|(ال)?دقيقة|(ال)?ثانية|(ال)?ثوان|(ال)?ساعتين|(ال)?دقيقتين|(ال)?ثانيتين)\b";
       public const string RestrictedTimeUnitRegex = @"(?<unit>(ال)?ساعة|(ال)?دقيقة)\b";
       public const string FivesRegex = @"(?<tens>(?:fifteen|(?:twen|thir|fou?r|fif)ty(\s*five)?|ten|five))\b";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string PeriodHourNumRegex = @"\b(?<hour>twenty(\s+(one|two|three|four))?|eleven|twelve|thirteen|fifteen|eighteen|(four|six|seven|nine)(teen)?|zero|one|two|three|five|eight|ten)\b";
       public static readonly string ConnectNumRegex = $@"\b{BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex}";
       public static readonly string TimeRegexWithDotConnector = $@"({BaseDateTime.HourRegex}(\s*\.\s*){BaseDateTime.MinuteRegex})";
-      public static readonly string TimeRegex1 = $@"\b({TimePrefix}\s+)?({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*|[.]){DescRegex}";
+      public static readonly string TimeRegex1 = $@"\b({TimePrefix}\s+)?({WrittenTimeRegex}(\s{TimePrefix})?|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*|[.]){DescRegex}";
       public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(?<iam>a)?((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex3 = $@"(\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})";
-      public static readonly string TimeRegex4 = $@"\b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex5 = $@"\b{TimePrefix}\s+{BasicTime}((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex4 = $@"\b({TimePrefix}\s+)?{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}(\s*{DescRegex})?\b";
+      public static readonly string TimeRegex5 = $@"\b({DescRegex}\s)?{BasicTime}((\s*{DescRegex})((\s+{TimePrefix})?)|(\s+{TimePrefix}(\s+{TimePrefix})?))(\s{DescRegex})?";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex7 = $@"\b{TimeSuffixFull}\s+(at\s+)?{BasicTime}((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex7 = $@"\b({DescRegex}\s)?(وقت الغداء\s)?{TimeSuffixFull}\s+(في\s+)?{BasicTime}(\s{DescRegex})?(\sوقت الغداء)?(\s{{TimePrefix}})?((\s*{DescRegex})|\b)?";
       public static readonly string TimeRegex8 = $@".^";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}(\s+|-){FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*h\s*){BaseDateTime.MinuteRegex}(\s*{DescRegex})?";
@@ -299,7 +305,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
       public static readonly string SpecialYearTermsRegex = $@"\b((({SpecialYearPrefixes}\s+)?year)|(cy|(?<special>fy|sy)))";
       public static readonly string YearPlusNumberRegex = $@"\b({SpecialYearTermsRegex}\s*((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b";
-      public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(before|no later than|by|after)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
+      public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(ب|((قبل|في موعد لا يتجاوز| بعد)\s))(وقت\s+)?)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+at)\s*$";
       public const string DecadeRegex = @"(?<decade>(?:nough|twen|thir|fou?r|fif|six|seven|eight|nine)ties|two\s+thousands)";
       public static readonly string DecadeWithCenturyRegex = $@"(the\s+)?(((?<century>\d|1\d|2\d)?(')?(?<decade>\d0)(')?(\s)?s\b)|(({CenturyRegex}(\s+|-)(and\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)(and\s+)?(?<decade>tens|hundreds)))";
@@ -542,14 +548,19 @@ namespace Microsoft.Recognizers.Definitions.Arabic
             { @"واحد", 1 },
             { @"اثنان", 2 },
             { @"ثلاثة", 3 },
+            { @"ثلاث", 3 },
             { @"أربعة", 4 },
             { @"خمسة", 5 },
+            { @"الخامسة", 5 },
             { @"ستة", 6 },
             { @"سبعة", 7 },
+            { @"السابعة", 7 },
             { @"ثمانية", 8 },
+            { @"الثامنة", 8 },
             { @"تسعة", 9 },
             { @"عشرة", 10 },
             { @"أحد عشر", 11 },
+            { @"الحادية عشر", 11 },
             { @"اثنا عشر", 12 },
             { @"ثلاثة عشر", 13 },
             { @"أربعة عشر", 14 },
@@ -559,6 +570,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
             { @"ثمانية عشر", 18 },
             { @"تسعة عشر", 19 },
             { @"عشرون", 20 },
+            { @"عشرين", 20 },
             { @"واحد وعشرون", 21 },
             { @"اثنان وعشرون", 22 },
             { @"ثلاثة وعشرون", 23 },
@@ -569,6 +581,7 @@ namespace Microsoft.Recognizers.Definitions.Arabic
             { @"ثمانية وعشرون", 28 },
             { @"تسعة وعشرون", 29 },
             { @"الثلاثين", 30 },
+            { @"ثلاثين", 30 },
             { @"واحد وثلاثون", 31 },
             { @"اثنان وثلاثون", 32 },
             { @"ثلاثة وثلاثون", 33 },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Arabic/Parsers/ArabicTimeParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Arabic/Parsers/ArabicTimeParserConfiguration.cs
@@ -22,6 +22,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Arabic
         private static readonly Regex NightRegex =
             new Regex(DateTimeDefinitions.NightRegex, RegexFlags);
 
+        private static readonly Regex HalfTokenRegex =
+            new Regex(DateTimeDefinitions.HalfTokenRegex, RegexFlags);
+
+        private static readonly Regex QuarterTokenRegex =
+            new Regex(DateTimeDefinitions.QuarterTokenRegex, RegexFlags);
+
+        private static readonly Regex ThreeQuarterTokenRegex =
+            new Regex(DateTimeDefinitions.ThreeQuarterTokenRegex, RegexFlags);
+
+        private static readonly Regex ToTokenRegex =
+            new Regex(DateTimeDefinitions.ToTokenRegex, RegexFlags);
+
+        private static readonly Regex ToHalfTokenRegex =
+            new Regex(DateTimeDefinitions.ToHalfTokenRegex, RegexFlags);
+
+        private static readonly Regex ForHalfTokenRegex =
+            new Regex(DateTimeDefinitions.ForHalfTokenRegex, RegexFlags);
+
         public ArabicTimeParserConfiguration(ICommonDateTimeParserConfiguration config)
          : base(config)
         {
@@ -53,18 +71,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Arabic
 
             var trimmedPrefix = prefix.Trim();
 
-            // @TODO move hardcoded values to resources file
-
-            if (trimmedPrefix.StartsWith("half", StringComparison.Ordinal))
+            if (HalfTokenRegex.IsMatch(trimmedPrefix))
             {
-                deltaMin = 30;
+                deltaMin = -30;
             }
-            else if (trimmedPrefix.StartsWith("a quarter", StringComparison.Ordinal) ||
-                     trimmedPrefix.StartsWith("quarter", StringComparison.Ordinal))
+            else if (QuarterTokenRegex.IsMatch(trimmedPrefix))
             {
                 deltaMin = 15;
             }
-            else if (trimmedPrefix.StartsWith("three quarter", StringComparison.Ordinal))
+            else if (ThreeQuarterTokenRegex.IsMatch(trimmedPrefix))
             {
                 deltaMin = 45;
             }
@@ -83,7 +98,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Arabic
                 }
             }
 
-            if (trimmedPrefix.EndsWith("to", StringComparison.Ordinal))
+            if (ToHalfTokenRegex.IsMatch(trimmedPrefix))
+            {
+                deltaMin = deltaMin - 30;
+            }
+            else if (ForHalfTokenRegex.IsMatch(trimmedPrefix))
+            {
+                deltaMin = -deltaMin - 30;
+            }
+            else if (ToTokenRegex.IsMatch(trimmedPrefix))
             {
                 deltaMin = -deltaMin;
             }

--- a/Patterns/Arabic/Arabic-DateTime.yaml
+++ b/Patterns/Arabic/Arabic-DateTime.yaml
@@ -74,17 +74,17 @@ FullTextYearRegex: !nestedRegex
   def: \b((?<firsttwoyearnum>{CenturyRegex})\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s*مائة(\s*و)?))\b
   references: [ CenturyRegex, WrittenCenturyFullYearRegex, WrittenCenturyOrdinalYearRegex, LastTwoYearNumRegex ]
 OclockRegex: !simpleRegex
-  def: (?<oclock>o\s*((’|‘|')\s*)?clock|sharp)
+  def: (?<oclock>(ال)?ساعة|(ال)?ساعات)
 SpecialDescRegex: !simpleRegex
   def: ((?<ipm>)p\b)
 AmDescRegex: !nestedRegex
-  def: (?:{BaseDateTime.BaseAmDescRegex})
+  def: (في\s)?(صباح(ا)?|صباحًا|الصباح|{BaseDateTime.BaseAmDescRegex})
   references: [BaseDateTime.BaseAmDescRegex]
 PmDescRegex: !nestedRegex
-  def: (:?{BaseDateTime.BasePmDescRegex})
+  def: (في\s)?((ال)?مساء|مساءً|ليلًا|ليلا|(ال)?ليل(ة)?|بعد الظهر|الظهر|ظهرا|{BaseDateTime.BasePmDescRegex})
   references: [BaseDateTime.BasePmDescRegex]
 AmPmDescRegex: !nestedRegex
-  def: (:?{BaseDateTime.BaseAmPmDescRegex})
+  def: (في\s)?(صباح(ا)?|صباحًا|الصباح|(ال)?مساء|مساءً|{BaseDateTime.BaseAmPmDescRegex})
   references: [BaseDateTime.BaseAmPmDescRegex]
 DescRegex: !nestedRegex
   def: (:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})
@@ -118,6 +118,18 @@ DateTokenPrefix: 'في '
 TimeTokenPrefix: 'عند '
 TokenBeforeDate: 'في '
 TokenBeforeTime: 'عند '
+HalfTokenRegex: !simpleRegex
+  def: ^(النصف|نصف|والنصف|ونصف)
+QuarterTokenRegex: !simpleRegex
+  def: ^(ربع|الربع|وربع|والربع|إلا ربع|إلا الربع)
+ThreeQuarterTokenRegex: !simpleRegex
+  def: ^(وثلاثة أرباع|ثلاثة أرباع|إلا الربع)
+ToTokenRegex: !simpleRegex
+  def: \b(إلا)$
+ToHalfTokenRegex: !simpleRegex
+  def: \b(إلا\s+(النصف|نصف))$
+ForHalfTokenRegex: !simpleRegex
+  def: \b(ل(s+)?(نصف))$
 FromRegex: !simpleRegex
   def: \b(from(\s+the)?)$
 BetweenTokenRegex: !simpleRegex
@@ -348,31 +360,31 @@ WeekDayStart: !simpleRegex
 RangeUnitRegex: !simpleRegex
   def: \b(?<unit>years?|months?|weeks?)\b
 HourNumRegex: !simpleRegex
-  def: \b(?<hournum>zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b
+  def: \b(?<hournum>الأولى|(ال)?واحدة|(ال)?ثانية|(ال)?ثالثة|(ال)?رابعة|(ال)?خامسة|(ال)?سادسة|(ال)?سابعة|(ال)?ثامنة|(ال)?تاسعة|(ال)?عاشرة|(ال)?حادية عشر(ة)?|(ال)?ثانية عشر(ة)?|خمسة عشر|أحد عشر)\b
 MinuteNumRegex: !simpleRegex
-  def: (?<minnum>ten|eleven|twelve|thirteen|fifteen|eighteen|(four|six|seven|nine)(teen)?|twenty|thirty|forty|fifty|one|two|three|five|eight)
+  def: \b(?<minnum>أربع|خمس|ست|سبع|ثمان|تسع|عشر|عشرة|أحد عشر|إثني عشر|إثنا عشر|ثلاثة عشر|خمسة عشر|ثمانية عشر|أربعة عشر|ستة عشر|سبعة عشر|(ال)?حادية عشر(ة)?|تسعة عشر|عشرون|ثلاثون|أربعون|خمسون|عشرين|ثلاث(ين)?|أربعين|خمسين|واحد|إثنان|ثلاثة|خمسة|ثمانية)\b
 DeltaMinuteNumRegex: !simpleRegex
-  def: (?<deltaminnum>ten|eleven|twelve|thirteen|fifteen|eighteen|(four|six|seven|nine)(teen)?|twenty|thirty|forty|fifty|one|two|three|five|eight)
+  def: (?<deltaminnum>عشرة|أحد عشر|اثنا عشر|ثلاثة عشر|خمسة عشر|ثمانية عشر|أربعة|ستة|سبعة|تسعة|عشرين|أربعة عشر|ستة عشر|سبعة عشر|تسعة عشر| ثلاثون|أربعون|خمسين|أربعين|خمسون|واحد|اثنان|ثلاثة|خمسة|ثمانية|ثلاث(ين)?|أربع|خمس|ست|سبع|ثمان|تسع|(ال)?واحدة|(ال)?ثانية|(ال)?ثالثة|(ال)?رابعة|(ال)?خامسة|(ال)?سادسة|(ال)?سابعة|(ال)?ثامنة|(ال)?تاسعة|(ال)?عاشرة|(ال)?حادية عشر(ة)?|(ال)?ثانية عشر(ة)?)
 PmRegex: !simpleRegex
-  def: (?<pm>(((?:at|in|around|on|for)\s+(the\s+)?)?(afternoon|evening|midnight|lunchtime))|((at|in|around|on|for)\s+(the\s+)?night))
+  def: (?<pm>(?:(في|حول)\s|ل)?(وقت\s)?(بعد الظهر|بعد الظهيرة|(ال)?مساء|مساءً|منتصف(\s|-)الليل|الغداء|الليل|ليلا))
 PmRegexFull: !simpleRegex
-  def: (?<pm>((?:at|in|around|on|for)\s+(the\s+)?)?(afternoon|evening|(mid)?night|lunchtime))
+  def: (?<pm>(?:(في|حول)\s|ل)?(وقت\s)?(بعد الظهر|بعد الظهيرة|(ال)?مساء|مساءً|منتصف(\s|-)الليل|الغداء|الليل|ليلا))
 AmRegex: !simpleRegex
-  def: (?<am>((?:at|in|around|on|for)\s+(the\s+)?)?(morning))
+  def: (?<am>(?:(في|حول)\s|ل)?(وقت\s)?((ال)?صباح|صباحا|صباحًا))
 LunchRegex: !simpleRegex
-  def: \blunchtime\b
+  def: \b(موعد الغذاء|وقت الغذاء)\b
 NightRegex: !simpleRegex
-  def: \b(mid)?night\b
+  def: \bمنتصف(\s|-)الليل\b
 CommonDatePrefixRegex: !simpleRegex
   def: ^[\.]
 LessThanOneHour: !nestedRegex
-  def: (?<lth>(a\s+)?quarter|three quarter(s)?|half( an hour)?|{BaseDateTime.DeltaMinuteRegex}(\s+(minutes?|mins?))|{DeltaMinuteNumRegex}(\s+(minutes?|mins?)))
+  def: (?<lth>((ال)?ربع|ثلاثة أرباع|(ال)?نصف)|({BaseDateTime.DeltaMinuteRegex}(\s(دقيقة|دقائق))?)|({DeltaMinuteNumRegex}(\s(دقيقة|دقائق))?))
   references: [ BaseDateTime.DeltaMinuteRegex, DeltaMinuteNumRegex ]
 WrittenTimeRegex: !nestedRegex
-  def: (?<writtentime>{HourNumRegex}\s+({MinuteNumRegex}|(?<tens>twenty|thirty|fou?rty|fifty)\s+{MinuteNumRegex}))
+  def: (?<writtentime>((ال)?ساعة\s)?{HourNumRegex}\s+(و(\s)?)?({MinuteNumRegex}|{LessThanOneHour}|({MinuteNumRegex}\s+(و(\s)?)?(?<tens>عشرون|ثلاثون|أربعون|خمسون|عشرين|ثلاثين|أربعين|خمسين))))
   references: [ HourNumRegex, MinuteNumRegex ]
 TimePrefix: !nestedRegex
-  def: (?<prefix>{LessThanOneHour}\s+(past|to))
+  def: (?<prefix>(إلا|حتى|و|قبل)?(\s)?{LessThanOneHour})
   references: [ LessThanOneHour ]
 TimeSuffix: !nestedRegex
   def: (?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})
@@ -381,27 +393,27 @@ TimeSuffixFull: !nestedRegex
   def: (?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})
   references: [ AmRegex, PmRegexFull, OclockRegex ]
 BasicTime: !nestedRegex
-  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex}(?![%\d]))
-  references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
+  def: \b(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|({MinuteNumRegex}(\s(دقيقة|دقائق))?)|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex}(?![%\d]))
+  references: [ WrittenTimeRegex, HourNumRegex, MinuteNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
 MidnightRegex: !simpleRegex
-  def: (?<midnight>mid\s*(-\s*)?night)
+  def: (?<midnight>منتصف(\s|(\s?-\s?))الليل)
 MidmorningRegex: !simpleRegex
-  def: (?<midmorning>mid\s*(-\s*)?morning)
+  def: (?<midmorning>منتصف(\s|(\s?-\s?))الصباح)
 MidafternoonRegex: !simpleRegex
-  def: (?<midafternoon>mid\s*(-\s*)?afternoon)
+  def: (?<midafternoon>منتصف(\s|(\s?-\s?))بعد الظهر)
 MiddayRegex: !simpleRegex
-  def: (?<midday>mid\s*(-\s*)?day|((12\s)?noon))
+  def: (?<midday>(وقت الغداء\s)?(منتصف(\s|(\s?-\s?)))?(النهار|(الساعة\s)?((((12\s)?الظهر)|(12\s)?الظهيرة)|(12\s)?ظهرا))(\sوقت الغداء)?)
 MidTimeRegex: !nestedRegex
   def: (?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))
   references: [ MidnightRegex, MidmorningRegex, MidafternoonRegex, MiddayRegex ]
 AtRegex: !nestedRegex
-  def: \b(?:(?:(?<=\bat\s+)(?:{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b
+  def: \b(?:(?:(?<=\bفي\s+)?(?:{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)|{MidTimeRegex}))|{MidTimeRegex})\b
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, MidTimeRegex ]
 IshRegex: !nestedRegex
-  def: '\b({BaseDateTime.HourRegex}(-|——)?ish|noon(ish)?)\b'
-  references: [ BaseDateTime.HourRegex ]
+  def: \b((({BaseDateTime.HourRegex}|{WrittenTimeRegex})(\s|-))?(وقت\s)?((الظهيرة|الظهر|ظهر(ا|اً))))\b
+  references: [ BaseDateTime.HourRegex, WrittenTimeRegex ]
 TimeUnitRegex: !simpleRegex
-  def: ([^A-Za-z]{1,}|\b)(?<unit>h(ou)?rs?|h|min(ute)?s?|sec(ond)?s?)\b
+  def: ([^A-Za-z]{1,}|\b)(?<unit>(ال)?ساعة|(ال)?ساعات|(ال)?دقائق|(ال)?دقيقة|(ال)?ثانية|(ال)?ثوان|(ال)?ساعتين|(ال)?دقيقتين|(ال)?ثانيتين)\b
 RestrictedTimeUnitRegex: !simpleRegex
   def: (?<unit>(ال)?ساعة|(ال)?دقيقة)\b
 FivesRegex: !simpleRegex
@@ -418,7 +430,7 @@ TimeRegexWithDotConnector: !nestedRegex
   def: ({BaseDateTime.HourRegex}(\s*\.\s*){BaseDateTime.MinuteRegex})
   references: [ BaseDateTime.HourRegex, BaseDateTime.MinuteRegex ]
 TimeRegex1: !nestedRegex
-  def: \b({TimePrefix}\s+)?({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*|[.]){DescRegex}
+  def: \b({TimePrefix}\s+)?({WrittenTimeRegex}(\s{TimePrefix})?|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*|[.]){DescRegex}
   references: [ TimePrefix, WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, DescRegex ]
 TimeRegex2: !nestedRegex
   def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(?<iam>a)?((\s*{DescRegex})|\b)
@@ -427,16 +439,16 @@ TimeRegex3: !nestedRegex
   def: (\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})
   references: [ TimePrefix, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, DescRegex ]
 TimeRegex4: !nestedRegex
-  def: \b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b
+  def: \b({TimePrefix}\s+)?{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}(\s*{DescRegex})?\b
   references: [ TimePrefix, BasicTime, DescRegex, TimeSuffix ]
 TimeRegex5: !nestedRegex
-  def: \b{TimePrefix}\s+{BasicTime}((\s*{DescRegex})|\b)
+  def: \b({DescRegex}\s)?{BasicTime}((\s*{DescRegex})((\s+{TimePrefix})?)|(\s+{TimePrefix}(\s+{TimePrefix})?))(\s{DescRegex})?
   references: [ TimePrefix, BasicTime, DescRegex ]
 TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
 TimeRegex7: !nestedRegex
-  def: \b{TimeSuffixFull}\s+(at\s+)?{BasicTime}((\s*{DescRegex})|\b)
+  def: \b({DescRegex}\s)?(وقت الغداء\s)?{TimeSuffixFull}\s+(في\s+)?{BasicTime}(\s{DescRegex})?(\sوقت الغداء)?(\s{TimePrefix})?((\s*{DescRegex})|\b)?
   references: [ TimeSuffixFull, BasicTime, DescRegex ]
 TimeRegex8: !nestedRegex
   def: .^
@@ -719,7 +731,7 @@ NumberAsTimeRegex: !nestedRegex
   def: \b({WrittenTimeRegex}|{PeriodHourNumRegex}|{BaseDateTime.HourRegex})\b
   references: [ WrittenTimeRegex, PeriodHourNumRegex, BaseDateTime.HourRegex ]
 TimeBeforeAfterRegex: !nestedRegex
-  def: \b(((?<=\b(before|no later than|by|after)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b
+  def: \b(((?<=\b(ب|((قبل|في موعد لا يتجاوز| بعد)\s))(وقت\s+)?)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, MidTimeRegex ]
 DateNumberConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>\s+at)\s*$
@@ -982,14 +994,19 @@ Numbers: !dictionary
     'واحد': 1
     'اثنان': 2
     'ثلاثة': 3
+    'ثلاث': 3
     'أربعة': 4
     'خمسة': 5
+    'الخامسة': 5
     'ستة': 6
     'سبعة': 7
+    'السابعة': 7
     'ثمانية': 8
+    'الثامنة': 8
     'تسعة': 9
     'عشرة': 10
     'أحد عشر': 11
+    'الحادية عشر': 11
     'اثنا عشر': 12
     'ثلاثة عشر': 13
     'أربعة عشر': 14
@@ -999,6 +1016,7 @@ Numbers: !dictionary
     'ثمانية عشر': 18
     'تسعة عشر': 19
     'عشرون': 20
+    'عشرين': 20
     'واحد وعشرون': 21
     'اثنان وعشرون': 22
     'ثلاثة وعشرون': 23
@@ -1009,6 +1027,7 @@ Numbers: !dictionary
     'ثمانية وعشرون': 28
     'تسعة وعشرون': 29
     'الثلاثين': 30
+    'ثلاثين': 30
     'واحد وثلاثون': 31
     'اثنان وثلاثون': 32
     'ثلاثة وثلاثون': 33

--- a/Specs/DateTime/Arabic/TimeExtractor.json
+++ b/Specs/DateTime/Arabic/TimeExtractor.json
@@ -1,59 +1,66 @@
 [
   {
+    "Input": "سأعود في 7",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7",
+        "Start": 9,
+        "Length": 1,
+        "Type": "time"
+      }
+    ]
+  },
+  {
     "Input": "سأعود في السابعة",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "7.0",
-        "Start": -1,
-        "Length": 3,
-        "Type": "time"
-      }
-    ]
-  },
-  {
-    "Input": "سأعود 7 مساء",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": " 7 مساء",
-        "Start": 5,
+        "Text": "السابعة",
+        "Start": 9,
         "Length": 7,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود 7 مساء.",
-    "NotSupported": "dotnet",
+    "Input": "سأعود عند 7 مساء.",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": " 7 مساء",
-        "Start": 5,
-        "Length": 7,
+        "Text": "7 مساء",
+        "Start": 10,
+        "Length": 6,
+        "Type": "time"
+      }
+    ]
+  },
+  {
+    "Input": "سأعود في 7 مساء",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7 مساء",
+        "Start": 9,
+        "Length": 6,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 7:56 مساء",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "7:56 مساءً",
-        "Start": -1,
-        "Length": 10,
+        "Text": "7:56 مساء",
+        "Start": 6,
+        "Length": 9,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 7:56:35 مساءً",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -65,47 +72,55 @@
     ]
   },
   {
-    "Input": "سأعود 12:34",
-    "NotSupported": "dotnet",
+    "Input": "سأعود في 7:56:35 مساء",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.5236111111111111",
-        "Start": -1,
-        "Length": 18,
+        "Text": "7:56:35 مساء",
+        "Start": 9,
+        "Length": 12,
+        "Type": "time"
+      }
+    ]
+  },
+  {
+    "Input": "سأعود 12:34",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "12:34",
+        "Start": 6,
+        "Length": 5,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 12:34:20",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.5238425925925926",
-        "Start": -1,
-        "Length": 18,
+        "Text": "12:34:20",
+        "Start": 6,
+        "Length": 8,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود T12: 34: 20",
-    "NotSupported": "dotnet",
+    "Input": "سأعود T12:34:20",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "T12: 34: 20",
+        "Text": "T12:34:20",
         "Start": 6,
-        "Length": 11,
+        "Length": 9,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 00:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -118,33 +133,30 @@
   },
   {
     "Input": "سأعود 00:00:30",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.00034722222222222224",
-        "Start": -1,
-        "Length": 22,
-        "Type": "time"
-      }
-    ]
-  },
-  {
-    "Input": "إنها الساعة 7",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "الساعه 7",
-        "Start": -1,
+        "Text": "00:00:30",
+        "Start": 6,
         "Length": 8,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "انها الساعة السابعة",
-    "NotSupported": "dotnet",
+    "Input": "إنها الساعة 7",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "الساعة 7",
+        "Start": 5,
+        "Length": 8,
+        "Type": "time"
+      }
+    ]
+  },
+  {
+    "Input": "إنها الساعة السابعة",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -157,7 +169,6 @@
   },
   {
     "Input": "إنها 8 صباحًا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -170,7 +181,6 @@
   },
   {
     "Input": "إنها 8 في الليل",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -182,8 +192,7 @@
     ]
   },
   {
-    "Input": "انها الثامنة والنصف",
-    "NotSupported": "dotnet",
+    "Input": "إنها الثامنة والنصف",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -196,7 +205,6 @@
   },
   {
     "Input": "إنها الثامنة والنصف مساءً",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -208,21 +216,19 @@
     ]
   },
   {
-    "Input": "الساعة الثامنة و 30 دقيقة",
-    "NotSupported": "dotnet",
+    "Input": "إنها الساعة الثامنة و 30 دقيقة",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الثامنة و 30 دقيقة",
-        "Start": 7,
-        "Length": 18,
+        "Text": "الساعة الثامنة و 30 دقيقة",
+        "Start": 5,
+        "Length": 25,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "انها الثامنة والربع",
-    "NotSupported": "dotnet",
+    "Input": "إنها الثامنة والربع",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -234,8 +240,7 @@
     ]
   },
   {
-    "Input": "انها ثامنة والربع",
-    "NotSupported": "dotnet",
+    "Input": "إنها ثامنة والربع",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -248,7 +253,6 @@
   },
   {
     "Input": "إنها التاسعة مساءً و ثلاثة أرباع",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -261,7 +265,6 @@
   },
   {
     "Input": "إنها ثلاث دقائق حتى الثامنة",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -274,7 +277,6 @@
   },
   {
     "Input": "إنها الساعة السابعة والنصف",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -286,60 +288,55 @@
     ]
   },
   {
-    "Input": "الساعة السابعة والنصف بعد الظهر",
-    "NotSupported": "dotnet",
+    "Input": "إنها الساعة السابعة والنصف بعد الظهر",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف بعد الظهر",
-        "Start": 7,
-        "Length": 24,
+        "Text": "الساعة السابعة والنصف بعد الظهر",
+        "Start": 5,
+        "Length": 31,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "إنها السابعة والنصف صباحًا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف صباحا",
-        "Start": -1,
-        "Length": 20,
+        "Text": "السابعة والنصف صباحًا",
+        "Start": 5,
+        "Length": 21,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "إنها الساعة الثامنة إلا ربع صباحًا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الثامنة والربع صباحا",
-        "Start": -1,
-        "Length": 20,
+        "Text": "الساعة الثامنة إلا ربع صباحًا",
+        "Start": 5,
+        "Length": 29,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "الساعة الثامنة وعشرين دقيقة مساءً",
-    "NotSupported": "dotnet",
+    "Input": "إنها الساعة الثامنة وعشرين دقيقة مساءً",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الثامنة وعشرين دقيقة مساءً",
-        "Start": 7,
-        "Length": 26,
+        "Text": "الساعة الثامنة وعشرين دقيقة مساءً",
+        "Start": 5,
+        "Length": 33,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود بعد الظهر الساعة 7",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -351,8 +348,19 @@
     ]
   },
   {
+    "Input": "سأعود الساعة 7 الظهر",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "الساعة 7 الظهر",
+        "Start": 6,
+        "Length": 14,
+        "Type": "time"
+      }
+    ]
+  },
+  {
     "Input": "سأعود بعد الظهر 7:00",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -365,7 +373,6 @@
   },
   {
     "Input": "سأعود بعد الظهر 7:00:14",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -378,7 +385,6 @@
   },
   {
     "Input": "سأعود بعد الظهر السابعة مساء",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -391,33 +397,30 @@
   },
   {
     "Input": "سأعود الساعة السابعة والنصف مساءً",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف مساءً",
-        "Start": 13,
-        "Length": 20,
+        "Text": "الساعة السابعة والنصف مساءً",
+        "Start": 6,
+        "Length": 27,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود في السابعة وخمسة وثلاثين مساءً",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": " السابعة وخمسة وثلاثين مساءً",
-        "Start": 8,
-        "Length": 28,
+        "Text": "السابعة وخمسة وثلاثين مساءً",
+        "Start": 9,
+        "Length": 27,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود في الحادية عشرة والخامسة",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -430,7 +433,6 @@
   },
   {
     "Input": "سأعود ثلاث دقائق قبل الخامسة والنصف",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -442,21 +444,19 @@
     ]
   },
   {
-    "Input": "سأعود خمسة وثلاثين في الليل",
-    "NotSupported": "dotnet",
+    "Input": "سأعود الخامسة وثلاثين في الليل",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "خمسة وثلاثين في الليل",
+        "Text": "الخامسة وثلاثين في الليل",
         "Start": 6,
-        "Length": 21,
+        "Length": 24,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود في الليل الخامسة والنصف",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -469,7 +469,6 @@
   },
   {
     "Input": "سأعود الظهيرة",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -482,7 +481,6 @@
   },
   {
     "Input": "سأعود الظهر",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -495,24 +493,22 @@
   },
   {
     "Input": "سأعود الساعة 12 ظهرا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "12 ظهرا",
-        "Start": 13,
-        "Length": 7,
+        "Text": "الساعة 12 ظهرا",
+        "Start": 6,
+        "Length": 14,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود في الحاديه عشر\n",
-    "NotSupported": "dotnet",
+    "Input": "سأعود في الحادية عشرة",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الحاديه عشر\n",
+        "Text": "الحادية عشرة",
         "Start": 9,
         "Length": 12,
         "Type": "time"
@@ -520,12 +516,11 @@
     ]
   },
   {
-    "Input": "سأعود الحاديه عشر\n",
-    "NotSupported": "dotnet",
+    "Input": "سأعود الحادية عشرة",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الحاديه عشر\n",
+        "Text": "الحادية عشرة",
         "Start": 6,
         "Length": 12,
         "Type": "time"
@@ -534,33 +529,30 @@
   },
   {
     "Input": "سأعود 340 مساء",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "340 مساءً",
-        "Start": -1,
-        "Length": 9,
+        "Text": "340 مساء",
+        "Start": 6,
+        "Length": 8,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 1140 صباحا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "1140 صباحًا",
-        "Start": -1,
-        "Length": 11,
+        "Text": "1140 صباحا",
+        "Start": 6,
+        "Length": 10,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "منتصف الليل",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -572,21 +564,7 @@
     ]
   },
   {
-    "Input": "منتصف.الليل",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الليل",
-        "Start": 0,
-        "Length": 11,
-        "Type": "time"
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الليل",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -599,7 +577,6 @@
   },
   {
     "Input": "منتصف الصباح",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -611,21 +588,7 @@
     ]
   },
   {
-    "Input": "منتصف.الصباح",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الصباح",
-        "Start": 0,
-        "Length": 12,
-        "Type": "time"
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الصباح",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -638,7 +601,6 @@
   },
   {
     "Input": "منتصف الظهر",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -650,21 +612,7 @@
     ]
   },
   {
-    "Input": "منتصف.الظهر",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الظهر",
-        "Start": 0,
-        "Length": 11,
-        "Type": "time"
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الظهر",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -677,7 +625,6 @@
   },
   {
     "Input": "منتصف النهار",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -689,21 +636,7 @@
     ]
   },
   {
-    "Input": "منتصف.النهار",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.النهار",
-        "Start": 0,
-        "Length": 12,
-        "Type": "time"
-      }
-    ]
-  },
-  {
     "Input": "منتصف-النهار",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -716,7 +649,6 @@
   },
   {
     "Input": "وقت الظهيرة",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -728,34 +660,55 @@
     ]
   },
   {
-    "Input": "سأعود مساء. 7",
-    "NotSupported": "dotnet",
+    "Input": "سأعود 7 مساء",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": " مساء. 7",
-        "Start": 5,
-        "Length": 8,
+        "Text": "7 مساء",
+        "Start": 6,
+        "Length": 6,
+        "Type": "time"
+      }
+    ]
+  },
+  {
+    "Input": "سأعود 7 مساء.",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7 مساء",
+        "Start": 6,
+        "Length": 6,
+        "Type": "time"
+      }
+    ]
+  },
+  {
+    "Input": "سأعود مساء 7",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "مساء 7",
+        "Start": 6,
+        "Length": 6,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود مساء 7.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": " مساء 7.",
-        "Start": 5,
-        "Length": 8,
+        "Text": "مساء 7",
+        "Start": 6,
+        "Length": 6,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 7:56 صباحا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -768,7 +721,6 @@
   },
   {
     "Input": "سأعود 7:56:35 في الصباح",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -780,21 +732,19 @@
     ]
   },
   {
-    "Input": "سأعود 7:56:35  الصباح",
-    "NotSupported": "dotnet",
+    "Input": "سأعود 7:56:35 الصباح",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "7:56:35  الصباح",
+        "Text": "7:56:35 الصباح",
         "Start": 6,
-        "Length": 15,
+        "Length": 14,
         "Type": "time"
       }
     ]
   },
   {
     "Input": "سأعود 7:56:35 صباحا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -807,24 +757,22 @@
   },
   {
     "Input": "سأعود الساعة السابعة والنصف مساءً.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الساعة السابعة والنصف مساءً.",
+        "Text": "الساعة السابعة والنصف مساءً",
         "Start": 6,
-        "Length": 28,
+        "Length": 27,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود سبعة وثلاثين  في المساءً.",
-    "NotSupported": "dotnet",
+    "Input": "سأعود السابعة وثلاثين في المساء.",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "سبعة وثلاثين  في المساءً.",
+        "Text": "السابعة وثلاثين في المساء",
         "Start": 6,
         "Length": 25,
         "Type": "time"
@@ -832,38 +780,35 @@
     ]
   },
   {
-    "Input": "سأعود سبعة وثلاثين المساءً.",
-    "NotSupported": "dotnet",
+    "Input": "سأعود السابعة وثلاثين المساء",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "سبعة وثلاثين المساءً.",
+        "Text": "السابعة وثلاثين المساء",
         "Start": 6,
-        "Length": 21,
+        "Length": 22,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود سبعة وثلاثين مساء",
-    "NotSupported": "dotnet",
+    "Input": "سأعود السابعة وثلاثين مساء",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "سبعة وثلاثين مساء",
+        "Text": "السابعة وثلاثين مساء",
         "Start": 6,
-        "Length": 17,
+        "Length": 20,
         "Type": "time"
       }
     ]
   },
   {
-    "Input": "سأعود 340 مساءا",
-    "NotSupported": "dotnet",
+    "Input": "سأعود 340 مساءً",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "340 مساءا",
+        "Text": "340 مساءً",
         "Start": 6,
         "Length": 9,
         "Type": "time"
@@ -872,7 +817,6 @@
   },
   {
     "Input": "سأعود 1140 المساء",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -885,19 +829,16 @@
   },
   {
     "Input": "الرسائل الإلكترونية التي حصلت على  ب كموضوع",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": []
   },
   {
     "Input": "رسائل البريد الإلكتروني التي حصلت على رد",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": []
   },
   {
     "Input": "سأعود الساعة 12 ظهرا وقت الغداء",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -910,7 +851,6 @@
   },
   {
     "Input": "سأعود وقت الغداء الساعة 12 ظهرا",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -923,13 +863,12 @@
   },
   {
     "Input": "سأعود في وقت الغداء الساعة 12",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": " وقت الغداء الساعة 12",
-        "Start": 8,
-        "Length": 21,
+        "Text": "وقت الغداء الساعة 12",
+        "Start": 9,
+        "Length": 20,
         "Type": "time"
       }
     ]

--- a/Specs/DateTime/Arabic/TimeParser.json
+++ b/Specs/DateTime/Arabic/TimeParser.json
@@ -2,7 +2,6 @@
   {
     "Input": "ضبط المنبه على ثمانية وأربعين",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -25,7 +24,6 @@
   {
     "Input": "ضبط المنبه على ثمانية وأربعين صباحا",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -48,13 +46,12 @@
   {
     "Input": "ضبط المنبه على ثمانية وأربعين مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الثامنة والأربعين مساءً",
-        "Start": -1,
-        "Length": 23,
+        "Text": "ثمانية وأربعين مساءً",
+        "Start": 15,
+        "Length": 20,
         "Type": "time",
         "Value": {
           "Timex": "T20:40",
@@ -71,7 +68,6 @@
   {
     "Input": "ضبط المنبه على عشرة وخمسة وأربعين",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -92,15 +88,14 @@
     ]
   },
   {
-    "Input": "ضبط المنبه على خمسة عشر خمسة عشر  مساءً",
+    "Input": "ضبط المنبه على خمسة عشر خمسة عشر مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "خمسة عشر خمسة عشر",
+        "Text": "خمسة عشر خمسة عشر مساءً",
         "Start": 15,
-        "Length": 17,
+        "Length": 23,
         "Type": "time",
         "Value": {
           "Timex": "T15:15",
@@ -115,15 +110,14 @@
     ]
   },
   {
-    "Input": "ضبط المنبه لخمسة عشر وثلاثين مساءً",
+    "Input": "ضبط المنبه على خمسة عشر وثلاثين مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "خمسة عشر وثلاثين",
-        "Start": 12,
-        "Length": 16,
+        "Text": "خمسة عشر وثلاثين مساءً",
+        "Start": 15,
+        "Length": 22,
         "Type": "time",
         "Value": {
           "Timex": "T15:30",
@@ -140,7 +134,6 @@
   {
     "Input": "ضبط المنبه على عشرة عشرة",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -163,7 +156,6 @@
   {
     "Input": "ضبط المنبه على عشرة وخمسة وخمسين  مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -184,14 +176,12 @@
     ]
   },
   {
-    "Input": "سأعود في 7",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "سأعود في 7 صباحا",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "مساءً 7",
-        "Start": -1,
+        "Text": "7 صباحا",
+        "Start": 9,
         "Length": 7,
         "Type": "time",
         "Value": {
@@ -207,9 +197,28 @@
     ]
   },
   {
+    "Input": "سأعود عند 7",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7",
+        "Start": 10,
+        "Length": 1,
+        "Type": "time",
+        "Value": {
+          "Timex": "T07",
+          "FutureResolution": {
+            "time": "07:00:00"
+          },
+          "PastResolution": {
+            "time": "07:00:00"
+          }
+        }
+      }
+    ]
+  },
+  {
     "Input": "سأعود في السابعة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -230,15 +239,14 @@
     ]
   },
   {
-    "Input": "سأعود في السابعة مساء",
+    "Input": "سأعود في 7 مساء",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة مساء",
+        "Text": "7 مساء",
         "Start": 9,
-        "Length": 12,
+        "Length": 6,
         "Type": "time",
         "Value": {
           "Timex": "T19",
@@ -253,14 +261,13 @@
     ]
   },
   {
-    "Input": "سأعود 7:56 مساء",
+    "Input": "سأعود 7:56 مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "7:56 مساءً",
-        "Start": -1,
+        "Start": 6,
         "Length": 10,
         "Type": "time",
         "Value": {
@@ -276,14 +283,35 @@
     ]
   },
   {
-    "Input": "سأعود 7:56:30 مساء",
+    "Input": "سأعود في 7:56:30 مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "7:56:30 مساءً",
-        "Start": -1,
+        "Start": 9,
+        "Length": 13,
+        "Type": "time",
+        "Value": {
+          "Timex": "T19:56:30",
+          "FutureResolution": {
+            "time": "19:56:30"
+          },
+          "PastResolution": {
+            "time": "19:56:30"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Input": "سأعود 7:56:30 مساءً",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7:56:30 مساءً",
+        "Start": 6,
         "Length": 13,
         "Type": "time",
         "Value": {
@@ -300,14 +328,12 @@
   },
   {
     "Input": "سأعود 12:34",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.5236111111111111",
-        "Start": -1,
-        "Length": 18,
+        "Text": "12:34",
+        "Start": 6,
+        "Length": 5,
         "Type": "time",
         "Value": {
           "Timex": "T12:34",
@@ -323,14 +349,12 @@
   },
   {
     "Input": "سأعود 12:34:25",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.523900462962963",
-        "Start": -1,
-        "Length": 17,
+        "Text": "12:34:25",
+        "Start": 6,
+        "Length": 8,
         "Type": "time",
         "Value": {
           "Timex": "T12:34:25",
@@ -346,13 +370,11 @@
   },
   {
     "Input": "إنها الساعة 7",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الساعه 7",
-        "Start": -1,
+        "Text": "الساعة 7",
+        "Start": 5,
         "Length": 8,
         "Type": "time",
         "Value": {
@@ -369,8 +391,6 @@
   },
   {
     "Input": "انها الساعة السابعة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -392,8 +412,6 @@
   },
   {
     "Input": "إنها 8 صباحًا",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -415,8 +433,6 @@
   },
   {
     "Input": "إنها 8 في الليل",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -439,7 +455,6 @@
   {
     "Input": "انها الثامنة والنصف",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -462,7 +477,6 @@
   {
     "Input": "إنها 8 والنصف مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -483,15 +497,13 @@
     ]
   },
   {
-    "Input": "الساعة الثامنة و 30 دقيقة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "إنها الساعة الثامنة و 30 دقيقة",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الثامنة و 30 دقيقة",
-        "Start": 7,
-        "Length": 18,
+        "Text": "الساعة الثامنة و 30 دقيقة",
+        "Start": 5,
+        "Length": 25,
         "Type": "time",
         "Value": {
           "Timex": "T08:30",
@@ -507,8 +519,6 @@
   },
   {
     "Input": "انها الثامنة والربع",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -530,8 +540,6 @@
   },
   {
     "Input": "انها الثامنة وربع",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -554,7 +562,6 @@
   {
     "Input": "إنها 9 مساءً وثلاثة أرباع",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -577,7 +584,6 @@
   {
     "Input": "إنها ثلاث دقائق قبل الثامنة",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -600,7 +606,6 @@
   {
     "Input": "إنها الساعة السابعة والنصف",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -623,13 +628,12 @@
   {
     "Input": "إنها الساعة السابعة والنصف بعد الظهر",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف بعد الظهر",
-        "Start": 12,
-        "Length": 24,
+        "Text": "الساعة السابعة والنصف بعد الظهر",
+        "Start": 5,
+        "Length": 31,
         "Type": "time",
         "Value": {
           "Timex": "T19:30",
@@ -646,13 +650,12 @@
   {
     "Input": "إنها السابعة والنصف صباحًا",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف صباحا",
-        "Start": -1,
-        "Length": 20,
+        "Text": "السابعة والنصف صباحًا",
+        "Start": 5,
+        "Length": 21,
         "Type": "time",
         "Value": {
           "Timex": "T07:30",
@@ -669,7 +672,6 @@
   {
     "Input": "إنها الساعة 8 إلا ربع صباحًا",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -692,7 +694,6 @@
   {
     "Input": "إنها الساعة الثامنة و20 دقيقة مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -714,8 +715,6 @@
   },
   {
     "Input": "سأعود بعد الظهر الساعة 7",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -737,8 +736,6 @@
   },
   {
     "Input": "سأعود الظهر الساعة 7",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -760,8 +757,6 @@
   },
   {
     "Input": "سأعود بعد الظهر 7:00",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -783,8 +778,6 @@
   },
   {
     "Input": "سأعود بعد الظهر 7:00:05",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -806,8 +799,6 @@
   },
   {
     "Input": "سأعود بعد الظهر السابعة مساء",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -830,13 +821,12 @@
   {
     "Input": "سأعود الساعة السابعة والنصف مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف مساءً",
-        "Start": 13,
-        "Length": 20,
+        "Text": "الساعة السابعة والنصف مساءً",
+        "Start": 6,
+        "Length": 27,
         "Type": "time",
         "Value": {
           "Timex": "T19:30",
@@ -853,13 +843,12 @@
   {
     "Input": "سأعود في السابعة وخمسة وثلاثين مساء",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة وخمس وثلاثين مساء",
-        "Start": -1,
-        "Length": 25,
+        "Text": "السابعة وخمسة وثلاثين مساء",
+        "Start": 9,
+        "Length": 26,
         "Type": "time",
         "Value": {
           "Timex": "T19:35",
@@ -874,15 +863,14 @@
     ]
   },
   {
-    "Input": "الحادية عشر وعشرين مساء",
+    "Input": "سأعود الحادية عشر وعشرين مساء",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "سأعود الحادية عشر وعشرين مساء",
-        "Start": -1,
-        "Length": 29,
+        "Text": "الحادية عشر وعشرين مساء",
+        "Start": 6,
+        "Length": 23,
         "Type": "time",
         "Value": {
           "Timex": "T23:20",
@@ -898,8 +886,6 @@
   },
   {
     "Input": "سأعود الظهيرة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -921,14 +907,12 @@
   },
   {
     "Input": "سأعود الساعة 12 ظهرا",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "12 ظهرا",
-        "Start": 13,
-        "Length": 7,
+        "Text": "الساعة 12 ظهرا",
+        "Start": 6,
+        "Length": 14,
         "Type": "time",
         "Value": {
           "Timex": "T12",
@@ -943,15 +927,13 @@
     ]
   },
   {
-    "Input": "سأعود في الحاديه عشر\n",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "سأعود في الحادية عشر",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الحاديه عشر\n",
+        "Text": "الحادية عشر",
         "Start": 9,
-        "Length": 12,
+        "Length": 11,
         "Type": "time",
         "Value": {
           "Timex": "T11",
@@ -966,15 +948,13 @@
     ]
   },
   {
-    "Input": "سأعود الحاديه عشر\n",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "سأعود الحادية عشر",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الحاديه عشر\n",
+        "Text": "الحادية عشر",
         "Start": 6,
-        "Length": 12,
+        "Length": 11,
         "Type": "time",
         "Value": {
           "Timex": "T11",
@@ -989,14 +969,13 @@
     ]
   },
   {
-    "Input": "سأعود 340 مساء",
+    "Input": "سأعود 340 مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "340 مساءً",
-        "Start": -1,
+        "Start": 6,
         "Length": 9,
         "Type": "time",
         "Value": {
@@ -1012,14 +991,12 @@
     ]
   },
   {
-    "Input": "سأعود 1140 صباحا",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "سأعود 1140 صباحًا",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "1140 صباحًا",
-        "Start": -1,
+        "Start": 6,
         "Length": 11,
         "Type": "time",
         "Value": {
@@ -1036,8 +1013,6 @@
   },
   {
     "Input": "منتصف الليل",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1058,32 +1033,7 @@
     ]
   },
   {
-    "Input": "منتصف.الليل",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الليل",
-        "Start": 0,
-        "Length": 11,
-        "Type": "time",
-        "Value": {
-          "Timex": "T00",
-          "FutureResolution": {
-            "time": "00:00:00"
-          },
-          "PastResolution": {
-            "time": "00:00:00"
-          }
-        }
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الليل",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1105,8 +1055,6 @@
   },
   {
     "Input": "منتصف الصباح",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1127,32 +1075,7 @@
     ]
   },
   {
-    "Input": "منتصف.الصباح",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الصباح",
-        "Start": 0,
-        "Length": 12,
-        "Type": "time",
-        "Value": {
-          "Timex": "T10",
-          "FutureResolution": {
-            "time": "10:00:00"
-          },
-          "PastResolution": {
-            "time": "10:00:00"
-          }
-        }
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الصباح",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1175,7 +1098,6 @@
   {
     "Input": "منتصف الظهر",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1196,32 +1118,8 @@
     ]
   },
   {
-    "Input": "منتصف.الظهر",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.الظهر",
-        "Start": 0,
-        "Length": 11,
-        "Type": "time",
-        "Value": {
-          "Timex": "T14",
-          "FutureResolution": {
-            "time": "14:00:00"
-          },
-          "PastResolution": {
-            "time": "14:00:00"
-          }
-        }
-      }
-    ]
-  },
-  {
     "Input": "منتصف-الظهر",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1243,8 +1141,6 @@
   },
   {
     "Input": "منتصف النهار",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1265,32 +1161,7 @@
     ]
   },
   {
-    "Input": "منتصف.النهار",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "منتصف.النهار",
-        "Start": 0,
-        "Length": 12,
-        "Type": "time",
-        "Value": {
-          "Timex": "T12",
-          "FutureResolution": {
-            "time": "12:00:00"
-          },
-          "PastResolution": {
-            "time": "12:00:00"
-          }
-        }
-      }
-    ]
-  },
-  {
     "Input": "منتصف-النهار",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1312,8 +1183,6 @@
   },
   {
     "Input": "وقت الظهيرة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1335,8 +1204,6 @@
   },
   {
     "Input": "سأعود 12 وقت الغداء",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1358,8 +1225,6 @@
   },
   {
     "Input": "سأعود 12 منتصف الليل",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1382,7 +1247,6 @@
   {
     "Input": "سأعود 12 في الليل",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1405,7 +1269,6 @@
   {
     "Input": "سأعود 1:00 منتصف الليل",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1427,8 +1290,6 @@
   },
   {
     "Input": "سأعود الساعة 12 ظهرا وقت الغداء",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1450,8 +1311,6 @@
   },
   {
     "Input": "سأعود الساعة 11 صباحًا وقت الغداء",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1474,7 +1333,6 @@
   {
     "Input": "سأعود الساعة 1 وقت الغداء",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1496,8 +1354,6 @@
   },
   {
     "Input": "سأعود في وقت الغداء الساعة 11 صباحا",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1520,7 +1376,6 @@
   {
     "Input": "سأعود 7:56:13 مساءً",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1542,14 +1397,12 @@
   },
   {
     "Input": "سأعود 12:34:45",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "0.5241319444444444",
-        "Start": -1,
-        "Length": 18,
+        "Text": "12:34:45",
+        "Start": 6,
+        "Length": 8,
         "Type": "time",
         "Value": {
           "Timex": "T12:34:45",
@@ -1565,8 +1418,6 @@
   },
   {
     "Input": "سأعود بعد الظهر 7:00:25",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1589,13 +1440,12 @@
   {
     "Input": "سأعود الساعة السابعة والنصف صباحًا",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "السابعة والنصف صباحا",
-        "Start": -1,
-        "Length": 20,
+        "Text": "الساعة السابعة والنصف صباحًا",
+        "Start": 6,
+        "Length": 28,
         "Type": "time",
         "Value": {
           "Timex": "T07:30",
@@ -1611,8 +1461,6 @@
   },
   {
     "Input": "سأعود أحد عشر وخمسة",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1633,15 +1481,14 @@
     ]
   },
   {
-    "Input": "سأعود الخامسة والنصف إلا  ثلاث دقائق",
+    "Input": "سأعود الخامسة والنصف إلا ثلاث دقائق",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "الخامسة والنصف إلا  ثلاث دقائق",
+        "Text": "الخامسة والنصف إلا ثلاث دقائق",
         "Start": 6,
-        "Length": 30,
+        "Length": 29,
         "Type": "time",
         "Value": {
           "Timex": "T05:27",
@@ -1658,7 +1505,6 @@
   {
     "Input": "سأعود خمسة وثلاثين في الليل",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1681,7 +1527,6 @@
   {
     "Input": "سأعود في الليلة الخامسة والنصف",
     "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1703,8 +1548,6 @@
   },
   {
     "Input": "سأعود الظهر",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1725,14 +1568,12 @@
     ]
   },
   {
-    "Input": "سأعود في وقت الغداء الساعة 12",
-    "IgnoreResolution": "true",
-    "NotSupported": "dotnet",
+    "Input": "سأعود في وقت الغداء الساعة 12 ظهرا",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "وقت الغداء الساعة 12 ظهرا",
-        "Start": -1,
+        "Start": 9,
         "Length": 25,
         "Type": "time",
         "Value": {


### PR DESCRIPTION
TimeExtractor: 74 pass, 0 fail.
TimeParser: 39 pass, 35 only resolution, 0 fail.

Some of the duplicate test cases that were previously removed have been reintroduced with variations.

Test cases modified in TimeExtractor:

- "الساعة الثامنة و 30 دقيقة" ( missing "it's" "إنها ") -> "إنها الساعة الثامنة و 30 دقيقة" (It's 30 mins past eight)
- "الساعة السابعة والنصف بعد الظهر" (missing "it's" "إنها ") -> "إنها الساعة السابعة والنصف بعد الظهر" (It's half past seven afternoon)
- "سأعود في الحاديه عشر" (Correct the Arabic writing of number 11 "الحادية عشرة") -> "سأعود في الحادية عشرة" (I'll be back 11ish)
- "سأعود الحاديه عشر" (Correct the Arabic writing of number 11 "الحادية عشرة") -> "سأعود الحادية عشرة" (I'll be back 11-ish)
- "منتصف.الليل" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-night)
- "منتصف.الصباح" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-morning)
- "منتصف.الظهر" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-afternoon)
- "منتصف.النهار" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-day)
- "سأعود مساء. 7" (unnecessary ".") -> "سأعود مساء 7" (I'll be back 7 p. m.)
- "سأعود سبعة وثلاثين  في المساءً." (- grammatical error incorrect diacritics at the end  " المساءً" . - better to write "السابعة "  in this sentence to refer to the hour 7) -> "سأعود السابعة وثلاثين في المساء" (I'll go back seven thirty p m)
- "سأعود سبعة وثلاثين المساءً." (- grammatical error incorrect diacritics at the end  " المساءً" . - better to write "السابعة "  in this sentence to refer to the hour 7.) -> "سأعود السابعة وثلاثين في المساء." (I'll go back seven thirty p. m)
-"سأعود سبعة وثلاثين مساء" (- better to write "السابعة "  in this sentence to refer to the hour 7) -> "سأعود السابعة وثلاثين المساء" (I'll go back seven thirty p. m.)
- "سأعود 340 مساءا" (grammatical error "مساءا") -> "سأعود 340 مساءً" (I'll be back 340 pm)

Test cases modified in TimeParser:

- "ضبط المنبه لخمسة عشر وثلاثين مساءً" ("على " instead of " ل" in this sentence) -> "ضبط المنبه على خمسة عشر وثلاثين مساءً" (set an alarm for fifteen thirty p m)
- "الساعة الثامنة و 30 دقيقة" ( missing "it's" "إنها ") -> "إنها الساعة الثامنة و 30 دقيقة" (It's 30 mins past eight)
- "سأعود في الحاديه عشر" (Correct the Arabic writing of number 11 "الحادية عشرة") -> "سأعود في الحادية عشر" (I'll be back 11ish)
- "سأعود الحاديه عشر" (Correct the Arabic writing of number 11 "الحادية عشرة") -> "سأعود الحادية عشر" (I'll be back 11-ish)
-"منتصف.الليل" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate) -> "removed" (mid-night)
- "منتصف.الصباح" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-morning)
- "منتصف.الظهر" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-afternoon)
- "منتصف.النهار" (uncommon to use "." between two words in Arabic except abbreviation or it just mean a full stop, so remove it or replace it with "-" make it a duplicate ) -> "removed" (mid-day)
- "سأعود مساء. 7" (unnecessary ".") -> "سأعود مساء 7" (I'll be back 7 p. m.)
- "سأعود في وقت الغداء الساعة 12" (Missing "ظهرا" to match the extraction "وقت الغداء الساعة 12 ظهرا") -> "سأعود في وقت الغداء الساعة 12 ظهرا" (I'll be back at lunchtime 12 o'clock)
