### PR TITLE
[PT/ES DateTimeV2] Fixed time of day entities are identified but not always resolved correctly (#2472)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -124,7 +124,12 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public static readonly string TimePrefix = $@"(?<prefix>{LessThanOneHour}(\s+(passad[ao]s)\s+(as)?|\s+depois\s+(das?|do)|\s+pras?|\s+(para|antes)?\s+([àa]s?))?)";
       public static readonly string TimeSuffix = $@"(?<suffix>({LessThanOneHour}\s+)?({AmRegex}|{PmRegex}|{OclockRegex}))";
       public static readonly string BasicTime = $@"(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex})";
-      public static readonly string AtRegex = $@"\b((?<=\b([aà]s?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b)?|(?<=\b(s(er)?[aã]o|v[aã]o\s+ser|^[eé]h?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b))(\s+{OclockRegex})?\b";
+      public const string MidnightRegex = @"(?<midnight>meia\s*(-\s*)?noite)";
+      public const string MidmorningRegex = @"(?<midmorning>meio\s+da\s+manhã)";
+      public const string MidafternoonRegex = @"(?<midafternoon>meio\s+da\s+tarde)";
+      public const string MiddayRegex = @"(?<midday>meio\s*(-\s*)?dia)";
+      public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
+      public static readonly string AtRegex = $@"\b(((?<=\b([aà]s?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b)?|(?<=\b(s(er)?[aã]o|v[aã]o\s+ser|^[eé]h?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b))(\s+{OclockRegex})?|{MidTimeRegex}|(?<=\b([àa]|ao?|na|de|da|pela)\s+)madrugada)\b";
       public static readonly string ConnectNumRegex = $@"({BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex})";
       public static readonly string TimeRegex1 = $@"(\b{TimePrefix}\s+)?({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\s*({DescRegex})";
       public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?((\s*{DescRegex})|\b)";
@@ -135,7 +140,6 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+[àa]s?\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex8 = $@"\b{TimeSuffix}\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex9 = $@"\b(?<writtentime>{HourNumRegex}\s+({TensTimeRegex}\s*)(e\s+)?{MinuteNumRegex}?)\b";
-      public const string TimeRegex10 = @"(\b([àa]|ao?)|na|de|da|pela)\s+(madrugada|manh[ãa]|meio\s*dia|meia\s*noite|tarde|noite)";
       public static readonly string TimeRegex11 = $@"\b({WrittenTimeRegex})(\s+{DescRegex})?\b";
       public static readonly string TimeRegex12 = $@"(\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*h\s*){BaseDateTime.MinuteRegex}(\s*{DescRegex})?";
       public const string PrepositionRegex = @"(?<prep>([àa]s?|em|por|pel[ao]|n[ao]|de|d[ao]?)?$)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string GeneralDescRegex = $@"({DescRegex}|(?<suffix>{AmRegex}|{PmRegex}))";
       public static readonly string BasicTime = $@"(?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex})";
       public const string MidTimeRegex = @"(?<mid>((?<midnight>media\s*noche)|(?<midmorning>media\s*mañana)|(?<midafternoon>media\s*tarde)|(?<midday>medio\s*d[ií]a)))";
-      public static readonly string AtRegex = $@"\b((?<=\b((a|de(sde)?)\s+las?|al)\s+)(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\b(\s*\bh\b)?(DescRegex)?|{MidTimeRegex})|{MidTimeRegex})";
+      public static readonly string AtRegex = $@"\b((?<=\b((a|de(sde)?)\s+las?|al)\s+)(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\b(\s*\bh\b)?(DescRegex)?|{MidTimeRegex}|madrugada)|{MidTimeRegex})";
       public static readonly string ConnectNumRegex = $@"({BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex})";
       public static readonly string TimeRegexWithDotConnector = $@"({BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex})";
       public static readonly string TimeRegex1 = $@"(\b{TimePrefix}\s+)?({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\s*({DescRegex}|\s*\bh\b)";
@@ -158,7 +158,6 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+a\s+las\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex8 = $@"\b{TimeSuffix}\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex9 = $@"\b(?<writtentime>{HourNumRegex}\s+({TensTimeRegex}\s*)(y\s+)?{MinuteNumRegex}?)\b";
-      public const string TimeRegex10 = @"(a\s+la|al)\s+(madrugada|mañana|tarde|noche)";
       public static readonly string TimeRegex11 = $@"\b({WrittenTimeRegex})(\s+{DescRegex})?\b";
       public static readonly string TimeRegex12 = $@"(\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*h\s*){BaseDateTime.MinuteRegex}(\s*{DescRegex})?";
       public const string PrepositionRegex = @"(?<prep>^(,\s*)?(a(l)?|en|de(l)?)?(\s*(la(s)?|el|los))?$)";
@@ -179,7 +178,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string PeriodTimeOfDayRegex = $@"\b((en\s+(el|la|lo)?\s+)?({LaterEarlyRegex}\s+)?(est[ae]\s+)?{DateTimeTimeOfDayRegex})\b";
       public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({LaterEarlyRegex}\s+)?est[ae]\s+{DateTimeTimeOfDayRegex}|({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})|anoche)\b";
       public const string UnitRegex = @"(?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|fin(es)?\s+de\s+semana|finde|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b";
-      public const string ConnectorRegex = @"^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?(cerca|alrededor) de las?)$";
+      public const string ConnectorRegex = @"^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?((cerca|alrededor)\s+)?(de\s+las?|del))$";
       public const string TimeHourNumRegex = @"(?<hour>veint(i(uno|dos|tres|cuatro)|e)|cero|uno|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieci(s([eé])is|siete|ocho|nueve))";
       public static readonly string PureNumFromTo = $@"((\b(desde|de)\s+(la(s)?\s+)?)?({BaseDateTime.HourRegex}|{TimeHourNumRegex})(?!\s+al?\b)(\s*(?<leftDesc>{DescRegex}))?|(\b(desde|de)\s+(la(s)?\s+)?)({BaseDateTime.HourRegex}|{TimeHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?)\s*{TillRegex}\s*({BaseDateTime.HourRegex}|{TimeHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{DescRegex})?";
       public static readonly string PureNumBetweenAnd = $@"(\bentre\s+(la(s)?\s+)?)(({BaseDateTime.TwoDigitHourRegex}{BaseDateTime.TwoDigitMinuteRegex})|{BaseDateTime.HourRegex}|{TimeHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?\s*{RangeConnectorRegex}\s*(({BaseDateTime.TwoDigitHourRegex}{BaseDateTime.TwoDigitMinuteRegex})|{BaseDateTime.HourRegex}|{TimeHourNumRegex})\s*(?<rightDesc>{PmRegex}|{AmRegex}|{DescRegex})?";
@@ -610,6 +609,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"^mes$", @"(?<!el\s+)mes" },
             { @"^(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)$", @"([$%£&!?@#])(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)|(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)([$%£&@#])" }
         };
+      public const string MorningStartEndRegex = @"(^((la\s+)?mañana))|(((la\s+)?mañana)$)";
+      public const string AfternoonStartEndRegex = @"(^(pasado\s+(el\s+)?medio\s*dia))|((pasado\s+(el\s+)?medio\s*dia)$)";
+      public const string EveningStartEndRegex = @"(^(tarde))|((tarde)$)";
+      public const string NightStartEndRegex = @"(^(noche)|(noche)$)";
       public static readonly IList<string> EarlyMorningTermList = new List<string>
         {
             @"madrugada"

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseTimeExtractorConfiguration.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             // once (y)? veinticinco
             new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            // It does not represent time entities
+            // new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // (tres menos veinte) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Extractors/SpanishTimeExtractorConfiguration.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             // once (y)? veinticinco
             new Regex(DateTimeDefinitions.TimeRegex9, RegexFlags),
 
-            new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
+            // It does not represent time entities
+            // new Regex(DateTimeDefinitions.TimeRegex10, RegexFlags),
 
             // (tres menos veinte) (pm)?
             new Regex(DateTimeDefinitions.TimeRegex11, RegexFlags),

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/DateTimePeriodParser.cs
@@ -78,14 +78,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
             var startIndex = trimmedText.IndexOf(DateTimeDefinitions.Tomorrow, StringComparison.Ordinal) == 0 ? DateTimeDefinitions.Tomorrow.Length : 0;
 
-            // handle Date followed by morning, afternoon
-            // Add handling code to handle morning, afternoon followed by Date
-            // Add handling code to handle early/late morning, afternoon
+            // handle Date preceded/followed by morning, afternoon
+            // @TODO Add handling code to handle early/late morning, afternoon
             var match = this.Config.TimeOfDayRegex.Match(trimmedText.Substring(startIndex));
             if (match.Success)
             {
-                var beforeStr = trimmedText.Substring(0, match.Index + startIndex).Trim();
-                var ers = this.Config.DateExtractor.Extract(beforeStr, referenceTime);
+                var subStr = match.Index > 0 ? trimmedText.Substring(0, match.Index + startIndex).Trim() : trimmedText.Substring(match.Index + match.Length).Trim();
+                var ers = this.Config.DateExtractor.Extract(subStr, referenceTime);
 
                 if (ers.Count == 0)
                 {
@@ -93,7 +92,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 }
 
                 // Check if Date and TimeOfDay are contiguous
-                var middleStr = beforeStr.Substring((int)ers[0].Start + (int)ers[0].Length).Trim();
+                var middleStr = match.Index > 0 ? subStr.Substring((int)ers[0].Start + (int)ers[0].Length).Trim() : subStr.Substring(0, (int)ers[0].Start).Trim();
                 if (!(string.IsNullOrWhiteSpace(middleStr) || ConnectorRegex.IsMatch(middleStr)))
                 {
                     return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDateTimePeriodParserConfiguration.cs
@@ -9,6 +9,20 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 {
     public class SpanishDateTimePeriodParserConfiguration : BaseDateTimeOptionsConfiguration, IDateTimePeriodParserConfiguration
     {
+        public static readonly Regex MorningStartEndRegex =
+            new Regex(DateTimeDefinitions.MorningStartEndRegex, RegexFlags);
+
+        public static readonly Regex AfternoonStartEndRegex =
+            new Regex(DateTimeDefinitions.AfternoonStartEndRegex, RegexFlags);
+
+        public static readonly Regex EveningStartEndRegex =
+            new Regex(DateTimeDefinitions.EveningStartEndRegex, RegexFlags);
+
+        public static readonly Regex NightStartEndRegex =
+            new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
+
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
         public SpanishDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
@@ -133,37 +147,30 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             beginHour = 0;
             endHour = 0;
             endMin = 0;
-
-            if (DateTimeDefinitions.EarlyMorningTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
-            {
-                timeStr = Constants.EarlyMorning;
-                beginHour = 4;
-                endHour = 8;
-            }
-            else if (DateTimeDefinitions.MorningTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
-            {
-                timeStr = Constants.Morning;
-                beginHour = 8;
-                endHour = Constants.HalfDayHourCount;
-            }
-            else if (DateTimeDefinitions.AfternoonTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            if (AfternoonStartEndRegex.IsMatch(trimmedText))
             {
                 timeStr = Constants.Afternoon;
                 beginHour = Constants.HalfDayHourCount;
                 endHour = 16;
             }
-            else if (DateTimeDefinitions.EveningTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            else if (EveningStartEndRegex.IsMatch(trimmedText))
             {
                 timeStr = Constants.Evening;
                 beginHour = 16;
                 endHour = 20;
             }
-            else if (DateTimeDefinitions.NightTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            else if (NightStartEndRegex.IsMatch(trimmedText))
             {
                 timeStr = Constants.Night;
                 beginHour = 20;
                 endHour = 23;
                 endMin = 59;
+            }
+            else if (MorningStartEndRegex.IsMatch(trimmedText))
+            {
+                timeStr = Constants.Morning;
+                beginHour = 8;
+                endHour = Constants.HalfDayHourCount;
             }
             else
             {

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -285,10 +285,21 @@ TimeSuffix: !nestedRegex
 BasicTime: !nestedRegex
   def: (?<basictime>{WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}:{BaseDateTime.MinuteRegex}(:{BaseDateTime.SecondRegex})?|{BaseDateTime.HourRegex})
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
+MidnightRegex: !simpleRegex
+  def: (?<midnight>meia\s*(-\s*)?noite)
+MidmorningRegex: !simpleRegex
+  def: (?<midmorning>meio\s+da\s+manhã)
+MidafternoonRegex: !simpleRegex
+  def: (?<midafternoon>meio\s+da\s+tarde)
+MiddayRegex: !simpleRegex
+  def: (?<midday>meio\s*(-\s*)?dia)
+MidTimeRegex: !nestedRegex
+  def: (?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))
+  references: [ MidnightRegex, MidmorningRegex, MidafternoonRegex, MiddayRegex ]
 AtRegex: !nestedRegex
   # "as quatro" "às 3"
-  def: \b((?<=\b([aà]s?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b)?|(?<=\b(s(er)?[aã]o|v[aã]o\s+ser|^[eé]h?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b))(\s+{OclockRegex})?\b
-  references: [ HourNumRegex, BaseDateTime.HourRegex, WrittenTimeRegex, OclockRegex ]
+  def: \b(((?<=\b([aà]s?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b)?|(?<=\b(s(er)?[aã]o|v[aã]o\s+ser|^[eé]h?)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s+horas?|\s*h\b))(\s+{OclockRegex})?|{MidTimeRegex}|(?<=\b([àa]|ao?|na|de|da|pela)\s+)madrugada)\b
+  references: [ HourNumRegex, BaseDateTime.HourRegex, WrittenTimeRegex, OclockRegex, MidTimeRegex ]
 ConnectNumRegex: !nestedRegex
   def: ({BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex})
   references: [ BaseDateTime.HourRegex, DescRegex ]
@@ -328,8 +339,8 @@ TimeRegex9: !nestedRegex
   # onze (e)? vinte e cinco
   def: \b(?<writtentime>{HourNumRegex}\s+({TensTimeRegex}\s*)(e\s+)?{MinuteNumRegex}?)\b
   references: [ HourNumRegex, TensTimeRegex, MinuteNumRegex ]
-TimeRegex10: !simpleRegex
-  def: (\b([àa]|ao?)|na|de|da|pela)\s+(madrugada|manh[ãa]|meio\s*dia|meia\s*noite|tarde|noite)
+#TimeRegex10: !simpleRegex
+#  def: (\b([àa]|ao?)|na|de|da|pela)\s+(madrugada|manh[ãa]|meio\s*dia|meia\s*noite|tarde|noite)
 TimeRegex11: !nestedRegex
   # (tres menos vinte) (pm)?
   def: \b({WrittenTimeRegex})(\s+{DescRegex})?\b

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -333,7 +333,7 @@ MidTimeRegex: !simpleRegex
   def: (?<mid>((?<midnight>media\s*noche)|(?<midmorning>media\s*mañana)|(?<midafternoon>media\s*tarde)|(?<midday>medio\s*d[ií]a)))
 AtRegex: !nestedRegex
   # "a las cuatro" "a las 3 h?"
-  def: \b((?<=\b((a|de(sde)?)\s+las?|al)\s+)(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\b(\s*\bh\b)?(DescRegex)?|{MidTimeRegex})|{MidTimeRegex})
+  def: \b((?<=\b((a|de(sde)?)\s+las?|al)\s+)(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\b(\s*\bh\b)?(DescRegex)?|{MidTimeRegex}|madrugada)|{MidTimeRegex})
   references: [ HourNumRegex, BaseDateTime.HourRegex, WrittenTimeRegex, DescRegex, MidTimeRegex ]
 ConnectNumRegex: !nestedRegex
   def: ({BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex})
@@ -377,8 +377,8 @@ TimeRegex9: !nestedRegex
   # once (y)? veinticinco
   def: \b(?<writtentime>{HourNumRegex}\s+({TensTimeRegex}\s*)(y\s+)?{MinuteNumRegex}?)\b
   references: [ HourNumRegex, TensTimeRegex, MinuteNumRegex ]
-TimeRegex10: !simpleRegex
-  def: (a\s+la|al)\s+(madrugada|mañana|tarde|noche)
+#TimeRegex10: !simpleRegex
+#  def: (a\s+la|al)\s+(madrugada|mañana|tarde|noche)
 TimeRegex11: !nestedRegex
   # (tres menos veinte) (pm)?
   def: \b({WrittenTimeRegex})(\s+{DescRegex})?\b
@@ -434,7 +434,7 @@ PeriodSpecificTimeOfDayRegex: !nestedRegex
 UnitRegex: !simpleRegex
   def: (?<unit>años?|(bi|tri|cuatri|se)mestre|mes(es)?|semanas?|fin(es)?\s+de\s+semana|finde|d[ií]as?|horas?|hra?s?|hs?|minutos?|mins?|segundos?|segs?|noches?)\b
 ConnectorRegex: !simpleRegex
-  def: ^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?(cerca|alrededor) de las?)$
+  def: ^(,|t|(para|y|a|en|por) las?|(\s*,\s*)?((cerca|alrededor)\s+)?(de\s+las?|del))$
 # SpanishTimePeriodExtractorConfiguration
 TimeHourNumRegex: !simpleRegex
   def: (?<hour>veint(i(uno|dos|tres|cuatro)|e)|cero|uno|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|dieci(s([eé])is|siete|ocho|nueve))
@@ -1014,6 +1014,14 @@ AmbiguityFiltersDict: !dictionary
     '^mes$': '(?<!el\s+)mes'
     '^(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)$': '([$%£&!?@#])(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)|(abr|ago|dic|feb|ene|ju[ln]|mar|may|nov|oct|sep?t|sep)([$%£&@#])'
 # For TimeOfDay resolution
+MorningStartEndRegex: !simpleRegex
+  def: (^((la\s+)?mañana))|(((la\s+)?mañana)$)
+AfternoonStartEndRegex: !simpleRegex
+  def: (^(pasado\s+(el\s+)?medio\s*dia))|((pasado\s+(el\s+)?medio\s*dia)$)
+EveningStartEndRegex: !simpleRegex
+  def: (^(tarde))|((tarde)$)
+NightStartEndRegex: !simpleRegex
+  def: (^(noche)|(noche)$)
 EarlyMorningTermList: !list
   types: [ string ]
   entries: 

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -1902,5 +1902,79 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Eu voltarei da tarde",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "tarde",
+        "Start": 15,
+        "End": 19,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "TEV",
+              "type": "timerange",
+              "start": "16:00:00",
+              "end": "20:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu voltarei da noite",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "noite",
+        "Start": 15,
+        "End": 19,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "TNI",
+              "type": "timerange",
+              "start": "20:00:00",
+              "end": "23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu voltarei ao meio dia",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "meio dia",
+        "Start": 15,
+        "End": 22,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T12",
+              "type": "time",
+              "value": "12:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/TimeExtractor.json
+++ b/Specs/DateTime/Portuguese/TimeExtractor.json
@@ -568,10 +568,10 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "de madrugada",
+        "Text": "madrugada",
         "Type": "time",
-        "Start": 9,
-        "Length": 12
+        "Start": 12,
+        "Length": 9
       }
     ]
   },
@@ -580,34 +580,34 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "na madrugada",
+        "Text": "madrugada",
         "Type": "time",
-        "Start": 9,
-        "Length": 12
+        "Start": 12,
+        "Length": 9
       }
     ]
   },
   {
-    "Input": "Voltarei de manhã",
+    "Input": "Voltarei de meio da manhã",
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "de manhã",
+        "Text": "meio da manhã",
         "Type": "time",
-        "Start": 9,
-        "Length": 8
+        "Start": 12,
+        "Length": 13
       }
     ]
   },
   {
-    "Input": "Voltarei pela manhã",
+    "Input": "Voltarei pela meio da manhã",
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "pela manhã",
+        "Text": "meio da manhã",
         "Type": "time",
-        "Start": 9,
-        "Length": 10
+        "Start": 14,
+        "Length": 13
       }
     ]
   },
@@ -616,10 +616,10 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "ao meio dia",
+        "Text": "meio dia",
         "Type": "time",
-        "Start": 9,
-        "Length": 11
+        "Start": 12,
+        "Length": 8
       }
     ]
   },
@@ -628,34 +628,34 @@
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "de meio dia",
+        "Text": "meio dia",
         "Type": "time",
-        "Start": 9,
-        "Length": 11
+        "Start": 12,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "Voltarei a tarde",
+    "Input": "Voltarei a meio da tarde",
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "a tarde",
+        "Text": "meio da tarde",
         "Type": "time",
-        "Start": 9,
-        "Length": 7
+        "Start": 11,
+        "Length": 13
       }
     ]
   },
   {
-    "Input": "Voltarei a noite",
+    "Input": "Voltarei a meia-noite",
     "NotSupported": "javascript, python",
     "Results": [
       {
-        "Text": "a noite",
+        "Text": "meia-noite",
         "Type": "time",
-        "Start": 9,
-        "Length": 7
+        "Start": 11,
+        "Length": 10
       }
     ]
   },

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -21136,5 +21136,110 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Regresaré por la tarde",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "tarde",
+        "Start": 17,
+        "End": 21,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "TEV",
+              "type": "timerange",
+              "start": "16:00:00",
+              "end": "20:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Regresaré por la noche",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "noche",
+        "Start": 17,
+        "End": 21,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "TNI",
+              "type": "timerange",
+              "start": "20:00:00",
+              "end": "23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Regresaré al mediodía",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "mediodía",
+        "Start": 13,
+        "End": 20,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T12",
+              "type": "time",
+              "value": "12:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Recuerdas la noche del 21 de septiembre",
+    "Context": {
+      "ReferenceDateTime": "2019-08-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "noche del 21 de septiembre",
+        "Start": 13,
+        "End": 38,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-09-21TNI",
+              "type": "datetimerange",
+              "start": "2018-09-21 20:00:00",
+              "end": "2018-09-21 23:59:59"
+            },
+            {
+              "timex": "XXXX-09-21TNI",
+              "type": "datetimerange",
+              "start": "2019-09-21 20:00:00",
+              "end": "2019-09-21 23:59:59"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/TimeExtractor.json
+++ b/Specs/DateTime/Spanish/TimeExtractor.json
@@ -520,21 +520,21 @@
     "Input": "Volvere a la madrugada",
     "Results": [
       {
-        "Text": "a la madrugada",
+        "Text": "madrugada",
         "Type": "time",
-        "Start": 8,
-        "Length": 14
+        "Start": 13,
+        "Length": 9
       }
     ]
   },
   {
-    "Input": "Volvere a la mañana",
+    "Input": "Volvere a la media mañana",
     "Results": [
       {
-        "Text": "a la mañana",
+        "Text": "media mañana",
         "Type": "time",
-        "Start": 8,
-        "Length": 11
+        "Start": 13,
+        "Length": 12
       }
     ]
   },
@@ -563,24 +563,24 @@
     ]
   },
   {
-    "Input": "Volvere a la tarde",
+    "Input": "Volvere a la media tarde",
     "Results": [
       {
-        "Text": "a la tarde",
+        "Text": "media tarde",
         "Type": "time",
-        "Start": 8,
-        "Length": 10
+        "Start": 13,
+        "Length": 11
       }
     ]
   },
   {
-    "Input": "Volvere al noche",
+    "Input": "Volvere a la medianoche",
     "Results": [
       {
-        "Text": "al noche",
+        "Text": "medianoche",
         "Type": "time",
-        "Start": 8,
-        "Length": 8
+        "Start": 13,
+        "Length": 10
       }
     ]
   },


### PR DESCRIPTION
Fix to issue #2472.
The problem was expressions like "da tarde", "da noite"... were incorrectly extracted as Time in PT and ES. 
Modified test cases referring to these patterns in TimeExtractor with expressions like "mid-afternoon", "mid-night" (that are treated as time in English).
Also modified method ParseSpecificTimeOfDay in Spanish DateTimePeriodParser to support patterns where the time of day precedes the date (like in "Recuerdas la noche del 21 de septiembre").

Test cases added to Portuguese and Spanish DateTimeModel.