### PR TITLE
[ZH DateTimeV2] Fixed handling of modifiers "since" and "until" in CJK implementation (#2557)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseMergedDateTimeParser.cs
@@ -12,10 +12,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 {
     public class BaseMergedDateTimeParser : IDateTimeParser
     {
-        public const string ParserTypeName = "datetimeV2";
-
-        public static readonly string DateMinString = DateTimeFormatUtil.FormatDate(DateObject.MinValue);
-        public static readonly string DateTimeMinString = DateTimeFormatUtil.FormatDateTime(DateObject.MinValue);
 
         public BaseMergedDateTimeParser(IMergedParserConfiguration configuration)
         {
@@ -24,243 +20,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         protected IMergedParserConfiguration Config { get; private set; }
 
-        public static void AddAltSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type, string mod,
-                                                            Dictionary<string, string> res)
+        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
         {
-            if (resolutionDic.ContainsKey(TimeTypeConstants.DATE))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATE, mod, res);
-            }
-            else if (resolutionDic.ContainsKey(TimeTypeConstants.DATETIME))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIME, mod, res);
-            }
-            else if (resolutionDic.ContainsKey(TimeTypeConstants.TIME))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.TIME, mod, res);
-            }
-        }
-
-        public static void AddSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type, string mod,
-                                                         Dictionary<string, string> res)
-        {
-
-            // If an "invalid" Date or DateTime is extracted, it should not have an assigned resolution.
-            // Only valid entities should pass this condition.
-            if (resolutionDic.ContainsKey(type) &&
-                !resolutionDic[type].StartsWith(DateMinString, StringComparison.Ordinal))
-            {
-                if (!string.IsNullOrEmpty(mod))
-                {
-                    if (mod.StartsWith(Constants.BEFORE_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.End, resolutionDic[type]);
-                        return;
-                    }
-
-                    if (mod.StartsWith(Constants.AFTER_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.Start, resolutionDic[type]);
-                        return;
-                    }
-
-                    if (mod.StartsWith(Constants.SINCE_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.Start, resolutionDic[type]);
-                        return;
-                    }
-
-                    if (mod.StartsWith(Constants.UNTIL_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.End, resolutionDic[type]);
-                        return;
-                    }
-                }
-
-                res.Add(ResolutionKey.Value, resolutionDic[type]);
-            }
-        }
-
-        public static void AddPeriodToResolution(Dictionary<string, string> resolutionDic, string startType, string endType, string mod,
-                                                 Dictionary<string, string> res)
-        {
-            var start = string.Empty;
-            var end = string.Empty;
-
-            if (resolutionDic.ContainsKey(startType))
-            {
-                start = resolutionDic[startType];
-                if (start.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
-                {
-                    return;
-                }
-            }
-
-            if (resolutionDic.ContainsKey(endType))
-            {
-                end = resolutionDic[endType];
-                if (end.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
-                {
-                    return;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(mod))
-            {
-                // For the 'before' mod
-                // 1. Cases like "Before December", the start of the period should be the end of the new period, not the start
-                // (but not for cases like "Before the end of December")
-                // 2. Cases like "More than 3 days before today", the date point should be the end of the new period
-                if (mod.StartsWith(Constants.BEFORE_MOD, StringComparison.Ordinal))
-                {
-                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.LATE_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.End, start);
-                    }
-                    else
-                    {
-                        res.Add(DateTimeResolutionKey.End, end);
-                    }
-
-                    return;
-                }
-
-                // For the 'after' mod
-                // 1. Cases like "After January", the end of the period should be the start of the new period, not the end
-                // (but not for cases like "After the beginning of January")
-                // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
-                if (mod.StartsWith(Constants.AFTER_MOD, StringComparison.Ordinal))
-                {
-                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.EARLY_MOD, StringComparison.Ordinal))
-                    {
-                        res.Add(DateTimeResolutionKey.Start, end);
-                    }
-                    else
-                    {
-                        res.Add(DateTimeResolutionKey.Start, start);
-                    }
-
-                    return;
-                }
-
-                // For the 'since' mod, the start of the period should be the start of the new period, not the end
-                if (mod.StartsWith(Constants.SINCE_MOD, StringComparison.Ordinal))
-                {
-                    res.Add(DateTimeResolutionKey.Start, start);
-                    return;
-                }
-
-                // For the 'until' mod, the end of the period should be the end of the new period, not the start
-                if (mod.StartsWith(Constants.UNTIL_MOD, StringComparison.Ordinal))
-                {
-                    res.Add(DateTimeResolutionKey.End, end);
-                    return;
-                }
-            }
-
-            if (!AreUnresolvedDates(start, end))
-            {
-                res.Add(DateTimeResolutionKey.Start, start);
-                res.Add(DateTimeResolutionKey.End, end);
-
-                // Preserving any present timex values. Useful for Holiday weekend where the timex is known during parsing.
-                if (resolutionDic.ContainsKey(DateTimeResolutionKey.Timex))
-                {
-                    res.Add(DateTimeResolutionKey.Timex, resolutionDic[DateTimeResolutionKey.Timex]);
-                }
-            }
-        }
-
-        public static DateTimeParseResult SetInclusivePeriodEnd(DateTimeParseResult slot)
-        {
-            if (slot.Type == $"{ParserTypeName}.{Constants.SYS_DATETIME_DATEPERIOD}")
-            {
-                var timexComponents = slot.TimexStr.Split(Constants.DatePeriodTimexSplitter, StringSplitOptions.RemoveEmptyEntries);
-
-                // Only handle DatePeriod like "(StartDate,EndDate,Duration)"
-                if (timexComponents.Length == 3)
-                {
-                    var value = (SortedDictionary<string, object>)slot.Value;
-                    var altTimex = string.Empty;
-
-                    if (value != null && value.ContainsKey(ResolutionKey.ValueSet))
-                    {
-                        if (value[ResolutionKey.ValueSet] is IList<Dictionary<string, string>> valueSet && valueSet.Any())
-                        {
-                            foreach (var values in valueSet)
-                            {
-                                // This is only a sanity check, as here we only handle DatePeriod like "(StartDate,EndDate,Duration)"
-                                if (values.ContainsKey(DateTimeResolutionKey.Start) && values.ContainsKey(DateTimeResolutionKey.End) &&
-                                    values.ContainsKey(DateTimeResolutionKey.Timex))
-                                {
-                                    var startDate = DateObject.Parse(values[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
-                                    var endDate = DateObject.Parse(values[DateTimeResolutionKey.End], CultureInfo.InvariantCulture);
-                                    var durationStr = timexComponents[2];
-                                    var datePeriodTimexType = TimexUtility.GetDatePeriodTimexType(durationStr);
-
-                                    endDate = TimexUtility.OffsetDateObject(endDate, offset: 1, timexType: datePeriodTimexType);
-                                    values[DateTimeResolutionKey.End] = DateTimeFormatUtil.LuisDate(endDate);
-                                    values[DateTimeResolutionKey.Timex] =
-                                        TimexUtility.GenerateEndInclusiveTimex(slot.TimexStr, datePeriodTimexType, startDate, endDate);
-
-                                    if (string.IsNullOrEmpty(altTimex))
-                                    {
-                                        altTimex = values[DateTimeResolutionKey.Timex];
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    slot.Value = value;
-                    slot.TimexStr = altTimex;
-                }
-            }
-
-            return slot;
-        }
-
-        public static void AddAltPeriodToResolution(Dictionary<string, string> resolutionDic, string mod, Dictionary<string, string> res)
-        {
-            if (resolutionDic.ContainsKey(TimeTypeConstants.START_DATETIME) || resolutionDic.ContainsKey(TimeTypeConstants.END_DATETIME))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATETIME, TimeTypeConstants.END_DATETIME, mod, res);
-            }
-            else if (resolutionDic.ContainsKey(TimeTypeConstants.START_DATE) || resolutionDic.ContainsKey(TimeTypeConstants.END_DATE))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATE, TimeTypeConstants.END_DATE, mod, res);
-            }
-            else if (resolutionDic.ContainsKey(TimeTypeConstants.START_TIME) || resolutionDic.ContainsKey(TimeTypeConstants.END_TIME))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_TIME, TimeTypeConstants.END_TIME, mod, res);
-            }
-        }
-
-        public static bool AreUnresolvedDates(string startDate, string endDate)
-        {
-            return string.IsNullOrEmpty(startDate) || string.IsNullOrEmpty(endDate) ||
-                   startDate.StartsWith(DateMinString, StringComparison.Ordinal) ||
-                   endDate.StartsWith(DateMinString, StringComparison.Ordinal);
-        }
-
-        public static string DetermineSourceEntityType(string sourceType, string newType, bool hasMod)
-        {
-            if (!hasMod)
-            {
-                return null;
-            }
-
-            if (!newType.Equals(sourceType, StringComparison.Ordinal))
-            {
-                return Constants.SYS_DATETIME_DATETIMEPOINT;
-            }
-
-            if (newType.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal))
-            {
-                return Constants.SYS_DATETIME_DATETIMEPERIOD;
-            }
-
-            return null;
+            return candidateResults;
         }
 
         public ParseResult Parse(ExtractResult er)
@@ -444,11 +206,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Text = matchIsAfter ? pr.Text + modStr : modStr + pr.Text;
                 var val = (DateTimeResolutionResult)pr.Value;
 
-                val.Mod = CombineMod(val.Mod, !hasInclusiveModifier ? Constants.BEFORE_MOD : Constants.UNTIL_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, !hasInclusiveModifier ? Constants.BEFORE_MOD : Constants.UNTIL_MOD);
 
                 if (hasAround)
                 {
-                    val.Mod = CombineMod(Constants.APPROX_MOD, val.Mod);
+                    val.Mod = MergedParserUtil.CombineMod(Constants.APPROX_MOD, val.Mod);
                     hasAround = false;
                 }
 
@@ -462,11 +224,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Text = matchIsAfter ? pr.Text + modStr : modStr + pr.Text;
                 var val = (DateTimeResolutionResult)pr.Value;
 
-                val.Mod = CombineMod(val.Mod, !hasInclusiveModifier ? Constants.AFTER_MOD : Constants.SINCE_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, !hasInclusiveModifier ? Constants.AFTER_MOD : Constants.SINCE_MOD);
 
                 if (hasAround)
                 {
-                    val.Mod = CombineMod(Constants.APPROX_MOD, val.Mod);
+                    val.Mod = MergedParserUtil.CombineMod(Constants.APPROX_MOD, val.Mod);
                     hasAround = false;
                 }
 
@@ -479,11 +241,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Start -= matchIsAfter ? 0 : modStr.Length;
                 pr.Text = matchIsAfter ? pr.Text + modStr : modStr + pr.Text;
                 var val = (DateTimeResolutionResult)pr.Value;
-                val.Mod = CombineMod(val.Mod, Constants.SINCE_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, Constants.SINCE_MOD);
 
                 if (hasAround)
                 {
-                    val.Mod = CombineMod(Constants.APPROX_MOD, val.Mod);
+                    val.Mod = MergedParserUtil.CombineMod(Constants.APPROX_MOD, val.Mod);
                     hasAround = false;
                 }
 
@@ -496,7 +258,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Start -= matchIsAfter ? 0 : modStr.Length;
                 pr.Text = matchIsAfter ? pr.Text + modStr : modStr + pr.Text;
                 var val = (DateTimeResolutionResult)pr.Value;
-                val.Mod = CombineMod(val.Mod, Constants.APPROX_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, Constants.APPROX_MOD);
                 pr.Value = val;
             }
 
@@ -512,7 +274,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Length += modStr.Length;
                 pr.Text += modStr;
                 var val = (DateTimeResolutionResult)pr.Value;
-                val.Mod = CombineMod(val.Mod, Constants.SINCE_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, Constants.SINCE_MOD);
                 pr.Value = val;
                 hasSince = true;
             }
@@ -522,7 +284,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 pr.Type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal) && !this.Config.CheckBothBeforeAfter)
             {
                 var val = (DateTimeResolutionResult)pr.Value;
-                val.Mod = CombineMod(val.Mod, Constants.SINCE_MOD);
+                val.Mod = MergedParserUtil.CombineMod(val.Mod, Constants.SINCE_MOD);
                 pr.Value = val;
                 hasSince = true;
             }
@@ -530,7 +292,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             if ((Config.Options & DateTimeOptions.SplitDateAndTime) != 0 &&
                 ((DateTimeResolutionResult)pr?.Value)?.SubDateTimeEntities != null)
             {
-                pr.Value = DateTimeResolutionForSplit(pr);
+                pr.Value = MergedParserUtil.DateTimeResolutionForSplit(pr, this.Config);
             }
             else
             {
@@ -540,7 +302,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     ((DateTimeResolutionResult)pr.Value).HasRangeChangingMod = hasRangeChangingMod;
                 }
 
-                pr = SetParseResult(pr, hasRangeChangingMod);
+                pr = MergedParserUtil.SetParseResult(pr, hasRangeChangingMod, this.Config);
             }
 
             // In this version, ExperimentalMode only cope with the "IncludePeriodEnd" case
@@ -548,7 +310,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 if (pr?.Metadata != null && pr.Metadata.PossiblyIncludePeriodEnd)
                 {
-                    pr = SetInclusivePeriodEnd(pr);
+                    pr = MergedParserUtil.SetInclusivePeriodEnd(pr);
                 }
             }
 
@@ -564,447 +326,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             return pr;
         }
 
-        public List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
-        {
-            return candidateResults;
-        }
-
-        public DateTimeParseResult SetParseResult(DateTimeParseResult slot, bool hasMod)
-        {
-            slot.Value = DateTimeResolution(slot);
-
-            // Change the type at last for the after or before modes
-            slot.Type = $"{ParserTypeName}.{DetermineDateTimeType(slot.Type, hasMod)}";
-            return slot;
-        }
-
-        public string DetermineDateTimeType(string type, bool hasMod)
-        {
-            if ((Config.Options & DateTimeOptions.SplitDateAndTime) != 0)
-            {
-                if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
-                {
-                    return Constants.SYS_DATETIME_TIME;
-                }
-            }
-            else
-            {
-                if (hasMod)
-                {
-                    if (type.Equals(Constants.SYS_DATETIME_DATE, StringComparison.Ordinal))
-                    {
-                        return Constants.SYS_DATETIME_DATEPERIOD;
-                    }
-
-                    if (type.Equals(Constants.SYS_DATETIME_TIME, StringComparison.Ordinal))
-                    {
-                        return Constants.SYS_DATETIME_TIMEPERIOD;
-                    }
-
-                    if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
-                    {
-                        return Constants.SYS_DATETIME_DATETIMEPERIOD;
-                    }
-                }
-            }
-
-            return type;
-        }
-
-        public List<DateTimeParseResult> DateTimeResolutionForSplit(DateTimeParseResult slot)
-        {
-            var results = new List<DateTimeParseResult>();
-            if (((DateTimeResolutionResult)slot.Value).SubDateTimeEntities != null)
-            {
-                var subEntities = ((DateTimeResolutionResult)slot.Value).SubDateTimeEntities;
-                foreach (var subEntity in subEntities)
-                {
-                    var result = (DateTimeParseResult)subEntity;
-                    result.Start += slot.Start;
-                    results.AddRange(DateTimeResolutionForSplit(result));
-                }
-            }
-            else
-            {
-                slot.Value = DateTimeResolution(slot);
-                slot.Type = $"{ParserTypeName}.{DetermineDateTimeType(slot.Type, hasMod: false)}";
-                results.Add(slot);
-            }
-
-            return results;
-        }
-
-        public SortedDictionary<string, object> DateTimeResolution(DateTimeParseResult slot)
-        {
-            if (slot == null)
-            {
-                return null;
-            }
-
-            var resolutions = new List<Dictionary<string, string>>();
-            var res = new Dictionary<string, object>();
-
-            var type = slot.Type;
-            var timex = slot.TimexStr;
-
-            var val = (DateTimeResolutionResult)slot.Value;
-            if (val == null)
-            {
-                return null;
-            }
-
-            var isLunar = val.IsLunar;
-            var mod = val.Mod;
-            string list = null;
-
-            // Resolve dates list for date periods
-            if (slot.Type.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal) && val.List != null)
-            {
-                list = string.Join(",", val.List.Select(o => DateTimeFormatUtil.LuisDate((DateObject)o)).ToArray());
-            }
-
-            // With modifier, output Type might not be the same with type in resolution result
-            // For example, if the resolution type is "date", with modifier the output type should be "daterange"
-            var typeOutput = DetermineDateTimeType(slot.Type, hasMod: !string.IsNullOrEmpty(mod));
-
-            var sourceEntity = DetermineSourceEntityType(slot.Type, typeOutput, val.HasRangeChangingMod);
-
-            var comment = val.Comment;
-
-            // The following should be added to res first, since ResolveAmPm requires these fields.
-            AddResolutionFields(res, DateTimeResolutionKey.Timex, timex);
-            AddResolutionFields(res, Constants.Comment, comment);
-            AddResolutionFields(res, DateTimeResolutionKey.Mod, mod);
-            AddResolutionFields(res, ResolutionKey.Type, typeOutput);
-            AddResolutionFields(res, DateTimeResolutionKey.IsLunar, isLunar ? isLunar.ToString(CultureInfo.InvariantCulture) : string.Empty);
-
-            var hasTimeZone = false;
-
-            // For standalone timezone entity recognition, we generate TimeZoneResolution for each entity we extracted.
-            // We also merge time entity with timezone entity and add the information in TimeZoneResolution to every DateTime resolutions.
-            if (val.TimeZoneResolution != null)
-            {
-                if (slot.Type.Equals(Constants.SYS_DATETIME_TIMEZONE, StringComparison.Ordinal))
-                {
-                    // single timezone
-                    AddResolutionFields(res, Constants.ResolveTimeZone, new Dictionary<string, string>
-                    {
-                        { ResolutionKey.Value, val.TimeZoneResolution.Value },
-                        { Constants.UtcOffsetMinsKey, val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture) },
-                    });
-                }
-                else
-                {
-                    // timezone as clarification of datetime
-                    hasTimeZone = true;
-                    AddResolutionFields(res, Constants.TimeZone, val.TimeZoneResolution.Value);
-                    AddResolutionFields(res, Constants.TimeZoneText, val.TimeZoneResolution.TimeZoneText);
-                    AddResolutionFields(res, Constants.UtcOffsetMinsKey,
-                                        val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture));
-                }
-            }
-
-            var pastResolutionStr = ((DateTimeResolutionResult)slot.Value).PastResolution;
-            var futureResolutionStr = ((DateTimeResolutionResult)slot.Value).FutureResolution;
-
-            if (typeOutput == Constants.SYS_DATETIME_DATETIMEALT && pastResolutionStr.Count > 0)
-            {
-                typeOutput = DetermineResolutionDateTimeType(pastResolutionStr);
-            }
-
-            var resolutionPast = GenerateResolution(type, pastResolutionStr, mod);
-            var resolutionFuture = GenerateResolution(type, futureResolutionStr, mod);
-
-            // If past and future are same, keep only one
-            if (resolutionFuture.OrderBy(t => t.Key).Select(t => t.Value)
-                .SequenceEqual(resolutionPast.OrderBy(t => t.Key).Select(t => t.Value)))
-            {
-                if (resolutionPast.Count > 0)
-                {
-                    AddResolutionFields(res, Constants.Resolve, resolutionPast);
-                }
-            }
-            else
-            {
-                if (resolutionPast.Count > 0)
-                {
-                    AddResolutionFields(res, Constants.ResolveToPast, resolutionPast);
-                }
-
-                if (resolutionFuture.Count > 0)
-                {
-                    AddResolutionFields(res, Constants.ResolveToFuture, resolutionFuture);
-                }
-            }
-
-            // If 'ampm', double our resolution accordingly
-            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_AmPm, StringComparison.Ordinal))
-            {
-                if (res.ContainsKey(Constants.Resolve))
-                {
-                    ResolveAmpm(res, Constants.Resolve);
-                }
-                else
-                {
-                    ResolveAmpm(res, Constants.ResolveToPast);
-                    ResolveAmpm(res, Constants.ResolveToFuture);
-                }
-            }
-
-            // If WeekOf and in CalendarMode, modify the past part of our resolution
-            if ((Config.Options & DateTimeOptions.CalendarMode) != 0 &&
-                !string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_WeekOf, StringComparison.Ordinal))
-            {
-                ResolveWeekOf(res, Constants.ResolveToPast);
-            }
-
-            if (!string.IsNullOrEmpty(comment) && TimexUtility.HasDoubleTimex(comment))
-            {
-                TimexUtility.ProcessDoubleTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
-            }
-
-            foreach (var p in res)
-            {
-                if (p.Value is Dictionary<string, string> dictionary)
-                {
-                    var value = new Dictionary<string, string>();
-
-                    AddResolutionFields(value, DateTimeResolutionKey.Timex, timex);
-                    AddResolutionFields(value, DateTimeResolutionKey.Mod, mod);
-                    AddResolutionFields(value, ResolutionKey.Type, typeOutput);
-                    AddResolutionFields(value, DateTimeResolutionKey.IsLunar,
-                                        isLunar ? isLunar.ToString(CultureInfo.InvariantCulture) : string.Empty);
-                    AddResolutionFields(value, DateTimeResolutionKey.List, list);
-                    AddResolutionFields(value, DateTimeResolutionKey.SourceEntity, sourceEntity);
-
-                    if (hasTimeZone)
-                    {
-                        AddResolutionFields(value, Constants.TimeZone, val.TimeZoneResolution.Value);
-                        AddResolutionFields(value, Constants.TimeZoneText, val.TimeZoneResolution.TimeZoneText);
-                        AddResolutionFields(value, Constants.UtcOffsetMinsKey,
-                                            val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture));
-                    }
-
-                    foreach (var q in dictionary)
-                    {
-                        value[q.Key] = q.Value;
-                    }
-
-                    resolutions.Add(value);
-                }
-            }
-
-            if (resolutionPast.Count == 0 && resolutionFuture.Count == 0 && val.TimeZoneResolution == null)
-            {
-                var notResolved = new Dictionary<string, string>
-                {
-                    {
-                        DateTimeResolutionKey.Timex, timex
-                    },
-                    {
-                        ResolutionKey.Type, typeOutput
-                    },
-                    {
-                        ResolutionKey.Value, "not resolved"
-                    },
-                };
-
-                resolutions.Add(notResolved);
-            }
-
-            return new SortedDictionary<string, object> { { ResolutionKey.ValueSet, resolutions } };
-        }
-
-        internal static void AddResolutionFields(Dictionary<string, string> dic, string key, string value)
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                dic.Add(key, value);
-            }
-        }
-
-        internal static void AddResolutionFields(Dictionary<string, object> dic, string key, object value)
-        {
-            if (value != null)
-            {
-                dic.Add(key, value);
-            }
-        }
-
-        internal static void ResolveAmpm(Dictionary<string, object> resolutionDic, string keyName)
-        {
-            if (resolutionDic.ContainsKey(keyName))
-            {
-                var resolution = (Dictionary<string, string>)resolutionDic[keyName];
-                var resolutionPm = new Dictionary<string, string>();
-
-                if (!resolutionDic.ContainsKey(DateTimeResolutionKey.Timex))
-                {
-                    return;
-                }
-
-                var timex = (string)resolutionDic[DateTimeResolutionKey.Timex];
-
-                resolutionDic.Remove(keyName);
-                resolutionDic.Add(keyName + "Am", resolution);
-
-                switch ((string)resolutionDic[ResolutionKey.Type])
-                {
-                    case Constants.SYS_DATETIME_TIME:
-                        resolutionPm[ResolutionKey.Value] = DateTimeFormatUtil.ToPm(resolution[ResolutionKey.Value]);
-                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.ToPm(timex);
-                        break;
-
-                    case Constants.SYS_DATETIME_DATETIME:
-                        var split = resolution[ResolutionKey.Value].Split(' ');
-                        resolutionPm[ResolutionKey.Value] = split[0] + " " + DateTimeFormatUtil.ToPm(split[1]);
-                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
-                        break;
-
-                    case Constants.SYS_DATETIME_TIMEPERIOD:
-                        if (resolution.ContainsKey(DateTimeResolutionKey.Start))
-                        {
-                            resolutionPm[DateTimeResolutionKey.Start] = DateTimeFormatUtil.ToPm(resolution[DateTimeResolutionKey.Start]);
-                        }
-
-                        if (resolution.ContainsKey(DateTimeResolutionKey.End))
-                        {
-                            resolutionPm[DateTimeResolutionKey.End] = DateTimeFormatUtil.ToPm(resolution[DateTimeResolutionKey.End]);
-                        }
-
-                        if (resolution.ContainsKey(DateTimeResolutionKey.Value))
-                        {
-                            resolutionPm[ResolutionKey.Value] = DateTimeFormatUtil.ToPm(resolution[ResolutionKey.Value]);
-                        }
-
-                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
-                        break;
-
-                    case Constants.SYS_DATETIME_DATETIMEPERIOD:
-                        if (resolution.ContainsKey(DateTimeResolutionKey.Start))
-                        {
-                            var start = Convert.ToDateTime(resolution[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
-                            start = start.Hour == Constants.HalfDayHourCount ?
-                                start.AddHours(-Constants.HalfDayHourCount) : start.AddHours(Constants.HalfDayHourCount);
-
-                            resolutionPm[DateTimeResolutionKey.Start] = DateTimeFormatUtil.FormatDateTime(start);
-                        }
-
-                        if (resolution.ContainsKey(DateTimeResolutionKey.End))
-                        {
-                            var end = Convert.ToDateTime(resolution[DateTimeResolutionKey.End], CultureInfo.InvariantCulture);
-                            end = end.Hour == Constants.HalfDayHourCount ?
-                                end.AddHours(-Constants.HalfDayHourCount) : end.AddHours(Constants.HalfDayHourCount);
-
-                            resolutionPm[DateTimeResolutionKey.End] = DateTimeFormatUtil.FormatDateTime(end);
-                        }
-
-                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
-                        break;
-                }
-
-                resolutionDic.Add(keyName + "Pm", resolutionPm);
-            }
-        }
-
-        internal static void ResolveWeekOf(Dictionary<string, object> resolutionDic, string keyName)
-        {
-            if (resolutionDic.ContainsKey(keyName))
-            {
-                var resolution = (Dictionary<string, string>)resolutionDic[keyName];
-
-                var monday = DateObject.Parse(resolution[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
-                resolution[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.ToIsoWeekTimex(monday);
-
-                resolutionDic.Remove(keyName);
-                resolutionDic.Add(keyName, resolution);
-            }
-        }
-
-        internal static Dictionary<string, string> GenerateResolution(string type, Dictionary<string, string> resolutionDic, string mod)
-        {
-            var res = new Dictionary<string, string>();
-
-            if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIME, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_TIME, StringComparison.Ordinal))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.TIME, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_DATE, StringComparison.Ordinal))
-            {
-                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATE, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_DURATION, StringComparison.Ordinal))
-            {
-                if (resolutionDic.ContainsKey(TimeTypeConstants.DURATION))
-                {
-                    res.Add(ResolutionKey.Value, resolutionDic[TimeTypeConstants.DURATION]);
-                }
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_TIMEPERIOD, StringComparison.Ordinal))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_TIME, TimeTypeConstants.END_TIME, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATE, TimeTypeConstants.END_DATE, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_DATETIMEPERIOD, StringComparison.Ordinal))
-            {
-                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATETIME, TimeTypeConstants.END_DATETIME, mod, res);
-            }
-            else if (type.Equals(Constants.SYS_DATETIME_DATETIMEALT, StringComparison.Ordinal))
-            {
-                // For a period
-                if (resolutionDic.Count > 2 || !string.IsNullOrEmpty(mod))
-                {
-                    AddAltPeriodToResolution(resolutionDic, mod, res);
-                }
-                else
-                {
-                    // For a datetime point
-                    AddAltSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIMEALT, mod, res);
-                }
-            }
-
-            return res;
-        }
-
-        private static string CombineMod(string originalMod, string newMod)
-        {
-            var combinedMod = newMod;
-
-            if (!string.IsNullOrEmpty(originalMod) && !originalMod.Equals(newMod, StringComparison.Ordinal))
-            {
-                combinedMod = $"{newMod}-{originalMod}";
-            }
-
-            return combinedMod;
-        }
-
-        private static string DetermineResolutionDateTimeType(Dictionary<string, string> pastResolutionStr)
-        {
-            switch (pastResolutionStr.Keys.First())
-            {
-                case TimeTypeConstants.START_DATE:
-                    return Constants.SYS_DATETIME_DATEPERIOD;
-
-                case TimeTypeConstants.START_DATETIME:
-                    return Constants.SYS_DATETIME_DATETIMEPERIOD;
-
-                case TimeTypeConstants.START_TIME:
-                    return Constants.SYS_DATETIME_TIMEPERIOD;
-
-                default:
-                    // ToLowerInvariant needed for legacy reasons with subtype code.
-                    // @TODO remove in future refactoring of test code and double-check there's no impact in output schema.
-                    return pastResolutionStr.Keys.First().ToLowerInvariant();
-            }
-        }
-
+        // @TODO move to MergedParserUtil (if possible)
         private DateTimeParseResult ParseResult(ExtractResult extractResult, DateObject referenceTime)
         {
             DateTimeParseResult parseResult = null;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MergedParserUtil.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/MergedParserUtil.cs
@@ -1,0 +1,725 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Recognizers.Text.Utilities;
+using DateObject = System.DateTime;
+
+namespace Microsoft.Recognizers.Text.DateTime
+{
+    public static class MergedParserUtil
+    {
+        public const string ParserTypeName = "datetimeV2";
+
+        public static readonly string DateMinString = DateTimeFormatUtil.FormatDate(DateObject.MinValue);
+
+        public static List<DateTimeParseResult> FilterResults(string query, List<DateTimeParseResult> candidateResults)
+        {
+            return candidateResults;
+        }
+
+        public static string CombineMod(string originalMod, string newMod)
+        {
+            var combinedMod = newMod;
+
+            if (!string.IsNullOrEmpty(originalMod))
+            {
+                combinedMod = $"{newMod}-{originalMod}";
+            }
+
+            return combinedMod;
+        }
+
+        public static bool IsDurationWithAgoAndLater(ExtractResult er)
+        {
+            return er.Metadata != null && er.Metadata.IsDurationWithAgoAndLater;
+        }
+
+        public static void AddSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type, string mod,
+                                                         Dictionary<string, string> res)
+        {
+
+            // If an "invalid" Date or DateTime is extracted, it should not have an assigned resolution.
+            // Only valid entities should pass this condition.
+            if (resolutionDic.ContainsKey(type) &&
+                !resolutionDic[type].StartsWith(DateMinString, StringComparison.Ordinal))
+            {
+                if (!string.IsNullOrEmpty(mod))
+                {
+                    if (mod.StartsWith(Constants.BEFORE_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.End, resolutionDic[type]);
+                        return;
+                    }
+
+                    if (mod.StartsWith(Constants.AFTER_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.Start, resolutionDic[type]);
+                        return;
+                    }
+
+                    if (mod.StartsWith(Constants.SINCE_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.Start, resolutionDic[type]);
+                        return;
+                    }
+
+                    if (mod.StartsWith(Constants.UNTIL_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.End, resolutionDic[type]);
+                        return;
+                    }
+                }
+
+                res.Add(ResolutionKey.Value, resolutionDic[type]);
+            }
+        }
+
+        public static void AddPeriodToResolution(Dictionary<string, string> resolutionDic, string startType, string endType, string mod,
+                                                 Dictionary<string, string> res)
+        {
+            var start = string.Empty;
+            var end = string.Empty;
+
+            if (resolutionDic.ContainsKey(startType))
+            {
+                start = resolutionDic[startType];
+                if (start.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+
+            if (resolutionDic.ContainsKey(endType))
+            {
+                end = resolutionDic[endType];
+                if (end.Equals(Constants.InvalidDateString, StringComparison.Ordinal))
+                {
+                    return;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(mod))
+            {
+                // For the 'before' mod
+                // 1. Cases like "Before December", the start of the period should be the end of the new period, not the start
+                // (but not for cases like "Before the end of December")
+                // 2. Cases like "More than 3 days before today", the date point should be the end of the new period
+                if (mod.StartsWith(Constants.BEFORE_MOD, StringComparison.Ordinal))
+                {
+                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.LATE_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.End, start);
+                    }
+                    else
+                    {
+                        res.Add(DateTimeResolutionKey.End, end);
+                    }
+
+                    return;
+                }
+
+                // For the 'after' mod
+                // 1. Cases like "After January", the end of the period should be the start of the new period, not the end
+                // (but not for cases like "After the beginning of January")
+                // 2. Cases like "More than 3 days after today", the date point should be the start of the new period
+                if (mod.StartsWith(Constants.AFTER_MOD, StringComparison.Ordinal))
+                {
+                    if (!string.IsNullOrEmpty(start) && !string.IsNullOrEmpty(end) && !mod.EndsWith(Constants.EARLY_MOD, StringComparison.Ordinal))
+                    {
+                        res.Add(DateTimeResolutionKey.Start, end);
+                    }
+                    else
+                    {
+                        res.Add(DateTimeResolutionKey.Start, start);
+                    }
+
+                    return;
+                }
+
+                // For the 'since' mod, the start of the period should be the start of the new period, not the end
+                if (mod.StartsWith(Constants.SINCE_MOD, StringComparison.Ordinal))
+                {
+                    res.Add(DateTimeResolutionKey.Start, start);
+                    return;
+                }
+
+                // For the 'until' mod, the end of the period should be the end of the new period, not the start
+                if (mod.StartsWith(Constants.UNTIL_MOD, StringComparison.Ordinal))
+                {
+                    res.Add(DateTimeResolutionKey.End, end);
+                    return;
+                }
+            }
+
+            if (!AreUnresolvedDates(start, end))
+            {
+                res.Add(DateTimeResolutionKey.Start, start);
+                res.Add(DateTimeResolutionKey.End, end);
+            }
+        }
+
+        public static void AddAltPeriodToResolution(Dictionary<string, string> resolutionDic, string mod, Dictionary<string, string> res)
+        {
+            if (resolutionDic.ContainsKey(TimeTypeConstants.START_DATETIME) || resolutionDic.ContainsKey(TimeTypeConstants.END_DATETIME))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATETIME, TimeTypeConstants.END_DATETIME, mod, res);
+            }
+            else if (resolutionDic.ContainsKey(TimeTypeConstants.START_DATE) || resolutionDic.ContainsKey(TimeTypeConstants.END_DATE))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATE, TimeTypeConstants.END_DATE, mod, res);
+            }
+            else if (resolutionDic.ContainsKey(TimeTypeConstants.START_TIME) || resolutionDic.ContainsKey(TimeTypeConstants.END_TIME))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_TIME, TimeTypeConstants.END_TIME, mod, res);
+            }
+        }
+
+        public static void AddAltSingleDateTimeToResolution(Dictionary<string, string> resolutionDic, string type, string mod,
+                                                            Dictionary<string, string> res)
+        {
+            if (resolutionDic.ContainsKey(TimeTypeConstants.DATE))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATE, mod, res);
+            }
+            else if (resolutionDic.ContainsKey(TimeTypeConstants.DATETIME))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIME, mod, res);
+            }
+            else if (resolutionDic.ContainsKey(TimeTypeConstants.TIME))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.TIME, mod, res);
+            }
+        }
+
+        public static bool AreUnresolvedDates(string startDate, string endDate)
+        {
+            return string.IsNullOrEmpty(startDate) || string.IsNullOrEmpty(endDate) ||
+                   startDate.StartsWith(DateMinString, StringComparison.Ordinal) ||
+                   endDate.StartsWith(DateMinString, StringComparison.Ordinal);
+        }
+
+        public static string GenerateEndInclusiveTimex(string originalTimex, DatePeriodTimexType datePeriodTimexType,
+                                                       DateObject startDate, DateObject endDate)
+        {
+
+            var timexEndInclusive = TimexUtility.GenerateDatePeriodTimex(startDate, endDate, datePeriodTimexType);
+
+            // Sometimes the original timex contains fuzzy part like "XXXX-05-31"
+            // The fuzzy part needs to stay the same in the new end-inclusive timex
+            if (originalTimex.Contains(Constants.TimexFuzzy) && originalTimex.Length == timexEndInclusive.Length)
+            {
+                var timexCharSet = new char[timexEndInclusive.Length];
+
+                for (int i = 0; i < originalTimex.Length; i++)
+                {
+                    if (originalTimex[i] != Constants.TimexFuzzy)
+                    {
+                        timexCharSet[i] = timexEndInclusive[i];
+                    }
+                    else
+                    {
+                        timexCharSet[i] = Constants.TimexFuzzy;
+                    }
+                }
+
+                timexEndInclusive = new string(timexCharSet);
+            }
+
+            return timexEndInclusive;
+        }
+
+        public static DateTimeParseResult SetInclusivePeriodEnd(DateTimeParseResult slot)
+        {
+            if (slot.Type == $"{ParserTypeName}.{Constants.SYS_DATETIME_DATEPERIOD}")
+            {
+                var timexComponents = slot.TimexStr.Split(Constants.DatePeriodTimexSplitter, StringSplitOptions.RemoveEmptyEntries);
+
+                // Only handle DatePeriod like "(StartDate,EndDate,Duration)"
+                if (timexComponents.Length == 3)
+                {
+                    var value = (SortedDictionary<string, object>)slot.Value;
+                    var altTimex = string.Empty;
+
+                    if (value != null && value.ContainsKey(ResolutionKey.ValueSet))
+                    {
+                        if (value[ResolutionKey.ValueSet] is IList<Dictionary<string, string>> valueSet && valueSet.Any())
+                        {
+                            foreach (var values in valueSet)
+                            {
+                                // This is only a sanity check, as here we only handle DatePeriod like "(StartDate,EndDate,Duration)"
+                                if (values.ContainsKey(DateTimeResolutionKey.Start) && values.ContainsKey(DateTimeResolutionKey.End) &&
+                                    values.ContainsKey(DateTimeResolutionKey.Timex))
+                                {
+                                    var startDate = DateObject.Parse(values[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
+                                    var endDate = DateObject.Parse(values[DateTimeResolutionKey.End], CultureInfo.InvariantCulture);
+                                    var durationStr = timexComponents[2];
+                                    var datePeriodTimexType = TimexUtility.GetDatePeriodTimexType(durationStr);
+
+                                    endDate = TimexUtility.OffsetDateObject(endDate, offset: 1, timexType: datePeriodTimexType);
+                                    values[DateTimeResolutionKey.End] = DateTimeFormatUtil.LuisDate(endDate);
+                                    values[DateTimeResolutionKey.Timex] =
+                                        GenerateEndInclusiveTimex(slot.TimexStr, datePeriodTimexType, startDate, endDate);
+
+                                    if (string.IsNullOrEmpty(altTimex))
+                                    {
+                                        altTimex = values[DateTimeResolutionKey.Timex];
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    slot.Value = value;
+                    slot.TimexStr = altTimex;
+                }
+            }
+
+            return slot;
+        }
+
+        public static DateTimeParseResult SetParseResult(DateTimeParseResult slot, bool hasMod, IDateTimeOptionsConfiguration config)
+        {
+            slot.Value = DateTimeResolution(slot, config);
+
+            // Change the type at last for the after or before modes
+            slot.Type = $"{ParserTypeName}.{DetermineDateTimeType(slot.Type, hasMod, config)}";
+            return slot;
+        }
+
+        public static string DetermineDateTimeType(string type, bool hasMod, IDateTimeOptionsConfiguration config)
+        {
+            if ((config.Options & DateTimeOptions.SplitDateAndTime) != 0)
+            {
+                if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
+                {
+                    return Constants.SYS_DATETIME_TIME;
+                }
+            }
+            else
+            {
+                if (hasMod)
+                {
+                    if (type.Equals(Constants.SYS_DATETIME_DATE, StringComparison.Ordinal))
+                    {
+                        return Constants.SYS_DATETIME_DATEPERIOD;
+                    }
+
+                    if (type.Equals(Constants.SYS_DATETIME_TIME, StringComparison.Ordinal))
+                    {
+                        return Constants.SYS_DATETIME_TIMEPERIOD;
+                    }
+
+                    if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
+                    {
+                        return Constants.SYS_DATETIME_DATETIMEPERIOD;
+                    }
+                }
+            }
+
+            return type;
+        }
+
+        public static string DetermineSourceEntityType(string sourceType, string newType, bool hasMod)
+        {
+            if (!hasMod)
+            {
+                return null;
+            }
+
+            if (!newType.Equals(sourceType, StringComparison.Ordinal))
+            {
+                return Constants.SYS_DATETIME_DATETIMEPOINT;
+            }
+
+            if (newType.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal))
+            {
+                return Constants.SYS_DATETIME_DATETIMEPERIOD;
+            }
+
+            return null;
+        }
+
+        public static SortedDictionary<string, object> DateTimeResolution(DateTimeParseResult slot, IDateTimeOptionsConfiguration config)
+        {
+            if (slot == null)
+            {
+                return null;
+            }
+
+            var resolutions = new List<Dictionary<string, string>>();
+            var res = new Dictionary<string, object>();
+
+            var type = slot.Type;
+            var timex = slot.TimexStr;
+
+            var val = (DateTimeResolutionResult)slot.Value;
+            if (val == null)
+            {
+                return null;
+            }
+
+            var isLunar = val.IsLunar;
+            var mod = val.Mod;
+            string list = null;
+
+            // Resolve dates list for date periods
+            if (slot.Type.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal) && val.List != null)
+            {
+                list = string.Join(",", val.List.Select(o => DateTimeFormatUtil.LuisDate((DateObject)o)).ToArray());
+            }
+
+            // With modifier, output Type might not be the same with type in resolution result
+            // For example, if the resolution type is "date", with modifier the output type should be "daterange"
+            var typeOutput = DetermineDateTimeType(slot.Type, hasMod: !string.IsNullOrEmpty(mod), config);
+
+            var sourceEntity = DetermineSourceEntityType(slot.Type, typeOutput, val.HasRangeChangingMod);
+
+            var comment = val.Comment;
+
+            // The following should be added to res first, since ResolveAmPm requires these fields.
+            AddResolutionFields(res, DateTimeResolutionKey.Timex, timex);
+            AddResolutionFields(res, Constants.Comment, comment);
+            AddResolutionFields(res, DateTimeResolutionKey.Mod, mod);
+            AddResolutionFields(res, ResolutionKey.Type, typeOutput);
+            AddResolutionFields(res, DateTimeResolutionKey.IsLunar, isLunar ? isLunar.ToString(CultureInfo.InvariantCulture) : string.Empty);
+
+            var hasTimeZone = false;
+
+            // For standalone timezone entity recognition, we generate TimeZoneResolution for each entity we extracted.
+            // We also merge time entity with timezone entity and add the information in TimeZoneResolution to every DateTime resolutions.
+            if (val.TimeZoneResolution != null)
+            {
+                if (slot.Type.Equals(Constants.SYS_DATETIME_TIMEZONE, StringComparison.Ordinal))
+                {
+                    // single timezone
+                    AddResolutionFields(res, Constants.ResolveTimeZone, new Dictionary<string, string>
+                    {
+                        { ResolutionKey.Value, val.TimeZoneResolution.Value },
+                        { Constants.UtcOffsetMinsKey, val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture) },
+                    });
+                }
+                else
+                {
+                    // timezone as clarification of datetime
+                    hasTimeZone = true;
+                    AddResolutionFields(res, Constants.TimeZone, val.TimeZoneResolution.Value);
+                    AddResolutionFields(res, Constants.TimeZoneText, val.TimeZoneResolution.TimeZoneText);
+                    AddResolutionFields(res, Constants.UtcOffsetMinsKey,
+                                        val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            var pastResolutionStr = ((DateTimeResolutionResult)slot.Value).PastResolution;
+            var futureResolutionStr = ((DateTimeResolutionResult)slot.Value).FutureResolution;
+
+            if (typeOutput == Constants.SYS_DATETIME_DATETIMEALT && pastResolutionStr.Count > 0)
+            {
+                typeOutput = DetermineResolutionDateTimeType(pastResolutionStr);
+            }
+
+            var resolutionPast = GenerateResolution(type, pastResolutionStr, mod);
+            var resolutionFuture = GenerateResolution(type, futureResolutionStr, mod);
+
+            // If past and future are same, keep only one
+            if (resolutionFuture.OrderBy(t => t.Key).Select(t => t.Value)
+                .SequenceEqual(resolutionPast.OrderBy(t => t.Key).Select(t => t.Value)))
+            {
+                if (resolutionPast.Count > 0)
+                {
+                    AddResolutionFields(res, Constants.Resolve, resolutionPast);
+                }
+            }
+            else
+            {
+                if (resolutionPast.Count > 0)
+                {
+                    AddResolutionFields(res, Constants.ResolveToPast, resolutionPast);
+                }
+
+                if (resolutionFuture.Count > 0)
+                {
+                    AddResolutionFields(res, Constants.ResolveToFuture, resolutionFuture);
+                }
+            }
+
+            // If 'ampm', double our resolution accordingly
+            if (!string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_AmPm, StringComparison.Ordinal))
+            {
+                if (res.ContainsKey(Constants.Resolve))
+                {
+                    ResolveAmpm(res, Constants.Resolve);
+                }
+                else
+                {
+                    ResolveAmpm(res, Constants.ResolveToPast);
+                    ResolveAmpm(res, Constants.ResolveToFuture);
+                }
+            }
+
+            // If WeekOf and in CalendarMode, modify the past part of our resolution
+            if ((config.Options & DateTimeOptions.CalendarMode) != 0 &&
+                !string.IsNullOrEmpty(comment) && comment.Equals(Constants.Comment_WeekOf, StringComparison.Ordinal))
+            {
+                ResolveWeekOf(res, Constants.ResolveToPast);
+            }
+
+            if (!string.IsNullOrEmpty(comment) && TimexUtility.HasDoubleTimex(comment))
+            {
+                TimexUtility.ProcessDoubleTimex(res, Constants.ResolveToFuture, Constants.ResolveToPast, timex);
+            }
+
+            foreach (var p in res)
+            {
+                if (p.Value is Dictionary<string, string> dictionary)
+                {
+                    var value = new Dictionary<string, string>();
+
+                    AddResolutionFields(value, DateTimeResolutionKey.Timex, timex);
+                    AddResolutionFields(value, DateTimeResolutionKey.Mod, mod);
+                    AddResolutionFields(value, ResolutionKey.Type, typeOutput);
+                    AddResolutionFields(value, DateTimeResolutionKey.IsLunar,
+                                        isLunar ? isLunar.ToString(CultureInfo.InvariantCulture) : string.Empty);
+                    AddResolutionFields(value, DateTimeResolutionKey.List, list);
+                    AddResolutionFields(value, DateTimeResolutionKey.SourceEntity, sourceEntity);
+
+                    if (hasTimeZone)
+                    {
+                        AddResolutionFields(value, Constants.TimeZone, val.TimeZoneResolution.Value);
+                        AddResolutionFields(value, Constants.TimeZoneText, val.TimeZoneResolution.TimeZoneText);
+                        AddResolutionFields(value, Constants.UtcOffsetMinsKey,
+                                            val.TimeZoneResolution.UtcOffsetMins.ToString(CultureInfo.InvariantCulture));
+                    }
+
+                    foreach (var q in dictionary)
+                    {
+                        value[q.Key] = q.Value;
+                    }
+
+                    resolutions.Add(value);
+                }
+            }
+
+            if (resolutionPast.Count == 0 && resolutionFuture.Count == 0 && val.TimeZoneResolution == null)
+            {
+                var notResolved = new Dictionary<string, string>
+                {
+                    {
+                        DateTimeResolutionKey.Timex, timex
+                    },
+                    {
+                        ResolutionKey.Type, typeOutput
+                    },
+                    {
+                        ResolutionKey.Value, "not resolved"
+                    },
+                };
+
+                resolutions.Add(notResolved);
+            }
+
+            return new SortedDictionary<string, object> { { ResolutionKey.ValueSet, resolutions } };
+        }
+
+        public static List<DateTimeParseResult> DateTimeResolutionForSplit(DateTimeParseResult slot, IDateTimeOptionsConfiguration config)
+        {
+            var results = new List<DateTimeParseResult>();
+            if (((DateTimeResolutionResult)slot.Value).SubDateTimeEntities != null)
+            {
+                var subEntities = ((DateTimeResolutionResult)slot.Value).SubDateTimeEntities;
+                foreach (var subEntity in subEntities)
+                {
+                    var result = (DateTimeParseResult)subEntity;
+                    result.Start += slot.Start;
+                    results.AddRange(DateTimeResolutionForSplit(result, config));
+                }
+            }
+            else
+            {
+                slot.Value = DateTimeResolution(slot, config);
+                slot.Type = $"{ParserTypeName}.{DetermineDateTimeType(slot.Type, hasMod: false, config)}";
+                results.Add(slot);
+            }
+
+            return results;
+        }
+
+        internal static void AddResolutionFields(Dictionary<string, string> dic, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                dic.Add(key, value);
+            }
+        }
+
+        internal static void AddResolutionFields(Dictionary<string, object> dic, string key, object value)
+        {
+            if (value != null)
+            {
+                dic.Add(key, value);
+            }
+        }
+
+        internal static void ResolveAmpm(Dictionary<string, object> resolutionDic, string keyName)
+        {
+            if (resolutionDic.ContainsKey(keyName))
+            {
+                var resolution = (Dictionary<string, string>)resolutionDic[keyName];
+                var resolutionPm = new Dictionary<string, string>();
+
+                if (!resolutionDic.ContainsKey(DateTimeResolutionKey.Timex))
+                {
+                    return;
+                }
+
+                var timex = (string)resolutionDic[DateTimeResolutionKey.Timex];
+
+                resolutionDic.Remove(keyName);
+                resolutionDic.Add(keyName + "Am", resolution);
+
+                switch ((string)resolutionDic[ResolutionKey.Type])
+                {
+                    case Constants.SYS_DATETIME_TIME:
+                        resolutionPm[ResolutionKey.Value] = DateTimeFormatUtil.ToPm(resolution[ResolutionKey.Value]);
+                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.ToPm(timex);
+                        break;
+
+                    case Constants.SYS_DATETIME_DATETIME:
+                        var split = resolution[ResolutionKey.Value].Split(' ');
+                        resolutionPm[ResolutionKey.Value] = split[0] + " " + DateTimeFormatUtil.ToPm(split[1]);
+                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
+                        break;
+
+                    case Constants.SYS_DATETIME_TIMEPERIOD:
+                        if (resolution.ContainsKey(DateTimeResolutionKey.Start))
+                        {
+                            resolutionPm[DateTimeResolutionKey.Start] = DateTimeFormatUtil.ToPm(resolution[DateTimeResolutionKey.Start]);
+                        }
+
+                        if (resolution.ContainsKey(DateTimeResolutionKey.End))
+                        {
+                            resolutionPm[DateTimeResolutionKey.End] = DateTimeFormatUtil.ToPm(resolution[DateTimeResolutionKey.End]);
+                        }
+
+                        if (resolution.ContainsKey(DateTimeResolutionKey.Value))
+                        {
+                            resolutionPm[ResolutionKey.Value] = DateTimeFormatUtil.ToPm(resolution[ResolutionKey.Value]);
+                        }
+
+                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
+                        break;
+
+                    case Constants.SYS_DATETIME_DATETIMEPERIOD:
+                        if (resolution.ContainsKey(DateTimeResolutionKey.Start))
+                        {
+                            var start = Convert.ToDateTime(resolution[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
+                            start = start.Hour == Constants.HalfDayHourCount ?
+                                start.AddHours(-Constants.HalfDayHourCount) : start.AddHours(Constants.HalfDayHourCount);
+
+                            resolutionPm[DateTimeResolutionKey.Start] = DateTimeFormatUtil.FormatDateTime(start);
+                        }
+
+                        if (resolution.ContainsKey(DateTimeResolutionKey.End))
+                        {
+                            var end = Convert.ToDateTime(resolution[DateTimeResolutionKey.End], CultureInfo.InvariantCulture);
+                            end = end.Hour == Constants.HalfDayHourCount ?
+                                end.AddHours(-Constants.HalfDayHourCount) : end.AddHours(Constants.HalfDayHourCount);
+
+                            resolutionPm[DateTimeResolutionKey.End] = DateTimeFormatUtil.FormatDateTime(end);
+                        }
+
+                        resolutionPm[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.AllStringToPm(timex);
+                        break;
+                }
+
+                resolutionDic.Add(keyName + "Pm", resolutionPm);
+            }
+        }
+
+        internal static void ResolveWeekOf(Dictionary<string, object> resolutionDic, string keyName)
+        {
+            if (resolutionDic.ContainsKey(keyName))
+            {
+                var resolution = (Dictionary<string, string>)resolutionDic[keyName];
+
+                var monday = DateObject.Parse(resolution[DateTimeResolutionKey.Start], CultureInfo.InvariantCulture);
+                resolution[DateTimeResolutionKey.Timex] = DateTimeFormatUtil.ToIsoWeekTimex(monday);
+
+                resolutionDic.Remove(keyName);
+                resolutionDic.Add(keyName, resolution);
+            }
+        }
+
+        internal static Dictionary<string, string> GenerateResolution(string type, Dictionary<string, string> resolutionDic, string mod)
+        {
+            var res = new Dictionary<string, string>();
+
+            if (type.Equals(Constants.SYS_DATETIME_DATETIME, StringComparison.Ordinal))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIME, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_TIME, StringComparison.Ordinal))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.TIME, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_DATE, StringComparison.Ordinal))
+            {
+                AddSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATE, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_DURATION, StringComparison.Ordinal))
+            {
+                if (resolutionDic.ContainsKey(TimeTypeConstants.DURATION))
+                {
+                    res.Add(ResolutionKey.Value, resolutionDic[TimeTypeConstants.DURATION]);
+                }
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_TIMEPERIOD, StringComparison.Ordinal))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_TIME, TimeTypeConstants.END_TIME, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_DATEPERIOD, StringComparison.Ordinal))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATE, TimeTypeConstants.END_DATE, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_DATETIMEPERIOD, StringComparison.Ordinal))
+            {
+                AddPeriodToResolution(resolutionDic, TimeTypeConstants.START_DATETIME, TimeTypeConstants.END_DATETIME, mod, res);
+            }
+            else if (type.Equals(Constants.SYS_DATETIME_DATETIMEALT, StringComparison.Ordinal))
+            {
+                // for a period
+                if (resolutionDic.Count > 2 || !string.IsNullOrEmpty(mod))
+                {
+                    AddAltPeriodToResolution(resolutionDic, mod, res);
+                }
+                else
+                {
+                    // for a datetime point
+                    AddAltSingleDateTimeToResolution(resolutionDic, TimeTypeConstants.DATETIMEALT, mod, res);
+                }
+            }
+
+            return res;
+        }
+
+        private static string DetermineResolutionDateTimeType(Dictionary<string, string> pastResolutionStr)
+        {
+            switch (pastResolutionStr.Keys.First())
+            {
+                case TimeTypeConstants.START_DATE:
+                    return Constants.SYS_DATETIME_DATEPERIOD;
+
+                case TimeTypeConstants.START_DATETIME:
+                    return Constants.SYS_DATETIME_DATETIMEPERIOD;
+
+                case TimeTypeConstants.START_TIME:
+                    return Constants.SYS_DATETIME_TIMEPERIOD;
+
+                default:
+                    // ToLowerInvariant needed for legacy reasons with subtype code.
+                    // @TODO remove in future refactoring of test code and double-check there's no impact in output schema.
+                    return pastResolutionStr.Keys.First().ToLowerInvariant();
+            }
+        }
+    }
+}

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -225,6 +225,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "农历2015年十月初一",
@@ -234,6 +235,7 @@
             {
               "timex": "2015-10-01",
               "type": "date",
+              "isLunar": "True",
               "value": "2015-10-01"
             }
           ]
@@ -248,6 +250,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "正月三十",
@@ -257,11 +260,13 @@
             {
               "timex": "XXXX-01-30",
               "type": "date",
+              "isLunar": "True",
               "value": "2017-01-30"
             },
             {
               "timex": "XXXX-01-30",
               "type": "date",
+              "isLunar": "True",
               "value": "2018-01-30"
             }
           ]
@@ -645,6 +650,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "2015年十月初一早上九点二十",
@@ -654,6 +660,7 @@
             {
               "timex": "2015-10-01T09:20",
               "type": "datetime",
+              "isLunar": "True",
               "value": "2015-10-01 09:20:00"
             }
           ]
@@ -3856,7 +3863,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-03-01"
+              "start": "2016-03-01"
             }
           ]
         }
@@ -3882,7 +3889,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -3934,7 +3941,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-14"
+              "start": "2014-06-14"
             }
           ]
         }
@@ -3977,7 +3984,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-08-06"
+              "start": "2019-08-06"
             }
           ]
         }
@@ -4018,7 +4025,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
+              "end": "2010-01-10"
             }
           ]
         }
@@ -4059,7 +4066,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
@@ -4076,7 +4083,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "start": "2012-01-01"
             }
           ]
         }
@@ -4102,7 +4109,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "end": "2012-01-01"
             }
           ]
         }
@@ -4145,7 +4152,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
+              "start": "2010-01-10"
             }
           ]
         }
@@ -4188,7 +4195,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -4248,7 +4255,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "end": "2019-04-05"
             }
           ]
         }
@@ -4274,7 +4281,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
@@ -4317,7 +4324,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-04"
+              "start": "2014-06-04"
             }
           ]
         }
@@ -4334,7 +4341,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-08-16"
+              "end": "2009-08-16"
             }
           ]
         }
@@ -4360,7 +4367,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-03-22"
+              "end": "2011-03-22"
             }
           ]
         }
@@ -4403,7 +4410,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -4429,7 +4436,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -4455,7 +4462,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
@@ -4530,7 +4537,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
@@ -4571,7 +4578,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-09-01"
+              "start": "2016-09-01"
             }
           ]
         }
@@ -4614,7 +4621,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -4674,7 +4681,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -4717,7 +4724,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "end": "2019-04-05"
             }
           ]
         }
@@ -4743,7 +4750,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
@@ -4801,7 +4808,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-12-01"
+              "start": "2016-12-01"
             }
           ]
         }
@@ -4842,7 +4849,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -4868,7 +4875,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-05-05"
+              "end": "2019-05-05"
             }
           ]
         }
@@ -4909,7 +4916,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-01-01"
+              "start": "2019-01-01"
             }
           ]
         }
@@ -4935,7 +4942,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "start": "2010-01-04"
             }
           ]
         }
@@ -4961,7 +4968,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-09-01"
+              "start": "2009-09-01"
             }
           ]
         }
@@ -4987,7 +4994,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -5013,7 +5020,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -5039,7 +5046,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-01-01"
+              "start": "2019-01-01"
             }
           ]
         }
@@ -5065,7 +5072,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
@@ -5091,7 +5098,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -5117,7 +5124,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-11"
+              "end": "2019-11-11"
             }
           ]
         }
@@ -5158,7 +5165,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-07"
+              "end": "2012-01-07"
             }
           ]
         }
@@ -5184,7 +5191,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "end": "2013-01-01"
+              "end": "2014-01-01"
             }
           ]
         }
@@ -5210,7 +5217,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2018-07-09"
+              "end": "2018-07-09"
             }
           ]
         }
@@ -5236,7 +5243,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -5262,7 +5269,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-09-14"
+              "end": "2019-09-14"
             }
           ]
         }
@@ -5288,7 +5295,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-09"
+              "end": "2019-11-09"
             }
           ]
         }
@@ -5314,7 +5321,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-01-10"
+              "end": "2011-01-10"
             }
           ]
         }
@@ -5340,7 +5347,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2007-01-10"
+              "end": "2007-01-10"
             }
           ]
         }
@@ -5366,7 +5373,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
@@ -5409,7 +5416,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2001-10-01"
+              "end": "2001-10-01"
             }
           ]
         }
@@ -5435,7 +5442,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2018-07-09"
+              "end": "2018-07-09"
             }
           ]
         }
@@ -5461,7 +5468,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -5487,7 +5494,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
@@ -5513,7 +5520,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -5875,6 +5882,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "神龙二年正月初一",
@@ -5884,6 +5892,7 @@
             {
               "timex": "0706-01-01",
               "type": "date",
+              "isLunar": "True",
               "value": "0706-01-01"
             }
           ]
@@ -5898,6 +5907,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
+    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "雍正四年大年三十",
@@ -5907,6 +5917,7 @@
             {
               "timex": "1726-01-30",
               "type": "date",
+              "isLunar": "True",
               "value": "1726-01-30"
             }
           ]

--- a/Specs/DateTime/Chinese/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/Chinese/DateTimeModelExperimentalMode.json
@@ -18,7 +18,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-03-01"
+              "start": "2016-03-01"
             }
           ]
         }
@@ -44,7 +44,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -96,7 +96,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-14"
+              "start": "2014-06-14"
             }
           ]
         }
@@ -139,7 +139,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-08-06"
+              "start": "2019-08-06"
             }
           ]
         }
@@ -180,7 +180,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
+              "end": "2010-01-10"
             }
           ]
         }
@@ -221,7 +221,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
@@ -238,7 +238,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "start": "2012-01-01"
             }
           ]
         }
@@ -264,7 +264,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-01"
+              "end": "2012-01-01"
             }
           ]
         }
@@ -307,7 +307,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-10"
+              "start": "2010-01-10"
             }
           ]
         }
@@ -350,7 +350,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -410,7 +410,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "end": "2019-04-05"
             }
           ]
         }
@@ -436,7 +436,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "end": "2010-01-04"
             }
           ]
         }
@@ -479,7 +479,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2014-06-04"
+              "start": "2014-06-04"
             }
           ]
         }
@@ -496,7 +496,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-08-16"
+              "end": "2009-08-16"
             }
           ]
         }
@@ -522,7 +522,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-03-22"
+              "end": "2011-03-22"
             }
           ]
         }
@@ -565,7 +565,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -591,7 +591,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -617,7 +617,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
@@ -692,7 +692,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-04"
+              "end": "2019-04-04"
             }
           ]
         }
@@ -733,7 +733,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-09-01"
+              "start": "2016-09-01"
             }
           ]
         }
@@ -776,7 +776,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -836,7 +836,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -879,7 +879,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-04-05"
+              "end": "2019-04-05"
             }
           ]
         }
@@ -905,7 +905,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
@@ -963,7 +963,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2016-12-01"
+              "start": "2016-12-01"
             }
           ]
         }
@@ -1004,7 +1004,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "start": "2015-02-01"
             }
           ]
         }
@@ -1030,7 +1030,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-05-05"
+              "end": "2019-05-05"
             }
           ]
         }
@@ -1071,7 +1071,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-01-01"
+              "start": "2019-01-01"
             }
           ]
         }
@@ -1097,7 +1097,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-04"
+              "start": "2010-01-04"
             }
           ]
         }
@@ -1123,7 +1123,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2009-09-01"
+              "start": "2009-09-01"
             }
           ]
         }
@@ -1149,7 +1149,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -1175,7 +1175,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -1201,7 +1201,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-01-01"
+              "start": "2019-01-01"
             }
           ]
         }
@@ -1227,7 +1227,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
@@ -1253,7 +1253,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "start": "2015-01-01"
             }
           ]
         }
@@ -1279,7 +1279,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2012-01-07"
+              "end": "2012-01-07"
             }
           ]
         }
@@ -1305,7 +1305,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimerange",
-              "end": "2013-01-01"
+              "end": "2014-01-01"
             }
           ]
         }
@@ -1331,7 +1331,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2018-07-09"
+              "end": "2018-07-09"
             }
           ]
         }
@@ -1357,7 +1357,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -1383,7 +1383,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-09-14"
+              "end": "2019-09-14"
             }
           ]
         }
@@ -1409,7 +1409,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-09"
+              "end": "2019-11-09"
             }
           ]
         }
@@ -1435,7 +1435,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2011-01-10"
+              "end": "2011-01-10"
             }
           ]
         }
@@ -1461,7 +1461,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2019-11-11"
+              "end": "2019-11-11"
             }
           ]
         }
@@ -1502,7 +1502,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2007-01-10"
+              "end": "2007-01-10"
             }
           ]
         }
@@ -1528,7 +1528,7 @@
               "Mod": "since",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2010-01-01"
+              "start": "2010-01-01"
             }
           ]
         }
@@ -1571,7 +1571,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2001-10-01"
+              "end": "2001-10-01"
             }
           ]
         }
@@ -1597,7 +1597,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2018-07-09"
+              "end": "2018-07-09"
             }
           ]
         }
@@ -1623,7 +1623,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }
@@ -1649,7 +1649,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-01-01"
+              "end": "2015-01-01"
             }
           ]
         }
@@ -1675,7 +1675,7 @@
               "Mod": "until",
               "type": "daterange",
               "sourceEntity": "datetimepoint",
-              "value": "2015-02-01"
+              "end": "2015-02-01"
             }
           ]
         }


### PR DESCRIPTION
Fix to issue #2557.
Moved common methods in BaseMergedDateTimeParser and BaseCJKMergedDateTimeParser to MergedParserUtil. 
In this way, the modifiers "since" and "until" produce the same results in English and Chinese.
Moreover, test cases referring to the Lunar calendar in Chinese are now labelled with the tag "isLunar":
- "农历2015年十月初一"
- "正月三十"
- "2015年十月初一早上九点二十" ????
- "神龙二年正月初一"
- "雍正四年大年三十"

Updated affected test cases in Chinese DateTimeModel and DateTimeModelExperimentalMode.