### PR TITLE
[* DateTimeV2] Fixed duration patterns wrongly normalized/resolved when number is missing (#2617)

### DIFF
--- a/Specs/DateTime/Dutch/MergedParser.json
+++ b/Specs/DateTime/Dutch/MergedParser.json
@@ -4357,7 +4357,6 @@
   },
   {
     "Input": "Ik zal binnen de komende dag en 5 uren terug zijn",
-    "Comment": "The resolution of this case is wrong (but coincides with that of the corresponding English 'I'll be back within the next day and 5 hours') and needs to be fixed in DateTimePeriodParser",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
@@ -4369,10 +4368,10 @@
         "Value": {
           "values": [
             {
-              "timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
+              "timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
               "type": "datetimerange",
               "start": "2016-11-07 16:12:00",
-              "end": "2016-11-07 21:12:00"
+              "end": "2016-11-08 21:12:00"
             }
           ]
         },

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -20555,7 +20555,6 @@
   },
   {
     "Input": "I'll be back within the next day and 5 hours",
-    "Comment": "The resolution of this case is wrong and needs to be fixed in DateTimePeriodParser",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
@@ -20569,10 +20568,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
+              "timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
               "type": "datetimerange",
               "start": "2016-11-07 16:12:00",
-              "end": "2016-11-07 21:12:00"
+              "end": "2016-11-08 21:12:00"
             }
           ]
         }


### PR DESCRIPTION
Fix to issue #2617.

Updated affected test cases in Dutch and English.