### PR TITLE
[EN DateTimeV2] Fix to dates not properly extracted (#2568)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/BaseDateTime.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/BaseDateTime.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Recognizers.Definitions
       public const string BasePmDescRegex = @"(pm\b|p\s*\.\s*m\s*\.|p[\.]?\s*m\b)";
       public const string BaseAmPmDescRegex = @"(ampm)";
       public const string EqualRegex = @"(?<!<|>)=";
+      public const string BracketRegex = @"^\s*[\)\]]|[\[\(]\s*$";
       public const string MinYearNum = @"1500";
       public const string MaxYearNum = @"2100";
       public const string MaxTwoDigitYearFutureNum = @"30";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimeZoneUtility.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions;
 
 using Microsoft.Recognizers.Text.Matcher;
 
@@ -7,14 +9,22 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public static class TimeZoneUtility
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+        private static readonly Regex BracketRegex =
+            new Regex(BaseDateTime.BracketRegex, RegexFlags);
+
         public static List<ExtractResult> MergeTimeZones(List<ExtractResult> originalErs, List<ExtractResult> timeZoneErs, string text)
         {
             foreach (var er in originalErs)
             {
                 foreach (var timeZoneEr in timeZoneErs)
                 {
+                    // Extend timezone extraction to include brackets if any.
+                    var tzEr = ExtendTimeZoneExtraction(timeZoneEr, text);
+
                     var begin = er.Start + er.Length;
-                    var end = timeZoneEr.Start;
+                    var end = tzEr.Start;
 
                     if (begin < end)
                     {
@@ -22,7 +32,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                         if (string.IsNullOrWhiteSpace(gapText))
                         {
-                            var newLength = (int)(timeZoneEr.Start + timeZoneEr.Length - er.Start);
+                            var newLength = (int)(tzEr.Start + tzEr.Length - er.Start);
 
                             er.Text = text.Substring((int)er.Start, newLength);
                             er.Length = newLength;
@@ -85,6 +95,21 @@ namespace Microsoft.Recognizers.Text.DateTime
             matcher.Init(matcherList);
 
             return matcher;
+        }
+
+        private static ExtractResult ExtendTimeZoneExtraction(ExtractResult timeZoneEr, string text)
+        {
+            var beforeStr = text.Substring(0, (int)timeZoneEr.Start);
+            var afterStr = text.Substring((int)timeZoneEr.Start + (int)timeZoneEr.Length);
+            var matchLeft = BracketRegex.Match(beforeStr);
+            var matchRight = BracketRegex.Match(afterStr);
+            if (matchLeft.Success && matchRight.Success)
+            {
+                timeZoneEr.Start -= matchLeft.Length;
+                timeZoneEr.Length += matchLeft.Length + matchRight.Length;
+            }
+
+            return timeZoneEr;
         }
     }
 }

--- a/Patterns/Base-DateTime.yaml
+++ b/Patterns/Base-DateTime.yaml
@@ -29,6 +29,8 @@ BaseAmPmDescRegex: !simpleRegex
   def: (ampm)
 EqualRegex: !simpleRegex
   def: (?<!<|>)=
+BracketRegex: !simpleRegex
+  def: ^\s*[\)\]]|[\[\(]\s*$
 MinYearNum: 1500
 MaxYearNum: 2100
 MaxTwoDigitYearFutureNum: 30

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -20055,5 +20055,67 @@
         "End": 57
       }
     ]
+  },
+  {
+    "Input": "Our 24th retweet competition #WINNER has been randomly selected! Congratulations, @dreaming_70! You have won $100 in $ETH. This tweet begins (and counts towards) the next day of the retweet competition. Winners will be selected daily until April 27th",
+    "Context": {
+      "ReferenceDateTime": "2018-05-22T16:12:00"
+    },
+    "Results": [
+      {
+        "Text": "the next day",
+        "Start": 162,
+        "End": 173,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-23",
+              "type": "date",
+              "value": "2018-05-23"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "daily",
+        "Start": 228,
+        "End": 232,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P1D",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "until april 27th",
+        "Start": 234,
+        "End": 249,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-04-27",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-04-27"
+            },
+            {
+              "timex": "XXXX-04-27",
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2019-04-27"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -13385,5 +13385,69 @@
         }
       }
     ]
+  },
+  {
+    "Input": "The event is scheduled 16:00, 23 Apr - 22:00, 27 April (UTC+8)",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "16:00, 23 apr - 22:00, 27 april (utc+8)",
+        "Start": 23,
+        "End": 61,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-23T16:00,XXXX-04-27T22:00,PT102H)",
+              "type": "datetimerange",
+              "timezone": "UTC+08:00",
+              "timezoneText": "utc+8",
+              "utcOffsetMins": "480",
+              "start": "2016-04-23 16:00:00",
+              "end": "2016-04-27 22:00:00"
+            },
+            {
+              "timex": "(XXXX-04-23T16:00,XXXX-04-27T22:00,PT102H)",
+              "type": "datetimerange",
+              "timezone": "UTC+08:00",
+              "timezoneText": "utc+8",
+              "utcOffsetMins": "480",
+              "start": "2017-04-23 16:00:00",
+              "end": "2017-04-27 22:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The meeting will start at 10.30 am ( CET ).",
+    "Context": {
+      "ReferenceDateTime": "2018-06-06T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "at 10.30 am ( cet )",
+        "Start": 23,
+        "End": 41,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T10:30",
+              "type": "time",
+              "timezone": "UTC+01:00",
+              "timezoneText": "cet",
+              "utcOffsetMins": "60",
+              "value": "10:30:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2568.

Fixed by modifying the method MergeTimeZones to take into account any brackets. 
The second sentence was already working as expected.

Test cases added to DateTimeModel and DateTimeModelComplexCalendar.