### PR TITLE
[.NET] Korean Date support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
@@ -31,37 +31,39 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string TwoNumYear = @"50";
       public const string YearNumRegex = @"(?<year>((1[5-9]|20)\d{2})|2100)";
       public const string SimpleYearRegex = @"(?<year>(\d{2,4}))";
-      public const string ZeroToNineIntegerRegexCJK = @"[일이삼사오육륙칠팔구영공]";
+      public const string ZeroToNineIntegerRegexCJK = @"[일이삼사오육륙칠팔구영공십]";
       public const string DynastyStartYear = @"元";
       public const string RegionTitleRegex = @"(贞观|开元|神龙|洪武|建文|永乐|景泰|天顺|成化|嘉靖|万历|崇祯|顺治|康熙|雍正|乾隆|嘉庆|道光|咸丰|同治|光绪|宣统|民国)";
       public static readonly string DynastyYearRegex = $@"(?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{{1,3}}|[十拾]?({ZeroToNineIntegerRegexCJK}[十百拾佰]?){{0,3}}))";
-      public static readonly string DateYearInCJKRegex = $@"(?<yearCJK>({ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{DynastyYearRegex}))";
+      public static readonly string DateYearInCJKRegex = $@"(?<yearCJK>({ZeroToNineIntegerRegexCJK}{{2,4}}|[일이]천{ZeroToNineIntegerRegexCJK}{{1,2}}|{DynastyYearRegex}))";
       public const string WeekDayRegex = @"(?<weekday>일요일|월요일|화요일|수요일|목요일|금요일|토요일)";
       public const string LunarRegex = @"음력";
-      public static readonly string DateThisRegex = $@"(이번\s?주?)\s*{WeekDayRegex}";
-      public static readonly string DateLastRegex = $@"((저번|지난)\s?주?)\s*{WeekDayRegex}";
-      public static readonly string DateNextRegex = $@"(다음\s?주?)\s*{WeekDayRegex}";
+      public static readonly string DateThisRegex = $@"(이번(\s+)?(주\s+)?){WeekDayRegex}";
+      public static readonly string DateLastRegex = $@"((저번|지난)(\s+)?(주\s+)?){WeekDayRegex}";
+      public static readonly string DateNextRegex = $@"(다음(\s+)?(주\s+)?){WeekDayRegex}";
       public const string SpecialMonthRegex = @"^[.]";
       public const string SpecialYearRegex = @"^[.]";
-      public const string SpecialDayRegex = @"(최근|그저께|그제|((내일)?\s?모레)|그끄저께|어제|내일|오늘|금일|작일|익일|당일|명일|전일)";
+      public const string SpecialDayRegex = @"(최근|그저께|그제|((내일)?\s?모레)|그끄저께|어제|내일|오늘|금일|작일|익일|당일|명일|전일|다음 날|마지막 날|며칠|글피|그글피)";
+      public static readonly string DurationFromSpecialDayRegex = $@"({SpecialDayRegex}|지금(으로)?)\s*((부터)\s*(\d+|{ZeroToNineIntegerRegexCJK}+)\s*{DateUnitRegex})(\s*후)?";
       public const string SpecialDayWithNumRegex = @"(하루|이틀|사흘|나흘|닷새|엿새)";
-      public static readonly string WeekDayOfMonthRegex = $@"((({MonthRegex}|{MonthNumRegex}(월|달))의?\s*)?(?<cardinal>첫\s?번?째|두\s?번째|둘째|세\s?번째|셋째|네\s?번째|넷째|다섯\s?번?째|다섯째|여섯\s?번?째|여섯째|마지막)\s*{WeekDayRegex})";
+      public static readonly string WeekDayOfMonthRegex = $@"(((((이번|저번|지난|다음)\s)?{MonthRegex}|((이번|저번|지난|다음)\s)?{MonthNumRegex}월|(이번|저번|지난|다음)\s*달)의?\s*)?(?<cardinal>첫\s?번?째|두\s?번째|둘째|세\s?번째|셋째|네\s?번째|넷째|다섯\s?번?째|다섯째|여섯\s?번?째|여섯째|일곱\s?번?째|여덟\s?번?째|아홉\s?번?째|열\s?번?\s?째|마지막)\s*주?\s*{WeekDayRegex})";
       public const string ThisPrefixRegex = @"이번|금";
       public const string LastPrefixRegex = @"저번|지난";
       public const string NextPrefixRegex = @"다음";
       public static readonly string RelativeRegex = $@"(?<order>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex}))";
-      public static readonly string SpecialDate = $@"(?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})년)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})\s달의?)?{DateDayRegexInCJK}";
+      public static readonly string SpecialDate = $@"(?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})년)?({RelativeRegex}\s달의?\s)?{DateDayRegexInCJK}";
       public const string DateUnitRegex = @"(?<unit>년|월|주|일)";
-      public const string BeforeRegex = @"이전|之前|前";
-      public const string AfterRegex = @"이?후|후에|";
-      public static readonly string DateRegexList1 = $@"({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?";
-      public static readonly string DateRegexList2 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?";
-      public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*)({DayRegexNumInCJK}|{DayRegex})((\s*|,|，){WeekDayRegex})?";
-      public static readonly string DateRegexList4 = $@"{MonthNumRegex}\s*/\s*{DayRegex}";
-      public static readonly string DateRegexList5 = $@"{DayRegex}\s*/\s*{MonthNumRegex}";
-      public static readonly string DateRegexList6 = $@"{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{SimpleYearRegex}";
-      public static readonly string DateRegexList7 = $@"{DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{SimpleYearRegex}";
+      public const string BeforeRegex = @"이?전|之前|前";
+      public const string AfterRegex = @"이?후|후에";
+      public static readonly string DateRegexList1 = $@"({RelativeRegex}\s*)?({SimpleYearRegex}년\s*)?({LunarRegex}\s*)?({MonthRegex}\s*)?{DateDayRegexInCJK}(\s*(,\s*)?{WeekDayRegex})?(\s*(,\s*)?{SimpleYearRegex})?";
+      public static readonly string DateRegexList2 = $@"({WeekDayRegex},?\s*)?({MonthRegex}\s*[/\\\-\.]?\s*{DateDayRegexInCJK})(\s*{WeekDayRegex})?(\s*(,\s*)?({SimpleYearRegex}|{DateYearInCJKRegex})년?)?";
+      public static readonly string DateRegexList3 = $@"(({SpecialDayRegex}으?로?부터)\s((\d+\s*주간?(\s*{WeekDayRegex})?)|({DateDayRegexInCJK}|{SpecialDayRegex})\s[전후]))|((\d+년\s*)?(((한|두|세|네|다섯|여섯|일곱|여덟|아홉|열|열한|열두)\s?달\s*)|(\d+개월\s*))?(((,\s*)|(\s*하고\s*))?{DateDayRegexInCJK}|{SpecialDayRegex})\s(전|후|지나서))|(((그\s)?(다음날|전날))|([그이] 날)|(지난 날)|(새해\s첫\s?날))|({DayRegex}일\s*{MonthNumRegex}월\s*{SimpleYearRegex}년)|(((앞으로\s+)|({SpecialDayRegex}으?로?부터\s+))?\d+\s*주\s(후|동안)\s+{WeekDayRegex})|(나의 하루)|(몇\s*[달일] 전)";
+      public static readonly string DateRegexList4 = $@"{MonthNumRegex}\s*/\s*{DayRegex}(?!\s*퍼센트)";
+      public static readonly string DateRegexList5 = $@"{DayRegex}\s*/\s*{MonthNumRegex}(?!\s*퍼센트)";
+      public static readonly string DateRegexList6 = $@"{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-,]\s*{SimpleYearRegex}";
+      public static readonly string DateRegexList7 = $@"{DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.,]\s*{SimpleYearRegex}";
       public static readonly string DateRegexList8 = $@"{SimpleYearRegex}\s*[/\\\-\. ]\s*{MonthNumRegex}\s*[/\\\-\. ]\s*{DayRegex}";
+      public static readonly string DateRegexList9 = $@"({WeekDayRegex},\s*{MonthRegex}\s*{DateDayRegexInCJK},\s*{SimpleYearRegex}년)";
       public const string DatePeriodTillRegex = @"(?<till>까지|--|-|—|——|~|–)";
       public const string DatePeriodTillSuffixRequiredRegex = @"(?<till>까지)";
       public const string DatePeriodDayRegexInCJK = @"(?<day>初一|三十|一日|十一日|二十一日|三十一日|二日|三日|四日|五日|六日|七日|八日|九日|十二日|十三日|十四日|十五日|十六日|十七日|十八日|十九日|二十二日|二十三日|二十四日|二十五日|二十六日|二十七日|二十八日|二十九日|一日|十一日|十日|二十一日|二十日|三十一日|三十日|二日|三日|四日|五日|六日|七日|八日|九日|十二日|十三日|十四日|十五日|十六日|十七日|十八日|十九日|二十二日|二十三日|二十四日|二十五日|二十六日|二十七日|二十八日|二十九日|十日|二十日|三十日|10日|11日|12日|13日|14日|15日|16日|17日|18日|19日|1日|20日|21日|22日|23日|24日|25日|26日|27日|28日|29日|2日|30日|31日|3日|4日|5日|6日|7日|8日|9日|一号|十一号|二十一号|三十一号|二号|三号|四号|五号|六号|七号|八号|九号|十二号|十三号|十四号|十五号|十六号|十七号|十八号|十九号|二十二号|二十三号|二十四号|二十五号|二十六号|二十七号|二十八号|二十九号|一号|十一号|十号|二十一号|二十号|三十一号|三十号|二号|三号|四号|五号|六号|七号|八号|九号|十二号|十三号|十四号|十五号|十六号|十七号|十八号|十九号|二十二号|二十三号|二十四号|二十五号|二十六号|二十七号|二十八号|二十九号|十号|二十号|三十号|10号|11号|12号|13号|14号|15号|16号|17号|18号|19号|1号|20号|21号|22号|23号|24号|25号|26号|27号|28号|29号|2号|30号|31号|3号|4号|5号|6号|7号|8号|9号|一|十一|二十一|三十一|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|一|十一|十|二十一|二十|三十一|三十|二|三|四|五|六|七|八|九|十二|十三|十四|十五|十六|十七|十八|十九|二十二|二十三|二十四|二十五|二十六|二十七|二十八|二十九|十|二十|三十|廿|卅)";
@@ -136,7 +138,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
             { @"BD", @"영업일 기준으로" },
             { @"QD", @"한나절" },
             { @"W", @"주|주일" },
-            { @"MON", @"월|달" },
+            { @"MON", @"개월|월|달" },
             { @"Y", @"년" },
             { @"P1D", @"하루" },
             { @"P2D", @"이틀" },
@@ -458,6 +460,68 @@ namespace Microsoft.Recognizers.Definitions.Korean
             { @"이십구일", 29 },
             { @"삼십일", 31 },
             { @"초하루", 32 },
+            { @"1번", 1 },
+            { @"2번", 2 },
+            { @"3번", 3 },
+            { @"4번", 4 },
+            { @"5번", 5 },
+            { @"6번", 6 },
+            { @"7번", 7 },
+            { @"8번", 8 },
+            { @"9번", 9 },
+            { @"10번", 10 },
+            { @"11번", 11 },
+            { @"12번", 12 },
+            { @"13번", 13 },
+            { @"14번", 14 },
+            { @"15번", 15 },
+            { @"16번", 16 },
+            { @"17번", 17 },
+            { @"18번", 18 },
+            { @"19번", 19 },
+            { @"20번", 20 },
+            { @"21번", 21 },
+            { @"22번", 22 },
+            { @"23번", 23 },
+            { @"24번", 24 },
+            { @"25번", 25 },
+            { @"26번", 26 },
+            { @"27번", 27 },
+            { @"28번", 28 },
+            { @"29번", 29 },
+            { @"30번", 30 },
+            { @"31번", 31 },
+            { @"일번", 1 },
+            { @"십일번", 11 },
+            { @"이십번", 20 },
+            { @"십번", 10 },
+            { @"이십일번", 21 },
+            { @"삼십일번", 31 },
+            { @"이번", 2 },
+            { @"삼번", 3 },
+            { @"사번", 4 },
+            { @"오번", 5 },
+            { @"육번", 6 },
+            { @"칠번", 7 },
+            { @"팔번", 8 },
+            { @"구번", 9 },
+            { @"십이번", 12 },
+            { @"십삼번", 13 },
+            { @"십사번", 14 },
+            { @"십오번", 15 },
+            { @"십육번", 16 },
+            { @"십칠번", 17 },
+            { @"십팔번", 18 },
+            { @"십구번", 19 },
+            { @"이십이번", 22 },
+            { @"이십삼번", 23 },
+            { @"이십사번", 24 },
+            { @"이십오번", 25 },
+            { @"이십육번", 26 },
+            { @"이십칠번", 27 },
+            { @"이십팔번", 28 },
+            { @"이십구번", 29 },
+            { @"삼십번", 30 },
             { @"삼십", 30 },
             { @"일", 1 },
             { @"이십", 20 },

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateExtractorConfiguration.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex SpecialDate = new Regex(DateTimeDefinitions.SpecialDate, RegexFlags);
 
+        public static readonly Regex DurationFromSpecialDayRegex = new Regex(DateTimeDefinitions.DurationFromSpecialDayRegex, RegexFlags);
+
         public static readonly Regex BeforeRegex = new Regex(DateTimeDefinitions.BeforeRegex, RegexFlags);
 
         public static readonly Regex AfterRegex = new Regex(DateTimeDefinitions.AfterRegex, RegexFlags);
@@ -64,7 +66,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             ImplicitDateList = new List<Regex>
             {
                 LunarRegex, SpecialDayRegex, ThisRegex, LastRegex, NextRegex,
-                WeekDayRegex, WeekDayOfMonthRegex, SpecialDate,
+                WeekDayRegex, WeekDayOfMonthRegex, SpecialDate, DurationFromSpecialDayRegex,
             };
 
             // (음력)? (2016)? 1 월 3 일 (수)?
@@ -78,6 +80,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
             // 2015-12-23
             var dateRegex8 = new Regex(DateTimeDefinitions.DateRegexList8, RegexFlags);
+
+            var dateRegex9 = new Regex(DateTimeDefinitions.DateRegexList9, RegexFlags);
 
             // 23/7
             var dateRegex5 = new Regex(DateTimeDefinitions.DateRegexList5, RegexFlags);
@@ -95,7 +99,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             var enableDmy = DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_DMY;
             var enableYmd = DateTimeDefinitions.DefaultLanguageFallback == Constants.DefaultLanguageFallback_YMD;
 
-            DateRegexList = new List<Regex> { dateRegex1, dateRegex2, dateRegex3, dateRegex8 };
+            DateRegexList = new List<Regex> { dateRegex1, dateRegex2, dateRegex3, dateRegex8, dateRegex9 };
             DateRegexList = DateRegexList.Concat(
                 enableDmy ?
                 new[] { dateRegex5, dateRegex4, dateRegex7, dateRegex6 } :

--- a/Patterns/Korean/Korean-DateTime.yaml
+++ b/Patterns/Korean/Korean-DateTime.yaml
@@ -22,7 +22,7 @@ YearNumRegex: !simpleRegex
 SimpleYearRegex: !simpleRegex
   def: (?<year>(\d{2,4}))
 ZeroToNineIntegerRegexCJK: !simpleRegex
-  def: '[일이삼사오육륙칠팔구영공]'
+  def: '[일이삼사오육륙칠팔구영공십]'
 DynastyStartYear: '元'
 RegionTitleRegex: !simpleRegex
   def: (贞观|开元|神龙|洪武|建文|永乐|景泰|天顺|成化|嘉靖|万历|崇祯|顺治|康熙|雍正|乾隆|嘉庆|道光|咸丰|同治|光绪|宣统|民国)
@@ -30,20 +30,20 @@ DynastyYearRegex: !nestedRegex
   def: (?<dynasty>{RegionTitleRegex})(?<biasYear>({DynastyStartYear}|\d{1,3}|[十拾]?({ZeroToNineIntegerRegexCJK}[十百拾佰]?){0,3}))
   references: [RegionTitleRegex, DynastyStartYear, ZeroToNineIntegerRegexCJK]
 DateYearInCJKRegex: !nestedRegex
-  def: (?<yearCJK>({ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}{ZeroToNineIntegerRegexCJK}|{DynastyYearRegex}))
+  def: (?<yearCJK>({ZeroToNineIntegerRegexCJK}{2,4}|[일이]천{ZeroToNineIntegerRegexCJK}{1,2}|{DynastyYearRegex}))
   references: [ZeroToNineIntegerRegexCJK, DynastyYearRegex]
 WeekDayRegex: !simpleRegex
   def: (?<weekday>일요일|월요일|화요일|수요일|목요일|금요일|토요일)
 LunarRegex: !simpleRegex
   def: 음력
 DateThisRegex: !nestedRegex
-  def: (이번\s?주?)\s*{WeekDayRegex}
+  def: (이번(\s+)?(주\s+)?){WeekDayRegex}
   references: [WeekDayRegex]
 DateLastRegex: !nestedRegex
-  def: ((저번|지난)\s?주?)\s*{WeekDayRegex}
+  def: ((저번|지난)(\s+)?(주\s+)?){WeekDayRegex}
   references: [WeekDayRegex]
 DateNextRegex: !nestedRegex
-  def: (다음\s?주?)\s*{WeekDayRegex}
+  def: (다음(\s+)?(주\s+)?){WeekDayRegex}
   references: [WeekDayRegex]
 SpecialMonthRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
@@ -52,11 +52,14 @@ SpecialYearRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
   def: ^[.]
 SpecialDayRegex: !simpleRegex
-  def: (최근|그저께|그제|((내일)?\s?모레)|그끄저께|어제|내일|오늘|금일|작일|익일|당일|명일|전일)
+  def: (최근|그저께|그제|((내일)?\s?모레)|그끄저께|어제|내일|오늘|금일|작일|익일|당일|명일|전일|다음 날|마지막 날|며칠|글피|그글피)
+DurationFromSpecialDayRegex: !nestedRegex
+  def: ({SpecialDayRegex}|지금(으로)?)\s*((부터)\s*(\d+|{ZeroToNineIntegerRegexCJK}+)\s*{DateUnitRegex})(\s*후)?
+  references: [SpecialDayRegex, DateUnitRegex, ZeroToNineIntegerRegexCJK ]
 SpecialDayWithNumRegex: !simpleRegex
   def: (하루|이틀|사흘|나흘|닷새|엿새)
 WeekDayOfMonthRegex: !nestedRegex
-  def: ((({MonthRegex}|{MonthNumRegex}(월|달))의?\s*)?(?<cardinal>첫\s?번?째|두\s?번째|둘째|세\s?번째|셋째|네\s?번째|넷째|다섯\s?번?째|다섯째|여섯\s?번?째|여섯째|마지막)\s*{WeekDayRegex})
+  def: (((((이번|저번|지난|다음)\s)?{MonthRegex}|((이번|저번|지난|다음)\s)?{MonthNumRegex}월|(이번|저번|지난|다음)\s*달)의?\s*)?(?<cardinal>첫\s?번?째|두\s?번째|둘째|세\s?번째|셋째|네\s?번째|넷째|다섯\s?번?째|다섯째|여섯\s?번?째|여섯째|일곱\s?번?째|여덟\s?번?째|아홉\s?번?째|열\s?번?\s?째|마지막)\s*주?\s*{WeekDayRegex})
   references: [MonthRegex, MonthNumRegex, WeekDayRegex]
 ThisPrefixRegex: !simpleRegex
   def: 이번|금
@@ -68,46 +71,48 @@ RelativeRegex: !nestedRegex
   def: (?<order>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex}))
   references: [ThisPrefixRegex, LastPrefixRegex, NextPrefixRegex]
 SpecialDate: !nestedRegex
-  def: (?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})년)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})\s달의?)?{DateDayRegexInCJK}
-  references: [ThisPrefixRegex, LastPrefixRegex, NextPrefixRegex, DateDayRegexInCJK]
+  def: (?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})년)?({RelativeRegex}\s달의?\s)?{DateDayRegexInCJK}
+  references: [ThisPrefixRegex, LastPrefixRegex, NextPrefixRegex, DateDayRegexInCJK, RelativeRegex]
 DateUnitRegex: !simpleRegex
   def: (?<unit>년|월|주|일)
 BeforeRegex: !simpleRegex
-  def: 이전|之前|前
+  def: 이?전|之前|前
 AfterRegex: !simpleRegex
-  def: 이?후|후에|
-# (农历)?(2016年)?一月三日(星期三)?
+  def: 이?후|후에
 DateRegexList1: !nestedRegex
-  def: ({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
-  references: [LunarRegex, SimpleYearRegex, DateYearInCJKRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]
-# (2015年)?(农历)?十月初一(星期三)?
+  def: ({RelativeRegex}\s*)?({SimpleYearRegex}년\s*)?({LunarRegex}\s*)?({MonthRegex}\s*)?{DateDayRegexInCJK}(\s*(,\s*)?{WeekDayRegex})?(\s*(,\s*)?{SimpleYearRegex})?
+  references: [RelativeRegex, LunarRegex, SimpleYearRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]
+# 1월-1일(화요일)?(, 2016)?
 DateRegexList2: !nestedRegex
-  def: ((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
-  references: [MonthRegex, DateDayRegexInCJK, SimpleYearRegex, LunarRegex, WeekDayRegex, DateYearInCJKRegex]
-# (2015年)?(农历)?十月二十(星期三)?
+  def: ({WeekDayRegex},?\s*)?({MonthRegex}\s*[/\\\-\.]?\s*{DateDayRegexInCJK})(\s*{WeekDayRegex})?(\s*(,\s*)?({SimpleYearRegex}|{DateYearInCJKRegex})년?)?
+  references: [MonthRegex, DateDayRegexInCJK, WeekDayRegex, SimpleYearRegex, DateYearInCJKRegex]
+# oo부터(2주)(후)?
 DateRegexList3: !nestedRegex
-  def: ((({SimpleYearRegex}|{DateYearInCJKRegex})년)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*)({DayRegexNumInCJK}|{DayRegex})((\s*|,|，){WeekDayRegex})?
-  references: [MonthRegex, DayRegexNumInCJK, SimpleYearRegex, LunarRegex, WeekDayRegex, DateYearInCJKRegex, DayRegex]
+  def: (({SpecialDayRegex}으?로?부터)\s((\d+\s*주간?(\s*{WeekDayRegex})?)|({DateDayRegexInCJK}|{SpecialDayRegex})\s[전후]))|((\d+년\s*)?(((한|두|세|네|다섯|여섯|일곱|여덟|아홉|열|열한|열두)\s?달\s*)|(\d+개월\s*))?(((,\s*)|(\s*하고\s*))?{DateDayRegexInCJK}|{SpecialDayRegex})\s(전|후|지나서))|(((그\s)?(다음날|전날))|([그이] 날)|(지난 날)|(새해\s첫\s?날))|({DayRegex}일\s*{MonthNumRegex}월\s*{SimpleYearRegex}년)|(((앞으로\s+)|({SpecialDayRegex}으?로?부터\s+))?\d+\s*주\s(후|동안)\s+{WeekDayRegex})|(나의 하루)|(몇\s*[달일] 전)
+  references: [MonthRegex, DayRegexNumInCJK, SimpleYearRegex, LunarRegex, WeekDayRegex, DateYearInCJKRegex, DayRegex, DateDayRegexInCJK, SpecialDayRegex, MonthNumRegex]
 # 7/23
 DateRegexList4: !nestedRegex
-  def: '{MonthNumRegex}\s*/\s*{DayRegex}'
+  def: '{MonthNumRegex}\s*/\s*{DayRegex}(?!\s*퍼센트)'
   references: [MonthNumRegex, DayRegex]
 # 23/7
 DateRegexList5: !nestedRegex
-  def: '{DayRegex}\s*/\s*{MonthNumRegex}'
+  def: '{DayRegex}\s*/\s*{MonthNumRegex}(?!\s*퍼센트)'
   references: [DayRegex, MonthNumRegex]
 # 3-23-2017
 DateRegexList6: !nestedRegex
-  def: '{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-]\s*{SimpleYearRegex}'
+  def: '{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}\s*[/\\\-,]\s*{SimpleYearRegex}'
   references: [DayRegex, MonthNumRegex, SimpleYearRegex]
 # 23-3-2015
 DateRegexList7: !nestedRegex
-  def: '{DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.]\s*{SimpleYearRegex}'
+  def: '{DayRegex}\s*[/\\\-\.]\s*{MonthNumRegex}\s*[/\\\-\.,]\s*{SimpleYearRegex}'
   references: [DayRegex, MonthNumRegex, SimpleYearRegex]
 # 2015-12-23 - This regex represents the standard format in CJK dates (YMD) and has precedence over other orderings
 DateRegexList8: !nestedRegex
   def: '{SimpleYearRegex}\s*[/\\\-\. ]\s*{MonthNumRegex}\s*[/\\\-\. ]\s*{DayRegex}'
   references: [SimpleYearRegex, MonthNumRegex, DayRegex]
+DateRegexList9: !nestedRegex
+  def: ({WeekDayRegex},\s*{MonthRegex}\s*{DateDayRegexInCJK},\s*{SimpleYearRegex}년)
+  references: [WeekDayRegex, MonthRegex, DateDayRegexInCJK, SimpleYearRegex]
 # Note that these "Till" connector can be used without any suffix like "之间|之内|期间|中间|间"
 # DatePeriodExtractorCJK
 DatePeriodTillRegex: !simpleRegex
@@ -283,7 +288,7 @@ DurationSuffixList: !dictionary
     BD: 영업일 기준으로
     QD: 한나절
     W: 주|주일
-    MON: 월|달
+    MON: 개월|월|달
     Y: 년
     P1D: 하루
     P2D: 이틀
@@ -684,6 +689,68 @@ ParserConfigurationDayOfMonth: !dictionary
     이십구일: 29
     삼십일: 30
     초하루: 32
+    1번: 1
+    2번: 2
+    3번: 3
+    4번: 4
+    5번: 5
+    6번: 6
+    7번: 7
+    8번: 8
+    9번: 9
+    10번: 10
+    11번: 11
+    12번: 12
+    13번: 13
+    14번: 14
+    15번: 15
+    16번: 16
+    17번: 17
+    18번: 18
+    19번: 19
+    20번: 20
+    21번: 21
+    22번: 22
+    23번: 23
+    24번: 24
+    25번: 25
+    26번: 26
+    27번: 27
+    28번: 28
+    29번: 29
+    30번: 30
+    31번: 31
+    일번: 1
+    십일번: 11
+    이십번: 20
+    십번: 10
+    이십일번: 21
+    삼십일번: 31
+    이번: 2
+    삼번: 3
+    사번: 4
+    오번: 5
+    육번: 6
+    칠번: 7
+    팔번: 8
+    구번: 9
+    십이번: 12
+    십삼번: 13
+    십사번: 14
+    십오번: 15
+    십육번: 16
+    십칠번: 17
+    십팔번: 18
+    십구번: 19
+    이십이번: 22
+    이십삼번: 23
+    이십사번: 24
+    이십오번: 25
+    이십육번: 26
+    이십칠번: 27
+    이십팔번: 28
+    이십구번: 29
+    삼십번: 30
     삼십: 30
     일: 1
     십일: 11

--- a/Specs/DateTime/Korean/DateExtractor.json
+++ b/Specs/DateTime/Korean/DateExtractor.json
@@ -1245,18 +1245,6 @@
     ]
   },
   {
-    "Input": "4/22에 돌아갈게요",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "4/22",
-        "Type": "date",
-        "Start": 0,
-        "Length": 4
-      }
-    ]
-  },
-  {
     "Input": "4/22 에 돌아갈게요",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -1277,18 +1265,6 @@
         "Type": "date",
         "Start": 0,
         "Length": 5
-      }
-    ]
-  },
-  {
-    "Input": "4/22에 돌아갈게요",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "4/22",
-        "Type": "date",
-        "Start": 0,
-        "Length": 4
       }
     ]
   },
@@ -1641,18 +1617,6 @@
     ]
   },
   {
-    "Input": "5월 11일에 야구",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "5월 11일",
-        "Type": "date",
-        "Start": 0,
-        "Length": 6
-      }
-    ]
-  },
-  {
     "Input": "5월 4일에 돌아갈게요",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -1682,18 +1646,6 @@
     "Results": [
       {
         "Text": "새해 첫 날",
-        "Type": "date",
-        "Start": 0,
-        "Length": 6
-      }
-    ]
-  },
-  {
-    "Input": "5월 21일에 돌아갈게요",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "5월 21일",
         "Type": "date",
         "Start": 0,
         "Length": 6

--- a/Specs/DateTime/Korean/DateExtractor.json
+++ b/Specs/DateTime/Korean/DateExtractor.json
@@ -1,20 +1,18 @@
 [
   {
     "Input": "나는 15일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15",
+        "Text": "15일",
         "Type": "date",
         "Start": 3,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
   {
     "Input": "나는 4월 22일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "나는 1월 1일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "나는 10월 2일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "2016년 1월 12일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "2016년 1월 12일 월요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +73,6 @@
   },
   {
     "Input": "2016년 2월 22일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -92,7 +85,6 @@
   },
   {
     "Input": "2016년 4월 21일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "2015년 9월 18일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "4월 22일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "2015년 8월 12일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +133,6 @@
   },
   {
     "Input": "2016년 11월 12일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -157,7 +145,6 @@
   },
   {
     "Input": "1월 1일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -170,7 +157,6 @@
   },
   {
     "Input": "11월 28일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -183,7 +169,6 @@
   },
   {
     "Input": "1월 22일 수요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -196,7 +181,6 @@
   },
   {
     "Input": "7월의 첫 번째 금요일에 돌아가 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -209,7 +193,6 @@
   },
   {
     "Input": "이번 달의 첫 번째 금요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,7 +205,6 @@
   },
   {
     "Input": "지금으로부터 2주 후에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -235,7 +217,6 @@
   },
   {
     "Input": "다음 주 금요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,6 @@
   },
   {
     "Input": "지난 월요일",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -261,7 +241,6 @@
   },
   {
     "Input": "화요일에 떠날 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -274,7 +253,6 @@
   },
   {
     "Input": "화요일에 떠날 거야.  좋은 소식",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -287,7 +265,6 @@
   },
   {
     "Input": "금요일에 떠날 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,20 +277,18 @@
   },
   {
     "Input": "오늘 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "오늘 ",
+        "Text": "오늘",
         "Type": "date",
         "Start": 0,
-        "Length": 3
+        "Length": 2
       }
     ]
   },
   {
     "Input": "내일 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -326,7 +301,6 @@
   },
   {
     "Input": "어제 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -339,7 +313,6 @@
   },
   {
     "Input": "그저께 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -352,20 +325,18 @@
   },
   {
     "Input": "내일 모레 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "내일 모레 ",
+        "Text": "내일 모레",
         "Type": "date",
         "Start": 0,
-        "Length": 6
+        "Length": 5
       }
     ]
   },
   {
     "Input": "다음 날에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -378,7 +349,6 @@
   },
   {
     "Input": "이번 주 금요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -391,7 +361,6 @@
   },
   {
     "Input": "다음 주 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -404,7 +373,6 @@
   },
   {
     "Input": "지난 주 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -417,7 +385,6 @@
   },
   {
     "Input": "마지막 날에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -430,7 +397,6 @@
   },
   {
     "Input": "2016년 6월 15일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -443,7 +409,6 @@
   },
   {
     "Input": "5월 11일에 야구",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -456,7 +421,6 @@
   },
   {
     "Input": "5월 4일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -469,7 +433,6 @@
   },
   {
     "Input": "5월 21일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -482,7 +445,6 @@
   },
   {
     "Input": "8월 2일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -495,7 +457,6 @@
   },
   {
     "Input": "6월 22일에 돌아갈 거야.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -508,33 +469,30 @@
   },
   {
     "Input": "나는 2개월 전에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2개월 전에",
+        "Text": "2개월 전",
         "Type": "date",
         "Start": 3,
-        "Length": 6
-      }
-    ]
-  },
-  {
-    "Input": "이틀 후에 떠날 거야. ",
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "이틀 후에",
-        "Type": "date",
-        "Start": 0,
         "Length": 5
       }
     ]
   },
   {
+    "Input": "이틀 후에 떠날 거야. ",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "이틀 후",
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
     "Input": "나는 27일에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -547,7 +505,6 @@
   },
   {
     "Input": "나는 27일에 돌아갔어!",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -560,7 +517,6 @@
   },
   {
     "Input": "나는 21일에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -573,7 +529,6 @@
   },
   {
     "Input": "나는 22일에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -586,7 +541,6 @@
   },
   {
     "Input": "나는 2일에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -599,7 +553,6 @@
   },
   {
     "Input": "나는 31일에 돌아갔어. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -612,25 +565,21 @@
   },
   {
     "Input": "첫 번째 상",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "나는 27층으로 갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "싱가포르와 중국의 외교 관계 수립 25주년 기념 행사",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "제17회 Door Haunted Experience 티켓 받기",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -639,7 +588,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -655,14 +603,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일 수요일 ",
+        "Text": "27일 수요일",
         "Type": "date",
         "Start": 0,
-        "Length": 8
+        "Length": 7
       }
     ]
   },
@@ -671,7 +618,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -687,7 +633,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -703,7 +648,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -719,7 +663,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -735,7 +678,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -748,7 +690,6 @@
   },
   {
     "Input": "두 번째 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -761,7 +702,6 @@
   },
   {
     "Input": "첫 번째 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -774,7 +714,6 @@
   },
   {
     "Input": "세 번째 화요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -787,7 +726,6 @@
   },
   {
     "Input": "다섯 번째 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -800,7 +738,6 @@
   },
   {
     "Input": "여섯 번째 일요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -813,7 +750,6 @@
   },
   {
     "Input": "열 번째 월요일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -826,7 +762,6 @@
   },
   {
     "Input": "다음 달 20일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -839,7 +774,6 @@
   },
   {
     "Input": "이번 달 31일에 돌아갈 거야. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -852,7 +786,6 @@
   },
   {
     "Input": "코르타나, 이번 주 금요일 또는 다음 주 화요일에 스카이프 통화 준비해 줄래?  ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -871,7 +804,6 @@
   },
   {
     "Input": "2016년 11월 16일",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -884,46 +816,42 @@
   },
   {
     "Input": "한 달 21일 전에 우리는 미팅을 했다. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "한 달 21일 전에",
+        "Text": "한 달 21일 전",
         "Type": "date",
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
   {
     "Input": "2년 한 달 21일 전에 여기를 떠났다. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2년 한 달 21일 전에",
+        "Text": "2년 한 달 21일 전",
         "Type": "date",
         "Start": 0,
-        "Length": 13
+        "Length": 12
       }
     ]
   },
   {
     "Input": "2년 21일 후에 여기를 떠날 것이다. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2년 21일 후에 ",
+        "Text": "2년 21일 후",
         "Type": "date",
         "Start": 0,
-        "Length": 10
+        "Length": 8
       }
     ]
   },
   {
     "Input": "다음 달 20일에 여기를 떠났다. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -936,7 +864,6 @@
   },
   {
     "Input": "1391년 12월 5일에 여기를 떠났다. ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -949,7 +876,6 @@
   },
   {
     "Input": "2018년 1월 22일 월요일에",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -962,7 +888,6 @@
   },
   {
     "Input": "2018년 1월 21일 일요일에",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -975,7 +900,6 @@
   },
   {
     "Input": "1978년 9월 21일에",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -988,7 +912,6 @@
   },
   {
     "Input": "1901년 9월 10일에",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1001,7 +924,6 @@
   },
   {
     "Input": "2000년 9월 10일에 ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1014,7 +936,6 @@
   },
   {
     "Input": "2015년 5월 13일에 시간 있니? ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1027,7 +948,6 @@
   },
   {
     "Input": "2015년 5월 13일에 시간 괜찮니? ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1040,6 +960,7 @@
   },
   {
     "Input": "너는 지금부터 한 달에 두 번씩 일요일마다 시간 괜찮니? ",
+    "Comment": "Not a proper sentence in Korean and it is not possible to give a better translation of the original case 'Are you available two sundays from now?'",
     "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -1053,6 +974,7 @@
   },
   {
     "Input": "너는 후에 두 번의 월요일에 시간 괜찮니?",
+    "Comment": "Not a proper sentence in Korean and it is not possible to give a better translation of the original case 'Are you available two monday later?'",
     "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
@@ -1066,7 +988,6 @@
   },
   {
     "Input": "너는모레에 괜찮니?",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1079,7 +1000,6 @@
   },
   {
     "Input": "너는 내일부터 3주 괜찮니? ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1092,14 +1012,13 @@
   },
   {
     "Input": "너는 그끄저께 어디에 있었니? ",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "그끄저께 ",
+        "Text": "그끄저께",
         "Type": "date",
         "Start": 3,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
@@ -1108,7 +1027,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1124,7 +1042,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1132,12 +1049,6 @@
         "Type": "date",
         "Start": 6,
         "Length": 10
-      },
-      {
-        "Text": "6월 23일 ",
-        "Type": "date",
-        "Start": 9,
-        "Length": 7
       }
     ]
   },
@@ -1146,7 +1057,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1162,7 +1072,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-06T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1175,739 +1084,868 @@
   },
   {
     "Input": "그것의 전환 가능한 6 1/4 퍼센트 액면가 ",
-    "Comment": "1/4 shouldn't recognized as date here",
-    "NotSupported": "dotnet",
+    "Comment": "1/4 shouldn't be recognized as date here",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "15일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15",
-        "Type": "date"
+        "Text": "15일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "4월 22일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2월 22일",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "1월-1일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "1월-1일",
-        "Type": "date"
+        "Text": "4월 22일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "1월/1일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월/1일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "10월.2일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "10월.2일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "1월 12일, 2016에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 12일, 2016",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "2016년 1월 12일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016년 1월 12일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "1월 12일 월요일, 2016에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 12일 월요일, 2016",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
   {
     "Input": "02/22/2016에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "02/22/2016",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
     "Input": "21/04/2016에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21/04/2016",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
     "Input": "21/04/16에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21/04/16",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "9-18-15에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9-18-15",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "4.22에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4.22",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "4-22에 돌아가요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4-22",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "4-22에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4-22",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "4/22 에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4/22",
-        "Type": "date"
-      }
-    ]
-  },
-  {
-    "Input": "22/04에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "22/04",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "4/22에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4/22",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "4/22에 돌아가요",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4/22",
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "4/22에 돌아갈게요",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4/22",
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "4/22 에 돌아갈게요",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4/22",
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "22/04에 돌아갈게요",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "22/04",
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "4/22에 돌아갈게요",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4/22",
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "2015/08/12에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015/08/12",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
     "Input": "11/12,2016에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11/12,2016",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
     "Input": "1월 1일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 1일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "11월-28일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "11월-28일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "1월 22일 수요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 22일 수요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
   {
     "Input": "7월 첫째 주 금요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "7월 첫째 주 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
     "Input": "이번 달 첫 번째 금요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 달 첫 번째 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
   {
     "Input": "2주 후에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2주 후",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "다음 주 금요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 주 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "다음 금요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "화요일에 돌아갈게요.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "화요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "좋은 소식. 화요일에 돌아갈게요.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "화요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 7,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "화요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "화요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "금요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "오늘 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오늘",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "내일 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "내일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "어제로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "어제",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "그제로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그제",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "모레 돌아올게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "모레",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "그 다음날 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 다음날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "다음날 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "이번 금요일에 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "다음주 일요일에 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음주 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "지난 주 일요일로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "지난 주 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "전날로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "전날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "그 전날로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 전날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "그 날로 돌아갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "다음 주 일요일에 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "다음주 일요일",
-        "Type": "date"
+        "Text": "다음 주 일요일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "2016년 6월 15에 돌아올거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "2016년 6월 15일에 돌아올거야",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2016년 6월 15",
-        "Type": "date"
+        "Text": "2016년 6월 15일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
   {
-    "Input": "5월 11에 야구",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "5월 11일에 야구",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5월 11",
-        "Type": "date"
+        "Text": "5월 11일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "5월 4일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5월 4일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "3월 4일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3월 4일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "새해 첫 날에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "새해 첫 날",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "5월 21일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5월 21일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "5월 21에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "5월 21일에 돌아갈게요",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5월 21",
-        "Type": "date"
+        "Text": "5월 21일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "8월 2일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "8월 2일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
   {
     "Input": "6월 22일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "6월 22일에 돌아갈게요",
-        "Type": "date"
+        "Text": "6월 22일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "두달 전에 돌아왔어요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "두달 전",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "이틀 후에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이틀 후",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "한달 전에 누구한테 메일 보냈지",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "한달 전",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "27일에 돌아왔다.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "27일에 돌아왔다!",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "27일에 돌아왔다 .",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "27일에 돌아옴!",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "27일에 돌아옴 .",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "21일에 돌아왔다",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21일에",
-        "Type": "date"
+        "Text": "21일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "22일에 돌아왔다",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22일에",
-        "Type": "date"
+        "Text": "22일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "이일에 돌아왔다",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "이십이일에 돌아옴",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십이일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "삼십일일에 돌아왔다",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼십일일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
     "Input": "27일에 돌아왔다",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일에",
-        "Type": "date"
+        "Text": "27일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "2일에 돌아왔어!",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2일에",
-        "Type": "date"
+        "Text": "2일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
   {
     "Input": "22일에 돌아왔어?",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22일에",
-        "Type": "date"
+        "Text": "22일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
     "Input": "1등상",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "27층으로 갈거야",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "싱가포르와 중국의 외교 관계 수립 25 주년 기념 행사",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "17번째 방탈출 체험 티켓 구하기",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
@@ -1915,11 +1953,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "둘째 토요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -1928,11 +1968,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21일 목요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -1941,11 +1983,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "22일 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -1954,11 +1998,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "23일 토요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -1967,11 +2013,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15일 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -1980,11 +2028,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일일 목요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1993,11 +2043,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십이일 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -2006,11 +2058,13 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "십오일 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2019,289 +2073,357 @@
     "Context": {
       "ReferenceDateTime": "2017-09-01T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "칠일 목요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
   {
     "Input": "두번째 일요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "두번째 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "첫번째 일요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "첫번째 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "세번째 화요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "세번째 화요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
   {
     "Input": "다섯 번째 일요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다섯 번째 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "여섯 번째 일요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "여섯 번째 일요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "열번 째 월요일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "열번 째 월요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "다음 달 20일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 20일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "이번 달 31일에 돌아갈게요",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 달 31일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Cortana는 이번 주 금요일이나 다음 주 화요일에 Skype통화를 하려고 합니다.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 주 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 9,
+        "Length": 8
       },
       {
         "Text": "다음 주 화요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 20,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "Cortana는 이번 주 금요일이나 이번 주 토요일에 Skype통화를 하려고 합니다.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 주 금요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 9,
+        "Length": 8
       },
       {
         "Text": "이번 주 토요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 20,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "16. 11월. 2016",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "16일 11월 2016년",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "16. 11월. 2016",
-        "Type": "date"
+        "Text": "16일 11월 2016년",
+        "Type": "date",
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
   {
     "Input": "우리는 한달 21일 전에 회의가 있었다.",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "한달 21일 전",
-        "Type": "date"
+        "Type": "date",
+        "Start": 4,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "나는 2년 1개월 21일 전에 이곳을 떠났다",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2년 1개월 21일 전",
-        "Type": "date"
+        "Type": "date",
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "나는 2년 21일 후에 이곳을 떠날 것이다",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2년 21일 후",
-        "Type": "date"
+        "Type": "date",
+        "Start": 3,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "나는 1개월 2년 21일 전에 이 곳을 떠났다.",
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "나는 2년 1개월 21일 전에 이 곳을 떠났다.",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1개월 2년 21일 전",
-        "Type": "date"
+        "Text": "2년 1개월 21일 전",
+        "Type": "date",
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "나는 다음 달 20일에 여기를 떠났다.",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 20일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 3,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "나는 5 12월 1391에 이곳을 떠났다.",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "나는 1391년 12월 5일에 이곳을 떠났다.",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5 12월 1391",
-        "Type": "date"
+        "Text": "1391년 12월 5일",
+        "Type": "date",
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
   {
-    "Input": "월요일, 1월 22일, 2018",
+    "Input": "월요일, 1월 22일, 2018년",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "월요일, 1월 22일, 2018",
-        "Type": "date"
+        "Text": "월요일, 1월 22일, 2018년",
+        "Type": "date",
+        "Start": 0,
+        "Length": 18
       }
     ]
   },
   {
-    "Input": "일요일 1월 이십일일 이천팔년에",
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "Input": "일요일 1월 이십일일 이천십팔년에",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "일요일 1월 이십일일 이천팔년",
-        "Type": "date"
+        "Text": "일요일 1월 이십일일 이천십팔년",
+        "Type": "date",
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
   {
     "Input": "9월 21일 1978에",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9월 21일 1978",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
     "Input": "9월 10일, 1901에",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9월 10일, 1901",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
   {
     "Input": "구월 십일, 2000에",
     "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "구월 십일, 2000",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
     "Input": "13.5.2015에 한가해?",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "13.5.2015",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "2015.5.13에 시간 괜찮아?",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015.5.13",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
   {
     "Input": "앞으로 2주 동안 일요일에 시간 괜찮아?",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "앞으로 2주 동안 일요일에",
-        "Type": "date"
+        "Text": "앞으로 2주 동안 일요일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
   {
     "Input": "2주 동안 월요일에 시간 괜찮아?",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2주 동안 월요일",
-        "Type": "date"
+        "Type": "date",
+        "Start": 0,
+        "Length": 9
+      }
+    ]
+  },
+  {
+    "Input": "2008년 1월 21일 일요일에",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2008년 1월 21일 일요일",
+        "Type": "date",
+        "Start": 0,
+        "Length": 16
       }
     ]
   }

--- a/Specs/DateTime/Korean/DateParser.json
+++ b/Specs/DateTime/Korean/DateParser.json
@@ -4,11 +4,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15",
+        "Text": "15일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-15",
@@ -19,8 +19,8 @@
             "date": "2016-10-15"
           }
         },
-        "Start": 16,
-        "Length": 2
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -29,7 +29,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -44,7 +43,7 @@
             "date": "2016-10-02"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 6
       }
     ]
@@ -54,7 +53,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -69,8 +67,8 @@
             "date": "2016-01-12"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -79,7 +77,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -94,8 +91,8 @@
             "date": "2016-01-12"
           }
         },
-        "Start": 13,
-        "Length": 25
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -104,7 +101,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -119,8 +115,8 @@
             "date": "2016-02-22"
           }
         },
-        "Start": 13,
-        "Length": 10
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -129,7 +125,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,8 +139,8 @@
             "date": "2016-04-21"
           }
         },
-        "Start": 13,
-        "Length": 10
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -154,7 +149,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -169,8 +163,8 @@
             "date": "2016-04-22"
           }
         },
-        "Start": 16,
-        "Length": 4
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -179,7 +173,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -194,8 +187,8 @@
             "date": "2015-08-12"
           }
         },
-        "Start": 13,
-        "Length": 10
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -204,7 +197,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -219,8 +211,8 @@
             "date": "2016-01-01"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -229,7 +221,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -244,8 +235,8 @@
             "date": "2016-01-22"
           }
         },
-        "Start": 13,
-        "Length": 14
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -254,7 +245,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -269,8 +259,8 @@
             "date": "2016-05-21"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -279,7 +269,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -294,8 +283,8 @@
             "date": "2016-08-02"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -304,11 +293,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "6월 22일 ",
+        "Text": "6월 22일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-06-22",
@@ -319,8 +307,8 @@
             "date": "2016-06-22"
           }
         },
-        "Start": 13,
-        "Length": 21
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -329,11 +317,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "금요일 ",
+        "Text": "금요일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-WXX-5",
@@ -344,8 +331,8 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 16,
-        "Length": 6
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -354,7 +341,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -369,8 +355,8 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 13,
-        "Length": 5
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -379,7 +365,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -394,8 +380,8 @@
             "date": "2016-11-08"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -404,7 +390,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -419,8 +405,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 9
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -429,7 +415,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -444,8 +430,8 @@
             "date": "2016-11-05"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -454,36 +440,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "내일 모레 ",
-        "Type": "date",
-        "Value": {
-          "Timex": "2016-11-09",
-          "FutureResolution": {
-            "date": "2016-11-09"
-          },
-          "PastResolution": {
-            "date": "2016-11-09"
-          }
-        },
-        "Start": 13,
-        "Length": 22
-      }
-    ]
-  },
-  {
-    "Input": "내일 모레 ",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "dotnet",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "내일 모레 ",
+        "Text": "내일 모레",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-09",
@@ -495,7 +456,32 @@
           }
         },
         "Start": 0,
-        "Length": 22
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "내일 모레 ",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "내일 모레",
+        "Type": "date",
+        "Value": {
+          "Timex": "2016-11-09",
+          "FutureResolution": {
+            "date": "2016-11-09"
+          },
+          "PastResolution": {
+            "date": "2016-11-09"
+          }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -504,7 +490,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -519,8 +505,8 @@
             "date": "2016-11-08"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -529,7 +515,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -544,8 +529,8 @@
             "date": "2016-11-11"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -554,7 +539,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -569,8 +553,8 @@
             "date": "2016-11-20"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -579,7 +563,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -594,8 +577,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 11
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -604,7 +587,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -619,8 +601,8 @@
             "date": "2016-11-11"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -629,7 +611,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -644,8 +625,8 @@
             "date": "2016-11-20"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -654,7 +635,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -669,8 +649,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -679,7 +659,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -694,8 +674,8 @@
             "date": "2016-11-06"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -704,7 +684,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -719,8 +699,8 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -729,7 +709,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -744,7 +723,7 @@
             "date": "2016-06-15"
           }
         },
-        "Start": 13,
+        "Start": 0,
         "Length": 12
       }
     ]
@@ -754,7 +733,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -769,8 +747,8 @@
             "date": "2016-07-01"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -779,7 +757,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -794,8 +771,8 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 13,
-        "Length": 30
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -804,7 +781,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -819,8 +795,8 @@
             "date": "2016-11-18"
           }
         },
-        "Start": 13,
-        "Length": 19
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -829,7 +805,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -844,8 +820,8 @@
             "date": "2016-11-07"
           }
         },
-        "Start": 10,
-        "Length": 6
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -854,11 +830,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "지금으로부터 2주",
+        "Text": "지금으로부터 2주 후",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-21",
@@ -869,8 +844,8 @@
             "date": "2016-11-21"
           }
         },
-        "Start": 13,
-        "Length": 18
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -879,11 +854,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "한 달 전에 ",
+        "Text": "한 달 전",
         "Type": "date",
         "Value": {
           "Timex": "2016-10-07",
@@ -894,8 +869,8 @@
             "date": "2016-10-07"
           }
         },
-        "Start": 16,
-        "Length": 11
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -904,11 +879,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "몇 달 전에 ",
+        "Text": "몇 달 전",
         "Type": "date",
         "Value": {
           "Timex": "2016-08-07",
@@ -919,8 +894,8 @@
             "date": "2016-08-07"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -929,11 +904,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "며칠 전에 ",
+        "Text": "며칠 전",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-04",
@@ -944,8 +919,8 @@
             "date": "2016-11-04"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -954,11 +929,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일 ",
+        "Text": "27일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-27",
@@ -969,8 +944,8 @@
             "date": "2016-10-27"
           }
         },
-        "Start": 16,
-        "Length": 6
+        "Start": 3,
+        "Length": 3
       }
     ]
   },
@@ -979,11 +954,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일 ",
+        "Text": "27일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-27",
@@ -994,8 +969,8 @@
             "date": "2016-10-27"
           }
         },
-        "Start": 16,
-        "Length": 6
+        "Start": 3,
+        "Length": 3
       }
     ]
   },
@@ -1004,11 +979,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21일 ",
+        "Text": "21일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-21",
@@ -1019,8 +994,8 @@
             "date": "2016-10-21"
           }
         },
-        "Start": 16,
-        "Length": 8
+        "Start": 3,
+        "Length": 3
       }
     ]
   },
@@ -1029,11 +1004,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22일 ",
+        "Text": "22일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -1044,8 +1019,8 @@
             "date": "2016-10-22"
           }
         },
-        "Start": 16,
-        "Length": 8
+        "Start": 3,
+        "Length": 3
       }
     ]
   },
@@ -1054,11 +1029,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2일 ",
+        "Text": "2일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-02",
@@ -1069,8 +1044,8 @@
             "date": "2016-11-02"
           }
         },
-        "Start": 16,
-        "Length": 10
+        "Start": 3,
+        "Length": 2
       }
     ]
   },
@@ -1079,11 +1054,11 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "27일 ",
+        "Text": "27일",
         "Type": "date",
         "Value": {
           "Timex": "2017-09-21",
@@ -1094,8 +1069,8 @@
             "date": "2017-09-21"
           }
         },
-        "Start": 12,
-        "Length": 17
+        "Start": 3,
+        "Length": 3
       }
     ]
   },
@@ -1104,7 +1079,7 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1119,8 +1094,8 @@
             "date": "2017-09-10"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1129,7 +1104,7 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1144,8 +1119,8 @@
             "date": "2017-09-03"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1154,7 +1129,7 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1169,8 +1144,8 @@
             "date": "2017-09-19"
           }
         },
-        "Start": 13,
-        "Length": 13
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1179,7 +1154,7 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1194,8 +1169,8 @@
             "date": "0001-01-01"
           }
         },
-        "Start": 13,
-        "Length": 12
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -1204,7 +1179,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1219,8 +1194,8 @@
             "date": "2016-12-20"
           }
         },
-        "Start": 12,
-        "Length": 18
+        "Start": 3,
+        "Length": 8
       }
     ]
   },
@@ -1229,11 +1204,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "이번 달 31일 ",
+        "Text": "이번 달 31일",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-31",
@@ -1244,8 +1219,8 @@
             "date": "0001-01-01"
           }
         },
-        "Start": 12,
-        "Length": 18
+        "Start": 3,
+        "Length": 8
       }
     ]
   },
@@ -1254,7 +1229,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1269,8 +1243,8 @@
             "date": "2018-01-12"
           }
         },
-        "Start": 13,
-        "Length": 16
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1279,7 +1253,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1294,8 +1267,8 @@
             "date": "2015-09-18"
           }
         },
-        "Start": 13,
-        "Length": 7
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1304,11 +1277,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "이틀 전 ",
+        "Text": "이틀 전",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-05",
@@ -1319,8 +1292,8 @@
             "date": "2016-11-05"
           }
         },
-        "Start": 12,
-        "Length": 12
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -1329,11 +1302,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2년 전 ",
+        "Text": "2년 전",
         "Type": "date",
         "Value": {
           "Timex": "2014-11-07",
@@ -1344,8 +1316,8 @@
             "date": "2014-11-07"
           }
         },
-        "Start": 12,
-        "Length": 13
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -1354,11 +1326,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2016년 11월 16일 ",
+        "Text": "2016년 11월 16일",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-16",
@@ -1379,11 +1350,11 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1개월 21일 전에",
+        "Text": "1개월 21일 전",
         "Type": "date",
         "Value": {
           "Timex": "2017-10-02",
@@ -1394,8 +1365,8 @@
             "date": "2017-10-02"
           }
         },
-        "Start": 17,
-        "Length": 19
+        "Start": 4,
+        "Length": 9
       }
     ]
   },
@@ -1404,11 +1375,11 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2년 1개월 21일 전에",
+        "Text": "2년 1개월 21일 전",
         "Type": "date",
         "Value": {
           "Timex": "2015-10-02",
@@ -1419,8 +1390,8 @@
             "date": "2015-10-02"
           }
         },
-        "Start": 12,
-        "Length": 27
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
@@ -1429,11 +1400,11 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 2년 21일 지나서",
+        "Text": "2년 21일 지나서",
         "Type": "date",
         "Value": {
           "Timex": "2019-12-14",
@@ -1444,8 +1415,8 @@
             "date": "2019-12-14"
           }
         },
-        "Start": 17,
-        "Length": 21
+        "Start": 3,
+        "Length": 10
       }
     ]
   },
@@ -1454,7 +1425,7 @@
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1469,8 +1440,8 @@
             "date": "2018-01-20"
           }
         },
-        "Start": 17,
-        "Length": 22
+        "Start": 4,
+        "Length": 8
       }
     ]
   },
@@ -1479,7 +1450,7 @@
     "Context": {
       "ReferenceDateTime": "2017-12-18T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1494,8 +1465,8 @@
             "date": "1391-12-05"
           }
         },
-        "Start": 17,
-        "Length": 15
+        "Start": 4,
+        "Length": 12
       }
     ]
   },
@@ -1504,7 +1475,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1520,7 +1490,7 @@
           }
         },
         "Start": 0,
-        "Length": 28
+        "Length": 16
       }
     ]
   },
@@ -1529,7 +1499,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1544,8 +1513,8 @@
             "date": "2018-01-21"
           }
         },
-        "Start": 3,
-        "Length": 47
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -1554,7 +1523,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1569,8 +1537,8 @@
             "date": "1978-09-21"
           }
         },
-        "Start": 3,
-        "Length": 49
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1579,7 +1547,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1594,8 +1561,8 @@
             "date": "1901-09-10"
           }
         },
-        "Start": 3,
-        "Length": 31
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1604,7 +1571,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1619,8 +1585,8 @@
             "date": "2000-09-10"
           }
         },
-        "Start": 7,
-        "Length": 32
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1629,7 +1595,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T09:58:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1644,8 +1610,8 @@
             "date": "2018-04-06"
           }
         },
-        "Start": 13,
-        "Length": 30
+        "Start": 3,
+        "Length": 13
       }
     ]
   },
@@ -1654,7 +1620,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1669,8 +1635,8 @@
             "date": "2018-04-09"
           }
         },
-        "Start": 12,
-        "Length": 31
+        "Start": 4,
+        "Length": 13
       }
     ]
   },
@@ -1679,7 +1645,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1694,8 +1660,8 @@
             "date": "2018-02-21"
           }
         },
-        "Start": 12,
-        "Length": 37
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -1704,7 +1670,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1719,8 +1684,8 @@
             "date": "2018-03-27"
           }
         },
-        "Start": 19,
-        "Length": 17
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1729,11 +1694,10 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "다음 주 일요일에",
+        "Text": "다음 주 일요일",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-01",
@@ -1744,8 +1708,8 @@
             "date": "2018-04-01"
           }
         },
-        "Start": 16,
-        "Length": 22
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1754,7 +1718,7 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1769,8 +1733,8 @@
             "date": "2018-04-23"
           }
         },
-        "Start": 13,
-        "Length": 22
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -1779,11 +1743,11 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "어제로부터 4일",
+        "Text": "어제로부터 4일 후",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-23",
@@ -1794,8 +1758,8 @@
             "date": "2018-04-23"
           }
         },
-        "Start": 13,
-        "Length": 24
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -1804,7 +1768,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1819,8 +1782,8 @@
             "date": "2015-05-13"
           }
         },
-        "Start": 16,
-        "Length": 9
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1829,7 +1792,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1844,8 +1806,8 @@
             "date": "2015-05-13"
           }
         },
-        "Start": 21,
-        "Length": 9
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -1854,7 +1816,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1869,8 +1830,8 @@
             "date": "2017-03-07"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -1879,7 +1840,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1894,8 +1854,8 @@
             "date": "2027-03-07"
           }
         },
-        "Start": 13,
-        "Length": 6
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -1904,7 +1864,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1919,17 +1879,17 @@
             "date": "1989-05-05"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
-    "Input": "2071년 3월 7일에 돌아갈 거야. ",
+    "Input": "2017년 3월 7일에 돌아갈 거야. ",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1944,13 +1904,14 @@
             "date": "1971-05-05"
           }
         },
-        "Start": 13,
-        "Length": 8
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
   {
     "Input": "너는 지금부터 한 달에 두 번씩 일요일마다 시간 괜찮니? ",
+    "Comment": "Not a proper sentence in Korean and it is not possible to give a better translation of the original case 'Are you available two sundays from now?'",
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
@@ -1976,6 +1937,7 @@
   },
   {
     "Input": "너는 후에 두 번의 월요일에 시간 괜찮니?",
+    "Comment": "Not a proper sentence in Korean and it is not possible to give a better translation of the original case 'Are you available two monday later?'",
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
@@ -2004,7 +1966,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2019,8 +1981,8 @@
             "date": "2018-06-02"
           }
         },
-        "Start": 18,
-        "Length": 20
+        "Start": 2,
+        "Length": 2
       }
     ]
   },
@@ -2029,7 +1991,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2044,8 +2006,8 @@
             "date": "2018-06-22"
           }
         },
-        "Start": 18,
-        "Length": 25
+        "Start": 3,
+        "Length": 7
       }
     ]
   },
@@ -2054,11 +2016,11 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "그끄저께 ",
+        "Text": "그끄저께",
         "Type": "date",
         "Value": {
           "Timex": "2018-05-28",
@@ -2069,8 +2031,8 @@
             "date": "2018-05-28"
           }
         },
-        "Start": 15,
-        "Length": 25
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -2079,11 +2041,10 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3주 후에",
+        "Text": "3주 후",
         "Type": "date",
         "Value": {
           "Timex": "2018-07-26",
@@ -2094,8 +2055,8 @@
             "date": "2018-07-26"
           }
         },
-        "Start": 13,
-        "Length": 10
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -2104,7 +2065,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-21T08:00:00"
     },
-    "NotSupported": "dotnet",
+    "IgnoreResolution": "true",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2119,8 +2080,8 @@
             "date": "2018-08-27"
           }
         },
-        "Start": 45,
-        "Length": 21
+        "Start": 6,
+        "Length": 13
       }
     ]
   },
@@ -2129,7 +2090,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15일",
@@ -2142,51 +2104,9 @@
           "PastResolution": {
             "date": "2016-10-15"
           }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "10.2에 돌아갈게요",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "10.2",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-10-02",
-          "FutureResolution": {
-            "date": "2017-10-02"
-          },
-          "PastResolution": {
-            "date": "2016-10-02"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "10-2에 돌아갈게요",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "10-2",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-10-02",
-          "FutureResolution": {
-            "date": "2017-10-02"
-          },
-          "PastResolution": {
-            "date": "2016-10-02"
-          }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -2195,7 +2115,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "10/2",
@@ -2208,7 +2128,57 @@
           "PastResolution": {
             "date": "2016-10-02"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "10/2에 돌아갈게요",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "10/2",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-10-02",
+          "FutureResolution": {
+            "date": "2017-10-02"
+          },
+          "PastResolution": {
+            "date": "2016-10-02"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "10/2에 돌아갈게요",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "10/2",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-10-02",
+          "FutureResolution": {
+            "date": "2017-10-02"
+          },
+          "PastResolution": {
+            "date": "2016-10-02"
+          }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -2217,7 +2187,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "10월 2일",
@@ -2230,7 +2200,9 @@
           "PastResolution": {
             "date": "2016-10-02"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -2239,7 +2211,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 12일, 2016년",
@@ -2252,7 +2224,9 @@
           "PastResolution": {
             "date": "2016-01-12"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -2261,7 +2235,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016년 1월 12일 월요일",
@@ -2274,7 +2248,9 @@
           "PastResolution": {
             "date": "2016-01-12"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 16
       }
     ]
   },
@@ -2283,7 +2259,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "02/22/2016",
@@ -2296,7 +2272,9 @@
           "PastResolution": {
             "date": "2016-02-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2305,7 +2283,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21/04/2016",
@@ -2318,7 +2296,9 @@
           "PastResolution": {
             "date": "2016-04-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2327,7 +2307,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21/04/16",
@@ -2340,7 +2321,9 @@
           "PastResolution": {
             "date": "2016-04-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -2349,7 +2332,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21-04-2016",
@@ -2362,51 +2345,9 @@
           "PastResolution": {
             "date": "2016-04-21"
           }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "4.22에 돌아가겠습니다",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4.22",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-04-22",
-          "FutureResolution": {
-            "date": "2017-04-22"
-          },
-          "PastResolution": {
-            "date": "2016-04-22"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "4-22에 돌아가겠습니다",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "4-22",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-04-22",
-          "FutureResolution": {
-            "date": "2017-04-22"
-          },
-          "PastResolution": {
-            "date": "2016-04-22"
-          }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2415,7 +2356,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4/22",
@@ -2428,19 +2369,21 @@
           "PastResolution": {
             "date": "2016-04-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
-    "Input": "22/04에 돌아가겠습니다",
+    "Input": "4/22에 돌아가겠습니다",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "22/04",
+        "Text": "4/22",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-04-22",
@@ -2450,7 +2393,57 @@
           "PastResolution": {
             "date": "2016-04-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "4/22에 돌아가겠습니다",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4/22",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-04-22",
+          "FutureResolution": {
+            "date": "2017-04-22"
+          },
+          "PastResolution": {
+            "date": "2016-04-22"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "04/22에 돌아가겠습니다",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "04/22",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-04-22",
+          "FutureResolution": {
+            "date": "2017-04-22"
+          },
+          "PastResolution": {
+            "date": "2016-04-22"
+          }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2459,7 +2452,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015/08/12",
@@ -2472,7 +2465,9 @@
           "PastResolution": {
             "date": "2015-08-12"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2481,7 +2476,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "08/12,2015",
@@ -2494,7 +2490,9 @@
           "PastResolution": {
             "date": "2015-08-12"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -2503,7 +2501,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 1일",
@@ -2516,7 +2514,9 @@
           "PastResolution": {
             "date": "2016-01-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2525,7 +2525,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월-1일",
@@ -2538,7 +2538,9 @@
           "PastResolution": {
             "date": "2016-01-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2547,7 +2549,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 22일, 수요일",
@@ -2560,7 +2562,9 @@
           "PastResolution": {
             "date": "2016-01-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -2569,7 +2573,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1월 1일",
@@ -2582,7 +2586,9 @@
           "PastResolution": {
             "date": "2016-01-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2591,7 +2597,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오월 이십일일",
@@ -2604,7 +2610,9 @@
           "PastResolution": {
             "date": "2016-05-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2613,7 +2621,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5월 이십일일",
@@ -2626,7 +2634,9 @@
           "PastResolution": {
             "date": "2016-05-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2635,7 +2645,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "8월 2일",
@@ -2648,7 +2658,9 @@
           "PastResolution": {
             "date": "2016-08-02"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2657,7 +2669,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "6월 22일",
@@ -2670,7 +2682,9 @@
           "PastResolution": {
             "date": "2016-06-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -2679,7 +2693,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "금요일",
@@ -2692,7 +2706,9 @@
           "PastResolution": {
             "date": "2016-11-04"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -2701,7 +2717,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "금요일",
@@ -2714,7 +2730,9 @@
           "PastResolution": {
             "date": "2016-11-04"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -2723,7 +2741,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오늘",
@@ -2736,7 +2754,9 @@
           "PastResolution": {
             "date": "2016-11-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2745,7 +2765,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "내일",
@@ -2758,7 +2779,9 @@
           "PastResolution": {
             "date": "2016-11-08"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2767,7 +2790,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "어제",
@@ -2780,7 +2804,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2789,7 +2815,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그제",
@@ -2802,7 +2829,9 @@
           "PastResolution": {
             "date": "2016-11-05"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2811,7 +2840,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "모레",
@@ -2824,7 +2854,9 @@
           "PastResolution": {
             "date": "2016-11-09"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2833,7 +2865,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "모레",
@@ -2846,7 +2879,9 @@
           "PastResolution": {
             "date": "2016-11-09"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -2855,7 +2890,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 다음날",
@@ -2868,7 +2904,9 @@
           "PastResolution": {
             "date": "2016-11-08"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 5
       }
     ]
   },
@@ -2877,7 +2915,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음날",
@@ -2890,7 +2929,9 @@
           "PastResolution": {
             "date": "2016-11-08"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -2899,7 +2940,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 금요일",
@@ -2912,7 +2953,9 @@
           "PastResolution": {
             "date": "2016-11-11"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -2921,7 +2964,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음주 일요일",
@@ -2934,7 +2977,9 @@
           "PastResolution": {
             "date": "2016-11-20"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2943,7 +2988,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "저번주 일요일",
@@ -2956,7 +3001,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2965,7 +3012,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번주 금요일",
@@ -2978,7 +3025,9 @@
           "PastResolution": {
             "date": "2016-11-11"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -2987,7 +3036,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음주 일요일",
@@ -3000,7 +3049,9 @@
           "PastResolution": {
             "date": "2016-11-20"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3009,7 +3060,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "저번주 일요일",
@@ -3022,7 +3073,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3031,7 +3084,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "전날",
@@ -3044,7 +3098,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -3053,7 +3109,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 전날",
@@ -3066,7 +3123,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -3075,7 +3134,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "그 날",
@@ -3088,19 +3148,21 @@
           "PastResolution": {
             "date": "2016-11-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
   {
-    "Input": "15 6월 2016에 돌아올게요",
+    "Input": "2016년 6월 15일에 돌아올게요",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15 6월 2016",
+        "Text": "2016년 6월 15일",
         "Type": "date",
         "Value": {
           "Timex": "2016-06-15",
@@ -3110,7 +3172,9 @@
           "PastResolution": {
             "date": "2016-06-15"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -3119,7 +3183,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "7월 첫째주 금요일",
@@ -3132,7 +3196,9 @@
           "PastResolution": {
             "date": "2016-07-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   },
@@ -3141,7 +3207,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번달 첫째주 금요일",
@@ -3154,7 +3220,9 @@
           "PastResolution": {
             "date": "2016-11-04"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -3163,7 +3231,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음주 금요일",
@@ -3176,7 +3244,9 @@
           "PastResolution": {
             "date": "2016-11-18"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3185,7 +3255,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 금요일",
@@ -3198,7 +3268,9 @@
           "PastResolution": {
             "date": "2016-11-18"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -3207,7 +3279,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이 날",
@@ -3220,7 +3293,9 @@
           "PastResolution": {
             "date": "2016-11-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -3229,7 +3304,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "지난 날",
@@ -3242,7 +3318,9 @@
           "PastResolution": {
             "date": "2016-11-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -3251,7 +3329,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2주 후",
@@ -3264,7 +3342,9 @@
           "PastResolution": {
             "date": "2016-11-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -3273,7 +3353,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "한달 전",
@@ -3286,7 +3367,9 @@
           "PastResolution": {
             "date": "2016-10-07"
           }
-        }
+        },
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -3295,7 +3378,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "몇달 전",
@@ -3308,7 +3392,9 @@
           "PastResolution": {
             "date": "2016-08-07"
           }
-        }
+        },
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -3317,7 +3403,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "몇일 전",
@@ -3330,7 +3417,9 @@
           "PastResolution": {
             "date": "2016-11-04"
           }
-        }
+        },
+        "Start": 3,
+        "Length": 4
       }
     ]
   },
@@ -3339,73 +3428,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "27일에",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-XX-27",
-          "FutureResolution": {
-            "date": "2016-11-27"
-          },
-          "PastResolution": {
-            "date": "2016-11-27"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "27일에 돌아왔어요.",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "27일에",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-XX-27",
-          "FutureResolution": {
-            "date": "2016-11-27"
-          },
-          "PastResolution": {
-            "date": "2016-11-27"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "나 27일에 돌아왔어요!",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
-    "Results": [
-      {
-        "Text": "27일에",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-XX-27",
-          "FutureResolution": {
-            "date": "2016-11-27"
-          },
-          "PastResolution": {
-            "date": "2016-11-27"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "Input": "나 27일에 돌아왔어.",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "27일",
@@ -3418,7 +3442,84 @@
           "PastResolution": {
             "date": "2016-11-27"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "27일에 돌아왔어요.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "27일",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-XX-27",
+          "FutureResolution": {
+            "date": "2016-11-27"
+          },
+          "PastResolution": {
+            "date": "2016-11-27"
+          }
+        },
+        "Start": 0,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "나 27일에 돌아왔어요!",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "27일",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-XX-27",
+          "FutureResolution": {
+            "date": "2016-11-27"
+          },
+          "PastResolution": {
+            "date": "2016-11-27"
+          }
+        },
+        "Start": 2,
+        "Length": 3
+      }
+    ]
+  },
+  {
+    "Input": "나 27일에 돌아왔어.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "27일",
+        "Type": "date",
+        "Value": {
+          "Timex": "XXXX-XX-27",
+          "FutureResolution": {
+            "date": "2016-11-27"
+          },
+          "PastResolution": {
+            "date": "2016-11-27"
+          }
+        },
+        "Start": 2,
+        "Length": 3
       }
     ]
   },
@@ -3427,10 +3528,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21일에",
+        "Text": "21일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-21",
@@ -3440,7 +3542,9 @@
           "PastResolution": {
             "date": "2016-11-21"
           }
-        }
+        },
+        "Start": 2,
+        "Length": 3
       }
     ]
   },
@@ -3449,10 +3553,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "for the 22nd",
+        "Text": "22일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -3462,7 +3567,9 @@
           "PastResolution": {
             "date": "2016-11-22"
           }
-        }
+        },
+        "Start": 2,
+        "Length": 3
       }
     ]
   },
@@ -3471,10 +3578,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2일에",
+        "Text": "2일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-02",
@@ -3484,7 +3592,9 @@
           "PastResolution": {
             "date": "2016-11-02"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   },
@@ -3493,10 +3603,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "21일에",
+        "Text": "21일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-22",
@@ -3506,7 +3617,9 @@
           "PastResolution": {
             "date": "2016-11-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -3515,10 +3628,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "30일에",
+        "Text": "30일",
         "Type": "date",
         "Value": {
           "Timex": "XXXX-XX-30",
@@ -3528,7 +3642,9 @@
           "PastResolution": {
             "date": "2016-11-30"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 3
       }
     ]
   },
@@ -3537,7 +3653,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8080661+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "21일 목요일",
@@ -3550,7 +3667,9 @@
           "PastResolution": {
             "date": "2017-09-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3559,7 +3678,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8110663+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "22일 금요일",
@@ -3572,7 +3692,9 @@
           "PastResolution": {
             "date": "2017-09-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3581,7 +3703,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8120465+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "23일 토요일",
@@ -3594,7 +3717,9 @@
           "PastResolution": {
             "date": "2017-09-23"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3603,7 +3728,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8130455+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15일 금요일",
@@ -3616,7 +3742,9 @@
           "PastResolution": {
             "date": "2017-09-15"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3625,7 +3753,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8140457+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일일 목요일",
@@ -3638,7 +3767,9 @@
           "PastResolution": {
             "date": "2017-09-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -3647,7 +3778,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8150456+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십이일 금요일",
@@ -3660,7 +3792,9 @@
           "PastResolution": {
             "date": "2017-09-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -3669,7 +3803,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8160454+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "십오일 금요일",
@@ -3682,7 +3817,9 @@
           "PastResolution": {
             "date": "2017-09-15"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3691,7 +3828,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8200463+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "둘째주 일요일",
@@ -3704,7 +3842,9 @@
           "PastResolution": {
             "date": "2017-09-10"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3713,7 +3853,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8200463+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "첫째주 일요일",
@@ -3726,7 +3867,9 @@
           "PastResolution": {
             "date": "2017-09-03"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3735,7 +3878,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8210454+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "셋째주 화요일",
@@ -3748,7 +3892,9 @@
           "PastResolution": {
             "date": "2017-09-19"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3757,7 +3903,8 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:49.8225493+03:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다섯째 주 일요일",
@@ -3770,7 +3917,9 @@
           "PastResolution": {
             "date": "0001-01-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -3779,7 +3928,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 20일",
@@ -3792,7 +3942,9 @@
           "PastResolution": {
             "date": "2016-12-20"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -3801,7 +3953,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이번 달 31일",
@@ -3814,7 +3967,9 @@
           "PastResolution": {
             "date": "0001-01-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -3823,7 +3978,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9-18-15",
@@ -3836,7 +3991,9 @@
           "PastResolution": {
             "date": "2015-09-18"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 7
       }
     ]
   },
@@ -3845,7 +4002,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이틀 전",
@@ -3858,7 +4016,9 @@
           "PastResolution": {
             "date": "2016-11-05"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -3867,7 +4027,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2년 전",
@@ -3880,19 +4040,21 @@
           "PastResolution": {
             "date": "2014-11-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
   {
-    "Input": "16. 11월. 2016",
+    "Input": "2016년 11월 16일",
     "Context": {
       "ReferenceDateTime": "2016-11-14T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "16. 11월. 2016",
+        "Text": "2016년 11월 16일",
         "Type": "date",
         "Value": {
           "Timex": "2016-11-16",
@@ -3902,7 +4064,9 @@
           "PastResolution": {
             "date": "2016-11-16"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 13
       }
     ]
   },
@@ -3911,8 +4075,8 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1개월 21일 전",
@@ -3925,7 +4089,9 @@
           "PastResolution": {
             "date": "2017-10-02"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 9
       }
     ]
   },
@@ -3934,8 +4100,8 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2년 1개월 21일 전",
@@ -3948,7 +4114,9 @@
           "PastResolution": {
             "date": "2015-10-02"
           }
-        }
+        },
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
@@ -3957,8 +4125,8 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2년 21일 후",
@@ -3971,20 +4139,22 @@
           "PastResolution": {
             "date": "2019-12-14"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "한달 2년 21일 전에 여기를 떠났어요",
+    "Input": "2년 1개월 21일 전에 여기를 떠났어요", 
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "한달 2년 21일 전",
+        "Text": "2년 1개월 21일 전",
         "Type": "date",
         "Value": {
           "Timex": "2015-10-02",
@@ -3994,7 +4164,9 @@
           "PastResolution": {
             "date": "2015-10-02"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -4003,8 +4175,8 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1개월 하고 21일 전",
@@ -4017,7 +4189,9 @@
           "PastResolution": {
             "date": "2017-10-02"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 12
       }
     ]
   },
@@ -4026,8 +4200,8 @@
     "Context": {
       "ReferenceDateTime": "2017-11-23T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1개월, 21일 전",
@@ -4040,7 +4214,9 @@
           "PastResolution": {
             "date": "2017-10-02"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 10
       }
     ]
   },
@@ -4049,8 +4225,8 @@
     "Context": {
       "ReferenceDateTime": "2017-12-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 20일",
@@ -4063,19 +4239,21 @@
           "PastResolution": {
             "date": "2018-01-20"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "우리는 5 12월 1391에 회의했어요",
+    "Input": "우리는 1391년 12월 5일에 회의했어요",
     "Context": {
       "ReferenceDateTime": "2017-12-18T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5 12월 1391",
+        "Text": "1391년 12월 5일",
         "Type": "date",
         "Value": {
           "Timex": "1391-12-05",
@@ -4085,7 +4263,9 @@
           "PastResolution": {
             "date": "1391-12-05"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 12
       }
     ]
   },
@@ -4094,8 +4274,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "월요일, 1월 22일, 2018",
@@ -4108,20 +4287,22 @@
           "PastResolution": {
             "date": "2018-01-22"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
   {
-    "Input": "일요일 1월 이십일일 이천팔년에",
+    "Input": "일요일 1월 이십일일 이천십팔년에",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "일요일 1월 이십일일 이천팔년",
+        "Text": "일요일 1월 이십일일 이천십팔년",
         "Type": "date",
         "Value": {
           "Timex": "2018-01-21",
@@ -4131,7 +4312,9 @@
           "PastResolution": {
             "date": "2018-01-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 17
       }
     ]
   },
@@ -4140,8 +4323,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9월 21일 1978",
@@ -4154,7 +4336,9 @@
           "PastResolution": {
             "date": "1978-09-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -4163,8 +4347,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9월 10일, 1901",
@@ -4177,7 +4360,9 @@
           "PastResolution": {
             "date": "1901-09-10"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -4186,8 +4371,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "javascript",
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "구월 십일, 2000",
@@ -4200,7 +4385,9 @@
           "PastResolution": {
             "date": "2000-09-10"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 11
       }
     ]
   },
@@ -4209,7 +4396,8 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T09:58:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 첫째주 금요일",
@@ -4222,7 +4410,9 @@
           "PastResolution": {
             "date": "2018-04-06"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -4231,7 +4421,8 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 달 둘째주 월요일",
@@ -4244,7 +4435,9 @@
           "PastResolution": {
             "date": "2018-04-09"
           }
-        }
+        },
+        "Start": 4,
+        "Length": 12
       }
     ]
   },
@@ -4253,7 +4446,8 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T10:45:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "저번 달 셋째주 수요일",
@@ -4266,7 +4460,9 @@
           "PastResolution": {
             "date": "2018-02-21"
           }
-        }
+        },
+        "Start": 3,
+        "Length": 12
       }
     ]
   },
@@ -4275,7 +4471,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 주 화요일",
@@ -4288,7 +4484,9 @@
           "PastResolution": {
             "date": "2018-03-27"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -4297,7 +4495,7 @@
     "Context": {
       "ReferenceDateTime": "2018-03-20T22:16:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "다음 주 일요일",
@@ -4310,7 +4508,9 @@
           "PastResolution": {
             "date": "2018-04-01"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -4319,7 +4519,8 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼일 후",
@@ -4332,7 +4533,9 @@
           "PastResolution": {
             "date": "2018-04-23"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 4
       }
     ]
   },
@@ -4341,7 +4544,8 @@
     "Context": {
       "ReferenceDateTime": "2018-04-20T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "어제부터 4일 후",
@@ -4354,7 +4558,9 @@
           "PastResolution": {
             "date": "2018-04-23"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -4363,7 +4569,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "13.5.2015",
@@ -4376,7 +4582,9 @@
           "PastResolution": {
             "date": "2015-05-13"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -4385,7 +4593,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2015.5.13",
@@ -4398,7 +4606,9 @@
           "PastResolution": {
             "date": "2015-05-13"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 9
       }
     ]
   },
@@ -4407,7 +4617,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3-7-2017",
@@ -4420,7 +4631,9 @@
           "PastResolution": {
             "date": "2017-03-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -4429,7 +4642,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3-7-07",
@@ -4442,7 +4656,9 @@
           "PastResolution": {
             "date": "2007-03-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -4451,7 +4667,8 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3-7-27",
@@ -4464,7 +4681,9 @@
           "PastResolution": {
             "date": "2027-03-07"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 6
       }
     ]
   },
@@ -4473,7 +4692,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "89/05/05",
@@ -4486,7 +4705,9 @@
           "PastResolution": {
             "date": "1989-05-05"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -4495,7 +4716,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "71/05/05",
@@ -4508,7 +4729,9 @@
           "PastResolution": {
             "date": "1971-05-05"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -4517,7 +4740,8 @@
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오늘부터 2주간 일요일",
@@ -4530,7 +4754,9 @@
           "PastResolution": {
             "date": "2018-05-20"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 12
       }
     ]
   },
@@ -4539,7 +4765,8 @@
     "Context": {
       "ReferenceDateTime": "2018-05-07T00:00:00"
     },
-    "NotSupportedByDesign": "dotNet,javascript,python,java",
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2주 후 월요일",
@@ -4552,7 +4779,34 @@
           "PastResolution": {
             "date": "2018-05-21"
           }
-        }
+        },
+        "Start": 0,
+        "Length": 8
+      }
+    ]
+  },
+  {
+    "Input": "2008년 1월 21일 일요일에",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "IgnoreResolution": "true",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "2008년 1월 21일 일요일",
+        "Type": "date",
+        "Value": {
+          "Timex": "2018-01-21",
+          "FutureResolution": {
+            "date": "2018-01-21"
+          },
+          "PastResolution": {
+            "date": "2018-01-21"
+          }
+        },
+        "Start": 0,
+        "Length": 16
       }
     ]
   }

--- a/Specs/DateTime/Korean/DateParser.json
+++ b/Specs/DateTime/Korean/DateParser.json
@@ -1885,31 +1885,6 @@
     ]
   },
   {
-    "Input": "2017년 3월 7일에 돌아갈 거야. ",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "IgnoreResolution": "true",
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "2017년 3월 7일",
-        "Type": "date",
-        "Value": {
-          "Timex": "1971-05-05",
-          "FutureResolution": {
-            "date": "1971-05-05"
-          },
-          "PastResolution": {
-            "date": "1971-05-05"
-          }
-        },
-        "Start": 0,
-        "Length": 11
-      }
-    ]
-  },
-  {
     "Input": "너는 지금부터 한 달에 두 번씩 일요일마다 시간 괜찮니? ",
     "Comment": "Not a proper sentence in Korean and it is not possible to give a better translation of the original case 'Are you available two sundays from now?'",
     "Context": {
@@ -2135,54 +2110,6 @@
     ]
   },
   {
-    "Input": "10/2에 돌아갈게요",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "10/2",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-10-02",
-          "FutureResolution": {
-            "date": "2017-10-02"
-          },
-          "PastResolution": {
-            "date": "2016-10-02"
-          }
-        },
-        "Start": 0,
-        "Length": 4
-      }
-    ]
-  },
-  {
-    "Input": "10/2에 돌아갈게요",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "10/2",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-10-02",
-          "FutureResolution": {
-            "date": "2017-10-02"
-          },
-          "PastResolution": {
-            "date": "2016-10-02"
-          }
-        },
-        "Start": 0,
-        "Length": 4
-      }
-    ]
-  },
-  {
     "Input": "10월 2일에 돌아갈게요",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -2348,54 +2275,6 @@
         },
         "Start": 0,
         "Length": 10
-      }
-    ]
-  },
-  {
-    "Input": "4/22에 돌아가겠습니다",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "4/22",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-04-22",
-          "FutureResolution": {
-            "date": "2017-04-22"
-          },
-          "PastResolution": {
-            "date": "2016-04-22"
-          }
-        },
-        "Start": 0,
-        "Length": 4
-      }
-    ]
-  },
-  {
-    "Input": "4/22에 돌아가겠습니다",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "4/22",
-        "Type": "date",
-        "Value": {
-          "Timex": "XXXX-04-22",
-          "FutureResolution": {
-            "date": "2017-04-22"
-          },
-          "PastResolution": {
-            "date": "2016-04-22"
-          }
-        },
-        "Start": 0,
-        "Length": 4
       }
     ]
   },


### PR DESCRIPTION
Extractor: 194 pass, 2 fail.
Parser: 87 pass, 102 only extraction, 2 fail.

Failing cases (both in Extractor and Parser):
- "너는 지금부터 한 달에 두 번씩 일요일마다 시간 괜찮니? " (Are you available two sundays from now?), it literally translates to "Are you available twice per month on Monday from now?".
- "너는 후에 두 번의 월요일에 시간 괜찮니?" (Are you available two monday later?), it literally translates to "Are you available on this coming two Monday after this?".
The problem is there is no correspondence for these expressions ("two sundays from now", "two monday later") in Korean and the two inputs as they are do not make sense.

A few inputs were updated because not grammatically correct or because containing date patterns not used in Korean:

In DateExtractor: 

Date separator not used in Korean:
- "4.22에 돌아갈게요" -> "4/22에 돌아갈게요"
- "4-22에 돌아가요" -> "4/22에 돌아가요"
- "4-22에 돌아갈게요" -> "4/22에 돌아갈게요"

Missing day/month/year indicator:
- "2016년 6월 15에 돌아올거야" -> "2016년 6월 15일에 돌아올거야"
- "5월 11에 야구" -> "5월 11일에 야구"
- "5월 21에 돌아갈게요" -> "5월 21일에 돌아갈게요"
- "16. 11월. 2016" -> "16일 11월 2016년"
- "월요일, 1월 22일, 2018" -> "월요일, 1월 22일, 2018년"

Wrong date order/sentence structure:
- "나는 1개월 2년 21일 전에 이 곳을 떠났다." -> "나는 2년 1개월 21일 전에 이 곳을 떠났다."
- "나는 5 12월 1391에 이곳을 떠났다." -> "나는 1391년 12월 5일에 이곳을 떠났다."


In DateParser:

Misspelled year:
- "2071년 3월 7일에 돌아갈 거야. " ->  "2017년 3월 7일에 돌아갈 거야. "

Date separator not used in Korean:
- "10.2에 돌아갈게요" -> "10/2에 돌아갈게요"
- "10-2에 돌아갈게요" -> "10/2에 돌아갈게요"
- "4.22에 돌아가겠습니다" -> "4/22에 돌아가겠습니다"
- "4-22에 돌아가겠습니다" -> "4/22에 돌아가겠습니다"

Wrong date order/sentence structure:
- "22/04에 돌아가겠습니다" -> "04/22에 돌아가겠습니다"
- "15 6월 2016에 돌아올게요" -> "2016년 6월 15일에 돌아올게요"
- "16. 11월. 2016" -> "2016년 11월 16일"
- "한달 2년 21일 전에 여기를 떠났어요" -> "2년 1개월 21일 전에 여기를 떠났어요"
- "우리는 5 12월 1391에 회의했어요" -> "우리는 1391년 12월 5일에 회의했어요"
