### PR TITLE
[PT, FR DateTimeV2] Fixed incorrectly splitting weekday from date (#2605)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string ThisPrefixRegex = @"(?<order>ce(tte)?|au\s+cours+(du|de))\b";
       public const string RangePrefixRegex = @"(du|depuis|des?|entre)";
       public const string DayRegex = @"(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(e(r)?)?)(?=\b|t)";
-      public const string WrittenDayRegex = @"(?<day>un|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|dix-sept|dix-huit|dix-neuf|vingt-et-un|vingt et un|vingt|vingt deux|vingt-deux|vingt trois|vingt-trois|vingt quatre|vingt-quatre|vingt cinq|vingt-cinq|vingt six|vingt-six|vingt sept|vingt-sept|vingt huit|vingt-huit|vingt neuf|vingt-neuf|trente|trente et un|trente-et-un)";
+      public const string WrittenDayRegex = @"(?<day>((vingt|trente)(\s*-\s*|\s+)et(\s*-\s*|\s+))?un|(vingt(\s*-\s*|\s+))?(deux|trois|quatre|cinq|six|sept|huit|neuf)|dix|onze|douze|treize|quatorze|quinze|seize|dix-(sept|huit|neuf)|vingt|trente)";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public const string SpecialDescRegex = @"(p\b)";
       public static readonly string AmDescRegex = $@"(h\b|{BaseDateTime.BaseAmDescRegex})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string ThisPrefixRegex = @"(?<order>ce(tte)?|au\s+cours+(du|de))\b";
       public const string RangePrefixRegex = @"(du|depuis|des?|entre)";
       public const string DayRegex = @"(?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(e(r)?)?)(?=\b|t)";
+      public const string WrittenDayRegex = @"(?<day>un|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|dix-sept|dix-huit|dix-neuf|vingt-et-un|vingt et un|vingt|vingt deux|vingt-deux|vingt trois|vingt-trois|vingt quatre|vingt-quatre|vingt cinq|vingt-cinq|vingt six|vingt-six|vingt sept|vingt-sept|vingt huit|vingt-huit|vingt neuf|vingt-neuf|trente|trente et un|trente-et-un)";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public const string SpecialDescRegex = @"(p\b)";
       public static readonly string AmDescRegex = $@"(h\b|{BaseDateTime.BaseAmDescRegex})";
@@ -229,7 +230,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string PrepositionSuffixRegex = @"\b(du|de|[àa]|vers|dans)$";
       public const string FlexibleDayRegex = @"(?<DayOfMonth>([A-Za-z]+\s)?[A-Za-z\d]+)";
       public static readonly string ForTheRegex = $@"\b(((pour le {FlexibleDayRegex})|(dans (le\s+)?{FlexibleDayRegex}(?<=(st|nd|rd|th))))(?<end>\s*(,|\.|!|\?|$)))";
-      public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(le\s+{FlexibleDayRegex})\b";
+      public static readonly string WeekDayAndDayOfMonthRegex = $@"\b({WeekDayRegex}\s+(le\s+{FlexibleDayRegex})|le\s+(?<DayOfMonth>{DayRegex}|{WrittenDayRegex})\s+{WeekDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+(?!(the)){DayRegex}(?!([-:]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public const string RestOfDateRegex = @"\b(reste|fin)\s+(d[eu]\s+)?((le|ce(tte)?)\s+)?(?<duration>semaine|mois|l'ann[ée]e)\b";
       public const string RestOfDateTimeRegex = @"\b(reste|fin)\s+(d[eu]\s+)?((le|ce(tte)?)\s+)?(?<unit>jour)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string TillRegex = @"(?<till>\b(at[eé]h?|[aà]s|ao?)\b|--|-|—|——)(\s+\b(o|[aà](s)?)\b)?";
       public static readonly string RangeConnectorRegex = $@"(?<and>(e\s*(([àa]s?)|o)?)|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string DayRegex = @"(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?=\b|t)";
+      public const string WrittenDayRegex = @"(?<day>um|dois|tres|três|quatro|cinco|seis|sete|oito|nove|dez|onze|doze|dezena|dezenas|treze|catorze|quatorze|quinze|dezesseis|dezasseis|dezessete|dezassete|dezoito|dezenove|dezanove|vinte(\s+e\s+(um|dois|duas|tres|três|quatro|cinco|seis|sete|oito|nove))?|trinta(\s+e\s+um)?)";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public static readonly string AmDescRegex = $@"({BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
@@ -86,7 +87,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string SpecialDayRegex = @"\b((d?o\s+)?(dia\s+antes\s+de\s+ontem|antes\s+de\s+ontem|anteontem)|((d?o\s+)?(dia\s+|depois\s+|dia\s+depois\s+)?de\s+amanh[aã])|(o\s)?dia\s+seguinte|(o\s)?pr[oó]ximo\s+dia|(o\s+)?[uú]ltimo\s+dia|ontem|amanh[ãa]|hoje)|(do\s+dia$)\b";
       public const string SpecialDayWithNumRegex = @"^[.]";
       public const string ForTheRegex = @".^";
-      public const string WeekDayAndDayOfMonthRegex = @".^";
+      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
+      public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(dia\s+{FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+({DayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(n?[ao]\s+)?(?<cardinal>primeir[ao]|1[ao]|segund[ao]|2[ao]|terceir[ao]|3[ao]|[qc]uart[ao]|4[ao]|quint[ao]|5[ao]|[uú]ltim[ao])\s+{WeekDayRegex}\s+{MonthSuffixRegex})";
       public const string RelativeWeekDayRegex = @"^[.]";
@@ -453,7 +455,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { @"vinte e sete", 27 },
             { @"vinte e oito", 28 },
             { @"vinte e nove", 29 },
-            { @"trinta", 30 }
+            { @"trinta", 30 },
+            { @"trinta e um", 31 }
         };
       public static readonly Dictionary<string, IEnumerable<string>> HolidayNames = new Dictionary<string, IEnumerable<string>>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string TillRegex = @"(?<till>\b(at[eé]h?|[aà]s|ao?)\b|--|-|—|——)(\s+\b(o|[aà](s)?)\b)?";
       public static readonly string RangeConnectorRegex = $@"(?<and>(e\s*(([àa]s?)|o)?)|{BaseDateTime.RangeConnectorSymbolRegex})";
       public const string DayRegex = @"(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?=\b|t)";
-      public const string WrittenDayRegex = @"(?<day>um|dois|tres|três|quatro|cinco|seis|sete|oito|nove|dez|onze|doze|dezena|dezenas|treze|catorze|quatorze|quinze|dezesseis|dezasseis|dezessete|dezassete|dezoito|dezenove|dezanove|vinte(\s+e\s+(um|dois|duas|tres|três|quatro|cinco|seis|sete|oito|nove))?|trinta(\s+e\s+um)?)";
+      public const string WrittenDayRegex = @"(?<day>(vinte\s+e\s+)?(um|dois|tr[eê]s|quatro|cinco|seis|sete|oito|nove)|dez|onze|doze|treze|(c|qu)atorze|quinze|dez[ae](s(seis|sete)|nove)|dezoito|vinte|trinta(\s+e\s+um)?)";
       public const string MonthNumRegex = @"(?<month>1[0-2]|(0)?[1-9])\b";
       public static readonly string AmDescRegex = $@"({BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"({BaseDateTime.BasePmDescRegex})";
@@ -87,7 +87,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string SpecialDayRegex = @"\b((d?o\s+)?(dia\s+antes\s+de\s+ontem|antes\s+de\s+ontem|anteontem)|((d?o\s+)?(dia\s+|depois\s+|dia\s+depois\s+)?de\s+amanh[aã])|(o\s)?dia\s+seguinte|(o\s)?pr[oó]ximo\s+dia|(o\s+)?[uú]ltimo\s+dia|ontem|amanh[ãa]|hoje)|(do\s+dia$)\b";
       public const string SpecialDayWithNumRegex = @"^[.]";
       public const string ForTheRegex = @".^";
-      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
+      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([a-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+(dia\s+{FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+({DayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(n?[ao]\s+)?(?<cardinal>primeir[ao]|1[ao]|segund[ao]|2[ao]|terceir[ao]|3[ao]|[qc]uart[ao]|4[ao]|quint[ao]|5[ao]|[uú]ltim[ao])\s+{WeekDayRegex}\s+{MonthSuffixRegex})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -94,8 +94,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string RelaxedOnRegex = @"(?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)(?![.,]\d)\b";
       public const string SpecialDayRegex = @"\b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+d)|ayer|mañana|hoy)\b";
       public const string SpecialDayWithNumRegex = @"^[.]";
-      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
-      public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))";
+      public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([a-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
+      public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+(el\s+)?)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))";
       public static readonly string WeekDayAndDayOfMonthRegex = $@"\b{WeekDayRegex}\s+((el\s+(d[ií]a\s+)?){FlexibleDayRegex})\b";
       public static readonly string WeekDayAndDayRegex = $@"\b{WeekDayRegex}\s+({DayRegex}|{WrittenDayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>(el\s+)?(?<cardinal>primera?|1era?|segund[ao]|2d[ao]|tercera?|3era?|cuart[ao]|4t[ao]|quint[ao]|5t[ao]|((1|2|3|4|5)(\.)?[ºª])|[uú]ltim[ao])\s+(semana\s+{MonthSuffixRegex}\s+el\s+{WeekDayRegex}|{WeekDayRegex}\s+{MonthSuffixRegex}))";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDateExtractor.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         if (matchCase.Success)
                         {
                             var ordinalNum = matchCase.Groups["DayOfMonth"].Value;
-                            if (ordinalNum == result.Text)
+                            if (ordinalNum == result.Text && matchCase.Groups["DayOfMonth"].Index == result.Start)
                             {
                                 // Get week of day for the ordinal number which is regarded as a date of reference month
                                 var date = DateObject.MinValue.SafeCreateFromValue(reference.Year, reference.Month, num);
@@ -379,24 +379,10 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 // to see whether they refer to the same week day
                                 var extractedWeekDayStr = matchCase.Groups["weekday"].Value;
 
-                                // Calculate matchLength considering that matchCase can precede or follow result
-                                var matchLength = matchCase.Index < result.Start ?
-                                                      result.Start + result.Length - matchCase.Index :
-                                                      matchCase.Index + matchCase.Length - result.Start;
-
                                 if (!date.Equals(DateObject.MinValue) &&
-                                    numWeekDayInt == Config.DayOfWeek[extractedWeekDayStr] &&
-                                    matchCase.Length == matchLength)
+                                    numWeekDayInt == Config.DayOfWeek[extractedWeekDayStr])
                                 {
-
-                                    if (matchCase.Index < result.Start)
-                                    {
-                                        ret.Add(new Token(matchCase.Index, result.Start + result.Length ?? 0));
-                                    }
-                                    else
-                                    {
-                                        ret.Add(new Token((int)result.Start, matchCase.Index + matchCase.Length));
-                                    }
+                                    ret.Add(new Token(matchCase.Index, matchCase.Index + matchCase.Length));
 
                                     isFound = true;
                                 }

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -21,7 +21,7 @@ RangePrefixRegex: !simpleRegex
 DayRegex: !simpleRegex
   def: (?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(e(r)?)?)(?=\b|t)
 WrittenDayRegex: !simpleRegex
-  def: (?<day>un|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|dix-sept|dix-huit|dix-neuf|vingt-et-un|vingt et un|vingt|vingt deux|vingt-deux|vingt trois|vingt-trois|vingt quatre|vingt-quatre|vingt cinq|vingt-cinq|vingt six|vingt-six|vingt sept|vingt-sept|vingt huit|vingt-huit|vingt neuf|vingt-neuf|trente|trente et un|trente-et-un)
+  def: (?<day>((vingt|trente)(\s*-\s*|\s+)et(\s*-\s*|\s+))?un|(vingt(\s*-\s*|\s+))?(deux|trois|quatre|cinq|six|sept|huit|neuf)|dix|onze|douze|treize|quatorze|quinze|seize|dix-(sept|huit|neuf)|vingt|trente)
 MonthNumRegex: !simpleRegex
   def: (?<month>1[0-2]|(0)?[1-9])\b
 SpecialDescRegex: !simpleRegex

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -20,6 +20,8 @@ RangePrefixRegex: !simpleRegex
   def: (du|depuis|des?|entre)
 DayRegex: !simpleRegex
   def: (?<day>(?:3[0-1]|[1-2]\d|0?[1-9])(e(r)?)?)(?=\b|t)
+WrittenDayRegex: !simpleRegex
+  def: (?<day>un|deux|trois|quatre|cinq|six|sept|huit|neuf|dix|onze|douze|treize|quatorze|quinze|seize|dix-sept|dix-huit|dix-neuf|vingt-et-un|vingt et un|vingt|vingt deux|vingt-deux|vingt trois|vingt-trois|vingt quatre|vingt-quatre|vingt cinq|vingt-cinq|vingt six|vingt-six|vingt sept|vingt-sept|vingt huit|vingt-huit|vingt neuf|vingt-neuf|trente|trente et un|trente-et-un)
 MonthNumRegex: !simpleRegex
   def: (?<month>1[0-2]|(0)?[1-9])\b
 SpecialDescRegex: !simpleRegex
@@ -524,8 +526,8 @@ ForTheRegex: !nestedRegex
   def: \b(((pour le {FlexibleDayRegex})|(dans (le\s+)?{FlexibleDayRegex}(?<=(st|nd|rd|th))))(?<end>\s*(,|\.|!|\?|$)))
   references: [FlexibleDayRegex]
 WeekDayAndDayOfMonthRegex: !nestedRegex
-  def: \b{WeekDayRegex}\s+(le\s+{FlexibleDayRegex})\b
-  references: [WeekDayRegex, FlexibleDayRegex]
+  def: \b({WeekDayRegex}\s+(le\s+{FlexibleDayRegex})|le\s+(?<DayOfMonth>{DayRegex}|{WrittenDayRegex})\s+{WeekDayRegex})\b
+  references: [WeekDayRegex, FlexibleDayRegex, DayRegex, WrittenDayRegex]
 WeekDayAndDayRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+(?!(the)){DayRegex}(?!([-:]|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, AmDescRegex, PmDescRegex, OclockRegex]

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -9,6 +9,8 @@ RangeConnectorRegex: !nestedRegex
   references: [ BaseDateTime.RangeConnectorSymbolRegex ]
 DayRegex: !simpleRegex
   def: (?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?=\b|t)
+WrittenDayRegex: !simpleRegex
+  def: (?<day>um|dois|tres|três|quatro|cinco|seis|sete|oito|nove|dez|onze|doze|dezena|dezenas|treze|catorze|quatorze|quinze|dezesseis|dezasseis|dezessete|dezassete|dezoito|dezenove|dezanove|vinte(\s+e\s+(um|dois|duas|tres|três|quatro|cinco|seis|sete|oito|nove))?|trinta(\s+e\s+um)?)
 MonthNumRegex: !simpleRegex
   def: (?<month>1[0-2]|(0)?[1-9])\b
 AmDescRegex: !nestedRegex
@@ -164,9 +166,12 @@ SpecialDayWithNumRegex: !simpleRegex
 ForTheRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: .^
-WeekDayAndDayOfMonthRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: .^
+FlexibleDayRegex: !nestedRegex
+  def: (?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))
+  references: [WrittenDayRegex, DayRegex ]
+WeekDayAndDayOfMonthRegex: !nestedRegex
+  def: \b{WeekDayRegex}\s+(dia\s+{FlexibleDayRegex})\b
+  references: [WeekDayRegex, FlexibleDayRegex]
 WeekDayAndDayRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+({DayRegex})(?!([-:/]|\.\d|(\s+({AmDescRegex}|{PmDescRegex}|{OclockRegex}))))\b
   references: [WeekDayRegex, DayRegex, AmDescRegex, PmDescRegex, OclockRegex]
@@ -769,6 +774,7 @@ Numbers: !dictionary
     'vinte e oito': 28
     'vinte e nove': 29
     trinta: 30
+    'trinta e um': 31
 HolidayNames: !dictionary
   types: [ string, 'string[]' ]
   entries:

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -10,7 +10,7 @@ RangeConnectorRegex: !nestedRegex
 DayRegex: !simpleRegex
   def: (?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?=\b|t)
 WrittenDayRegex: !simpleRegex
-  def: (?<day>um|dois|tres|três|quatro|cinco|seis|sete|oito|nove|dez|onze|doze|dezena|dezenas|treze|catorze|quatorze|quinze|dezesseis|dezasseis|dezessete|dezassete|dezoito|dezenove|dezanove|vinte(\s+e\s+(um|dois|duas|tres|três|quatro|cinco|seis|sete|oito|nove))?|trinta(\s+e\s+um)?)
+  def: (?<day>(vinte\s+e\s+)?(um|dois|tr[eê]s|quatro|cinco|seis|sete|oito|nove)|dez|onze|doze|treze|(c|qu)atorze|quinze|dez[ae](s(seis|sete)|nove)|dezoito|vinte|trinta(\s+e\s+um)?)
 MonthNumRegex: !simpleRegex
   def: (?<month>1[0-2]|(0)?[1-9])\b
 AmDescRegex: !nestedRegex
@@ -167,7 +167,7 @@ ForTheRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: .^
 FlexibleDayRegex: !nestedRegex
-  def: (?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))
+  def: (?<DayOfMonth>([a-z]+\s)?({WrittenDayRegex}|{DayRegex}))
   references: [WrittenDayRegex, DayRegex ]
 WeekDayAndDayOfMonthRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+(dia\s+{FlexibleDayRegex})\b

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -186,10 +186,10 @@ SpecialDayWithNumRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 FlexibleDayRegex: !nestedRegex
-  def: (?<DayOfMonth>([A-Za-z]+\s)?({WrittenDayRegex}|{DayRegex}))
+  def: (?<DayOfMonth>([a-z]+\s)?({WrittenDayRegex}|{DayRegex}))
   references: [WrittenDayRegex, DayRegex ]
 ForTheRegex: !nestedRegex
-  def: \b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))
+  def: \b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+(el\s+)?)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))
   references: [FlexibleDayRegex, MonthRegex, WeekDayRegex ]
 WeekDayAndDayOfMonthRegex: !nestedRegex
   def: \b{WeekDayRegex}\s+((el\s+(d[ií]a\s+)?){FlexibleDayRegex})\b

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -20801,5 +20801,53 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Mon prochain salaire sera le 25 Mardi",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "le 25 mardi",
+        "Start": 26,
+        "End": 36,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mon prochain salaire sera le vingt-cinq Mardi",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "le vingt-cinq mardi",
+        "Start": 26,
+        "End": 44,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1825,5 +1825,53 @@
         "End": 34
       }
     ]
+  },
+  {
+    "Input": "meu próximo salário será terça-feira dia 25",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "terça-feira dia 25",
+        "Start": 25,
+        "End": 42,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "meu próximo salário será terça-feira dia vinte e cinco",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "terça-feira dia vinte e cinco",
+        "Start": 25,
+        "End": 53,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1873,5 +1873,34 @@
         }
       }
     ]
+  },
+  {
+    "Input": "meu próximo salário será terça-feira 25",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "terça-feira 25",
+        "Start": 25,
+        "End": 38,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-2",
+              "type": "date",
+              "value": "2018-09-25"
+            },
+            {
+              "timex": "XXXX-WXX-2",
+              "type": "date",
+              "value": "2018-12-25"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -21059,5 +21059,82 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Regresaré martes el dia 25",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "martes el dia 25",
+        "Start": 10,
+        "End": 25,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Regresaré martes el veinticinco",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "martes el veinticinco",
+        "Start": 10,
+        "End": 30,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-25",
+              "type": "date",
+              "value": "2018-09-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Regresaré el martes 25",
+    "Context": {
+      "ReferenceDateTime": "2018-09-28T01:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "martes 25",
+        "Start": 13,
+        "End": 21,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-2",
+              "type": "date",
+              "value": "2018-09-25"
+            },
+            {
+              "timex": "XXXX-WXX-2",
+              "type": "date",
+              "value": "2018-12-25"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2605.
Modified handling of WeekDayAndDayOfMonthRegex in NumberWithMonth to allow extraction of patterns where the day number precedes the weekday like in the french case "le 25 Mardi".

Test cases added to French and Portuguese DateTimeModel.