### PR TITLE
[PT DateTimeV2] Fixed 'dia' followed by digits is resolved incorrectly (#2601)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string BetweenRegex = @"(entre\s*([oa](s)?)?)";
       public const string WeekDayRegex = @"\b(?<weekday>(domingos?|(segunda|ter[çc]a|quarta|quinta|sexta)s?([-\s+]feiras?)?|s[aá]bados?|(2|3|4|5|6)[aª])\b|(dom|seg|ter[cç]|qua|qui|sex|sab)\b(\.?(?=\s|,|;|$)))";
       public static readonly string OnRegex = $@"(?<=\b(em|no)\s+)({DayRegex}s?)\b";
-      public static readonly string RelaxedOnRegex = $@"(?<=\b(em|n[oa]|d[oa])\s+)(dia\s+)?({DayRegex}s?)\b(?!\s*[/\\\-\.,:\s]\s*(\d|{MonthRegex}))";
+      public static readonly string RelaxedOnRegex = $@"(?<=\b(em|n[oa]|d[oa])\s+)(dia\s+)?({DayRegex}s?)\b(?!\s*[/\\\-\.,:\s]\s*(\d|(de\s+)?{MonthRegex}))";
       public static readonly string ThisRegex = $@"\b(([nd]?es[st][ea]\s*){WeekDayRegex})|({WeekDayRegex}\s*([nd]?es[st]a\s+semana))\b";
       public static readonly string LastDateRegex = $@"\b(([uú]ltim[ao])\s*{WeekDayRegex})|({WeekDayRegex}(\s+(([nd]?es[st]a|na|da)\s+([uú]ltima\s+)?semana)))\b";
       public static readonly string NextDateRegex = $@"\b(((pr[oó]xim[oa]|seguinte)\s*){WeekDayRegex})|({WeekDayRegex}((\s+(pr[oó]xim[oa]|seguinte))|(\s+(da\s+)?(semana\s+seguinte|pr[oó]xima\s+semana))))\b";

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -145,7 +145,7 @@ OnRegex: !nestedRegex
   def: (?<=\b(em|no)\s+)({DayRegex}s?)\b
   references: [ DayRegex ]
 RelaxedOnRegex: !nestedRegex
-  def: (?<=\b(em|n[oa]|d[oa])\s+)(dia\s+)?({DayRegex}s?)\b(?!\s*[/\\\-\.,:\s]\s*(\d|{MonthRegex}))
+  def: (?<=\b(em|n[oa]|d[oa])\s+)(dia\s+)?({DayRegex}s?)\b(?!\s*[/\\\-\.,:\s]\s*(\d|(de\s+)?{MonthRegex}))
   references: [ DayRegex, MonthRegex ]
 ThisRegex: !nestedRegex
   def: \b(([nd]?es[st][ea]\s*){WeekDayRegex})|({WeekDayRegex}\s*([nd]?es[st]a\s+semana))\b

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1796,5 +1796,34 @@
         }
       }
     ]
+  },
+  {
+    "Input": "estarei de volta no dia 20 de junho",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "20 de junho",
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-20",
+              "type": "date",
+              "value": "2016-06-20"
+            },
+            {
+              "timex": "XXXX-06-20",
+              "type": "date",
+              "value": "2017-06-20"
+            }
+          ]
+        },
+        "Start": 24,
+        "End": 34
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2601.

Test case added to Portuguese DateTimeModel.