### PR TITLE
[DE DateTimeV2] Improvements to Holiday coverage in German (#2573)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/DateTimeDefinitions.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s+(?<lasttwoyearnum>((zwanzig|dreißig|vierzig|fünfzig|sechzig|siebzig|achtzig|neunzig)\s+{WrittenNumRegex})|{WrittenNumRegex}))\b|\b(?<firsttwoyearnum>{CenturyRegex})\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
-      public const string WeekDayRegex = @"(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.))";
-      public const string SingleWeekDayRegex = @"\b(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.))";
+      public const string WeekDayRegex = @"(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.|\b))";
+      public const string SingleWeekDayRegex = @"\b(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.|\b))";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>{RelativeRegex}\s+monat(s)?)";
       public const string WrittenMonthRegex = @"((monat\s*)?(?<month>apr(il|\.)|aug(ust|\.)|dez(ember|\.)|feb(ruar|ber|\.)|j[äa]n(uar|ner|\.)|jul(e?i|l\.)|jun([io]|\.)|märz|mai|nov(ember|\.)|okt(ober|\.)|sept?(ember|\.)))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>(im\s*|des\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}|{MonthNumRegex}))";
-      public const string DateUnitRegex = @"(?<unit>jahre|jahr|monate|monat|wochen?|tage|tag)(s)?";
+      public const string DateUnitRegex = @"(?<unit>jahre|jahr|monate|monat|wochen?|tage?|tg)(s)?";
       public const string HalfTokenRegex = @"^(halb)";
       public const string QuarterToTokenRegex = @"^(viertel\s+vor|dreiviertel)\s*$";
       public const string QuarterPastTokenRegex = @"^(viertel\s+nach)\s*$";
@@ -95,7 +95,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string DateExtractor2 = $@"\b({MonthRegex}\s*[/\\.,\- ]\s*{DayRegex}(\s*[/\\.,\- ]\s*{DateYearRegex})?)\b";
       public static readonly string DateExtractor3 = $@"\b({DayRegex}{MonthRegex})";
       public static readonly string DateExtractor4 = $@"\b({DayRegex}\s*{MonthNumRegex}\s*{DateYearRegex})\b";
-      public static readonly string DateExtractor5 = $@"\b({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)";
+      public static readonly string DateExtractor5 = $@"\b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)";
       public static readonly string DateExtractor6 = $@"^[.]";
       public static readonly string DateExtractor7 = $@"({DayRegex}\s*[\.]\s*{MonthNumRegex}[\.]){BaseDateTime.CheckDecimalRegex}";
       public static readonly string DateExtractor8 = $@"(?<=\b(am)\s+){DayRegex}[/\\\.]{MonthNumRegex}([/\\\.]{DateYearRegex})?{BaseDateTime.CheckDecimalRegex}\b";
@@ -172,7 +172,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"\b((((am|zur|von|in der)\s+)?{TimeOfDayRegex}(\s+am)?))|(?<timeOfDay>(?<=montag|dienstag|mittwoch|donnerstag|freitag|samstag|sonntag)((vor|nach)?mittags?|abends?|(nachts?|primetime)|morgens?))\b";
       public const string LessThanRegex = @"\b(weniger\s+als)\b";
       public const string MoreThanRegex = @"\b(mehr\s+als)\b";
-      public const string DurationUnitRegex = @"(?<unit>jahr(e(n|s)?)?|monat(en?|s)?|wochen?|tag(e(n|s)?)?|stunden?|std?|h|min(uten?)?|sek(unden?)?)\b";
+      public const string DurationUnitRegex = @"(?<unit>jahr(e(n|s)?)?|monat(en?|s)?|wochen?|tag(e(n|s)?)?|tg|stunden?|std?|h|min(uten?)?|sek(unden?)?)\b";
       public const string SpecialNumberUnitRegex = @"\b(?<specialNum>beiden)\b";
       public const string SuffixAndRegex = @"(?<suffix>\s*und\s+(eine\s+)?(?<suffix_num>halbe|viertel))";
       public const string PeriodicRegex = @"(?<periodic>(all)?täglich(e(r|n|s)?)?|(all)?monatlich(e(r|n|s)?)?|(all)?wöchentlich(e(r|n|s)?)?|(all)?jährlich(e(r|n|s)?)?)\b";
@@ -189,9 +189,9 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string AllRegex = @"\b(?<all>ganz(e(n|s|r)?)\s+(?<unit>jahr|monat|woche|tag))\b";
       public const string HalfRegex = @"(((ein(e(n|r|s)?)?)\s*)|\b)(?<half>halb(e(n|r|s)?)?\s+(?<unit>jahr(e(r|s)?)?|monat(s|e)?|woch(en?)?|tag(e(n|r|s)?)?|stund(en?)?))\b";
       public const string ConjunctionRegex = @"\b((und(\s+für)?)|mit|für)\b";
-      public static readonly string HolidayRegex1 = $@"\b((dieses jahr)\s*)?(?<holiday>reformations(tag|fest)|gedenktag der reformation|martinstag|st. martin|sankt martin|martinsfest|martini|nikolaustag|dreikönigstag|dreikönigsfest|walpurgisnacht|nationalfeiertag|mariä empfängnis|weihnachten|weihnachtstag|erste(r|n)? weihnachtstag|1. weihnachtstag|erste(r|n)? weihnachtsfeiertag|1\. weihnachtsfeiertag|zweite(r|n)? weihnachtstag|zweite(r|n)? weihnachtsfeiertag|2\. weihnachtstag|zweite(r|n)? weihnachtsfeiertag|stefanitag|stafanstag|berchtoldstag|bechtelistag|bächtelistag|berchtelistag|bärzelistag|josefstag|joseftag|josefitag|ostermontag|ostersonntag|bundesfeiertag|bundesfeier|mariä himmelfahrt|tag der deutschen einheit|ostern|vatertag|muttertag|erntedankfest|thanksgiving|martin luther king day|martin luther king jr day|washington's birthday|washington birthday|canberraday|tag der arbeit|columbus day|memorial day|yuandan|mao's birthday|teachersday|teacher day|single day|allerheiligen|tag der jugend|kindertag|frauentag|treeplanting day|tag des baumes|girlsday|white lover day|loverday|weihnachten|weihnachtstag|xmas|neujahr|neujahrstag|neujahr|neujahrstag|neujahr|inauguration day|murmeltiertag|sommeranfang|winteranfang|frühlingsanfang|herbstanfang|valentinstag|st patrick day|erster april|april scherz|georgstag|mayday|maitag|tag der arbeit|maifeiertag|geburt johannes des täufers|us unabhängigkeitstag|unabhängigkeitstag|sturm auf die bastille|halloween|allerheiligen|allerseelen|guy fawkes day|guy fawkes night|veterans day|heiligabend|silvester|pi-tag|pitag|pi (tag|day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?\b";
-      public static readonly string HolidayRegex2 = $@"\b((dieses jahr)\s*)?(?<holiday>martin luther king|martin luther king jr|allerheiligen|tree planting day|white lover|st patrick|st george|independence|us independence|allerheiligen|allerseelen|guy fawkes|silvester|weiberfastnacht|karneval|aschermittwoch|palmensonntag|karfreitag|christi himmelfahrt|pfingstsonntag|pfingstmontag|fronleichnam|rosenmontag|fastnacht|gründonnerstag|himmelfahrt|volkstrauertag|buß und bettag|buß- und bettag|buss- und bettag|buss und bettag|totensonntag|erste(r|n)? advent|1\. advent|zweite(r|n)? advent|2\. advent|dritte(r|n)? advent|3\. advent|vierte(r|n)? advent|4\. advent|schweizer buss- und bettag|schweizer buss und bettag|schweizer buß und bettag|schweizer buß- und bettag)(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?\b";
-      public static readonly string HolidayRegex3 = $@"((dieses jahr)\s*)?(?<holiday>(canberra|columbus|thanks\s*giving|groundhog|bastille|halloween|veterans|memorial|spring|lantern|qingming|dragon boat)\s+(day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?";
+      public static readonly string HolidayRegex1 = $@"\b((dieses jahr)\s*)?(?<holiday>reformations(tag|fest)|gedenktag der reformation|martinstag|st. martin|sankt martin|martinsfest|martini|nikolaustag|dreikönigstag|dreikönigsfest|walpurgisnacht|nationalfeiertag|mariä empfängnis|weihnachten|weihnachtstag|erste(r|n)? weihnachtstag|1. weihnachtstag|erste(r|n)? weihnachtsfeiertag|1\. weihnachtsfeiertag|zweite(r|n)? weihnachtstag|zweite(r|n)? weihnachtsfeiertag|2\. weihnachtstag|zweite(r|n)? weihnachtsfeiertag|stefanitag|stafanstag|berchtoldstag|bechtelistag|bächtelistag|berchtelistag|bärzelistag|josefstag|joseftag|josefitag|ostermontag|ostersonntag|bundesfeiertag|bundesfeier|mariä himmelfahrt|tag der deutschen einheit|ostern|vatertag|muttertag|erntedankfest|thanksgiving|martin luther king day|martin luther king jr day|washington's birthday|washington birthday|canberraday|tag der arbeit|columbus day|memorial day|yuandan|mao's birthday|teachersday|teacher day|single day|tag der jugend|kindertag|(Internationaler\s+)?frauentag|treeplanting day|tag des baumes|girlsday|white lover day|loverday|weihnachten|weihnachtstag|xmas|neujahr|neujahrstag|neujahr|neujahrstag|neujahr|inauguration day|murmeltiertag|sommeranfang|winteranfang|frühlingsanfang|herbstanfang|valentinstag|st patrick day|erster april|april scherz|georgstag|mayday|maitag|maifeiertag|geburt johannes des täufers|us unabhängigkeitstag|unabhängigkeitstag|sturm auf die bastille|halloween|guy fawkes day|guy fawkes night|veterans day|heiligabend|silvester|pi-tag|pitag|pi (tag|day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?\b";
+      public static readonly string HolidayRegex2 = $@"\b((dieses jahr)\s*)?(?<holiday>martin luther king|martin luther king jr|allerheiligen|tree planting day|white lover|st patrick|st george|independence|us independence|allerseelen|guy fawkes|silvester|weiberfastnacht|karneval|aschermittwoch|palm(en)?sonntag|karsamstag|fastnachtssamstag|fastnachtssonntag|heilige drei könige|barbaratag|reformationstag|weltkindertag|augsburger friedensfest|johannistag|peter und paul|karfreitag|christi himmelfahrt|pfingstsonntag|pfingstmontag|fronleichnam|rosenmontag|fastnacht|gründonnerstag|himmelfahrt|volkstrauertag|buß und bettag|buß- und bettag|buss- und bettag|buss und bettag|totensonntag|erste(r|n)? advent|1\. advent|zweite(r|n)? advent|2\. advent|dritte(r|n)? advent|3\. advent|vierte(r|n)? advent|4\. advent|schweizer buss- und bettag|schweizer buss und bettag|schweizer buß und bettag|schweizer buß- und bettag)(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?\b";
+      public static readonly string HolidayRegex3 = $@"((dieses jahr)\s*)?(?<holiday>(canberra|columbus|thanks\s*giving|groundhog|bastille|halloween|veterans|memorial|spring|lantern|qingming|dragon boat)\s+(day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?";
       public const string DateTokenPrefix = @"am ";
       public const string TimeTokenPrefix = @"um ";
       public const string TokenBeforeDate = @"am ";
@@ -269,6 +269,7 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"tages", @"D" },
             { @"tage", @"D" },
             { @"tag", @"D" },
+            { @"tg", @"D" },
             { @"stunden", @"H" },
             { @"stunde", @"H" },
             { @"h", @"H" },
@@ -293,6 +294,7 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"tagen", 86400 },
             { @"tage", 86400 },
             { @"tag", 86400 },
+            { @"tg", 86400 },
             { @"stunden", 3600 },
             { @"stunde", 3600 },
             { @"std", 3600 },
@@ -657,7 +659,7 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"singleday", new string[] { @"singleday" } },
             { @"allsaintsday", new string[] { @"allerheiligen" } },
             { @"youthday", new string[] { @"tag der jugend" } },
-            { @"childrenday", new string[] { @"kindertag" } },
+            { @"childrenday", new string[] { @"kindertag", @"weltkindertag" } },
             { @"femaleday", new string[] { @"frauentag" } },
             { @"treeplantingday", new string[] { @"treeplantingday" } },
             { @"arborday", new string[] { @"tag des baumes" } },
@@ -692,7 +694,7 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"weiberfastnacht", new string[] { @"weiberfastnacht" } },
             { @"carnival", new string[] { @"karneval" } },
             { @"ashwednesday", new string[] { @"aschermittwoch" } },
-            { @"palmsunday", new string[] { @"palmensonntag" } },
+            { @"palmsunday", new string[] { @"palmensonntag", @"palmsonntag" } },
             { @"goodfriday", new string[] { @"karfreitag" } },
             { @"ascensionofchrist", new string[] { @"christihimmelfahrt" } },
             { @"whitsunday", new string[] { @"pfingstsonntag" } },
@@ -712,7 +714,15 @@ namespace Microsoft.Recognizers.Definitions.German
             { @"beginningofsummer", new string[] { @"sommeranfang" } },
             { @"beginningofwinter", new string[] { @"winteranfang" } },
             { @"beginningofspring", new string[] { @"frühlingsanfang" } },
-            { @"beginningoffall", new string[] { @"herbstanfang" } }
+            { @"beginningoffall", new string[] { @"herbstanfang" } },
+            { @"eastersaturday", new string[] { @"karsamstag" } },
+            { @"fastnachtssamstag", new string[] { @"fastnachtssamstag" } },
+            { @"fastnachtssonntag", new string[] { @"fastnachtssonntag" } },
+            { @"heiligedreikönige", new string[] { @"heiligedreikönige" } },
+            { @"barbaratag", new string[] { @"barbaratag" } },
+            { @"augsburgerfriedensfest", new string[] { @"augsburgerfriedensfest" } },
+            { @"johannistag", new string[] { @"johannistag" } },
+            { @"peterundpaul", new string[] { @"peterundpaul" } }
         };
       public static readonly Dictionary<string, int> WrittenDecades = new Dictionary<string, int>
         {
@@ -744,8 +754,10 @@ namespace Microsoft.Recognizers.Definitions.German
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"\b(morgen|nachmittag|abend|nacht|tag)\b", @"\b(gut(en?)?\s+(morgen|nachmittag|abend|nacht|tag))\b" },
-            { @"^(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)$", @"([$%£&!?@#])(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)|(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)([$%£&@#])" }
+            { @"^(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)$", @"([$%£&!?@#])(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)|(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)([$%£&@#])" },
+            { @"^(mo|di|mi|do|fr|sa|so)$", @"\b(mo|di|mi|do|fr|sa|so)\b" }
         };
+      public static readonly string AmbiguousTimePeriodRegex = $@"\b((?<!{RelativeRegex}\s+)morgen|früh)\b";
       public static readonly IList<string> MorningTermList = new List<string>
         {
             @"morgen",

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Extractors/GermanTimePeriodExtractorConfiguration.cs
@@ -5,6 +5,7 @@ using Microsoft.Recognizers.Definitions.German;
 using Microsoft.Recognizers.Text.DateTime.German.Utilities;
 using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
@@ -60,6 +61,9 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         public static readonly Regex GeneralEndingRegex =
             new Regex(DateTimeDefinitions.GeneralEndingRegex, RegexFlags);
+
+        public static readonly Regex AmbiguousTimePeriodRegex =
+            new Regex(DateTimeDefinitions.AmbiguousTimePeriodRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -144,12 +148,27 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         // It should also be solvable through the config but we do not want to introduce changes to the interface and configs for all other languages.
         public List<ExtractResult> ApplyPotentialPeriodAmbiguityHotfix(string text, List<ExtractResult> timePeriodErs)
         {
-            if (text.Equals("morgen", StringComparison.Ordinal))
+            List<ExtractResult> timePeriodErsResult = new List<ExtractResult>();
+            var matches = AmbiguousTimePeriodRegex.Matches(text);
+            foreach (var timePeriodEr in timePeriodErs)
             {
-                timePeriodErs.Clear();
+                if (matches.Count > 0)
+                {
+                    foreach (Match match in matches)
+                    {
+                        if (!(timePeriodEr.Text == match.Value && timePeriodEr.Start == match.Index && timePeriodEr.Length == match.Length))
+                        {
+                            timePeriodErsResult.Add(timePeriodEr);
+                        }
+                    }
+                }
+                else
+                {
+                    timePeriodErsResult.Add(timePeriodEr);
+                }
             }
 
-            return timePeriodErs;
+            return timePeriodErsResult;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/GermanHolidayParserConfiguration.cs
@@ -1,42 +1,45 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions.German;
 
 namespace Microsoft.Recognizers.Text.DateTime.German
 {
     public class GermanHolidayParserConfiguration : BaseHolidayParserConfiguration
     {
+
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public GermanHolidayParserConfiguration(IDateTimeOptionsConfiguration config)
             : base(config)
         {
+            ThisPrefixRegex = new Regex(DateTimeDefinitions.ThisPrefixRegex, RegexFlags);
+            NextPrefixRegex = new Regex(DateTimeDefinitions.NextPrefixRegex, RegexFlags);
+            PreviousPrefixRegex = new Regex(DateTimeDefinitions.PreviousPrefixRegex, RegexFlags);
             this.HolidayRegexList = GermanHolidayExtractorConfiguration.HolidayRegexList;
             this.HolidayNames = DateTimeDefinitions.HolidayNames.ToImmutableDictionary();
         }
+
+        public Regex ThisPrefixRegex { get; }
+
+        public Regex NextPrefixRegex { get; }
+
+        public Regex PreviousPrefixRegex { get; }
 
         public override int GetSwiftYear(string text)
         {
             var trimmedText = text.Trim();
             var swift = -10;
 
-            // @TODO move hardcoded terms to resource file
-            if (trimmedText.StartsWith("nächster", StringComparison.Ordinal) ||
-                trimmedText.StartsWith("nächstes", StringComparison.Ordinal) ||
-                trimmedText.StartsWith("nächsten", StringComparison.Ordinal) ||
-                trimmedText.StartsWith("nächste", StringComparison.Ordinal))
+            if (NextPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 1;
             }
-            else if (trimmedText.StartsWith("letzter", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("letztes", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("letzten", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("letzte", StringComparison.Ordinal))
+            else if (PreviousPrefixRegex.IsMatch(trimmedText))
             {
                 swift = -1;
             }
-            else if (trimmedText.StartsWith("dieser", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("dieses", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("diesen", StringComparison.Ordinal) ||
-                     trimmedText.StartsWith("diese", StringComparison.Ordinal))
+            else if (ThisPrefixRegex.IsMatch(trimmedText))
             {
                 swift = 0;
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/HolidayParserGer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/German/Parsers/HolidayParserGer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 { "yuandan", NewYear },
                 { "teachersday", TeacherDay },
                 { "singleday", SinglesDay },
-                { "allsaintsday", HalloweenDay },
+                { "allsaintsday", AllHallowDay },
                 { "youthday", YouthDay },
                 { "childrenday", ChildrenDay },
                 { "femaleday", FemaleDay },
@@ -43,11 +43,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
                 { "girlsday", GirlsDay },
                 { "whiteloverday", WhiteLoverDay },
                 { "loverday", ValentinesDay },
+                { "barbaratag", BarbaraTag },
+                { "augsburgerfriedensfest", AugsburgerFriedensFest },
+                { "johannistag", JohannisTag },
+                { "peterundpaul", PeterUndPaul },
                 { "firstchristmasday", ChristmasDay },
                 { "xmas", ChristmasDay },
                 { "newyear", NewYear },
                 { "newyearday", NewYear },
                 { "newyearsday", NewYear },
+                { "heiligedreikönige", HeiligeDreiKönige },
                 { "inaugurationday", InaugurationDay },
                 { "groundhougday", GroundhogDay },
                 { "valentinesday", ValentinesDay },
@@ -81,6 +86,7 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             { "easterday", GetEasterDay },
             { "eastersunday", GetEasterDay },
             { "eastermonday", GetEasterMondayOfYear },
+            { "eastersaturday", GetEasterSaturday },
             { "weiberfastnacht", GetWeiberfastnacht },
             { "carnival", GetCarnival },
             { "ashwednesday", GetAshwednesday },
@@ -92,6 +98,8 @@ namespace Microsoft.Recognizers.Text.DateTime.German
             { "corpuschristi", GetCorpusChristi },
             { "rosenmontag", GetRosenmontag },
             { "fastnacht", GetFastnacht },
+            { "fastnachtssamstag", GetFastnachtSaturday },
+            { "fastnachtssonntag", GetFastnachtSunday },
             { "holythursday", GetHolyThursday },
             { "memorialdaygermany", GetMemorialDayGermany },
             { "dayofrepentance", GetDayOfRepentance },
@@ -310,6 +318,16 @@ namespace Microsoft.Recognizers.Text.DateTime.German
 
         private static DateObject BeginningOfFall(int year) => new DateObject(year, 9, 23);
 
+        private static DateObject BarbaraTag(int year) => new DateObject(year, 12, 4);
+
+        private static DateObject AugsburgerFriedensFest(int year) => new DateObject(year, 8, 8);
+
+        private static DateObject PeterUndPaul(int year) => new DateObject(year, 6, 29);
+
+        private static DateObject JohannisTag(int year) => new DateObject(year, 6, 24);
+
+        private static DateObject HeiligeDreiKönige(int year) => new DateObject(year, 1, 6);
+
         private static DateObject GetMothersDayOfYear(int year)
         {
             return DateObject.MinValue.SafeCreateFromValue(year, 5, (from day in Enumerable.Range(1, 31)
@@ -483,6 +501,21 @@ namespace Microsoft.Recognizers.Text.DateTime.German
         private static DateObject GetWeiberfastnacht(int year)
         {
             return HolidayFunctions.CalculateHolidayByEaster(year, -52);
+        }
+
+        private static DateObject GetEasterSaturday(int year)
+        {
+            return HolidayFunctions.CalculateHolidayByEaster(year, -1);
+        }
+
+        private static DateObject GetFastnachtSaturday(int year)
+        {
+            return HolidayFunctions.CalculateHolidayByEaster(year, -50);
+        }
+
+        private static DateObject GetFastnachtSunday(int year)
+        {
+            return HolidayFunctions.CalculateHolidayByEaster(year, -49);
         }
 
         private DateTimeResolutionResult ParseHolidayRegexMatch(string text, DateObject referenceDate)

--- a/Patterns/German/German-DateTime.yaml
+++ b/Patterns/German/German-DateTime.yaml
@@ -56,9 +56,9 @@ YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
 WeekDayRegex: !simpleRegex
-  def: (?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.))
+  def: (?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.|\b))
 SingleWeekDayRegex: !simpleRegex
-  def: \b(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.))
+  def: \b(?<weekday>sonntag|montag|dienstag|mittwoch|donnerstag|freitag|samstag|(mo|di|mi|do|fr|sa|so)(\.|\b))
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>{RelativeRegex}\s+monat(s)?)
   references: [RelativeRegex]
@@ -68,7 +68,7 @@ MonthSuffixRegex: !nestedRegex
   def: (?<msuf>(im\s*|des\s*)?({RelativeMonthRegex}|{WrittenMonthRegex}|{MonthNumRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex, MonthNumRegex ]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>jahre|jahr|monate|monat|wochen?|tage|tag)(s)?
+  def: (?<unit>jahre|jahr|monate|monat|wochen?|tage?|tg)(s)?
 HalfTokenRegex: !simpleRegex
   def: ^(halb)
 QuarterToTokenRegex: !simpleRegex
@@ -193,8 +193,8 @@ DateExtractor4: !nestedRegex
   references: [ MonthNumRegex, DayRegex, DateYearRegex ]
 # The final lookahead in DateExtractor5|A avoids extracting as date "10/1-11" from an input like "10/1-11/2/2017" 
 DateExtractor5: !nestedRegex
-  def: \b({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)
-  references: [ DayRegex, MonthNumRegex, MonthRegex, DateYearRegex ]
+  def: \b(({WeekDayRegex})(\s+|\s*,\s*))?({DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex})\b(?!\s*[/\\\-\.]\s*\d+)
+  references: [ WeekDayRegex, DayRegex, MonthNumRegex, MonthRegex, DateYearRegex ]
 DateExtractor6: !nestedRegex
   def: ^[.]
   references: [ WeekDayRegex ]
@@ -395,7 +395,7 @@ LessThanRegex: !simpleRegex
 MoreThanRegex: !simpleRegex
   def: \b(mehr\s+als)\b
 DurationUnitRegex: !simpleRegex
-  def: (?<unit>jahr(e(n|s)?)?|monat(en?|s)?|wochen?|tag(e(n|s)?)?|stunden?|std?|h|min(uten?)?|sek(unden?)?)\b
+  def: (?<unit>jahr(e(n|s)?)?|monat(en?|s)?|wochen?|tag(e(n|s)?)?|tg|stunden?|std?|h|min(uten?)?|sek(unden?)?)\b
 SpecialNumberUnitRegex: !simpleRegex
   def: \b(?<specialNum>beiden)\b
 SuffixAndRegex: !simpleRegex
@@ -433,13 +433,13 @@ HalfRegex: !simpleRegex
 ConjunctionRegex: !simpleRegex
   def: \b((und(\s+für)?)|mit|für)\b
 HolidayRegex1: !nestedRegex
-  def: \b((dieses jahr)\s*)?(?<holiday>reformations(tag|fest)|gedenktag der reformation|martinstag|st. martin|sankt martin|martinsfest|martini|nikolaustag|dreikönigstag|dreikönigsfest|walpurgisnacht|nationalfeiertag|mariä empfängnis|weihnachten|weihnachtstag|erste(r|n)? weihnachtstag|1. weihnachtstag|erste(r|n)? weihnachtsfeiertag|1\. weihnachtsfeiertag|zweite(r|n)? weihnachtstag|zweite(r|n)? weihnachtsfeiertag|2\. weihnachtstag|zweite(r|n)? weihnachtsfeiertag|stefanitag|stafanstag|berchtoldstag|bechtelistag|bächtelistag|berchtelistag|bärzelistag|josefstag|joseftag|josefitag|ostermontag|ostersonntag|bundesfeiertag|bundesfeier|mariä himmelfahrt|tag der deutschen einheit|ostern|vatertag|muttertag|erntedankfest|thanksgiving|martin luther king day|martin luther king jr day|washington's birthday|washington birthday|canberraday|tag der arbeit|columbus day|memorial day|yuandan|mao's birthday|teachersday|teacher day|single day|allerheiligen|tag der jugend|kindertag|frauentag|treeplanting day|tag des baumes|girlsday|white lover day|loverday|weihnachten|weihnachtstag|xmas|neujahr|neujahrstag|neujahr|neujahrstag|neujahr|inauguration day|murmeltiertag|sommeranfang|winteranfang|frühlingsanfang|herbstanfang|valentinstag|st patrick day|erster april|april scherz|georgstag|mayday|maitag|tag der arbeit|maifeiertag|geburt johannes des täufers|us unabhängigkeitstag|unabhängigkeitstag|sturm auf die bastille|halloween|allerheiligen|allerseelen|guy fawkes day|guy fawkes night|veterans day|heiligabend|silvester|pi-tag|pitag|pi (tag|day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?\b
+  def: \b((dieses jahr)\s*)?(?<holiday>reformations(tag|fest)|gedenktag der reformation|martinstag|st. martin|sankt martin|martinsfest|martini|nikolaustag|dreikönigstag|dreikönigsfest|walpurgisnacht|nationalfeiertag|mariä empfängnis|weihnachten|weihnachtstag|erste(r|n)? weihnachtstag|1. weihnachtstag|erste(r|n)? weihnachtsfeiertag|1\. weihnachtsfeiertag|zweite(r|n)? weihnachtstag|zweite(r|n)? weihnachtsfeiertag|2\. weihnachtstag|zweite(r|n)? weihnachtsfeiertag|stefanitag|stafanstag|berchtoldstag|bechtelistag|bächtelistag|berchtelistag|bärzelistag|josefstag|joseftag|josefitag|ostermontag|ostersonntag|bundesfeiertag|bundesfeier|mariä himmelfahrt|tag der deutschen einheit|ostern|vatertag|muttertag|erntedankfest|thanksgiving|martin luther king day|martin luther king jr day|washington's birthday|washington birthday|canberraday|tag der arbeit|columbus day|memorial day|yuandan|mao's birthday|teachersday|teacher day|single day|tag der jugend|kindertag|(Internationaler\s+)?frauentag|treeplanting day|tag des baumes|girlsday|white lover day|loverday|weihnachten|weihnachtstag|xmas|neujahr|neujahrstag|neujahr|neujahrstag|neujahr|inauguration day|murmeltiertag|sommeranfang|winteranfang|frühlingsanfang|herbstanfang|valentinstag|st patrick day|erster april|april scherz|georgstag|mayday|maitag|maifeiertag|geburt johannes des täufers|us unabhängigkeitstag|unabhängigkeitstag|sturm auf die bastille|halloween|guy fawkes day|guy fawkes night|veterans day|heiligabend|silvester|pi-tag|pitag|pi (tag|day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?\b
   references: [ YearRegex, RelativeRegex ]
 HolidayRegex2: !nestedRegex
-  def: \b((dieses jahr)\s*)?(?<holiday>martin luther king|martin luther king jr|allerheiligen|tree planting day|white lover|st patrick|st george|independence|us independence|allerheiligen|allerseelen|guy fawkes|silvester|weiberfastnacht|karneval|aschermittwoch|palmensonntag|karfreitag|christi himmelfahrt|pfingstsonntag|pfingstmontag|fronleichnam|rosenmontag|fastnacht|gründonnerstag|himmelfahrt|volkstrauertag|buß und bettag|buß- und bettag|buss- und bettag|buss und bettag|totensonntag|erste(r|n)? advent|1\. advent|zweite(r|n)? advent|2\. advent|dritte(r|n)? advent|3\. advent|vierte(r|n)? advent|4\. advent|schweizer buss- und bettag|schweizer buss und bettag|schweizer buß und bettag|schweizer buß- und bettag)(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?\b
+  def: \b((dieses jahr)\s*)?(?<holiday>martin luther king|martin luther king jr|allerheiligen|tree planting day|white lover|st patrick|st george|independence|us independence|allerseelen|guy fawkes|silvester|weiberfastnacht|karneval|aschermittwoch|palm(en)?sonntag|karsamstag|fastnachtssamstag|fastnachtssonntag|heilige drei könige|barbaratag|reformationstag|weltkindertag|augsburger friedensfest|johannistag|peter und paul|karfreitag|christi himmelfahrt|pfingstsonntag|pfingstmontag|fronleichnam|rosenmontag|fastnacht|gründonnerstag|himmelfahrt|volkstrauertag|buß und bettag|buß- und bettag|buss- und bettag|buss und bettag|totensonntag|erste(r|n)? advent|1\. advent|zweite(r|n)? advent|2\. advent|dritte(r|n)? advent|3\. advent|vierte(r|n)? advent|4\. advent|schweizer buss- und bettag|schweizer buss und bettag|schweizer buß und bettag|schweizer buß- und bettag)(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?\b
   references: [ YearRegex, RelativeRegex ]
 HolidayRegex3: !nestedRegex
-  def: ((dieses jahr)\s*)?(?<holiday>(canberra|columbus|thanks\s*giving|groundhog|bastille|halloween|veterans|memorial|spring|lantern|qingming|dragon boat)\s+(day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|{RelativeRegex}\s+jahres))?
+  def: ((dieses jahr)\s*)?(?<holiday>(canberra|columbus|thanks\s*giving|groundhog|bastille|halloween|veterans|memorial|spring|lantern|qingming|dragon boat)\s+(day))(\s+((diesen)\s+)?(im jahr {YearRegex}|{YearRegex}|(im\s+)?{RelativeRegex}\s+jahr(es)?))?
   references: [ YearRegex, RelativeRegex ]
 DateTokenPrefix: 'am '
 TimeTokenPrefix: 'um '
@@ -597,6 +597,7 @@ UnitMap: !dictionary
     tages: D
     tage: D
     tag: D
+    tg: D
     stunden: H
     stunde: H
     h: H
@@ -622,6 +623,7 @@ UnitValueMap: !dictionary
     tagen: 86400
     tage: 86400
     tag: 86400
+    tg: 86400
     stunden: 3600
     stunde: 3600
     std: 3600
@@ -989,7 +991,7 @@ HolidayNames: !dictionary
     singleday: [ singleday ]
     allsaintsday: [ allerheiligen ]
     youthday: [ tag der jugend ]
-    childrenday: [ kindertag ]
+    childrenday: [ kindertag, weltkindertag ]
     femaleday: [ frauentag ]
     treeplantingday: [ treeplantingday ]
     arborday: [ tag des baumes ]
@@ -1024,7 +1026,7 @@ HolidayNames: !dictionary
     weiberfastnacht: [ weiberfastnacht ]
     carnival: [ karneval ]
     ashwednesday: [ aschermittwoch ]
-    palmsunday: [ palmensonntag ]
+    palmsunday: [ palmensonntag, palmsonntag ]
     goodfriday: [ karfreitag ]
     ascensionofchrist: [ christihimmelfahrt ]
     whitsunday: [ pfingstsonntag ]
@@ -1045,6 +1047,14 @@ HolidayNames: !dictionary
     beginningofwinter: [ winteranfang ]
     beginningofspring: [ frühlingsanfang ]
     beginningoffall: [ herbstanfang ]
+    eastersaturday: [ karsamstag ]
+    fastnachtssamstag: [ fastnachtssamstag ]
+    fastnachtssonntag : [ fastnachtssonntag ]
+    heiligedreikönige: [ heiligedreikönige ]
+    barbaratag: [ barbaratag ]
+    augsburgerfriedensfest: [ augsburgerfriedensfest ]
+    johannistag: [ johannistag ]
+    peterundpaul: [ peterundpaul ]
 WrittenDecades: !dictionary
   types: [ string, int ]
   entries:
@@ -1077,9 +1087,13 @@ AmbiguityFiltersDict: !dictionary
   entries:
     '\b(morgen|nachmittag|abend|nacht|tag)\b': '\b(gut(en?)?\s+(morgen|nachmittag|abend|nacht|tag))\b'
     '^(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)$': '([$%£&!?@#])(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)|(apr|aug|dez|feb|j[äa]n|jul|jun|märz|mai|nov|okt|sept?)([$%£&@#])'
+    '^(mo|di|mi|do|fr|sa|so)$': '\b(mo|di|mi|do|fr|sa|so)\b'
 # As deciding between morgen (morning) and morgen (tomorrow) turns out to be rather difficult, we might want to ignore if for now
 #    '\bmorgen\b': '\b(morgen\s(morgen|nachmittag|abend|nacht|tag|früh))\b'
 # For TimeOfDay resolution
+AmbiguousTimePeriodRegex: !nestedRegex
+  def: \b((?<!{RelativeRegex}\s+)morgen|früh)\b
+  references: [ RelativeRegex ]
 MorningTermList: !list
   types: [ string ]
   entries:

--- a/Specs/DateTime/German/DateTimeModel.json
+++ b/Specs/DateTime/German/DateTimeModel.json
@@ -3616,5 +3616,392 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Ich besuche dich an Palmsonntag 2019" ,
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "palmsonntag 2019",
+        "Start": 20,
+        "End": 35,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-04-14",
+              "type": "date",
+              "value": "2019-04-14"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Karsamstag" ,
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "karsamstag",
+        "Start": 20,
+        "End": 29,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2016-03-26"
+            },
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2017-04-15"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Fastnachtssamstag" ,
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "fastnachtssamstag",
+        "Start": 20,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2016-02-06"
+            },
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2017-02-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Fastnachtssonntag im nächsten Jahr" ,
+    "Context": {
+      "ReferenceDateTime": "2017-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "fastnachtssonntag im nächsten jahr",
+        "Start": 20,
+        "End": 53,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-02-11",
+              "type": "date",
+              "value": "2018-02-11"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Heilige Drei Könige im Jahr 2020" ,
+    "Context": {
+      "ReferenceDateTime": "2017-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "heilige drei könige im jahr 2020",
+        "Start": 20,
+        "End": 51,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2020-01-06",
+              "type": "date",
+              "value": "2020-01-06"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Barbaratag" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "barbaratag",
+        "Start": 20,
+        "End": 29,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-12-04",
+              "type": "date",
+              "value": "2017-12-04"
+            },
+            {
+              "timex": "XXXX-12-04",
+              "type": "date",
+              "value": "2018-12-04"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Weltkindertag 2019" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "weltkindertag 2019",
+        "Start": 20,
+        "End": 37,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-06-01",
+              "type": "date",
+              "value": "2019-06-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Augsburger Friedensfest letzten Jahres" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "augsburger friedensfest letzten jahres",
+        "Start": 20,
+        "End": 57,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-08-08",
+              "type": "date",
+              "value": "2017-08-08"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Johannistag" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "johannistag",
+        "Start": 20,
+        "End": 30,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-24",
+              "type": "date",
+              "value": "2018-06-24"
+            },
+            {
+              "timex": "XXXX-06-24",
+              "type": "date",
+              "value": "2019-06-24"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Peter und Paul " ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "peter und paul",
+        "Start": 20,
+        "End": 33,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-29",
+              "type": "date",
+              "value": "2018-06-29"
+            },
+            {
+              "timex": "XXXX-06-29",
+              "type": "date",
+              "value": "2019-06-29"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an Allerheiligen" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "allerheiligen",
+        "Start": 20,
+        "End": 32,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-11-01",
+              "type": "date",
+              "value": "2018-11-01"
+            },
+            {
+              "timex": "XXXX-11-01",
+              "type": "date",
+              "value": "2019-11-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ostern ist dieses Jahr früh" ,
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "ostern",
+        "Start": 0,
+        "End": 5,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2016-03-27"
+            },
+            {
+              "timex": "XXXX",
+              "type": "date",
+              "value": "2017-04-16"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "dieses jahr",
+        "Start": 11,
+        "End": 21,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016",
+              "type": "daterange",
+              "start": "2016-01-01",
+              "end": "2017-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich an So 27.02.2022" ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "so 27.02.2022",
+        "Start": 20,
+        "End": 32,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2022-02-27",
+              "type": "date",
+              "value": "2022-02-27"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ich besuche dich in 15 Tg." ,
+    "Context": {
+      "ReferenceDateTime": "2018-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "in 15 tg",
+        "Start": 17,
+        "End": 24,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-11-22",
+              "type": "date",
+              "value": "2018-11-22"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2573.
Added support (and test cases) for the holidays in the list https://www.schulferien.org/deutschland/feiertage/ not already covered by the German Recognizer.