### PR TITLE
[.NET] Dutch DateTimeModel initial support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ArticleRegex = @"\b(de|het|een)\b";
       public const string ApostrofRegex = @"(’|‘|'|ʼ)";
       public static readonly string ApostrofsRegex = $@"({ApostrofRegex}\s*s)";
-      public const string RelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b";
-      public const string StrictRelativeRegex = @"\b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b";
-      public const string UpcomingPrefixRegex = @"(aankomende?|komende?|aanstaande?)";
-      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|aanstaande?|{UpcomingPrefixRegex})\b";
+      public const string RelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)";
+      public const string StrictRelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b)|gister(en)?)";
+      public const string UpcomingPrefixRegex = @"((deze\s+)?((aan)?komende?|aanstaande?))";
+      public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b";
       public const string AfterNextSuffixRegex = @"\b((na\s+(afloop\s+van\s+)?((de|het)\s+)?volgende?)|over)\b";
-      public const string PastPrefixRegex = @"((deze\s+)?verleden)\b";
-      public static readonly string PreviousPrefixRegex = $@"(voorgaand[e]|vorige?|afgelopen|verleden|laatste|{PastPrefixRegex})\b";
+      public const string PastPrefixRegex = @"((deze\s+)?(verleden|afgelopen))\b";
+      public static readonly string PreviousPrefixRegex = $@"((voorgaand[e]|vorige?|verleden|laatste|{PastPrefixRegex})\b|gister(en)?)";
       public const string ThisPrefixRegex = @"(dit|deze|huidige?)\b";
       public const string RangePrefixRegex = @"(?<desc>van|tussen)";
       public const string CenturySuffixRegex = @"(^eeuw|^centennium)\b";
@@ -55,25 +55,29 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string LastTwoYearNumRegex = $@"((zero|nul|en)\s+{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|({WrittenOneToNineRegex}[eë]n)?{WrittenTensRegex})";
       public static readonly string FullTextYearRegex = $@"\b((?<firsttwoyearnum>{CenturyRegex})\s*(?<lasttwoyearnum>{LastTwoYearNumRegex})\b|\b(?<firsttwoyearnum>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}\s+hundred(\s+and)?))\b";
       public const string OclockRegex = @"(?<oclock>u(ur)?)\b";
-      public const string SpecialDescRegex = @"(p\b)";
+      public const string SpecialDescRegex = @"((?<ipm>)p\b)";
       public static readonly string AmDescRegex = $@"(:?{BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"(:?{BaseDateTime.BasePmDescRegex})";
       public static readonly string AmPmDescRegex = $@"(:?{BaseDateTime.BaseAmPmDescRegex})";
       public static readonly string DescRegex = $@"(:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
-      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
+      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)";
+      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))";
+      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))";
+      public static readonly string FullDescRegex = $@"({DescRegex}|{AmRegex}|{PmRegexFull})";
+      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
       public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
-      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
+      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
-      public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
+      public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot|op)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
       public const string DateUnitRegex = @"(?<unit>eeuw(en)?|jaar|jaren|jr|decennia|maand(en)?|mnd|week|weken|(?<business>(werk))?dag(en)?|dgn)\b";
       public const string DateTokenPrefix = @"op ";
       public const string TimeTokenPrefix = @"om ";
       public const string TokenBeforeDate = @"op ";
       public const string TokenBeforeTime = @"om ";
       public const string HalfTokenRegex = @"^(half)";
-      public const string QuarterTokenRegex = @"^(een\s+kwart|kwart|een\s+kwartier|kwartier)";
+      public const string QuarterTokenRegex = @"^(een\s+kwart(\s+jaar)?|kwart|een\s+kwartier|kwartier)";
       public const string ThreeQuarterTokenRegex = @"^(drie\s+kwart|drie\s+kwartier)";
       public const string ToTokenRegex = @"\b(voor)$";
       public const string ToHalfTokenRegex = @"\b(over\s+half)$";
@@ -81,13 +85,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string FromRegex = @"\b(van(af)?)$";
       public const string BetweenTokenRegex = @"\b(tussen)$";
       public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
       public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
-      public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b";
+      public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b";
       public static readonly string WeekOfYearRegex = $@"(\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)";
       public static readonly string FollowedDateUnit = $@"^\s*{DateUnitRegex}";
       public static readonly string NumberCombinedWithDateUnit = $@"\b(?<num>\d+(\.\d*)?){DateUnitRegex}";
@@ -103,7 +107,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)";
       public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
-      public const string PrefixDayRegex = @"\b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later|aan\s+het\s+einde?(\s+van(\s+de)?)?))(\s+(in|op|van))?(\s+de\s+dag)\b";
+      public const string PrefixDayRegex = @"\b(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b";
       public const string SeasonDescRegex = @"(?<seas>lente|voorjaar|zomer|herfst|najaar|winter)";
       public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}(\s+)?)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b";
       public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
@@ -117,26 +121,29 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string PrefixWeekDayRegex = @"(\s*((,?\s*op)|[-—–]))";
       public static readonly string ThisRegex = $@"\b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
       public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
-      public static readonly string NextDateRegex = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b";
-      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)";
+      public const string WeekDayForNextDateRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))";
+      public static readonly string NextDateRegex1 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})";
+      public static readonly string NextDateRegex2 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})";
+      public static readonly string NextDateRegex = $@"({NextDateRegex1}|{NextDateRegex2})";
+      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)";
       public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
-      public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)(s|(?<suffix>e)n)\b";
+      public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)((?<suffix>e)n)\b";
       public static readonly string WeekDayOfMonthRegex = $@"(?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))";
       public static readonly string RelativeWeekDayRegex = $@"\b({WrittenNumRegex}\s+{WeekDayRegex}\s+(vanaf\s+nu|later))\b";
       public static readonly string SpecialDate = $@"(?=\b(op\s+)(de\s+)?){DayRegex}\b";
       public const string DatePreposition = @"\b(op(\s+de)?)";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*[,./-]\s*){DateYearRegex}";
-      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";
+      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";
       public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*)?(de\s+)?)?(({DayRegex}(\s*dag|\.)?)((\s+|\s*[,/-]\s*|\s+van\s+)?{MonthRegex})((\.)?(\s+|\s*[,/-]\s*|\s+in\s+)?{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[,./-]?\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(\s*dag|\.)?\s*[,./-]?\s*{MonthRegex})\b";
-      public static readonly string DateExtractor4 = $@"\b{DayRegex}(\.)?\s*[/\\\-]\s*{MonthNumRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
+      public static readonly string DateExtractor4 = $@"\b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}[\.]?\s*[/\\\-]\s*{ApostrofRegex}?{DateYearRegex}";
       public static readonly string DateExtractor5 = $@"\b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
-      public static readonly string DateExtractor6 = $@"(?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\-\.]{DayRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b";
+      public static readonly string DateExtractor6 = $@"(?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b|(?<={DatePreposition}\s+){MonthNumRegex}[\-\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractor7L = $@"\b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{DateExtractorYearTermRegex}(?![%])\b";
-      public static readonly string DateExtractor7S = $@"\b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b";
-      public static readonly string DateExtractor8 = $@"(?<={DatePreposition}\s+)({WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b";
+      public static readonly string DateExtractor7S = $@"\b((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
+      public static readonly string DateExtractor8 = $@"((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractor9L = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}((\s+|\s*,\s*|\s+in\s+){DateYearRegex})(?![%])\b";
-      public static readonly string DateExtractor9S = $@"\b(?<!naar\s+)({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b";
+      public static readonly string DateExtractor9S = $@"\b(?<!naar\s+)((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}\s*[\-\/.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?({BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})";
       public static readonly string OfMonth = $@"(^\s*((van|in)\s+)?)({MonthRegex})";
       public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
@@ -144,11 +151,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string WeekDayStart = @"^[\.]";
       public const string RangeUnitRegex = @"\b(?<unit>ja(ren|ar)|maand(en)?|we(ken|ek)|dag(en)?)\b";
       public const string HourNumRegex = @"\b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b";
-      public const string MinuteNumRegex = @"(?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
-      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
-      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)";
-      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))";
-      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))";
+      public const string MinuteNumRegex = @"(?<minnum>nul|een(?=\s+min(uut)?)|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)";
+      public const string DeltaMinuteNumRegex = @"(?<deltaminnum>nul|een(?=\s+min(uut)?)|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)";
       public const string LunchRegex = @"\b(lunchtijd)\b";
       public static readonly string NightRegex = $@"\b((({ApostrofsRegex}|des)\s+)?nachts|(midder)?nacht)\b";
       public const string CommonDatePrefixRegex = @"^[\.]";
@@ -175,8 +179,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string PeriodHourNumRegex = @"\b(?<hour>nul|een|één|twee|drie|vier|vijf(en)?|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b?";
       public static readonly string ConnectNumRegex = $@"\b{BaseDateTime.HourRegex}(?<min>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59)\s*{DescRegex}";
       public static readonly string TimeRegexWithDotConnector = $@"({BaseDateTime.HourRegex}(\s*\.\s*){BaseDateTime.MinuteRegex}(\s*:\s*{BaseDateTime.SecondRegex})?(\s*u\s*)?)";
+      public static readonly string TimeRegexFilter = $@"\b((iedere|elke|op)(\s+andere)?\s+)?(week|dag|{SingleWeekDayRegex}|vandaag)\b";
       public static readonly string TimeRegex1 = $@"\b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|((?<prefix>half)\s+)?(?!een){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)";
-      public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!\d)((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!(\d|\s*(per|pro)\s*cent|%))((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex3 = $@"(\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})";
       public static readonly string TimeRegex4 = $@"\b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
       public static readonly string TimeRegex5 = $@"\b({TimePrefix}\s+{BasicTime}|{BasicTime}\s+{TimePrefix})((\s*({DescRegex}|{TimeSuffix}))|\b)";
@@ -185,9 +190,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeRegex8 = $@".^";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s*{FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?";
-      public static readonly string TimeRegex11 = $@"\b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%|{EachUnitRegex})))";
+      public static readonly string TimeRegex11 = $@"\b(?<!{TimeRegexFilter}\s+)((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*(per|pro)\s*cent|%|\s+{TimeRegexFilter})))";
       public static readonly string TimeRegex12 = $@"({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))";
-      public static readonly string FirstTimeRegexInTimeRange = $@"\b{TimeRegexWithDotConnector}(\s*{DescRegex})?";
+      public static readonly string FirstTimeRegexInTimeRange = $@"\b{TimeRegexWithDotConnector}(?!\s*(per|pro)\s*cent|%|\s+{TimeRegexFilter})(\s*{DescRegex})?";
       public static readonly string PureNumFromToPrefixExcluded = $@"({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
       public static readonly string PureNumFromToPrefix = $@"(({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
       public static readonly string PureNumFromToWithDateBefore = $@"({RangePrefixRegex}\s+)({HourDTRegEx})(\s+(vandaag|morgen)\s+)?(\s*{RangeConnectorRegex}\s*)({HourDTRegEx})";
@@ -198,8 +203,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string SpecificTimeFromTo = $@"(({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)?(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{TillRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?))";
       public static readonly string SpecificTimeBetweenAnd = $@"(({PmRegexFull}|{AmRegex})\s+)?(tussen\s+)(?<time1>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>{DescRegex}))?))\s*{RangeConnectorRegex}\s*(?<time2>({TimeRegex2}|({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<rightDesc>{DescRegex}))?(\s+{TimeSuffix})?))";
       public const string PrepositionRegex = @"(?<prep>^(om|rond|tegen|op|van|deze)(\s+de)?$)";
-      public const string EarlyLateRegex = @"(((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)";
-      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b";
+      public const string EarlyLateRegex = @"\b(((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)";
+      public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|\b(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b";
       public static readonly string SpecificTimeOfDayRegex = $@"\b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|(van)?avond|nacht)))s?\b";
       public static readonly string TimeFollowedUnit = $@"^\s*{TimeUnitRegex}";
       public static readonly string TimeNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){TimeUnitRegex}";
@@ -213,15 +218,15 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$";
       public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*(?<!van(avond|nacht)\s+)({HourNumRegex}|{BaseDateTime.HourRegex})\b";
-      public const string SpecificEndOfRegex = @"((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
+      public const string SpecificEndOfRegex = @"((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+(de|het))?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
       public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b";
       public const string UnspecificEndOfRangeRegex = @"\b(evj)\b";
       public static readonly string PeriodTimeOfDayRegex = $@"((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|(eer)?gisteren|morgen)?(?<timeOfDay>ochtend|(na)?middag|avond|nacht))\b";
-      public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b";
+      public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}(\s+)?{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b";
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"(({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))\b";
       public const string LessThanRegex = @"\b((binnen\s+)?minder\s+dan)\b";
-      public const string MoreThanRegex = @"\b(meer\s+dan|ruim)\b";
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?";
+      public const string MoreThanRegex = @"\b((meer|langer)\s+dan|ruim)\b";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|minuut|mins|min|m|secondes|seconden|secs|sec|s|nacht(en)?)\b)(\s+lang\b)?";
       public const string SuffixAndRegex = @"(?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))";
       public const string PeriodicRegex = @"\b(?<periodic>dagelijkse?|(drie)?maandelijkse?|wekelijkse?|twee-?wekelijkse?|jaarlijkse?|kwartaal)\b";
       public static readonly string EachUnitRegex = $@"(?<each>((iedere|elke|eenmaal per)(?<other>\s+andere)?\s*{DurationUnitRegex})|(({DurationUnitRegex}|{WeekDayRegex})\s+om(\s+de)?(?<other>\s+andere)?\s*(week|{DurationUnitRegex})))";
@@ -232,21 +237,21 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string BeforeEachDayRegex = @"(iedere|elke)\s*dag\s*";
       public static readonly string DurationFollowedUnit = $@"^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}";
-      public static readonly string AnUnitRegex = $@"\b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}";
+      public static readonly string AnUnitRegex = $@"\b((?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}";
       public const string DuringRegex = @"\b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b";
-      public const string AllRegex = @"\b(?<all>((de|het|een)(\s+))?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
+      public const string AllRegex = @"\b(?<all>(voor\s+)?((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
       public const string HalfRegex = @"(((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b";
       public const string ConjunctionRegex = @"\b((en(\s+voor)?)|plus)\b";
       public static readonly string HolidayList1 = $@"(?<holiday>goede vrijdag|pasen|((eerste|tweede)\s+)?paasdag|paas(zondag|maandag)|kerst|kerstavond|kerstmis|thanksgiving|halloween|nieuwjaar|oud en nieuw|oud & nieuw|pinksteren|oude?jaar|oude?jaarsavond|silvester|silvesteravond|sinterklaas|sinterklaasfeest|sinterklaasavond|pakjesavond)";
       public static readonly string HolidayList2 = $@"(?<holiday>black friday|cyber monday|nationale dodenherdenking|nationale herdenking|dodenherdenking|dag van de leraar|dag van de leerkracht(en)?|dag van de arbeid|feest van de arbeid|yuandan|valentijn|sint-maartensfeest|sint-maarten|driekoningen|keti(\s+|-)?koti|ramadan|offerfeest|allerheiligen|allerheiligenavond|franse nationale feestdag|bestorming van de bastille)";
-      public static readonly string HolidayList3 = $@"(?<holiday>(martin luther king|mlk|dankzeggings|valentijns|nieuwjaars|(eerste|1e|tweede|2e)\s+paas|prinsjes|konings|koninginne|bevrijdings|hemelvaarts|(eerste|1e|tweede|2e)\s+kerst|vader|moeder|meisjes|(amerikaanse|us\s+)?onafhankelijkheids|(nederlandse\s+)?veteranen|boomplant|(nationale\s+)?boomfeest)dag)";
-      public static readonly string HolidayRegex = $@"\b(({StrictRelativeRegex}\s+({HolidayList1}|{HolidayList2}|{HolidayList3}))|(({HolidayList1}|{HolidayList2}|{HolidayList3})(\s+(van dit\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?))\b";
+      public static readonly string HolidayList3 = $@"(?<holiday>(martin luther king|mlk|dankzeggings|valentijns|nieuwjaars|(eerste|1e|tweede|2e)\s+paas|prinsjes|konings|koninginne|bevrijdings|hemelvaarts|(eerste|1e|tweede|2e)\s+kerst|vader|moeder|meisjes|(amerikaanse|us\s+)?onafhankelijk(heid)?s|(nederlandse\s+)?veteranen|boomplant|(nationale\s+)?boomfeest)dag)";
+      public static readonly string HolidayRegex = $@"\b(({StrictRelativeRegex}\s+({HolidayList1}|{HolidayList2}|{HolidayList3}))|(({HolidayList1}|{HolidayList2}|{HolidayList3})(\s+(van\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?))\b";
       public static readonly string AMTimeRegex = $@"(?<am>{ApostrofsRegex}\s*(morgens|ochtends)|in\s+de\s+(morgen|ochtend))";
       public static readonly string PMTimeRegex = $@"(?<pm>{ApostrofsRegex}\s*(middags|avonds|nachts)|(in\s+de\s+)?(deze\s+)?((na)?middag|avond|nacht))\b";
       public const string InclusiveModPrepositions = @"(?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))";
-      public static readonly string BeforeRegex = $@"(\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
+      public static readonly string BeforeRegex = $@"(\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>(al\s+)?zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
       public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";
-      public const string SinceRegex = @"(\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|zo\s+vroeg\s+als|ieder\s+moment\s+vanaf)\b\s*)|(?<!\w|<)(>=)";
+      public const string SinceRegex = @"(\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|(al\s+)?zo\s+vroeg\s+als|(elk|ieder)\s+moment\s+vanaf|een\s+tijdstip\s+vanaf)\b\s*)|(?<!\w|<)(>=)";
       public const string AroundRegex = @"(\b(rond(om)?|ongeveer(\s+om)?)\s*\b)";
       public const string AgoRegex = @"\b(geleden|(voor|eerder\s+dan)\s+(?<day>gisteren|vandaag))\b";
       public const string LaterRegex = @"\b(later|vanaf\s+nu|(vanaf|na|sedert)\s+(?<day>morgen|vandaag))\b";
@@ -259,7 +264,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string AfternoonStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+middags|in\s+de\s+(na)?middag|deze\s+middag|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+middag|{PmDescRegex}))|((({ApostrofsRegex}|des)?\s+middags|in\s+de\s+(na)?middag|deze\s+middag|middag\s+in\s+het\s+begin|middag\s+aan\s+het\s+einde?|{PmDescRegex}|middag)$)";
       public static readonly string EveningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{{PmDescRegex}}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{{PmDescRegex}}|avond)$)";
       public static readonly string NightStartEndRegex = $@"(^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)";
-      public const string InexactNumberRegex = @"\b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b";
+      public const string InexactNumberRegex = @"\b((een\s+)?aantal|meerdere|enkele|verscheidene|wat|enige|(?<NumTwoTerm>(een\s+)?paar))\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+({DurationUnitRegex})";
       public static readonly string RelativeTimeUnitRegex = $@"((({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+({TimeUnitRegex}))|((de|het|mijn))\s+({RestrictedTimeUnitRegex}))";
       public static readonly string RelativeDurationUnitRegex = $@"(((?<=({NextPrefixRegex}|{PreviousPrefixRegex}|{ThisPrefixRegex})\s+)({DurationUnitRegex}))|((the|my))\s+({RestrictedTimeUnitRegex}))";
@@ -294,7 +299,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|(ee|éé)nentwintigste\s+eeuw))";
       public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<=\b(de|jaren)\s+)(?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
       public static readonly string RelativeDecadeRegex = $@"\b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b";
-      public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna)(?!\s+dan))\b";
+      public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna|daarna|hoger)(?!\s+dan))\b";
       public const string DateAfterRegex = @"\b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b";
       public static readonly string YearPeriodRegex = $@"((((van(af)?|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
       public static readonly string ComplexDatePeriodRegex = $@"(((van(af)?|tijdens|gedurende|in(\s+de)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
@@ -317,6 +322,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"dag", @"D" },
             { @"vandaag", @"D" },
             { @"dgn", @"D" },
+            { @"nachten", @"D" },
+            { @"nacht", @"D" },
             { @"uren", @"H" },
             { @"uur", @"H" },
             { @"u", @"H" },
@@ -350,6 +357,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"dag", 86400 },
             { @"vandaag", 86400 },
             { @"dgn", 86400 },
+            { @"nachten", 86400 },
+            { @"nacht", 86400 },
             { @"werkdagen", 86400 },
             { @"werkdag", 86400 },
             { @"uren", 3600 },
@@ -734,7 +743,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
             { @"newyearsday", new string[] { @"nieuwjaarsdag" } },
             { @"newyeareve", new string[] { @"oudjaar", @"oudejaar", @"oudejaarsavond", @"oudjaarsavond", @"silvester", @"silvesteravond", @"oudennieuw", @"oud&nieuw" } },
             { @"valentinesday", new string[] { @"valentijnsdag", @"valetijnsdag" } },
-            { @"independenceday", new string[] { @"onafhankelijkheidsdag" } },
+            { @"independenceday", new string[] { @"onafhankelijkheidsdag", @"onafhankelijksdag" } },
             { @"bastilleday", new string[] { @"fransenationalefeestdag", @"bestormingvandebastille" } },
             { @"halloweenday", new string[] { @"halloween", @"allerheiligenavond" } },
             { @"allhallowday", new string[] { @"allerheiligen" } },
@@ -821,7 +830,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"^\d{4}$", @"(\d\.\d{4}|\d{4}\.\d)" },
-            { @"\b(lunch)$", @"(?<!\b(op|om|voor|ana(ar)?|rond)\b\s)(lunch)" }
+            { @"\b(lunch)$", @"(?<!\b(op|om|voor|ana(ar)?|rond)\b\s)(lunch)" },
+            { @"^(morgen|middag|avond|nacht|dag)\b", @"\b(goeden?\s*(morgen|middag|avond|nacht|dag))\b" }
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
@@ -877,6 +887,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         {
             @"gisteren",
             @"dag voor",
+            @"dag ervoor",
             @"vorige dag",
             @"gisterenochtend",
             @"gisterenavond"

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ArticleRegex = @"\b(de|het|een)\b";
       public const string ApostrofRegex = @"(’|‘|'|ʼ)";
       public static readonly string ApostrofsRegex = $@"({ApostrofRegex}\s*s)";
-      public const string RelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)";
-      public const string StrictRelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b)|gister(en)?)";
+      public const string RelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)";
+      public const string StrictRelativeRegex = @"\b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|laatste|afgelopen)\b)|gister(en)?)";
       public const string UpcomingPrefixRegex = @"((deze\s+)?((aan)?komende?|aanstaande?))";
       public static readonly string NextPrefixRegex = $@"\b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b";
       public const string AfterNextSuffixRegex = @"\b((na\s+(afloop\s+van\s+)?((de|het)\s+)?volgende?)|over)\b";
@@ -60,8 +60,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PmDescRegex = $@"(:?{BaseDateTime.BasePmDescRegex})";
       public static readonly string AmPmDescRegex = $@"(:?{BaseDateTime.BaseAmPmDescRegex})";
       public static readonly string DescRegex = $@"(:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
-      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)";
-      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))";
+      public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|dag)";
+      public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))))";
       public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))";
       public static readonly string FullDescRegex = $@"({DescRegex}|{AmRegex}|{PmRegexFull})";
       public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
@@ -88,7 +88,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b";
+      public static readonly string RelativeYearRegex = $@"({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)";
+      public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*){RelativeYearRegex})|({RelativeYearRegex}(\s*),?(\s*){WrittenMonthRegex}))\b";
       public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b";
@@ -125,7 +126,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string NextDateRegex1 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})";
       public static readonly string NextDateRegex2 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})";
       public static readonly string NextDateRegex = $@"({NextDateRegex1}|{NextDateRegex2})";
-      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)";
+      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)";
       public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
       public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)((?<suffix>e)n)\b";
@@ -205,7 +206,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string PrepositionRegex = @"(?<prep>^(om|rond|tegen|op|van|deze)(\s+de)?$)";
       public const string EarlyLateRegex = @"\b(((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)";
       public static readonly string TimeOfDayRegex = $@"(?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|\b(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b";
-      public static readonly string SpecificTimeOfDayRegex = $@"\b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|(van)?avond|nacht)))s?\b";
+      public static readonly string SpecificTimeOfDayRegex = $@"\b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|avond|nacht)))s?\b";
       public static readonly string TimeFollowedUnit = $@"^\s*{TimeUnitRegex}";
       public static readonly string TimeNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){TimeUnitRegex}";
       public static readonly string[] BusinessHourSplitStrings = { @"werk", @"uren" };
@@ -213,10 +214,10 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string NowRegex = @"(?<!vanaf\s+)\b(?<now>nu(\s+meteen)?|zo snel mogelijk|zo spoedig mogelijk|asap|recent|onlangs|zojuist)\b";
       public const string SuffixRegex = @"^\s*(in de\s+)?(vroege\s+|late\s+)?(ochtend|(na)?middag|avond|nacht)\b";
       public const string DateTimeTimeOfDayRegex = @"\b(?<timeOfDay>morgen|ochtend|(na)?middag|avond|nacht)\b";
-      public static readonly string DateTimeSpecificTimeOfDayRegex = $@"\b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend|morgen))\b";
+      public static readonly string DateTimeSpecificTimeOfDayRegex = $@"\b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})|van(nacht|avond|middag|ochtend|morgen))\b";
       public static readonly string TimeOfTodayAfterRegex = $@"^\s*(,\s*)?((in\s+de)|(op\s+de))?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string TimeOfTodayBeforeRegex = $@"{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$";
-      public static readonly string SimpleTimeOfTodayAfterRegex = $@"({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
+      public static readonly string SimpleTimeOfTodayAfterRegex = $@"\b({HourNumRegex}|{BaseDateTime.HourRegex})(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}";
       public static readonly string SimpleTimeOfTodayBeforeRegex = $@"\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*(?<!van(avond|nacht)\s+)({HourNumRegex}|{BaseDateTime.HourRegex})\b";
       public const string SpecificEndOfRegex = @"((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+(de|het))?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))";
       public const string UnspecificEndOfRegex = @"\b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b";
@@ -248,6 +249,11 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string HolidayRegex = $@"\b(({StrictRelativeRegex}\s+({HolidayList1}|{HolidayList2}|{HolidayList3}))|(({HolidayList1}|{HolidayList2}|{HolidayList3})(\s+(van\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?))\b";
       public static readonly string AMTimeRegex = $@"(?<am>{ApostrofsRegex}\s*(morgens|ochtends)|in\s+de\s+(morgen|ochtend))";
       public static readonly string PMTimeRegex = $@"(?<pm>{ApostrofsRegex}\s*(middags|avonds|nachts)|(in\s+de\s+)?(deze\s+)?((na)?middag|avond|nacht))\b";
+      public const string MorningTimeRegex = @"(morgens?|ochtends?)";
+      public const string NightTimeRegex = @"(nacht)";
+      public const string NowTimeRegex = @"\b(nu)\b";
+      public const string RecentlyTimeRegex = @"\b(kort\s+geleden|eerder)\b";
+      public const string AsapTimeRegex = @"\b(zo\s+snel\s+mogelijk|zsm)\b";
       public const string InclusiveModPrepositions = @"(?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))";
       public static readonly string BeforeRegex = $@"(\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>(al\s+)?zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
       public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string FullDescRegex = $@"({DescRegex}|{AmRegex}|{PmRegexFull})";
       public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
-      public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)";
-      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
+      public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|zat?|zo)(\.|\b))|((?:maan|dins|woens|donder|vrij|zater|zon)(dag(en)?)?(middag)?)\b)";
+      public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr|za)\b(\.)?)|(vrij|zat|zon?)\.(?!$)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater)(dag(en)?)?|(?<=(op|voor)\s+)(vrij|zon?|zat)|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
       public static readonly string RelativeMonthRegex = $@"(?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b";
       public const string WrittenMonthRegex = @"(((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))";
       public static readonly string MonthSuffixRegex = $@"(?<msuf>((in|van|tijdens|sinds|tot|op)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))";
@@ -121,7 +121,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string PrefixWeekDayRegex = @"(\s*((,?\s*op)|[-—–]))";
       public static readonly string ThisRegex = $@"\b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
       public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
-      public const string WeekDayForNextDateRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))";
+      public const string WeekDayForNextDateRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)(\.|\b))|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))";
       public static readonly string NextDateRegex1 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})";
       public static readonly string NextDateRegex2 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})";
       public static readonly string NextDateRegex = $@"({NextDateRegex1}|{NextDateRegex2})";
@@ -830,8 +830,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"^\d{4}$", @"(\d\.\d{4}|\d{4}\.\d)" },
-            { @"\b(lunch)$", @"(?<!\b(op|om|voor|ana(ar)?|rond)\b\s)(lunch)" },
-            { @"^(morgen|middag|avond|nacht|dag)\b", @"\b(goeden?\s*(morgen|middag|avond|nacht|dag))\b" }
+            { @"\b(lunch)$", @"(?<!\b(op|om|voor|na(ar)?|rond)\b\s)(lunch)" },
+            { @"^(morgen|middag|avond|nacht|dag)\b", @"\b(goe[di]en?\s*(morgen|middag|avond|nacht|dag))\b" }
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/DateTimeRecognizer.cs
@@ -139,14 +139,13 @@ namespace Microsoft.Recognizers.Text.DateTime
                     new BaseMergedDateTimeExtractor(
                         new HindiMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Hindi, options)))));
 
-            // TODO to be uncommented when all tests for Dutch are green.
-            // RegisterModel<DateTimeModel>(
-            //     Culture.Dutch,
-            //     options => new DateTimeModel(
-            //         new BaseMergedDateTimeParser(
-            //             new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options))),
-            //         new BaseMergedDateTimeExtractor(
-            //             new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options)))));
+            RegisterModel<DateTimeModel>(
+                Culture.Dutch,
+                options => new DateTimeModel(
+                    new BaseMergedDateTimeParser(
+                        new DutchMergedParserConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options))),
+                    new BaseMergedDateTimeExtractor(
+                        new DutchMergedExtractorConfiguration(new BaseDateTimeOptionsConfiguration(Culture.Dutch, options)))));
 
             // TODO to be uncommented when all tests for Japanese are green.
             // RegisterModel<DateTimeModel>(

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -2365,7 +2365,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 beginLuisStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
                 beginLuisStr = beginLuisStr.Replace("XXXX", beginYearStr);
 
-                var endYearStr = "XX" + (decade + totalLastYear);
+                var endYearStr = "XX" + ((decade + totalLastYear) % 100).ToString("D2", CultureInfo.InvariantCulture);
                 endLuisStr = DateTimeFormatUtil.LuisDate(-1, 1, 1);
                 endLuisStr = endLuisStr.Replace("XXXX", endYearStr);
             }

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -17,20 +17,20 @@ ApostrofsRegex: !nestedRegex
   def: ({ApostrofRegex}\s*s)
   references: [ ApostrofRegex ]
 RelativeRegex: !simpleRegex
-  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b
+  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)
 StrictRelativeRegex: !simpleRegex
-  def: \b(?<order>dit|deze|volgende?|komende?|aankomende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b
+  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b)|gister(en)?)
 UpcomingPrefixRegex: !simpleRegex
-  def: (aankomende?|komende?|aanstaande?)
+  def: ((deze\s+)?((aan)?komende?|aanstaande?))
 NextPrefixRegex: !nestedRegex
-  def: \b(volgende?|eerstvolgende|aanstaande?|{UpcomingPrefixRegex})\b
+  def: \b(volgende?|eerstvolgende|{UpcomingPrefixRegex})\b
   references: [ UpcomingPrefixRegex ]
 AfterNextSuffixRegex: !simpleRegex
   def: \b((na\s+(afloop\s+van\s+)?((de|het)\s+)?volgende?)|over)\b
 PastPrefixRegex: !simpleRegex
-  def: ((deze\s+)?verleden)\b
+  def: ((deze\s+)?(verleden|afgelopen))\b
 PreviousPrefixRegex: !nestedRegex
-  def: (voorgaand[e]|vorige?|afgelopen|verleden|laatste|{PastPrefixRegex})\b
+  def: ((voorgaand[e]|vorige?|verleden|laatste|{PastPrefixRegex})\b|gister(en)?)
   references: [ PastPrefixRegex ]
 ThisPrefixRegex: !simpleRegex
   def: (dit|deze|huidige?)\b
@@ -81,7 +81,7 @@ FullTextYearRegex: !nestedRegex
 OclockRegex: !simpleRegex
   def: (?<oclock>u(ur)?)\b
 SpecialDescRegex: !simpleRegex
-  def: (p\b)
+  def: ((?<ipm>)p\b)
 AmDescRegex: !nestedRegex
   def: (:?{BaseDateTime.BaseAmDescRegex})
   references: [BaseDateTime.BaseAmDescRegex]
@@ -94,10 +94,22 @@ AmPmDescRegex: !nestedRegex
 DescRegex: !nestedRegex
   def: (:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})
   references: [ OclockRegex, AmDescRegex, PmDescRegex, AmPmDescRegex, SpecialDescRegex ]
+PmRegex: !nestedRegex
+  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)
+  references: [ ApostrofsRegex ]
+PmRegexFull: !nestedRegex
+  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))
+  references: [ ApostrofsRegex ]
+AmRegex: !nestedRegex
+  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))
+  references: [ ApostrofsRegex ]
+FullDescRegex: !nestedRegex
+  def: ({DescRegex}|{AmRegex}|{PmRegexFull})
+  references: [ DescRegex, AmRegex, PmRegexFull ]
 # Exclude cases that include the "Am/Pm" suffix
 # Exclude when preceded by "$" symbol
 TwoDigitYearRegex: !nestedRegex
-  def: \b(?<!\$)(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
+  def: \b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
   references: [ AmDescRegex, PmDescRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
@@ -105,14 +117,14 @@ YearRegex: !nestedRegex
 WeekDayRegex: !simpleRegex
   def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)
 SingleWeekDayRegex: !simpleRegex
-  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?|zo)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)
+  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b
   references: [RelativeRegex]
 WrittenMonthRegex: !simpleRegex
   def: (((de\s+)?maand\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan|feb|mar|mrt|apr|jun|jul|aug|sep|sept|oct|okt|nov|dec))
 MonthSuffixRegex: !nestedRegex
-  def: (?<msuf>((in|van|tijdens|sinds|tot)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
+  def: (?<msuf>((in|van|tijdens|sinds|tot|op)\s+)?({RelativeMonthRegex}|{WrittenMonthRegex}))
   references: [ RelativeMonthRegex, WrittenMonthRegex ]
 DateUnitRegex: !simpleRegex
   def: (?<unit>eeuw(en)?|jaar|jaren|jr|decennia|maand(en)?|mnd|week|weken|(?<business>(werk))?dag(en)?|dgn)\b
@@ -123,7 +135,7 @@ TokenBeforeTime: 'om '
 HalfTokenRegex: !simpleRegex
   def: ^(half)
 QuarterTokenRegex: !simpleRegex
-  def: ^(een\s+kwart|kwart|een\s+kwartier|kwartier)
+  def: ^(een\s+kwart(\s+jaar)?|kwart|een\s+kwartier|kwartier)
 ThreeQuarterTokenRegex: !simpleRegex
   def: ^(drie\s+kwart|drie\s+kwartier)
 ToTokenRegex: !simpleRegex
@@ -140,7 +152,7 @@ SimpleCasesRegex: !nestedRegex
   def: \b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex ]
 MonthFrontSimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
+  def: \b({RangePrefixRegex}\s+)?({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ MonthSuffixRegex, DayRegex, TillRegex, YearRegex, RangePrefixRegex ]
 MonthFrontBetweenRegex: !nestedRegex
   def: \b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
@@ -158,8 +170,8 @@ MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
   references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex ]
 WeekOfMonthRegex: !nestedRegex
-  def: \b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex})\b
-  references: [ MonthSuffixRegex ]
+  def: \b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b
+  references: [ MonthSuffixRegex, BaseDateTime.FourDigitYearRegex, RelativeRegex ]
 WeekOfYearRegex: !nestedRegex
   def: (\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)
   references: [ YearRegex, RelativeRegex ]
@@ -201,7 +213,7 @@ PrefixPeriodRegex: !nestedRegex
   def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
   references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
 PrefixDayRegex: !simpleRegex
-  def: \b((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later|aan\s+het\s+einde?(\s+van(\s+de)?)?))(\s+(in|op|van))?(\s+de\s+dag)\b
+  def: \b(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b
 SeasonDescRegex: !simpleRegex
   def: (?<seas>lente|voorjaar|zomer|herfst|najaar|winter)
 SeasonRegex: !nestedRegex
@@ -237,11 +249,19 @@ ThisRegex: !nestedRegex
 LastDateRegex: !nestedRegex
   def: \b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b
   references: [ PreviousPrefixRegex, WeekDayRegex ]
-NextDateRegex: !nestedRegex
-  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex})|((op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week)\b
+WeekDayForNextDateRegex: !simpleRegex
+  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))
+NextDateRegex1: !nestedRegex
+  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})
+  references: [ NextPrefixRegex, WeekDayForNextDateRegex ]
+NextDateRegex2: !nestedRegex
+  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})
   references: [ NextPrefixRegex, WeekDayRegex ]
+NextDateRegex: !nestedRegex
+  def: ({NextDateRegex1}|{NextDateRegex2})
+  references: [ NextDateRegex1, NextDateRegex2 ]
 SpecialDayRegex: !nestedRegex
-  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)
+  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
   def: \b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
@@ -250,7 +270,7 @@ RelativeDayRegex: !nestedRegex
   def: \b(((de\s+)?{RelativeRegex}\s+dag))\b
   references: [ RelativeRegex ]
 SetWeekDayRegex: !simpleRegex
-  def: \b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)(s|(?<suffix>e)n)\b
+  def: \b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)((?<suffix>e)n)\b
 WeekDayOfMonthRegex: !nestedRegex
   def: (?<wom>((de\s+|\b))?(?<cardinal>eerste|tweede|derde|vierde|vijfde|zesde|tiende|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+{WeekDayRegex}(\s+{MonthSuffixRegex}))
   references: [ WeekDayRegex, MonthSuffixRegex ]
@@ -267,7 +287,7 @@ DateExtractorYearTermRegex: !nestedRegex
   references: [ DateYearRegex ]
 # Maandag, Mei 2
 DateExtractor1: !nestedRegex
-  def: \b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\)))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?
+  def: \b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?
   references: [ WeekDayRegex, MonthRegex, DayRegex, DateExtractorYearTermRegex ]
 # Maandag 2 Mei
 # TODO: add ... van 2019?
@@ -277,33 +297,33 @@ DateExtractor3: !nestedRegex
 # 05/02/2019
 # The final lookahead in DateExtractor4|5|A avoids extracting as date "10/1-11" from an input like "10/1-11/2/2017" 
 DateExtractor4: !nestedRegex
-  def: \b{DayRegex}(\.)?\s*[/\\\-]\s*{MonthNumRegex}\s*[/\\\-]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
-  references: [ MonthNumRegex, DayRegex, DateYearRegex ]
+  def: \b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}[\.]?\s*[/\\\-]\s*{ApostrofRegex}?{DateYearRegex}
+  references: [ MonthNumRegex, DayRegex, DateYearRegex, ApostrofRegex ]
 DateExtractor5: !nestedRegex
   def: \b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)
   references: [ DayRegex, MonthNumRegex, MonthRegex, DateYearRegex ]
 DateExtractor6: !nestedRegex
-  def: (?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\-\.]{DayRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b
-  references: [ MonthNumRegex, DayRegex, WeekDayRegex, DatePreposition, StrictRelativeRegex, BaseDateTime.CheckDecimalRegex ]
+  def: (?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b|(?<={DatePreposition}\s+){MonthNumRegex}[\-\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b
+  references: [ MonthNumRegex, DayRegex, WeekDayRegex, DatePreposition, StrictRelativeRegex, FullDescRegex ]
 DateExtractor7L: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{DateExtractorYearTermRegex}(?![%])\b
   references: [ MonthNumRegex, DayRegex, WeekDayRegex, DateExtractorYearTermRegex ]
 DateExtractor7S: !nestedRegex
-  def: \b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b
-  references: [ MonthNumRegex, DayRegex, WeekDayRegex, BaseDateTime.CheckDecimalRegex ]
+  def: \b((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
+  references: [ MonthNumRegex, DayRegex, WeekDayRegex, BaseDateTime.CheckDecimalRegex, FullDescRegex, DatePreposition ]
 # The only difference between 7L and 7S is whether "Year" part is required
 # We have both the long and short Regex because we would like to catch both "11/20, 12" and "11/20, 12/20"
 # Only use the long Regex would ignore "11/20" in "11/20, 12/20" and it is hard to exhaust all characters after the "year" as we also have cases like "11/20, 12 of April"
 # Same for DateExtractor9L and DateExtractor9S
 DateExtractor8: !nestedRegex
-  def: (?<={DatePreposition}\s+)({WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b
-  references: [ DayRegex, MonthNumRegex, WeekDayRegex, DatePreposition, BaseDateTime.CheckDecimalRegex ]
+  def: ((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
+  references: [ DayRegex, MonthNumRegex, WeekDayRegex, DatePreposition, BaseDateTime.CheckDecimalRegex, FullDescRegex ]
 DateExtractor9L: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}((\s+|\s*,\s*|\s+in\s+){DateYearRegex})(?![%])\b
   references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex ]
 DateExtractor9S: !nestedRegex
-  def: \b(?<!naar\s+)({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?![%])\b
-  references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex, BaseDateTime.CheckDecimalRegex ]
+  def: \b(?<!naar\s+)((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}\s*[\-\/.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
+  references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex, BaseDateTime.CheckDecimalRegex, FullDescRegex, DatePreposition ]
 DateExtractorA: !nestedRegex
   def: \b({WeekDayRegex}\s+)?({BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})
   references: [ BaseDateTime.FourDigitYearRegex, MonthNumRegex, MonthRegex, DayRegex, WeekDayRegex ]
@@ -323,18 +343,9 @@ RangeUnitRegex: !simpleRegex
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig)\b
 MinuteNumRegex: !simpleRegex
-  def: (?<minnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)
+  def: (?<minnum>nul|een(?=\s+min(uut)?)|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vij[fv]entwintig|ze(s|ven)entwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|ze(s|ven)endertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|ze(s|ven)enveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|ze(s|ven)envijftig|achtenvijftig|negenenvijftig)
 DeltaMinuteNumRegex: !simpleRegex
-  def: (?<deltaminnum>nul|een|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
-PmRegex: !nestedRegex
-  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)
-  references: [ ApostrofsRegex ]
-PmRegexFull: !nestedRegex
-  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))
-  references: [ ApostrofsRegex ]
-AmRegex: !nestedRegex
-  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))
-  references: [ ApostrofsRegex ]
+  def: (?<deltaminnum>nul|een(?=\s+min(uut)?)|één|twee|drie|vier|vijf|zes|zeven|acht|negen|tien|elf|elven|twaalf|dertien|veertien|vijftien|zestien|zeventien|achttien|negentien|twintig|eenentwintig|éénentwintig|tweeentwintig|tweeëntwintig|drieëntwintig|vierentwintig|vijfentwintig|vijventwintig|zesentwintig|zevenentwintig|achtentwintig|negenentwintig|dertig|eenendertig|tweeëndertig|drieëndertig|vierendertig|vijfendertig|zesendertig|zevenendertig|achtendertig|negenendertig|veertig|eenenveertig|tweeënveertig|drieënveertig|vierenveertig|vijfenveertig|zesenveertig|zevenenveertig|achtenveertig|negenenveertig|eenenvijftig|vijftig|tweeënvijftig|drieënvijftig|vierenvijftig|vijfenvijftig|zesenvijftig|zevenenvijftig|achtenvijftig|negenenvijftig)(?=\b)
 LunchRegex: !simpleRegex
   def: \b(lunchtijd)\b
 NightRegex: !nestedRegex
@@ -405,11 +416,14 @@ ConnectNumRegex: !nestedRegex
 TimeRegexWithDotConnector: !nestedRegex
   def: ({BaseDateTime.HourRegex}(\s*\.\s*){BaseDateTime.MinuteRegex}(\s*:\s*{BaseDateTime.SecondRegex})?(\s*u\s*)?)
   references: [ BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex ]
+TimeRegexFilter: !nestedRegex
+  def: \b((iedere|elke|op)(\s+andere)?\s+)?(week|dag|{SingleWeekDayRegex}|vandaag)\b
+  references: [ SingleWeekDayRegex ]
 TimeRegex1: !nestedRegex
   def: \b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|((?<prefix>half)\s+)?(?!een){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)
   references: [ TimePrefix, WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, DescRegex, AroundRegex, SingleWeekDayRegex ]
 TimeRegex2: !nestedRegex
-  def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!\d)((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)
+  def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!(\d|\s*(per|pro)\s*cent|%))((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)
   references: [ TimePrefix, BaseDateTime.HourRegex, BaseDateTime.SecondRegex, DescRegex ]
 TimeRegex3: !nestedRegex
   def: (\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})
@@ -436,14 +450,14 @@ TimeRegex10: !nestedRegex
   def: \b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?
   references: [ TimePrefix, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, DescRegex ]
 TimeRegex11: !nestedRegex
-  def: \b((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*per\s*cent|%|{EachUnitRegex})))
-  references: [ TimeTokenPrefix, TimeRegexWithDotConnector, DescRegex, TimeSuffix, EachUnitRegex ]
+  def: \b(?<!{TimeRegexFilter}\s+)((?:({TimeTokenPrefix})?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix})))|(?:(?:{TimeTokenPrefix}{TimeRegexWithDotConnector})(?!\s*(per|pro)\s*cent|%|\s+{TimeRegexFilter})))
+  references: [ TimeTokenPrefix, TimeRegexWithDotConnector, DescRegex, TimeSuffix, TimeRegexFilter ]
 TimeRegex12: !nestedRegex
   def: ({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))
   references: [ BaseDateTime.HourRegex ]
 FirstTimeRegexInTimeRange: !nestedRegex
-  def: \b{TimeRegexWithDotConnector}(\s*{DescRegex})?
-  references: [ TimeRegexWithDotConnector, DescRegex ]
+  def: \b{TimeRegexWithDotConnector}(?!\s*(per|pro)\s*cent|%|\s+{TimeRegexFilter})(\s*{DescRegex})?
+  references: [ TimeRegexWithDotConnector, DescRegex, TimeRegexFilter]
 PureNumFromToPrefixExcluded: !nestedRegex
   def: ({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
   references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, TillRegex, PmRegex, AmRegex ]
@@ -474,9 +488,9 @@ SpecificTimeBetweenAnd: !nestedRegex
 PrepositionRegex: !simpleRegex
   def: (?<prep>^(om|rond|tegen|op|van|deze)(\s+de)?$)
 EarlyLateRegex: !simpleRegex
-  def: (((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)
+  def: \b(((?<early>vroege?|(in\s+het\s+)?(begin))|(?<late>laat|later|late|aan\s+het\s+einde?))((\s+|-)(in\s+de|op\s+de|van\s+de|deze|in|op|van|de))?)
 TimeOfDayRegex: !nestedRegex
-  def: (?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b
+  def: (?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|\b(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b
   references: [ EarlyLateRegex, MealTimeRegex, ApostrofsRegex ]
 SpecificTimeOfDayRegex: !nestedRegex
   def: \b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|(van)?avond|nacht)))s?\b
@@ -511,7 +525,7 @@ SimpleTimeOfTodayBeforeRegex: !nestedRegex
   def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*(?<!van(avond|nacht)\s+)({HourNumRegex}|{BaseDateTime.HourRegex})\b'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
 SpecificEndOfRegex: !simpleRegex
-  def: ((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+de)?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
+  def: ((\baan\s+)?((de|het)\s+)?eind(e? van)?(\s+(de|het))?\s*$|^\s*(het\s+)?einde? van(\s+de(\s+dag)))
 UnspecificEndOfRegex: !simpleRegex
   def: \b(((om|rond|tegen|op)\s+)?het\s+)?(einde?\s+van\s+(de\s+)?dag)\b
 UnspecificEndOfRangeRegex: !simpleRegex
@@ -520,7 +534,7 @@ PeriodTimeOfDayRegex: !nestedRegex
   def: ((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|(eer)?gisteren|morgen)?(?<timeOfDay>ochtend|(na)?middag|avond|nacht))\b
   references: [ EarlyLateRegex ]
 PeriodSpecificTimeOfDayRegex: !nestedRegex
-  def: \b(({StrictRelativeRegex}\s+{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b
+  def: \b(({StrictRelativeRegex}(\s+)?{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b
   references: [ PeriodTimeOfDayRegex, StrictRelativeRegex ]
 PeriodTimeOfDayWithDateRegex: !nestedRegex
  def: (({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))\b
@@ -528,9 +542,9 @@ PeriodTimeOfDayWithDateRegex: !nestedRegex
 LessThanRegex: !simpleRegex
   def: \b((binnen\s+)?minder\s+dan)\b
 MoreThanRegex: !simpleRegex
-  def: \b(meer\s+dan|ruim)\b
+  def: \b((meer|langer)\s+dan|ruim)\b
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|mins|min|m|secondes|seconden|secs|sec|s)\b)(\s+lang\b)?
+  def: (?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|minuut|mins|min|m|secondes|seconden|secs|sec|s|nacht(en)?)\b)(\s+lang\b)?
   references: [ DateUnitRegex ]
 SuffixAndRegex: !simpleRegex
   def: (?<suffix>\s*(en|ën)(\s*een)?\s*(?<suffix_num>hal(f|ve)|kwart|kwartier)|(?<suffix_num>(een\s+)?kwartier))
@@ -558,12 +572,12 @@ NumberCombinedWithDurationUnit: !nestedRegex
   def: \b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 AnUnitRegex: !nestedRegex
-  def: \b(?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))\s*{DurationUnitRegex}
+  def: \b((?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 DuringRegex: !simpleRegex
   def: \b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b
 AllRegex: !simpleRegex
-  def: \b(?<all>((de|het|een)(\s+))?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b
+  def: \b(?<all>(voor\s+)?((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b
 HalfRegex: !simpleRegex
   def: (((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b
 ConjunctionRegex: !simpleRegex
@@ -575,11 +589,11 @@ HolidayList2: !nestedRegex
   def: (?<holiday>black friday|cyber monday|nationale dodenherdenking|nationale herdenking|dodenherdenking|dag van de leraar|dag van de leerkracht(en)?|dag van de arbeid|feest van de arbeid|yuandan|valentijn|sint-maartensfeest|sint-maarten|driekoningen|keti(\s+|-)?koti|ramadan|offerfeest|allerheiligen|allerheiligenavond|franse nationale feestdag|bestorming van de bastille)
   references: [ YearRegex, RelativeRegex ]
 HolidayList3: !nestedRegex # -dag suffix
-  def: (?<holiday>(martin luther king|mlk|dankzeggings|valentijns|nieuwjaars|(eerste|1e|tweede|2e)\s+paas|prinsjes|konings|koninginne|bevrijdings|hemelvaarts|(eerste|1e|tweede|2e)\s+kerst|vader|moeder|meisjes|(amerikaanse|us\s+)?onafhankelijkheids|(nederlandse\s+)?veteranen|boomplant|(nationale\s+)?boomfeest)dag)
+  def: (?<holiday>(martin luther king|mlk|dankzeggings|valentijns|nieuwjaars|(eerste|1e|tweede|2e)\s+paas|prinsjes|konings|koninginne|bevrijdings|hemelvaarts|(eerste|1e|tweede|2e)\s+kerst|vader|moeder|meisjes|(amerikaanse|us\s+)?onafhankelijk(heid)?s|(nederlandse\s+)?veteranen|boomplant|(nationale\s+)?boomfeest)dag)
   references: [ YearRegex, RelativeRegex ]
 # Combined holiday regex
 HolidayRegex: !nestedRegex
-  def: \b(({StrictRelativeRegex}\s+({HolidayList1}|{HolidayList2}|{HolidayList3}))|(({HolidayList1}|{HolidayList2}|{HolidayList3})(\s+(van dit\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?))\b
+  def: \b(({StrictRelativeRegex}\s+({HolidayList1}|{HolidayList2}|{HolidayList3}))|(({HolidayList1}|{HolidayList2}|{HolidayList3})(\s+(van\s+)?({YearRegex}|{RelativeRegex}\s+jaar))?))\b
   references: [ HolidayList1, HolidayList2, HolidayList3, YearRegex, RelativeRegex, StrictRelativeRegex ]
 AMTimeRegex: !nestedRegex
   def: (?<am>{ApostrofsRegex}\s*(morgens|ochtends)|in\s+de\s+(morgen|ochtend))
@@ -590,13 +604,13 @@ PMTimeRegex: !nestedRegex
 InclusiveModPrepositions: !simpleRegex
   def: (?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))
 BeforeRegex: !nestedRegex
-  def: (\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)
+  def: (\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>(al\s+)?zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)
   references: [ InclusiveModPrepositions ]
 AfterRegex: !nestedRegex
   def: (\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)
   references: [ InclusiveModPrepositions ]
 SinceRegex: !simpleRegex
-  def: (\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|zo\s+vroeg\s+als|ieder\s+moment\s+vanaf)\b\s*)|(?<!\w|<)(>=)
+  def: (\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|(al\s+)?zo\s+vroeg\s+als|(elk|ieder)\s+moment\s+vanaf|een\s+tijdstip\s+vanaf)\b\s*)|(?<!\w|<)(>=)
 AroundRegex: !simpleRegex
   def: (\b(rond(om)?|ongeveer(\s+om)?)\s*\b)
 AgoRegex: !simpleRegex
@@ -629,7 +643,7 @@ NightStartEndRegex: !nestedRegex
   def: (^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)
   references: [ ApostrofsRegex ]
 InexactNumberRegex: !simpleRegex
-  def: \b((een\s+)?aantal|meerdere|enkele|verscheidene|(?<NumTwoTerm>(een\s+)?paar))\b
+  def: \b((een\s+)?aantal|meerdere|enkele|verscheidene|wat|enige|(?<NumTwoTerm>(een\s+)?paar))\b
 InexactNumberUnitRegex: !nestedRegex
   def: ({InexactNumberRegex})\s+({DurationUnitRegex})
   references: [InexactNumberRegex, DurationUnitRegex]
@@ -716,7 +730,7 @@ RelativeDecadeRegex: !nestedRegex
   def: \b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b
   references: [ RelativeRegex ]
 SuffixAfterRegex: !simpleRegex
-  def: \b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna)(?!\s+dan))\b
+  def: \b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna|daarna|hoger)(?!\s+dan))\b
 DateAfterRegex: !simpleRegex
   def: \b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b
 YearPeriodRegex: !nestedRegex
@@ -745,6 +759,8 @@ UnitMap: !dictionary
     dag: D
     vandaag: D
     dgn: D
+    nachten: D
+    nacht: D
     uren: H
     uur: H
     u: H
@@ -778,6 +794,8 @@ UnitValueMap: !dictionary
     dag: 86400
     vandaag: 86400
     dgn: 86400
+    nachten: 86400
+    nacht: 86400
     werkdagen: 86400
     werkdag: 86400
     uren: 3600
@@ -1165,7 +1183,7 @@ HolidayNames: !dictionary
     newyearsday: [ nieuwjaarsdag ]
     newyeareve: [ oudjaar, oudejaar, oudejaarsavond, oudjaarsavond, silvester, silvesteravond, oudennieuw, oud&nieuw ]
     valentinesday: [ valentijnsdag, valetijnsdag ]
-    independenceday: [ onafhankelijkheidsdag ]
+    independenceday: [ onafhankelijkheidsdag, onafhankelijksdag ]
     bastilleday: [ fransenationalefeestdag, bestormingvandebastille ] # 14 July
     halloweenday: [ halloween, allerheiligenavond ]
     allhallowday: [ allerheiligen ]
@@ -1257,6 +1275,7 @@ AmbiguityFiltersDict: !dictionary
   entries:
     '^\d{4}$': '(\d\.\d{4}|\d{4}\.\d)'
     '\b(lunch)$': '(?<!\b(op|om|voor|ana(ar)?|rond)\b\s)(lunch)'
+    '^(morgen|middag|avond|nacht|dag)\b': '\b(goeden?\s*(morgen|middag|avond|nacht|dag))\b'
 # Used to exclude ambiguous time/duration patterns
 # TODO: Add more patterns to improve coverage
 AmbiguityTimeFiltersDict: !dictionary
@@ -1315,6 +1334,7 @@ MinusOneDayTerms: !list
   entries:
     - gisteren
     - dag voor
+    - dag ervoor
     - vorige dag
     - gisterenochtend
     - gisterenavond

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -17,9 +17,9 @@ ApostrofsRegex: !nestedRegex
   def: ({ApostrofRegex}\s*s)
   references: [ ApostrofRegex ]
 RelativeRegex: !simpleRegex
-  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)
+  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|laatste|afgelopen|(op\s+)?de|het)\b)|gister(en)?)
 StrictRelativeRegex: !simpleRegex
-  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|vorige?|laatste|afgelopen)\b)|gister(en)?)
+  def: \b(?<order>((dit|deze|volgende?|(aan)?komende?|aanstaande?|huidige?|vorige?|verleden|voorgaande?|laatste|afgelopen)\b)|gister(en)?)
 UpcomingPrefixRegex: !simpleRegex
   def: ((deze\s+)?((aan)?komende?|aanstaande?))
 NextPrefixRegex: !nestedRegex
@@ -95,10 +95,10 @@ DescRegex: !nestedRegex
   def: (:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})
   references: [ OclockRegex, AmDescRegex, PmDescRegex, AmPmDescRegex, SpecialDescRegex ]
 PmRegex: !nestedRegex
-  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)|dag)
+  def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|dag)
   references: [ ApostrofsRegex ]
 PmRegexFull: !nestedRegex
-  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))|van(avond|nacht)(?!\s+om\b)))
+  def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))))
   references: [ ApostrofsRegex ]
 AmRegex: !nestedRegex
   def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))
@@ -160,9 +160,12 @@ MonthFrontBetweenRegex: !nestedRegex
 BetweenRegex: !nestedRegex
   def: \b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, RangeConnectorRegex , MonthSuffixRegex, YearRegex ]
+RelativeYearRegex: !nestedRegex
+  def: ({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)
+  references: [ YearRegex ]
 MonthWithYear: !nestedRegex
-  def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*)({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar))|(({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)(\s*),?(\s*){WrittenMonthRegex}))\b
-  references: [ WrittenMonthRegex, YearRegex ]
+  def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*){RelativeYearRegex})|({RelativeYearRegex}(\s*),?(\s*){WrittenMonthRegex}))\b
+  references: [ WrittenMonthRegex, RelativeYearRegex ]
 OneWordPeriodRegex: !nestedRegex
   def: \b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
@@ -261,7 +264,7 @@ NextDateRegex: !nestedRegex
   def: ({NextDateRegex1}|{NextDateRegex2})
   references: [ NextDateRegex1, NextDateRegex2 ]
 SpecialDayRegex: !nestedRegex
-  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+|van)?morgen|vandaag|morgen(middag))(?!s\b)
+  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
   def: \b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
@@ -493,7 +496,7 @@ TimeOfDayRegex: !nestedRegex
   def: (?<timeOfDay>(({EarlyLateRegex}\s+)(aanstaande\s+)?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)\s*(ochtend|morgen|(na)?middag|avond|nacht))|(((van\s+deze\s+)|\b(in\s+(de)?\s+)|de\s+)?({EarlyLateRegex}\s+)?({ApostrofsRegex}\s+)?(ochtend(en)?|morgen|middag(en)?|avond(en)?|nacht(\s+van)?)s?((\s+|-)({EarlyLateRegex}))?)|{MealTimeRegex}|((tijdens\s+(de\s+)?)?(kantoor|werk)uren))\b
   references: [ EarlyLateRegex, MealTimeRegex, ApostrofsRegex ]
 SpecificTimeOfDayRegex: !nestedRegex
-  def: \b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|(van)?avond|nacht)))s?\b
+  def: \b((({StrictRelativeRegex}\s+{TimeOfDayRegex})\b|\bvan(ochtend|morgen|middag|avond|nacht)))s?\b
   references: [ TimeOfDayRegex, StrictRelativeRegex ]
 TimeFollowedUnit: !nestedRegex
   def: ^\s*{TimeUnitRegex}
@@ -510,7 +513,7 @@ SuffixRegex: !simpleRegex
 DateTimeTimeOfDayRegex: !simpleRegex
   def: \b(?<timeOfDay>morgen|ochtend|(na)?middag|avond|nacht)\b
 DateTimeSpecificTimeOfDayRegex: !nestedRegex
-  def: \b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})\b|\bvan(nacht|avond|middag|ochtend|morgen))\b
+  def: \b(({RelativeRegex}\s+{DateTimeTimeOfDayRegex})|van(nacht|avond|middag|ochtend|morgen))\b
   references: [ DateTimeTimeOfDayRegex, RelativeRegex ]
 TimeOfTodayAfterRegex: !nestedRegex
   def: ^\s*(,\s*)?((in\s+de)|(op\s+de))?{DateTimeSpecificTimeOfDayRegex}
@@ -519,8 +522,8 @@ TimeOfTodayBeforeRegex: !nestedRegex
   def: '{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op\s+de|op))?\s*$'
   references: [ DateTimeSpecificTimeOfDayRegex ]
 SimpleTimeOfTodayAfterRegex: !nestedRegex
-  def: ({HourNumRegex}|{BaseDateTime.HourRegex}(\s*:\s*{BaseDateTime.MinuteRegex})?)(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}
-  references: [ HourNumRegex, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, DateTimeSpecificTimeOfDayRegex, OclockRegex ]
+  def: \b({HourNumRegex}|{BaseDateTime.HourRegex})(\s*({OclockRegex}|u))?\s*(,\s*)?((in|op)\s+de\s+)?{DateTimeSpecificTimeOfDayRegex}
+  references: [ HourNumRegex, BaseDateTime.HourRegex, DateTimeSpecificTimeOfDayRegex, OclockRegex ]
 SimpleTimeOfTodayBeforeRegex: !nestedRegex
   def: '\b{DateTimeSpecificTimeOfDayRegex}(\s*,)?(\s+(om|rond|tegen|op(\s+de)?))?\s*(?<!van(avond|nacht)\s+)({HourNumRegex}|{BaseDateTime.HourRegex})\b'
   references: [ DateTimeSpecificTimeOfDayRegex, HourNumRegex, BaseDateTime.HourRegex ]
@@ -601,6 +604,16 @@ AMTimeRegex: !nestedRegex
 PMTimeRegex: !nestedRegex
   def: (?<pm>{ApostrofsRegex}\s*(middags|avonds|nachts)|(in\s+de\s+)?(deze\s+)?((na)?middag|avond|nacht))\b
   references: [ ApostrofsRegex ]
+MorningTimeRegex: !simpleRegex
+  def: (morgens?|ochtends?)
+NightTimeRegex: !simpleRegex
+  def: (nacht)
+NowTimeRegex: !simpleRegex
+  def: \b(nu)\b
+RecentlyTimeRegex: !simpleRegex
+  def: \b(kort\s+geleden|eerder)\b
+AsapTimeRegex: !simpleRegex
+  def: \b(zo\s+snel\s+mogelijk|zsm)\b
 InclusiveModPrepositions: !simpleRegex
   def: (?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))
 BeforeRegex: !nestedRegex

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -115,9 +115,9 @@ YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
 WeekDayRegex: !simpleRegex
-  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan|dins|woens|donder|vrij|zater|zon)(dag)?(en)?(middag)?)\b)
+  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|zat?|zo)(\.|\b))|((?:maan|dins|woens|donder|vrij|zater|zon)(dag(en)?)?(middag)?)\b)
 SingleWeekDayRegex: !simpleRegex
-  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij\.)?|za(t)?)\b(\.)?)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater|zon)(dag(en)?)?|(?<=op\s+)vrij|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)
+  def: \b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr|za)\b(\.)?)|(vrij|zat|zon?)\.(?!$)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater)(dag(en)?)?|(?<=(op|voor)\s+)(vrij|zon?|zat)|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)
 RelativeMonthRegex: !nestedRegex
   def: (?<relmonth>((van\s+)?(de\s+)?)?{RelativeRegex}\s+maand)\b
   references: [RelativeRegex]
@@ -250,7 +250,7 @@ LastDateRegex: !nestedRegex
   def: \b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b
   references: [ PreviousPrefixRegex, WeekDayRegex ]
 WeekDayForNextDateRegex: !simpleRegex
-  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)[\.\b])|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))
+  def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)(\.|\b))|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))
 NextDateRegex1: !nestedRegex
   def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})
   references: [ NextPrefixRegex, WeekDayForNextDateRegex ]
@@ -1274,8 +1274,8 @@ AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     '^\d{4}$': '(\d\.\d{4}|\d{4}\.\d)'
-    '\b(lunch)$': '(?<!\b(op|om|voor|ana(ar)?|rond)\b\s)(lunch)'
-    '^(morgen|middag|avond|nacht|dag)\b': '\b(goeden?\s*(morgen|middag|avond|nacht|dag))\b'
+    '\b(lunch)$': '(?<!\b(op|om|voor|na(ar)?|rond)\b\s)(lunch)'
+    '^(morgen|middag|avond|nacht|dag)\b': '\b(goe[di]en?\s*(morgen|middag|avond|nacht|dag))\b'
 # Used to exclude ambiguous time/duration patterns
 # TODO: Add more patterns to improve coverage
 AmbiguityTimeFiltersDict: !dictionary

--- a/Specs/DateTime/Dutch/DateParser.json
+++ b/Specs/DateTime/Dutch/DateParser.json
@@ -4711,7 +4711,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende week zondag",
+        "Text": "op volgende week zondag",
         "Type": "date",
         "Value": {
           "Timex": "2018-04-01",
@@ -4722,8 +4722,8 @@
             "date": "2018-04-01"
           }
         },
-        "Start": 18,
-        "Length": 20
+        "Start": 15,
+        "Length": 23
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimeExtractor.json
+++ b/Specs/DateTime/Dutch/DateTimeExtractor.json
@@ -348,26 +348,26 @@
     ]
   },
   {
-    "Input": "Ik ga terug om 20u vanavond, maandag",
+    "Input": "Ik ga terug om 20u 's avonds, maandag",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20u vanavond, maandag",
+        "Text": "20u 's avonds, maandag",
         "Type": "datetime",
         "Start": 15,
-        "Length": 21
+        "Length": 22
       }
     ]
   },
   {
-    "Input": "Ik ga terug 20u vanavond, 1 jan",
+    "Input": "Ik ga terug 20u in de avond, 1 jan",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20u vanavond, 1 jan",
+        "Text": "20u in de avond, 1 jan",
         "Type": "datetime",
         "Start": 12,
-        "Length": 19
+        "Length": 22
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -10076,30 +10076,6 @@
     ]
   },
   {
-    "Input": "Heb je een arrangement op volgende vrijdag?",
-    "Context": {
-      "ReferenceDateTime": "2019-01-31T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "volgende vrijdag",
-        "Start": 26,
-        "End": 41,
-        "TypeName": "datetimeV2.date",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2019-02-08",
-              "type": "date",
-              "value": "2019-02-08"
-            }
-          ]
-        }
-      }
-    ]
-  },
-  {
     "Input": "Gisterennacht verdwenen 26 mensen",
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -54,13 +52,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2e jan 2019 ",
+        "Text": "2e jan 2019",
         "Start": 6,
-        "End": 17,
+        "End": 16,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -79,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -104,21 +100,26 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "jaren '90",
-        "Start": 37,
+        "Text": "de jaren '90",
+        "Start": 34,
         "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
-              "timex": "(1990-01-01,2000-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
               "type": "daterange",
               "start": "1990-01-01",
               "end": "2000-01-01"
+            },
+            {
+              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2090-01-01",
+              "end": "2100-01-01"
             }
           ]
         }
@@ -130,7 +131,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -160,7 +160,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -190,7 +189,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -220,12 +218,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de tweede van augustus",
-        "Start": 6,
+        "Text": "tweede van augustus",
+        "Start": 9,
         "End": 27,
         "TypeName": "datetimeV2.date",
         "Resolution": {
@@ -250,7 +247,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -275,7 +271,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +295,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -325,7 +319,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -355,7 +348,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -381,7 +373,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -413,7 +404,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -424,10 +414,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-09",
+              "timex": "2017-09",
               "type": "daterange",
-              "start": "2016-09-01",
-              "end": "2016-10-01"
+              "start": "2017-09-01",
+              "end": "2017-10-01"
             }
           ]
         }
@@ -439,13 +429,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12 januari, 2016 - 22/01/2016 ",
+        "Text": "12 januari, 2016 - 22/01/2016",
         "Start": 7,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -465,7 +454,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -491,7 +479,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -523,7 +510,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -549,7 +535,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -574,7 +559,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -588,7 +572,8 @@
               "timex": "2016-11-08",
               "Mod": "since",
               "type": "daterange",
-              "start": "2016-11-08"
+              "start": "2016-11-08",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -600,7 +585,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -614,13 +598,15 @@
               "timex": "XXXX-08",
               "Mod": "since",
               "type": "daterange",
-              "start": "2016-08-01"
+              "start": "2016-08-01",
+              "sourceEntity": "datetimerange"
             },
             {
               "timex": "XXXX-08",
               "Mod": "since",
               "type": "daterange",
-              "start": "2017-08-01"
+              "start": "2017-08-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -632,7 +618,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -643,10 +628,11 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-08",
+              "timex": "2017-08",
               "Mod": "since",
               "type": "daterange",
-              "start": "2016-08-01"
+              "start": "2017-08-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -658,7 +644,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -683,7 +668,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -702,6 +686,16 @@
               "timex": "XXXX-10-14T08:00:31",
               "type": "datetime",
               "value": "2017-10-14 08:00:31"
+            },
+            {
+              "timex": "XXXX-10-14T20:00:31",
+              "type": "datetime",
+              "value": "2016-10-14 20:00:31"
+            },
+            {
+              "timex": "XXXX-10-14T20:00:31",
+              "type": "datetime",
+              "value": "2017-10-14 20:00:31"
             }
           ]
         }
@@ -713,7 +707,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -727,6 +720,11 @@
               "timex": "2016-11-08T08:00",
               "type": "datetime",
               "value": "2016-11-08 08:00:00"
+            },
+            {
+              "timex": "2016-11-08T20:00",
+              "type": "datetime",
+              "value": "2016-11-08 20:00:00"
             }
           ]
         }
@@ -738,7 +736,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -763,7 +760,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -777,6 +773,11 @@
               "timex": "2016-11-07T08",
               "type": "datetime",
               "value": "2016-11-07 08:00:00"
+            },
+            {
+              "timex": "2016-11-07T20",
+              "type": "datetime",
+              "value": "2016-11-07 20:00:00"
             }
           ]
         }
@@ -788,7 +789,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -813,7 +813,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -843,7 +842,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -868,7 +866,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -900,7 +897,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -932,7 +928,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -964,7 +959,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -990,7 +984,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1001,10 +994,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2016-11-08TNI",
+              "timex": "2016-11-08TEV",
               "type": "datetimerange",
-              "start": "2016-11-08 20:00:00",
-              "end": "2016-11-08 23:59:59"
+              "start": "2016-11-08 16:00:00",
+              "end": "2016-11-08 20:00:00"
             }
           ]
         }
@@ -1016,7 +1009,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1042,7 +1034,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1068,7 +1059,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1100,20 +1090,28 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3u",
-        "Start": 16,
+        "Text": "voor 3u",
+        "Start": 11,
         "End": 17,
-        "TypeName": "datetimeV2.duration",
+        "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "PT3H",
-              "type": "duration",
-              "value": "10800"
+              "timex": "T03",
+              "Mod": "before",
+              "type": "timerange",
+              "sourceEntity": "datetimepoint",
+              "end": "03:00:00"
+            },
+            {
+              "timex": "T15",
+              "Mod": "before",
+              "type": "timerange",
+              "sourceEntity": "datetimepoint",
+              "end": "15:00:00"
             }
           ]
         }
@@ -1125,18 +1123,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3,5 jaar",
-        "Start": 16,
+        "Text": "voor 3,5 jaar",
+        "Start": 11,
         "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3.5Y",
+              "Mod": "before",
               "type": "duration",
               "value": "110376000"
             }
@@ -1150,18 +1148,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3 minuten",
-        "Start": 16,
+        "Text": "voor 3 minuten",
+        "Start": 11,
         "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT3M",
+              "Mod": "before",
               "type": "duration",
               "value": "180"
             }
@@ -1175,18 +1173,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "123,45 sec",
-        "Start": 16,
+        "Text": "voor 123,45 sec",
+        "Start": 11,
         "End": 25,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT123.45S",
+              "Mod": "before",
               "type": "duration",
               "value": "123.45"
             }
@@ -1200,12 +1198,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele dag",
-        "Start": 16,
+        "Text": "voor de hele dag",
+        "Start": 11,
         "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -1225,18 +1222,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vierentwintig uur",
-        "Start": 16,
+        "Text": "voor vierentwintig uur",
+        "Start": 11,
         "End": 32,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT24H",
+              "Mod": "before",
               "type": "duration",
               "value": "86400"
             }
@@ -1250,12 +1247,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "hele maand",
-        "Start": 19,
+        "Text": "voor de hele maand",
+        "Start": 11,
         "End": 28,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -1275,18 +1271,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een uur",
-        "Start": 16,
+        "Text": "voor een uur",
+        "Start": 11,
         "End": 22,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT1H",
+              "Mod": "before",
               "type": "duration",
               "value": "3600"
             }
@@ -1300,20 +1296,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "paar uur",
-        "Start": 16,
+        "Text": "voor paar uur",
+        "Start": 11,
         "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "PT3H",
+              "timex": "PT2H",
+              "Mod": "before",
               "type": "duration",
-              "value": "10800"
+              "value": "7200"
             }
           ]
         }
@@ -1325,20 +1321,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een paar minuten",
-        "Start": 16,
+        "Text": "voor een paar minuten",
+        "Start": 11,
         "End": 31,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "PT3M",
+              "timex": "PT2M",
+              "Mod": "before",
               "type": "duration",
-              "value": "180"
+              "value": "120"
             }
           ]
         }
@@ -1350,18 +1346,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "wat dagen",
-        "Start": 16,
+        "Text": "voor wat dagen",
+        "Start": 11,
         "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3D",
+              "Mod": "before",
               "type": "duration",
               "value": "259200"
             }
@@ -1375,18 +1371,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "enige weken",
-        "Start": 16,
+        "Text": "voor enige weken",
+        "Start": 11,
         "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3W",
+              "Mod": "before",
               "type": "duration",
               "value": "1814400"
             }
@@ -1400,7 +1396,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1425,7 +1420,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1450,7 +1444,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1475,7 +1468,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1500,7 +1492,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1525,7 +1516,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1536,7 +1526,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T15",
+              "timex": "T15:00",
               "type": "set",
               "value": "not resolved"
             }
@@ -1550,7 +1540,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1575,7 +1564,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1586,7 +1574,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-1T16",
+              "timex": "XXXX-WXX-1T16:00",
               "type": "set",
               "value": "not resolved"
             }
@@ -1600,13 +1588,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12/31/1899 7:56:30 PM",
-        "Start": -1,
-        "End": 20,
+        "Text": "19:56:30",
+        "Start": 7,
+        "End": 14,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1625,7 +1612,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1655,7 +1641,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1680,12 +1665,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "s morgens om 7 uur",
-        "Start": 8,
+        "Text": "'s morgens om 7 uur",
+        "Start": 7,
         "End": 25,
         "TypeName": "datetimeV2.time",
         "Resolution": {
@@ -1705,12 +1689,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "s middags om 7 uur",
-        "Start": 8,
+        "Text": "'s middags om 7 uur",
+        "Start": 7,
         "End": 25,
         "TypeName": "datetimeV2.time",
         "Resolution": {
@@ -1730,7 +1713,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1755,7 +1737,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1769,6 +1750,11 @@
               "timex": "T11",
               "type": "time",
               "value": "11:00:00"
+            },
+            {
+              "timex": "T23",
+              "type": "time",
+              "value": "23:00:00"
             }
           ]
         }
@@ -1780,13 +1766,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12/31/1899 11:40:00 AM",
-        "Start": -1,
-        "End": 21,
+        "Text": "11:40",
+        "Start": 7,
+        "End": 11,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -1794,6 +1779,11 @@
               "timex": "T11:40",
               "type": "time",
               "value": "11:40:00"
+            },
+            {
+              "timex": "T23:40",
+              "type": "time",
+              "value": "23:40:00"
             }
           ]
         }
@@ -1805,7 +1795,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1830,7 +1819,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1856,12 +1844,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "s middags 5 tot zeven",
-        "Start": 8,
+        "Text": "'s middags 5 tot zeven",
+        "Start": 7,
         "End": 28,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
@@ -1871,6 +1858,12 @@
               "type": "timerange",
               "start": "05:00:00",
               "end": "07:00:00"
+            },
+            {
+              "timex": "(T17,T19,PT2H)",
+              "type": "timerange",
+              "start": "17:00:00",
+              "end": "19:00:00"
             }
           ]
         }
@@ -1882,7 +1875,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1908,27 +1900,24 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4:00 tot 7",
+        "Text": "4:00",
         "Start": 7,
-        "End": 16,
-        "TypeName": "datetimeV2.timerange",
+        "End": 10,
+        "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "(T04:00,T07,PT3H)",
-              "type": "timerange",
-              "start": "04:00:00",
-              "end": "07:00:00"
+              "timex": "T04:00",
+              "type": "time",
+              "value": "04:00:00"
             },
             {
-              "timex": "(T16:00,T19,PT3H)",
-              "type": "timerange",
-              "start": "16:00:00",
-              "end": "19:00:00"
+              "timex": "T16:00",
+              "type": "time",
+              "value": "16:00:00"
             }
           ]
         }
@@ -1940,7 +1929,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1966,7 +1954,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1992,12 +1979,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "s morgens",
-        "Start": 10,
+        "Text": "'s morgens",
+        "Start": 9,
         "End": 18,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
@@ -2018,12 +2004,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "s avonds",
-        "Start": 10,
+        "Text": "'s avonds",
+        "Start": 9,
         "End": 17,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
@@ -2044,7 +2029,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2069,7 +2053,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2094,33 +2077,37 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende week maandag 9:00",
-        "Start": -1,
-        "End": 25,
+        "Text": "op volgende week maandag om 9.00",
+        "Start": 28,
+        "End": 59,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "2017-12-11T09",
+              "timex": "2017-12-11T09:00",
               "type": "datetime",
               "value": "2017-12-11 09:00:00"
+            },
+            {
+              "timex": "2017-12-11T21:00",
+              "type": "datetime",
+              "value": "2017-12-11 21:00:00"
             }
           ]
         }
       },
       {
-        "Text": "1 pm",
-        "Start": 44,
-        "End": 47,
+        "Text": "13:00",
+        "Start": 64,
+        "End": 68,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T13",
+              "timex": "T13:00",
               "type": "time",
               "value": "13:00:00"
             }
@@ -2134,12 +2121,11 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende week maandag",
-        "Start": 31,
+        "Text": "op volgende week maandag",
+        "Start": 28,
         "End": 51,
         "TypeName": "datetimeV2.date",
         "Resolution": {
@@ -2153,9 +2139,9 @@
         }
       },
       {
-        "Text": "tue",
-        "Start": 39,
-        "End": 41,
+        "Text": "dinsdag",
+        "Start": 56,
+        "End": 62,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2183,8 +2169,8 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 's ochtends om 9 uur",
-        "Start": 4,
+        "Text": "'s ochtends om 9 uur",
+        "Start": 5,
         "End": 24,
         "TypeName": "datetimeV2.time",
         "Resolution": {
@@ -2198,9 +2184,9 @@
         }
       },
       {
-        "Text": "10 oclock",
-        "Start": 49,
-        "End": 57,
+        "Text": "10 uur",
+        "Start": 29,
+        "End": 35,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -2224,7 +2210,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2235,7 +2220,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2017-12-11T13,2017-12-11T15,PT2H)",
+              "timex": "(2017-12-11T13:00,2017-12-11T15:00,PT2H)",
               "type": "datetimerange",
               "start": "2017-12-11 13:00:00",
               "end": "2017-12-11 15:00:00"
@@ -2244,14 +2229,14 @@
         }
       },
       {
-        "Text": "5-6 pm",
-        "Start": 44,
-        "End": 49,
+        "Text": "17:00-18:00",
+        "Start": 63,
+        "End": 73,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(T17,T18,PT1H)",
+              "timex": "(T17:00,T18:00,PT1H)",
               "type": "timerange",
               "start": "17:00:00",
               "end": "18:00:00"
@@ -2266,13 +2251,12 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "maandag 8-9 's ochtends ",
+        "Text": "maandag 8-9 's ochtends",
         "Start": 0,
-        "End": 23,
+        "End": 22,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -2292,9 +2276,9 @@
         }
       },
       {
-        "Text": "9-10 am",
-        "Start": 16,
-        "End": 22,
+        "Text": "9-10 's ochtends",
+        "Start": 27,
+        "End": 42,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -2314,7 +2298,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2333,9 +2316,9 @@
         }
       },
       {
-        "Text": "thursday",
-        "Start": 66,
-        "End": 73,
+        "Text": "donderdag",
+        "Start": 77,
+        "End": 85,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2359,7 +2342,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2378,9 +2360,9 @@
         }
       },
       {
-        "Text": "thursday 1 pm",
-        "Start": 71,
-        "End": 83,
+        "Text": "donderdag 1 uur 's middags",
+        "Start": 98,
+        "End": 123,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -2404,7 +2386,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2413,7 +2394,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2422,7 +2402,6 @@
     "Context": {
       "ReferenceDateTime": "2018-01-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2452,7 +2431,6 @@
     "Context": {
       "ReferenceDateTime": "2018-01-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2484,7 +2462,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2503,9 +2480,9 @@
         }
       },
       {
-        "Text": "tuesday march 7",
-        "Start": 21,
-        "End": 35,
+        "Text": "dinsdag 7 maart",
+        "Start": 29,
+        "End": 43,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2529,7 +2506,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2561,7 +2537,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2570,7 +2545,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2579,7 +2553,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2588,7 +2561,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2597,7 +2569,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2606,7 +2577,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-14T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2631,7 +2601,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2640,7 +2609,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2649,7 +2617,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -2658,7 +2625,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2678,9 +2644,9 @@
         }
       },
       {
-        "Text": "within next 10 months",
-        "Start": 56,
-        "End": 76,
+        "Text": "binnen de komende 10 maanden",
+        "Start": 55,
+        "End": 82,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2700,7 +2666,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2720,8 +2685,8 @@
       },
       {
         "Text": "over twee weken",
-        "Start": 36,
-        "End": 50,
+        "Start": 100,
+        "End": 114,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -2740,7 +2705,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-23T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2760,9 +2724,9 @@
         }
       },
       {
-        "Text": "next forty days",
-        "Start": 37,
-        "End": 51,
+        "Text": "komende veertig dagen",
+        "Start": 35,
+        "End": 55,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -2782,7 +2746,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2812,7 +2775,6 @@
     "Context": {
       "ReferenceDateTime": "2018-03-25T01:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2831,8 +2793,8 @@
         }
       },
       {
-        "Text": "next month",
-        "Start": 29,
+        "Text": "volgende maand",
+        "Start": 25,
         "End": 38,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -2853,39 +2815,24 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 12-4",
         "Start": 49,
         "End": 60,
-        "TypeName": "datetimeV2.datetimerange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-1T00,XXXX-WXX-1T04,PT4H)",
-              "type": "datetimerange",
-              "start": "2018-05-14 00:00:00",
-              "end": "2018-05-14 04:00:00"
+              "timex": "XXXX-04-12",
+              "type": "date",
+              "value": "2018-04-12"
             },
             {
-              "timex": "(XXXX-WXX-1T00,XXXX-WXX-1T04,PT4H)",
-              "type": "datetimerange",
-              "start": "2018-05-21 00:00:00",
-              "end": "2018-05-21 04:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T12,XXXX-WXX-1T16,PT4H)",
-              "type": "datetimerange",
-              "start": "2018-05-14 12:00:00",
-              "end": "2018-05-14 16:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T12,XXXX-WXX-1T16,PT4H)",
-              "type": "datetimerange",
-              "start": "2018-05-21 12:00:00",
-              "end": "2018-05-21 16:00:00"
+              "timex": "XXXX-04-12",
+              "type": "date",
+              "value": "2019-04-12"
             }
           ]
         }
@@ -2897,39 +2844,24 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "maandag 11-4",
         "Start": 49,
         "End": 60,
-        "TypeName": "datetimeV2.datetimerange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-1T11,XXXX-WXX-1T16,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-14 11:00:00",
-              "end": "2018-05-14 16:00:00"
+              "timex": "XXXX-04-11",
+              "type": "date",
+              "value": "2018-04-11"
             },
             {
-              "timex": "(XXXX-WXX-1T11,XXXX-WXX-1T16,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-21 11:00:00",
-              "end": "2018-05-21 16:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-14 23:00:00",
-              "end": "2018-05-15 04:00:00"
-            },
-            {
-              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-05-21 23:00:00",
-              "end": "2018-05-22 04:00:00"
+              "timex": "XXXX-04-11",
+              "type": "date",
+              "value": "2019-04-11"
             }
           ]
         }
@@ -2941,7 +2873,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2966,7 +2897,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2985,7 +2915,7 @@
         }
       },
       {
-        "Text": "this week",
+        "Text": "deze week",
         "Start": 28,
         "End": 36,
         "TypeName": "datetimeV2.daterange",
@@ -3007,7 +2937,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-17T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3034,7 +2963,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-08T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3061,13 +2989,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-11T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "",
-        "Start": 0,
-        "End": 0,
+        "Text": "dat weekend",
+        "Start": 17,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3088,7 +3015,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-08T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3115,20 +3041,21 @@
     "Context": {
       "ReferenceDateTime": "2018-05-22T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de dag",
-        "Start": 16,
+        "Text": "voor de dag",
+        "Start": 11,
         "End": 21,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-05-22",
-              "type": "date",
-              "value": "2018-05-22"
+             "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-05-22"
             }
           ]
         }
@@ -3140,7 +3067,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-22T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3193,7 +3119,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3220,7 +3145,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3247,21 +3171,21 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het jaar",
-        "Start": 34,
+        "Text": "voor het jaar",
+        "Start": 29,
         "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018",
+              "Mod": "before",
               "type": "daterange",
-              "start": "2018-01-01",
-              "end": "2019-01-01"
+              "sourceEntity": "datetimerange",
+              "end": "2018-01-01"
             }
           ]
         }
@@ -3273,7 +3197,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3282,7 +3205,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3291,7 +3213,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -3300,13 +3221,12 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "4/1/2017 12:00:00 AM",
-        "Start": -1,
-        "End": 19,
+        "Text": "april 2017",
+        "Start": 20,
+        "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3326,7 +3246,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-24T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3352,7 +3271,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3378,7 +3296,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3404,7 +3321,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3430,7 +3346,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3456,7 +3371,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3482,7 +3396,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3508,7 +3421,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3534,7 +3446,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3559,7 +3470,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3584,13 +3494,12 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "twee dagen voor gisteren?",
+        "Text": "twee dagen voor gisteren",
         "Start": 12,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -3609,7 +3518,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3634,7 +3542,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3659,7 +3566,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3691,7 +3597,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3723,7 +3628,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3734,7 +3638,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2015-01-01T10:30,2015-01-01T15,PT4H30M)",
+              "timex": "(2015-01-01T10:30,2015-01-01T15:00,PT4H30M)",
               "type": "datetimerange",
               "start": "2015-01-01 10:30:00",
               "end": "2015-01-01 15:00:00"
@@ -3749,7 +3653,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3781,7 +3684,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3813,7 +3715,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3827,15 +3728,16 @@
               "timex": "2010",
               "Mod": "before",
               "type": "daterange",
-              "end": "2010-01-01"
+              "end": "2010-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
       },
       {
-        "Text": "after 2018",
-        "Start": 29,
-        "End": 38,
+        "Text": "na 2018",
+        "Start": 41,
+        "End": 47,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3843,7 +3745,8 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
-              "start": "2019-01-01"
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -3855,7 +3758,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3869,15 +3771,16 @@
               "timex": "2010",
               "Mod": "after",
               "type": "daterange",
-              "start": "2011-01-01"
+              "start": "2011-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
       },
       {
-        "Text": "before 2018",
-        "Start": 29,
-        "End": 39,
+        "Text": "voor 2018",
+        "Start": 39,
+        "End": 47,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3885,15 +3788,16 @@
               "timex": "2018",
               "Mod": "before",
               "type": "daterange",
-              "end": "2018-01-01"
+              "end": "2018-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
       },
       {
-        "Text": "before 2000",
-        "Start": 44,
-        "End": 54,
+        "Text": "voor 2000",
+        "Start": 52,
+        "End": 60,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -3901,7 +3805,8 @@
               "timex": "2000",
               "Mod": "before",
               "type": "daterange",
-              "end": "2000-01-01"
+              "end": "2000-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -3929,7 +3834,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3949,9 +3853,9 @@
         }
       },
       {
-        "Text": "less than 1 week",
-        "Start": 37,
-        "End": 52,
+        "Text": "minder dan 1 week",
+        "Start": 42,
+        "End": 58,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -3971,12 +3875,11 @@
     "Context": {
       "ReferenceDateTime": "2018-06-20T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " langer dan 1 uur en 30 minuten",
-        "Start": 22,
+        "Text": "langer dan 1 uur en 30 minuten",
+        "Start": 23,
         "End": 52,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -3997,7 +3900,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-12T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4023,13 +3925,12 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "dan 2 dagen voor gisteren ",
-        "Start": 19,
-        "End": 44,
+        "Text": "meer dan 2 dagen voor gisteren",
+        "Start": 14,
+        "End": 43,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4049,7 +3950,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4075,13 +3975,12 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "meer dan 2 weken na vandaag ",
+        "Text": "meer dan 2 weken na vandaag",
         "Start": 14,
-        "End": 41,
+        "End": 40,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4101,7 +4000,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4126,28 +4024,27 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "3 minuten",
-        "Start": 14,
+        "Text": "over 3 minuten",
+        "Start": 9,
         "End": 22,
-        "TypeName": "datetimeV2.duration",
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "PT3M",
-              "type": "duration",
-              "value": "180"
+              "timex": "2018-05-29T00:03:00",
+              "type": "datetime",
+              "value": "2018-05-29 00:03:00"
             }
           ]
         }
       },
       {
-        "Text": "today",
-        "Start": 27,
-        "End": 31,
+        "Text": "vandaag",
+        "Start": 30,
+        "End": 36,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -4166,41 +4063,45 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
+    "Comment": "Ambiguity issue of 'voor' that can be interpreted both as 'before' and 'for'",
     "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " de 9e van mei",
-        "Start": 32,
+        "Text": "voor de 9e van mei",
+        "Start": 28,
         "End": 45,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "XXXX-05-09",
-              "type": "date",
-              "value": "2018-05-09"
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-05-09"
             },
             {
               "timex": "XXXX-05-09",
-              "type": "date",
-              "value": "2019-05-09"
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2019-05-09"
             }
           ]
         }
       },
       {
-        "Text": "nights",
-        "Start": 45,
-        "End": 50,
-        "TypeName": "datetimeV2.timerange",
+        "Text": "2 nachten",
+        "Start": 52,
+        "End": 60,
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "TNI",
-              "type": "timerange",
-              "start": "20:00:00",
-              "end": "23:59:59"
+              "timex": "P2D",
+              "type": "duration",
+              "value": "172800"
             }
           ]
         }
@@ -4212,7 +4113,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4238,7 +4138,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4264,7 +4163,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4278,7 +4176,8 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
-              "start": "2019-01-01"
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -4290,7 +4189,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4304,7 +4202,8 @@
               "timex": "2018-02",
               "Mod": "after",
               "type": "daterange",
-              "start": "2018-03-01"
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -4316,7 +4215,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4330,13 +4228,15 @@
               "timex": "XXXX-02",
               "Mod": "after",
               "type": "daterange",
-              "start": "2018-03-01"
+              "start": "2018-03-01",
+              "sourceEntity": "datetimerange"
             },
             {
               "timex": "XXXX-02",
               "Mod": "after",
               "type": "daterange",
-              "start": "2019-03-01"
+              "start": "2019-03-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -4348,7 +4248,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-29T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4380,18 +4279,17 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vandaag voor 16:00 ",
+        "Text": "vandaag voor 16:00",
         "Start": 8,
-        "End": 26,
+        "End": 25,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-06-26T16",
+              "timex": "2018-06-26T16:00",
               "Mod": "before",
               "type": "datetimerange",
               "end": "2018-06-26 16:00:00"
@@ -4406,7 +4304,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4432,21 +4329,19 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vorige week dinsdag om 2 uur 's middags",
         "Start": 16,
         "End": 54,
-        "TypeName": "datetimeV2.datetimerange",
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
               "timex": "2018-06-19T14",
-              "Mod": "before",
-              "type": "datetimerange",
-              "end": "2018-06-19 14:00:00"
+              "type": "datetime",
+              "value": "2018-06-19 14:00:00"
             }
           ]
         }
@@ -4458,13 +4353,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 feb niet later dan 6:00 ",
+        "Text": "1 feb niet later dan 6:00",
         "Start": 23,
-        "End": 48,
+        "End": 47,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -4502,7 +4396,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4522,9 +4415,9 @@
         }
       },
       {
-        "Text": "after 2:00",
-        "Start": 25,
-        "End": 34,
+        "Text": "na 2:00",
+        "Start": 30,
+        "End": 36,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
@@ -4532,13 +4425,15 @@
               "timex": "T02:00",
               "Mod": "after",
               "type": "timerange",
-              "start": "02:00:00"
+              "start": "02:00:00",
+              "sourceEntity": "datetimepoint"
             },
             {
               "timex": "T14:00",
               "Mod": "after",
               "type": "timerange",
-              "start": "14:00:00"
+              "start": "14:00:00",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -4550,7 +4445,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4592,7 +4486,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4618,20 +4511,24 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vandaag om 9:00 ",
+        "Text": "vandaag om 9:00",
         "Start": 4,
-        "End": 19,
+        "End": 18,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-06-28T09",
+              "timex": "2018-06-28T09:00",
               "type": "datetime",
               "value": "2018-06-28 09:00:00"
+            },
+            {
+              "timex": "2018-06-28T21:00",
+              "type": "datetime",
+              "value": "2018-06-28 21:00:00"
             }
           ]
         }
@@ -4643,7 +4540,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4654,7 +4550,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-06-28T21",
+              "timex": "2018-06-28T21:00",
               "type": "datetime",
               "value": "2018-06-28 21:00:00"
             }
@@ -4668,13 +4564,12 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "jaar 2018",
-        "Start": -1,
-        "End": 8,
+        "Text": "jaar 2008",
+        "Start": 20,
+        "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -4694,7 +4589,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4720,7 +4614,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4746,7 +4639,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4772,7 +4664,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4798,7 +4689,6 @@
     "Context": {
       "ReferenceDateTime": "2019-03-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4824,7 +4714,6 @@
     "Context": {
       "ReferenceDateTime": "2019-03-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -4833,7 +4722,6 @@
     "Context": {
       "ReferenceDateTime": "2018-06-26T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4858,7 +4746,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4883,7 +4770,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4908,7 +4794,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4933,7 +4818,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-05T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -4958,12 +4842,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 2014-2018",
-        "Start": 13,
+        "Text": "2014-2018",
+        "Start": 14,
         "End": 22,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -4984,7 +4867,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5010,7 +4892,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5036,7 +4917,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5062,7 +4942,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5088,7 +4967,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5114,7 +4992,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5140,7 +5017,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5166,7 +5042,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5192,7 +5067,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5218,7 +5092,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5244,7 +5117,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5270,7 +5142,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5296,12 +5167,11 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2008",
-        "Start": 36,
+        "Text": "jaar 2008",
+        "Start": 31,
         "End": 39,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -5322,7 +5192,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-11T20:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5352,7 +5221,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-13T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5386,7 +5254,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-13T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5426,7 +5293,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5437,10 +5303,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2018-07-16TNI",
+              "timex": "2018-07-16TEV",
               "type": "datetimerange",
-              "start": "2018-07-16 20:00:00",
-              "end": "2018-07-16 23:59:59"
+              "start": "2018-07-16 16:00:00",
+              "end": "2018-07-16 20:00:00"
             }
           ]
         }
@@ -5452,7 +5318,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5478,7 +5343,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5503,7 +5367,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-24T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5517,13 +5380,15 @@
               "timex": "XXXX-07-04",
               "Mod": "before",
               "type": "daterange",
-              "end": "2018-07-04"
+              "end": "2018-07-04",
+              "sourceEntity": "datetimepoint"
             },
             {
               "timex": "XXXX-07-04",
               "Mod": "before",
               "type": "daterange",
-              "end": "2019-07-04"
+              "end": "2019-07-04",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -5535,7 +5400,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5561,7 +5425,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5572,10 +5435,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-08-15,P2W)",
+              "timex": "(2018-08-01,2018-08-08,P1W)",
               "type": "daterange",
               "start": "2018-08-01",
-              "end": "2018-08-15"
+              "end": "2018-08-08"
             }
           ]
         }
@@ -5587,7 +5450,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T13:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5612,7 +5474,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-30T20:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5631,6 +5492,16 @@
               "timex": "XXXX-05-22T11:30",
               "type": "datetime",
               "value": "2019-05-22 11:30:00"
+            },
+            {
+              "timex": "XXXX-05-22T23:30",
+              "type": "datetime",
+              "value": "2018-05-22 23:30:00"
+            },
+            {
+              "timex": "XXXX-05-22T23:30",
+              "type": "datetime",
+              "value": "2019-05-22 23:30:00"
             }
           ]
         }
@@ -5642,36 +5513,19 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het middaguur vandaag",
-        "Start": 22,
-        "End": 42,
+        "Text": "vanaf het middaguur vandaag tot het middaguur morgen",
+        "Start": 16,
+        "End": 67,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-07-31TAF",
+              "timex": "(2018-07-31T12,2018-08-01T12,PT24H)",
               "type": "datetimerange",
               "start": "2018-07-31 12:00:00",
-              "end": "2018-07-31 16:00:00"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "tomorrow am",
-        "Start": 36,
-        "End": 46,
-        "TypeName": "datetimeV2.datetimerange",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2018-08-01TMO",
-              "type": "datetimerange",
-              "start": "2018-08-01 08:00:00",
               "end": "2018-08-01 12:00:00"
             }
           ]
@@ -5684,7 +5538,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -5693,7 +5546,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -5702,7 +5554,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5722,17 +5573,18 @@
         }
       },
       {
-        "Text": "as early as 7:00 am",
-        "Start": 21,
-        "End": 39,
+        "Text": "al zo vroeg als 7 uur 's ochtends",
+        "Start": 36,
+        "End": 68,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
+              "timex": "T07",
               "Mod": "since",
               "type": "timerange",
-              "start": "07:00:00"
+              "start": "07:00:00",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -5744,7 +5596,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5755,10 +5606,11 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
+              "timex": "T07",
               "Mod": "until",
               "type": "timerange",
-              "end": "07:00:00"
+              "end": "07:00:00",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -5770,12 +5622,11 @@
     "Context": {
       "ReferenceDateTime": "2018-08-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 15 minuten",
-        "Start": 23,
+        "Text": "15 minuten",
+        "Start": 27,
         "End": 36,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -5789,35 +5640,37 @@
         }
       },
       {
-        "Text": "next monday",
-        "Start": 30,
-        "End": 40,
-        "TypeName": "datetimeV2.date",
+        "Text": "voor volgende maandag",
+        "Start": 38,
+        "End": 58,
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-09-03",
-              "type": "date",
-              "value": "2018-09-03"
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-09-03"
             }
           ]
         }
       },
       {
-        "Text": "tuesday after 1pm",
-        "Start": 45,
-        "End": 61,
+        "Text": "dinsdag na 13:00",
+        "Start": 63,
+        "End": 78,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-2T13",
+              "timex": "XXXX-WXX-2T13:00",
               "Mod": "after",
               "type": "datetimerange",
               "start": "2018-08-28 13:00:00"
             },
             {
-              "timex": "XXXX-WXX-2T13",
+              "timex": "XXXX-WXX-2T13:00",
               "Mod": "after",
               "type": "datetimerange",
               "start": "2018-09-04 13:00:00"
@@ -5832,13 +5685,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5 aankomende jaren ",
+        "Text": "5 aankomende jaren",
         "Start": 17,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5858,13 +5710,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2 aankomende maanden ",
+        "Text": "2 aankomende maanden",
         "Start": 17,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5888,9 +5739,9 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " 2 aankomende dagen ",
-        "Start": 16,
-        "End": 35,
+        "Text": "2 aankomende dagen",
+        "Start": 17,
+        "End": 34,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -5910,13 +5761,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5 aankomende minuten ",
+        "Text": "5 aankomende minuten",
         "Start": 17,
-        "End": 37,
+        "End": 36,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5936,13 +5786,12 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "afgelopen 5 minuten ",
+        "Text": "afgelopen 5 minuten",
         "Start": 16,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -5962,7 +5811,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5988,7 +5836,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6032,21 +5879,6 @@
             }
           ]
         }
-      },
-      {
-        "Text": "tomorrow",
-        "Start": 47,
-        "End": 54,
-        "TypeName": "datetimeV2.date",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "2018-09-01",
-              "type": "date",
-              "value": "2018-09-01"
-            }
-          ]
-        }
       }
     ]
   },
@@ -6055,7 +5887,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-06T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6069,7 +5900,8 @@
               "timex": "(2019-01-01,2019-04-01,P3M)",
               "Mod": "since",
               "type": "daterange",
-              "start": "2019-01-01"
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -6133,7 +5965,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6147,6 +5978,7 @@
               "timex": "2016",
               "Mod": "since",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2016-01-01"
             }
           ]
@@ -6159,7 +5991,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6173,6 +6004,7 @@
               "timex": "2016-01-01",
               "Mod": "since",
               "type": "daterange",
+              "sourceEntity": "datetimepoint",
               "start": "2016-01-01"
             }
           ]
@@ -6185,7 +6017,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6199,6 +6030,7 @@
               "timex": "2016-01-01",
               "Mod": "since",
               "type": "daterange",
+              "sourceEntity": "datetimepoint",
               "start": "2016-01-01"
             }
           ]
@@ -6212,7 +6044,6 @@
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
     "Comment": "Known false positive needs to be supported in the future",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6237,7 +6068,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6256,17 +6086,18 @@
         }
       },
       {
-        "Text": "after 6pm",
-        "Start": 33,
-        "End": 41,
+        "Text": "na 18:00",
+        "Start": 40,
+        "End": 47,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "T18",
+              "timex": "T18:00",
               "Mod": "after",
               "type": "timerange",
-              "start": "18:00:00"
+              "start": "18:00:00",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -6278,7 +6109,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6304,7 +6134,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6318,7 +6147,8 @@
               "timex": "2018",
               "Mod": "since",
               "type": "daterange",
-              "start": "2018-01-01"
+              "start": "2018-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -6327,6 +6157,7 @@
   },
   {
     "Input": "Wat is de verkoop voor tussen 2015 en 2018 of later dan 2020",
+    "Comment": "With 2 points ranges 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
@@ -6350,7 +6181,7 @@
         }
       },
       {
-        "Text": "later than 2020",
+        "Text": "later dan 2020",
         "Start": 46,
         "End": 60,
         "TypeName": "datetimeV2.daterange",
@@ -6372,7 +6203,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-17T15:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6392,16 +6222,17 @@
         }
       },
       {
-        "Text": "any time from 7:00 am",
-        "Start": 21,
-        "End": 41,
+        "Text": "een tijdstip vanaf 7 uur 's morgens",
+        "Start": 22,
+        "End": 56,
         "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
+              "timex": "T07",
               "Mod": "since",
               "type": "timerange",
+              "sourceEntity": "datetimepoint",
               "start": "07:00:00"
             }
           ]
@@ -6414,7 +6245,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6428,7 +6258,8 @@
               "timex": "2018",
               "Mod": "after",
               "type": "daterange",
-              "start": "2019-01-01"
+              "start": "2019-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -6440,35 +6271,28 @@
     "Context": {
       "ReferenceDateTime": "2018-09-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "voor maandag om half 3 's middags",
         "Start": 32,
         "End": 64,
-        "TypeName": "datetimeV2.datetime",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-WXX-1T02:30",
-              "type": "datetime",
-              "value": "2018-09-17 02:30:00"
-            },
-            {
-              "timex": "XXXX-WXX-1T02:30",
-              "type": "datetime",
-              "value": "2018-09-24 02:30:00"
+              "timex": "XXXX-WXX-1T14:30",
+              "Mod": "before",
+              "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-09-17 14:30:00"
             },
             {
               "timex": "XXXX-WXX-1T14:30",
-              "type": "datetime",
-              "value": "2018-09-17 14:30:00"
-            },
-            {
-              "timex": "XXXX-WXX-1T14:30",
-              "type": "datetime",
-              "value": "2018-09-24 14:30:00"
+              "Mod": "before",
+              "type": "datetimerange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-09-24 14:30:00"
             }
           ]
         }
@@ -6480,7 +6304,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6494,7 +6317,8 @@
               "timex": "T14:30",
               "Mod": "before",
               "type": "timerange",
-              "end": "14:30:00"
+              "end": "14:30:00",
+              "sourceEntity": "datetimepoint"
             }
           ]
         }
@@ -6510,7 +6334,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "donderdag 29-3 11 uur 's ochtends ",
+        "Text": "donderdag 29-3 11 uur 's ochtends",
         "Start": 3,
         "End": 36,
         "TypeName": "datetimeV2.datetime",
@@ -6525,6 +6349,16 @@
               "timex": "XXXX-03-29T11:00",
               "type": "datetime",
               "value": "2019-03-29 11:00:00"
+            },
+            {
+              "timex": "XXXX-03-29T23:00",
+              "type": "datetime",
+              "value": "2018-03-29 23:00:00"
+            },
+            {
+              "timex": "XXXX-03-29T23:00",
+              "type": "datetime",
+              "value": "2019-03-29 23:00:00"
             }
           ]
         }
@@ -6568,7 +6402,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6600,7 +6433,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6626,7 +6458,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6652,7 +6483,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6684,7 +6514,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6710,7 +6539,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6742,7 +6570,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -6751,7 +6578,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6781,7 +6607,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-17T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6800,9 +6625,9 @@
         }
       },
       {
-        "Text": "in a week",
-        "Start": 32,
-        "End": 40,
+        "Text": "over een week",
+        "Start": 39,
+        "End": 51,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -6821,7 +6646,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-16T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -6830,7 +6654,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6856,7 +6679,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6884,15 +6706,14 @@
     ]
   },
   {
-    "Input": "Mijn vakantie is van 10-1-2018-10-7-2018",
+    "Input": "Mijn vakantie is van 1-10-2018-7-10-2018",
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 10-1-2018-10-7-2018",
+        "Text": "van 1-10-2018-7-10-2018",
         "Start": 17,
         "End": 39,
         "TypeName": "datetimeV2.daterange",
@@ -6910,15 +6731,14 @@
     ]
   },
   {
-    "Input": "Mijn vakantie is van 10-1-2018 - 10-7-2018",
+    "Input": "Mijn vakantie is van 1-10-2018 - 7-10-2018",
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "van 10-1-2018 - 10-7-2018",
+        "Text": "van 1-10-2018 - 7-10-2018",
         "Start": 17,
         "End": 41,
         "TypeName": "datetimeV2.daterange",
@@ -6940,7 +6760,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6966,7 +6785,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6992,7 +6810,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7070,7 +6887,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7096,7 +6912,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7128,7 +6943,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7139,9 +6953,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2020-10-01,P29M)",
+              "timex": "(2019-05-01,2020-10-01,P17M)",
               "type": "daterange",
-              "start": "2018-05-01",
+              "start": "2019-05-01",
               "end": "2020-10-01"
             }
           ]
@@ -7154,7 +6968,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7180,7 +6993,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7206,7 +7018,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7232,7 +7043,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7258,13 +7068,12 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "8/5/2016 12:00:00 AM",
-        "Start": -1,
-        "End": 19,
+        "Text": "05-aug-2016",
+        "Start": 14,
+        "End": 24,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7283,7 +7092,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7326,16 +7134,28 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-1T10,XXXX-WXX-1T12,PT2H)",
+              "timex": "(XXXX-WXX-1T10:00,XXXX-WXX-1T12:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-10-29 10:00:00",
               "end": "2018-10-29 12:00:00"
             },
             {
-              "timex": "(XXXX-WXX-1T10,XXXX-WXX-1T12,PT2H)",
+              "timex": "(XXXX-WXX-1T10:00,XXXX-WXX-1T12:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-11-05 10:00:00",
               "end": "2018-11-05 12:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T22:00,XXXX-WXX-2T00:00,PT2H)",
+              "type": "datetimerange",
+              "start": "2018-10-29 22:00:00",
+              "end": "2018-10-30 00:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T22:00,XXXX-WXX-2T00:00,PT2H)",
+              "type": "datetimerange",
+              "start": "2018-11-05 22:00:00",
+              "end": "2018-11-06 00:00:00"
             }
           ]
         }
@@ -7347,7 +7167,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7358,7 +7177,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-10-31T15,2018-10-31T20,PT5H)",
+              "timex": "(2018-10-31T15:00,2018-10-31T20:00,PT5H)",
               "type": "datetimerange",
               "start": "2018-10-31 15:00:00",
               "end": "2018-10-31 20:00:00"
@@ -7373,7 +7192,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7425,7 +7243,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7469,7 +7286,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7501,7 +7317,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7516,6 +7331,12 @@
               "type": "datetimerange",
               "start": "2018-11-05 03:00:00",
               "end": "2018-11-05 08:00:00"
+            },
+            {
+              "timex": "(2018-11-05T15,2018-11-05T20,PT5H)",
+              "type": "datetimerange",
+              "start": "2018-11-05 15:00:00",
+              "end": "2018-11-05 20:00:00"
             }
           ]
         }
@@ -7523,17 +7344,16 @@
     ]
   },
   {
-    "Input": "Ben je volgende maandag tussen 3 uur 's middags - 12 uur 's middags beschikbaar",
+    "Input": "Ben je volgende maandag tussen 3 uur 's ochtends - 12 uur 's middags beschikbaar",
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": " volgende maandag tussen 3 uur 's middags - 12 uur 's middags",
-        "Start": 6,
-        "End": 66,
+        "Text": "volgende maandag tussen 3 uur 's ochtends - 12 uur 's middags",
+        "Start": 7,
+        "End": 67,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7553,13 +7373,12 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende maandag tussen 6-8 ",
+        "Text": "volgende maandag tussen 6-8",
         "Start": 7,
-        "End": 34,
+        "End": 33,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -7585,7 +7404,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7643,21 +7461,21 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "dec-2018",
-        "Start": 20,
+        "Text": "voor dec-2018",
+        "Start": 15,
         "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-12",
+              "Mod": "before",
               "type": "daterange",
-              "start": "2018-12-01",
-              "end": "2019-01-01"
+              "sourceEntity": "datetimerange",
+              "end": "2018-12-01"
             }
           ]
         }
@@ -7669,21 +7487,21 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "dec-2018",
-        "Start": -1,
-        "End": 7,
+        "Text": "voor dec/2018",
+        "Start": 15,
+        "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-12",
+              "Mod": "before",
               "type": "daterange",
-              "start": "2018-12-01",
-              "end": "2019-01-01"
+              "sourceEntity": "datetimerange",
+              "end": "2018-12-01"
             }
           ]
         }
@@ -7695,21 +7513,21 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "dec, 2018",
-        "Start": 20,
+        "Text": "voor dec, 2018",
+        "Start": 15,
         "End": 28,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-12",
+              "Mod": "before",
               "type": "daterange",
-              "start": "2018-12-01",
-              "end": "2019-01-01"
+              "sourceEntity": "datetimerange",
+              "end": "2018-12-01"
             }
           ]
         }
@@ -7718,6 +7536,7 @@
   },
   {
     "Input": "Wat is je plan voor dec/2018-mei/2019",
+    "Comment": "With 2 points ranges, 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
@@ -7747,7 +7566,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7797,7 +7615,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -7806,7 +7623,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-15T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7825,9 +7641,9 @@
         }
       },
       {
-        "Text": "next tuesday",
-        "Start": 55,
-        "End": 66,
+        "Text": "volgende dinsdag",
+        "Start": 58,
+        "End": 73,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7846,7 +7662,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-15T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7865,16 +7680,16 @@
         }
       },
       {
-        "Text": "previous monday",
-        "Start": 55,
-        "End": 69,
+        "Text": "afgelopen maandag",
+        "Start": 59,
+        "End": 75,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-11-05",
+              "timex": "2018-11-12",
               "type": "date",
-              "value": "2018-11-05"
+              "value": "2018-11-12"
             }
           ]
         }
@@ -7886,20 +7701,21 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "volgende week woensdag",
-        "Start": 20,
+        "Text": "voor volgende week woensdag",
+        "Start": 15,
         "End": 41,
-        "TypeName": "datetimeV2.date",
+        "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-12-05",
-              "type": "date",
-              "value": "2018-12-05"
+              "Mod": "before",
+              "type": "daterange",
+              "sourceEntity": "datetimepoint",
+              "end": "2018-12-05"
             }
           ]
         }
@@ -7936,7 +7752,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7961,13 +7776,12 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eind van de dag ",
+        "Text": "eind van de dag",
         "Start": 34,
-        "End": 49,
+        "End": 48,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
@@ -7986,12 +7800,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-21T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het eind van de dag",
-        "Start": 65,
+        "Text": "aan het eind van de dag",
+        "Start": 61,
         "End": 83,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
@@ -8011,12 +7824,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-23T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eind van het jaar",
-        "Start": 8,
+        "Text": "aan het eind van het jaar",
+        "Start": 0,
         "End": 24,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -8038,7 +7850,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8062,9 +7873,9 @@
         }
       },
       {
-        "Text": "12 of nov",
-        "Start": 29,
-        "End": 37,
+        "Text": "12 nov",
+        "Start": 25,
+        "End": 30,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8088,7 +7899,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-27T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8115,7 +7925,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8167,9 +7976,9 @@
         }
       },
       {
-        "Text": "thursday",
-        "Start": 61,
-        "End": 68,
+        "Text": "donderdag",
+        "Start": 82,
+        "End": 91,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8187,9 +7996,9 @@
         }
       },
       {
-        "Text": "friday",
-        "Start": 73,
-        "End": 78,
+        "Text": "vrijdag",
+        "Start": 95,
+        "End": 102,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8253,7 +8062,6 @@
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
     "Comment": "Cst can't be recognized as TimeZone is not enabled for now",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8285,7 +8093,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8311,12 +8118,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "eerste week van jan 2015",
-        "Start": 6,
+        "Text": "de eerste week van jan 2015",
+        "Start": 3,
         "End": 29,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -8337,12 +8143,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "laatste week van 2016",
-        "Start": 6,
+        "Text": "de laatste week van 2016",
+        "Start": 3,
         "End": 26,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -8363,7 +8168,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8385,17 +8189,16 @@
     ]
   },
   {
-    "Input": "How about first week of 2019",
+    "Input": "Wat dacht je van eerste week van 2019",
     "Context": {
       "ReferenceDateTime": "2019-03-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "first week of 2019",
-        "Start": 10,
-        "End": 27,
+        "Text": "eerste week van 2019",
+        "Start": 17,
+        "End": 36,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8411,17 +8214,16 @@
     ]
   },
   {
-    "Input": "How about last week of 2019",
+    "Input": "Wat dacht je van de laatste week van 2019",
     "Context": {
       "ReferenceDateTime": "2019-03-02T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "last week of 2019",
-        "Start": 10,
-        "End": 26,
+        "Text": "de laatste week van 2019",
+        "Start": 17,
+        "End": 40,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -8441,12 +8243,11 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de derde week van 2018",
-        "Start": -1,
+        "Text": "de 3e week van 2018",
+        "Start": 3,
         "End": 21,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -8467,7 +8268,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-29T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8499,7 +8299,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8526,7 +8325,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8552,18 +8350,17 @@
     "Context": {
       "ReferenceDateTime": "2018-11-30T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "12/31/1899 3:00:00 PM",
-        "Start": -1,
-        "End": 20,
+        "Text": "15:00",
+        "Start": 17,
+        "End": 21,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T15",
+              "timex": "T15:00",
               "type": "time",
               "value": "15:00:00"
             }
@@ -8577,7 +8374,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-05T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8606,9 +8402,9 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een jaar en een kwart jaar ",
+        "Text": "een jaar en een kwart",
         "Start": 10,
-        "End": 36,
+        "End": 30,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
@@ -8627,7 +8423,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8646,7 +8441,6 @@
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
     "Comment": "Not extracted may as a datetime range is not supported for now",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8655,7 +8449,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-13T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8664,7 +8457,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8694,7 +8486,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8724,7 +8515,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8754,7 +8544,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8784,7 +8573,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8798,13 +8586,15 @@
               "timex": "XXXX-05",
               "Mod": "after-mid",
               "type": "daterange",
-              "start": "2018-05-21"
+              "start": "2018-05-21",
+              "sourceEntity": "datetimerange"
             },
             {
               "timex": "XXXX-05",
               "Mod": "after-mid",
               "type": "daterange",
-              "start": "2019-05-21"
+              "start": "2019-05-21",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -8816,7 +8606,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8830,13 +8619,15 @@
               "timex": "XXXX-09",
               "Mod": "before-start",
               "type": "daterange",
-              "end": "2018-09-01"
+              "end": "2018-09-01",
+              "sourceEntity": "datetimerange"
             },
             {
               "timex": "XXXX-09",
               "Mod": "before-start",
               "type": "daterange",
-              "end": "2019-09-01"
+              "end": "2019-09-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -8848,7 +8639,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-25T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8862,13 +8652,15 @@
               "timex": "XXXX-07",
               "Mod": "since-end",
               "type": "daterange",
-              "start": "2018-07-16"
+              "start": "2018-07-16",
+              "sourceEntity": "datetimerange"
             },
             {
               "timex": "XXXX-07",
               "Mod": "since-end",
               "type": "daterange",
-              "start": "2019-07-16"
+              "start": "2019-07-16",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -8880,7 +8672,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8905,7 +8696,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8916,9 +8706,9 @@
         "Resolution": {
           "values": [
             {
-              "timex": "2019-02-08",
+              "timex": "2019-02-01",
               "type": "date",
-              "value": "2019-02-08"
+              "value": "2019-02-01"
             }
           ]
         }
@@ -8930,7 +8720,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8955,7 +8744,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8980,7 +8768,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9005,7 +8792,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9030,7 +8816,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9055,7 +8840,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9066,16 +8850,16 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T07:30,T09:30,PT2H)",
+              "timex": "(T07:30,T09:00,PT1H30M)",
               "type": "timerange",
               "start": "07:30:00",
-              "end": "09:30:00"
+              "end": "09:00:00"
             },
             {
-              "timex": "(T19:30,T21:30,PT2H)",
+              "timex": "(T19:30,T21:00,PT1H30M)",
               "type": "timerange",
               "start": "19:30:00",
-              "end": "21:30:00"
+              "end": "21:00:00"
             }
           ]
         }
@@ -9087,7 +8871,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9119,7 +8902,6 @@
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9147,16 +8929,16 @@
     ]
   },
   {
-    "Input": "Waar was je tussen 7:30-9:30",
+    "Input": "Waar was je tussen 730-930",
     "Context": {
       "ReferenceDateTime": "2019-01-31T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "Boek een meeting in voor maandag 21 tussen 9:30 en 15:00 pst",
+    "Comment": "With 2 points ranges, 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
@@ -9192,7 +8974,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9203,13 +8984,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M",
+              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M)",
               "type": "datetimerange",
               "start": "2019-01-15 13:00:00",
               "end": "2019-01-15 13:15:00"
             },
             {
-              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M",
+              "timex": "(XXXX-01-15T13:00,XXXX-01-15T13:15,PT15M)",
               "type": "datetimerange",
               "start": "2020-01-15 13:00:00",
               "end": "2020-01-15 13:15:00"
@@ -9224,7 +9005,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-28T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9243,14 +9023,14 @@
         }
       },
       {
-        "Text": "3pm today",
-        "Start": 127,
-        "End": 135,
+        "Text": "15:00 vandaag",
+        "Start": 158,
+        "End": 170,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "2019-02-28T15",
+              "timex": "2019-02-28T15:00",
               "type": "datetime",
               "value": "2019-02-28 15:00:00"
             }
@@ -9264,7 +9044,6 @@
     "Context": {
       "ReferenceDateTime": "2019-03-01T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9283,9 +9062,9 @@
         }
       },
       {
-        "Text": "thursday 19:00 - 21:00",
-        "Start": 44,
-        "End": 65,
+        "Text": "donderdag 19:00 - 21:00",
+        "Start": 47,
+        "End": 69,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
@@ -9311,7 +9090,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9337,7 +9115,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9346,7 +9123,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9355,7 +9131,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9364,7 +9139,6 @@
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -9373,7 +9147,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9384,10 +9157,10 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T16:00,T17:00,PT1H)",
+              "timex": "(2016-11-07T16:00,2016-11-07T17:00,PT1H)",
               "type": "datetimerange",
-              "start": "2015-12-01",
-              "end": "2016-01-01"
+              "start": "2016-11-07 16:00:00",
+              "end": "2016-11-07 17:00:00"
             }
           ]
         }
@@ -9399,7 +9172,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9425,13 +9197,12 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen",
-        "Start": 0,
-        "End": 13,
+        "Start": 6,
+        "End": 11,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9444,16 +9215,21 @@
         }
       },
       {
-        "Text": "om 8:00",
-        "Start": 0,
-        "End": 13,
+        "Text": "8:00",
+        "Start": 22,
+        "End": 25,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T08:00",
               "type": "time",
-              "value": "08:00"
+              "value": "08:00:00"
+            },
+            {
+              "timex": "T20:00",
+              "type": "time",
+              "value": "20:00:00"
             }
           ]
         }
@@ -9465,36 +9241,40 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "vanavond",
-        "Start": 0,
-        "End": 6,
+        "Start": 6,
+        "End": 13,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-10-24TNI",
+              "timex": "2018-10-24TEV",
               "type": "datetimerange",
-              "start": "2018-10-24 20:00:00",
-              "end": "2018-10-24 23:59:59"
+              "start": "2018-10-24 16:00:00",
+              "end": "2018-10-24 20:00:00"
             }
           ]
         }
       },
       {
-        "Text": "om 7",
-        "Start": 0,
-        "End": 13,
+        "Text": "7",
+        "Start": 24,
+        "End": 24,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
+              "timex": "T07",
               "type": "time",
-              "value": "07:00"
+              "value": "07:00:00"
+            },
+            {
+              "timex": "T19",
+              "type": "time",
+              "value": "19:00:00"
             }
           ]
         }
@@ -9506,35 +9286,39 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op de 5e",
-        "Start": 0,
-        "End": 6,
+        "Text": "de 5e",
+        "Start": 9,
+        "End": 13,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-10-05",
+              "timex": "XXXX-XX-05",
               "type": "date",
               "value": "2018-10-05"
+            },
+            {
+              "timex": "XXXX-XX-05",
+              "type": "date",
+              "value": "2018-11-05"
             }
           ]
         }
       },
       {
-        "Text": "om 4u ‘s morgens",
-        "Start": 0,
-        "End": 13,
+        "Text": "4u ‘s morgens",
+        "Start": 24,
+        "End": 36,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T04:00",
+              "timex": "T04",
               "type": "time",
-              "value": "04:00"
+              "value": "04:00:00"
             }
           ]
         }
@@ -9546,13 +9330,12 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "16-12-2016",
-        "Start": 0,
-        "End": 6,
+        "Start": 9,
+        "End": 18,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9566,8 +9349,8 @@
       },
       {
         "Text": "om 12.23:59u",
-        "Start": 0,
-        "End": 13,
+        "Start": 26,
+        "End": 37,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -9575,6 +9358,11 @@
               "timex": "T12:23:59",
               "type": "time",
               "value": "12:23:59"
+            },
+            {
+              "timex": "T00:23:59",
+              "type": "time",
+              "value": "00:23:59"
             }
           ]
         }
@@ -9616,35 +9404,39 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "20:00",
-        "Start": 0,
-        "End": 13,
+        "Text": "20.00",
+        "Start": 6,
+        "End": 10,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T20:00",
               "type": "time",
-              "value": "20:00"
+              "value": "20:00:00"
             }
           ]
         }
       },
       {
-        "Text": "op de 15e",
-        "Start": 0,
-        "End": 6,
+        "Text": "de 15e",
+        "Start": 21,
+        "End": 26,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-10-15",
+              "timex": "XXXX-XX-15",
               "type": "date",
               "value": "2018-10-15"
+            },
+            {
+              "timex": "XXXX-XX-15",
+              "type": "date",
+              "value": "2018-11-15"
             }
           ]
         }
@@ -9656,35 +9448,44 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "om zeven uur",
-        "Start": 0,
-        "End": 13,
+        "Text": "zeven uur",
+        "Start": 9,
+        "End": 17,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
-              "timex": "T07:00",
+              "timex": "T07",
               "type": "time",
-              "value": "07:00"
+              "value": "07:00:00"
+            },
+            {
+              "timex": "T19",
+              "type": "time",
+              "value": "19:00:00"
             }
           ]
         }
       },
       {
-        "Text": "op de 15e",
-        "Start": 0,
-        "End": 6,
+        "Text": "de 15e",
+        "Start": 28,
+        "End": 33,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
-              "timex": "2018-10-15",
+              "timex": "XXXX-XX-15",
               "type": "date",
               "value": "2018-10-15"
+            },
+            {
+              "timex": "XXXX-XX-15",
+              "type": "date",
+              "value": "2018-11-15"
             }
           ]
         }
@@ -9696,13 +9497,12 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "een paar maanden geleden",
-        "Start": 0,
-        "End": 6,
+        "Start": 11,
+        "End": 34,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -9721,20 +9521,19 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "om 20.15u",
-        "Start": 0,
-        "End": 13,
+        "Start": 12,
+        "End": 20,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
             {
               "timex": "T20:15",
               "type": "time",
-              "value": "20:15"
+              "value": "20:15:00"
             }
           ]
         }
@@ -9746,7 +9545,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9772,14 +9571,34 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "op 1 januari weg van 5 tot 6",
-        "Start": 7,
+        "Text": "1 januari",
+        "Start": 10,
+        "End": 18,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-01-01",
+              "type": "date",
+              "value": "2016-01-01"
+            },
+            {
+              "timex": "XXXX-01-01",
+              "type": "date",
+              "value": "2017-01-01"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "van 5 tot 6",
+        "Start": 24,
         "End": 34,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
@@ -9798,21 +9617,36 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
+      {
+        "Text": "morgen",
+        "Start": 0,
+        "End": 5,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-08",
+              "type": "date",
+              "value": "2016-11-08"
+            }
+          ]
+        }
+      },
       {
         "Text": "tussen 3 en 4 uur ’s middags",
         "Start": 18,
         "End": 45,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-08T15,2016-11-08T16,PT1H)",
-              "type": "daterange",
-              "start": "2016-11-08 15:00:00",
-              "end": "2016-11-08 16:00:00"
+              "timex": "(T15,T16,PT1H)",
+              "type": "timerange",
+              "start": "15:00:00",
+              "end": "16:00:00"
             }
           ]
         }
@@ -9824,21 +9658,35 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
      "NotSupportedByDesign": "javascript,python,java",
     "Results": [
+      {
+        "Text": "morgen",
+        "Start": 0,
+        "End": 5,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-08",
+              "type": "date",
+              "value": "2016-11-08"
+            }
+          ]
+        }
+      },
       {
         "Text": "van half acht tot 4 uur ‘s middags",
         "Start": 18,
         "End": 51,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-08T07:30,2016-11-08T16,PT8H30M)",
-              "type": "daterange",
-              "start": "2016-11-08 07:30:00",
-              "end": "2016-11-08 16:00:00"
+              "timex": "(T07:30,T16,PT8H30M)",
+              "type": "timerange",
+              "start": "07:30:00",
+              "end": "16:00:00"
             }
           ]
         }
@@ -9850,21 +9698,36 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
+    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
+      {
+        "Text": "vandaag",
+        "Start": 0,
+        "End": 6,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-07",
+              "type": "date",
+              "value": "2016-11-07"
+            }
+          ]
+        }
+      },
       {
         "Text": "tussen 4 en 5 uur in de middag",
         "Start": 15,
         "End": 44,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.timerange",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-07T16,2016-11-07T17,PT1H)",
-              "type": "daterange",
-              "start": "2016-11-07 16:00:00",
-              "end": "2016-11-07 17:00:00"
+              "timex": "T16,T17,PT1H)",
+              "type": "timerange",
+              "start": "16:00:00",
+              "end": "17:00:00"
             }
           ]
         }
@@ -9872,23 +9735,22 @@
     ]
   },
   {
-    "Input": "Ik ga deze middag terugI'll go back this afternoon",
+    "Input": "Ik ga deze middag terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "deze middag",
         "Start": 6,
         "End": 16,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "2016-11-07TAF",
-              "type": "daterange",
+              "type": "datetimerange",
               "start": "2016-11-07 12:00:00",
               "end": "2016-11-07 16:00:00"
             }
@@ -9902,21 +9764,44 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "een minuut terug",
+        "Text": "een minuut",
         "Start": 6,
-        "End": 21,
-        "TypeName": "datetimeV2.daterange",
+        "End": 15,
+        "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-07T16:11:00,2016-11-07T16:12:00,PT1M)",
-              "type": "daterange",
-              "start": "2016-11-07 16:11:00",
-              "end": "2016-11-07 16:12:00"
+              "timex": "PT1M",
+              "type": "duration",
+              "value": "60"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga volgende een uur terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende een uur",
+        "Start": 6,
+        "End": 21,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 16:12:00",
+              "end": "2016-11-07 17:12:00"
             }
           ]
         }
@@ -9928,21 +9813,19 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "over een uur",
         "Start": 6,
         "End": 17,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
-              "type": "daterange",
-              "start": "2016-11-07 16:12:00",
-              "end": "2016-11-07 17:12:00"
+              "timex": "2016-11-07T17:12:00",
+              "type": "datetime",
+              "value": "2016-11-07 17:12:00"
             }
           ]
         }
@@ -9950,23 +9833,22 @@
     ]
   },
   {
-    "Input": "Het zal over 2 uur in de toekomst gebeuren ",
+    "Input": "Het zal over 2 uur in de toekomst gebeuren",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2 uur in de toekomst",
         "Start": 13,
         "End": 32,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
-              "type": "daterange",
+              "type": "datetimerange",
               "start": "2016-11-07 16:12:00",
               "end": "2016-11-07 18:12:00"
             }
@@ -9981,7 +9863,6 @@
       "ReferenceDateTime": "2020-08-17T00:00:00"
     },
     "Comment": "Last Kingsday should be 2020, not 2019. Relative date should first look for a date in the same year.",
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10006,7 +9887,6 @@
     "Context": {
       "ReferenceDateTime": "2020-08-17T00:00:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10031,7 +9911,6 @@
     "Context": {
       "ReferenceDateTime": "2020-08-17T00:00:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10056,7 +9935,6 @@
     "Context": {
       "ReferenceDateTime": "2020-08-17T00:00:00"
     },
-    "NotSupported": "dotNet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10081,7 +9959,6 @@
     "Context": {
       "ReferenceDateTime": "2020-08-17T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10116,6 +9993,529 @@
               "timex": "T21:00",
               "type": "time",
               "value": "21:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben deze september weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "deze september",
+        "Start": 7,
+        "End": 20,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-09",
+              "type": "daterange",
+              "start": "2016-09-01",
+              "end": "2016-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga sinds deze augustus weg",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "sinds deze augustus",
+        "Start": 6,
+        "End": 24,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-08",
+              "Mod": "since",
+              "type": "daterange",
+              "start": "2016-08-01",
+              "sourceEntity": "datetimerange"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik zal vertrekken van deze mei tot okt 2020",
+    "Context": {
+      "ReferenceDateTime": "2018-10-24T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "van deze mei tot okt 2020",
+        "Start": 18,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-05-01,2020-10-01,P29M)",
+              "type": "daterange",
+              "start": "2018-05-01",
+              "end": "2020-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Heb je een arrangement op volgende vrijdag?",
+    "Context": {
+      "ReferenceDateTime": "2019-01-31T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende vrijdag",
+        "Start": 26,
+        "End": 41,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019-02-08",
+              "type": "date",
+              "value": "2019-02-08"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Gisterennacht verdwenen 26 mensen",
+    "Context": {
+      "ReferenceDateTime": "2018-07-17T13:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "gisterennacht",
+        "Start": 0,
+        "End": 12,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-07-16TNI",
+              "type": "datetimerange",
+              "start": "2018-07-16 20:00:00",
+              "end": "2018-07-16 23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Regel een Skypegesprek van 15 minuten volgende maandag of dinsdag na 13:00 GMT",
+    "Context": {
+      "ReferenceDateTime": "2018-08-29T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "15 minuten",
+        "Start": 27,
+        "End": 36,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT15M",
+              "type": "duration",
+              "value": "900"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "volgende maandag",
+        "Start": 38,
+        "End": 53,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-09-03",
+              "type": "date",
+              "value": "2018-09-03"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "dinsdag na 13:00",
+        "Start": 58,
+        "End": 73,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-2T13:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2018-08-28 13:00:00"
+            },
+            {
+              "timex": "XXXX-WXX-2T13:00",
+              "Mod": "after",
+              "type": "datetimerange",
+              "start": "2018-09-04 13:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik herinner me  de datum niet, het zou volgende maandag of vorige maandag moeten zijn",
+    "Context": {
+      "ReferenceDateTime": "2018-11-15T12:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "volgende maandag",
+        "Start": 39,
+        "End": 54,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-11-19",
+              "type": "date",
+              "value": "2018-11-19"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "vorige maandag",
+        "Start": 59,
+        "End": 72,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-11-05",
+              "type": "date",
+              "value": "2018-11-05"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Wie zijn presidenten van de VS in jaren 1990.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "jaren 1990",
+        "Start": 34,
+        "End": 43,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(1990-01-01,2000-01-01,P10Y)",
+              "type": "daterange",
+              "start": "1990-01-01",
+              "end": "2000-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga morgennacht terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "morgennacht",
+        "Start": 6,
+        "End": 16,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2016-11-08TNI",
+              "type": "datetimerange",
+              "start": "2016-11-08 20:00:00",
+              "end": "2016-11-08 23:59:59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Laten we 3 minuten vanaf vandaag beginnen",
+    "Context": {
+      "ReferenceDateTime": "2018-05-29T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "3 minuten",
+        "Start": 9,
+        "End": 17,
+        "TypeName": "datetimeV2.duration",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PT3M",
+              "type": "duration",
+              "value": "180"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "vandaag",
+        "Start": 25,
+        "End": 31,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-29",
+              "type": "date",
+              "value": "2018-05-29"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Het gebeurde op vorige week dinsdag tegen 2 uur 's middags",
+    "Context": {
+      "ReferenceDateTime": "2018-06-26T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "vorige week dinsdag tegen 2 uur 's middags",
+        "Start": 16,
+        "End": 57,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-19T14",
+              "Mod": "before",
+              "type": "datetimerange",
+              "end": "2018-06-19 14:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "laten we dat ergens in de komende paar weken vastleggen, okay?",
+    "Context": {
+      "ReferenceDateTime": "2018-07-31T13:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "komende paar weken",
+        "Start": 26,
+        "End": 43,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2018-08-01,2018-08-15,P2W)",
+              "type": "daterange",
+              "start": "2018-08-01",
+              "end": "2018-08-15"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "De deur is open vanaf middag vandaag tot ochtend morgen",
+    "Context": {
+      "ReferenceDateTime": "2018-07-31T12:00:00"
+    },
+    "NotSupported": "dotnet",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "middag vandaag",
+        "Start": 22,
+        "End": 35,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-07-31TAF",
+              "type": "datetimerange",
+              "start": "2018-07-31 12:00:00",
+              "end": "2018-07-31 16:00:00"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "ochtend morgen",
+        "Start": 41,
+        "End": 54,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-08-01TMO",
+              "type": "datetimerange",
+              "start": "2018-08-01 08:00:00",
+              "end": "2018-08-01 12:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 12-4",
+    "Context": {
+      "ReferenceDateTime": "2018-05-16T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "maandag 12-4",
+        "Start": 46,
+        "End": 57,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-WXX-1T00,XXXX-WXX-1T04,PT4H)",
+              "type": "datetimerange",
+              "start": "2018-05-14 00:00:00",
+              "end": "2018-05-14 04:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T00,XXXX-WXX-1T04,PT4H)",
+              "type": "datetimerange",
+              "start": "2018-05-21 00:00:00",
+              "end": "2018-05-21 04:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T12,XXXX-WXX-1T16,PT4H)",
+              "type": "datetimerange",
+              "start": "2018-05-14 12:00:00",
+              "end": "2018-05-14 16:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T12,XXXX-WXX-1T16,PT4H)",
+              "type": "datetimerange",
+              "start": "2018-05-21 12:00:00",
+              "end": "2018-05-21 16:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Cortana kan ons helpen een tijdstip te vinden maandag 11-4",
+    "Context": {
+      "ReferenceDateTime": "2018-05-16T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "maandag 11-4",
+        "Start": 46,
+        "End": 57,
+        "TypeName": "datetimeV2.datetimerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-WXX-1T11,XXXX-WXX-1T16,PT5H)",
+              "type": "datetimerange",
+              "start": "2018-05-14 11:00:00",
+              "end": "2018-05-14 16:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T11,XXXX-WXX-1T16,PT5H)",
+              "type": "datetimerange",
+              "start": "2018-05-21 11:00:00",
+              "end": "2018-05-21 16:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
+              "type": "datetimerange",
+              "start": "2018-05-14 23:00:00",
+              "end": "2018-05-15 04:00:00"
+            },
+            {
+              "timex": "(XXXX-WXX-1T23,XXXX-WXX-2T04,PT5H)",
+              "type": "datetimerange",
+              "start": "2018-05-21 23:00:00",
+              "end": "2018-05-22 04:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ben weg 4:00 tot 7",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4:00 tot 7",
+        "Start": 11,
+        "End": 20,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T04:00,T07,PT3H)",
+              "type": "timerange",
+              "start": "04:00:00",
+              "end": "07:00:00"
+            },
+            {
+              "timex": "(T16:00,T19,PT3H)",
+              "type": "timerange",
+              "start": "16:00:00",
+              "end": "19:00:00"
             }
           ]
         }

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -10497,5 +10497,95 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Ik ga op zat terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "zat",
+        "Start": 9,
+        "End": 11,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2016-11-05"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2016-11-12"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ik ga zat. terug",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "zat.",
+        "Start": 6,
+        "End": 9,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2016-11-05"
+            },
+            {
+              "timex": "XXXX-WXX-6",
+              "type": "date",
+              "value": "2016-11-12"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Ze zei dat je in de problemen zat.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "Jullie moeten deze verdieping vrij maken.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "Dat was zo meesterlijk, zo bazig, zo machteloos.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "Een unieke zuidkust met veel zon uren.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": []
   }
 ]

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -110,13 +110,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "1990-01-01",
               "end": "2000-01-01"
             },
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "2090-01-01",
               "end": "2100-01-01"
@@ -773,11 +773,6 @@
               "timex": "2016-11-07T08",
               "type": "datetime",
               "value": "2016-11-07 08:00:00"
-            },
-            {
-              "timex": "2016-11-07T20",
-              "type": "datetime",
-              "value": "2016-11-07 20:00:00"
             }
           ]
         }

--- a/Specs/DateTime/Dutch/DateTimeParser.json
+++ b/Specs/DateTime/Dutch/DateTimeParser.json
@@ -682,7 +682,7 @@
         "Text": "22:00 vanavond",
         "Type": "datetime",
         "Value": {
-          "Timex": "2016-11-07T22",
+          "Timex": "2016-11-07T22:00",
           "FutureResolution": {
             "dateTime": "2016-11-07 22:00:00"
           },
@@ -730,7 +730,7 @@
         "Text": "20:00 vanavond",
         "Type": "datetime",
         "Value": {
-          "Timex": "2016-11-07T20",
+          "Timex": "2016-11-07T20:00",
           "FutureResolution": {
             "dateTime": "2016-11-07 20:00:00"
           },

--- a/Specs/DateTime/Dutch/DurationExtractor.json
+++ b/Specs/DateTime/Dutch/DurationExtractor.json
@@ -688,10 +688,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele dag",
+        "Text": "voor de hele dag",
         "Type": "duration",
-        "Start": 16,
-        "Length": 11
+        "Start": 11,
+        "Length": 16
       }
     ]
   },
@@ -700,10 +700,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele week",
+        "Text": "voor de hele week",
         "Type": "duration",
-        "Start": 16,
-        "Length": 12
+        "Start": 11,
+        "Length": 17
       }
     ]
   },
@@ -712,10 +712,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele maand",
+        "Text": "voor de hele maand",
         "Type": "duration",
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -724,10 +724,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het hele jaar",
+        "Text": "voor het hele jaar",
         "Type": "duration",
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -736,10 +736,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele dag",
+        "Text": "voor de gehele dag",
         "Type": "duration",
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -748,10 +748,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele week",
+        "Text": "voor de gehele week",
         "Type": "duration",
-        "Start": 16,
-        "Length": 14
+        "Start": 11,
+        "Length": 19
       }
     ]
   },
@@ -760,10 +760,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele maand",
+        "Text": "voor de gehele maand",
         "Type": "duration",
-        "Start": 16,
-        "Length": 15
+        "Start": 11,
+        "Length": 20
       }
     ]
   },
@@ -772,10 +772,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het gehele jaar",
+        "Text": "voor het gehele jaar",
         "Type": "duration",
-        "Start": 16,
-        "Length": 15
+        "Start": 11,
+        "Length": 20
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -1209,7 +1209,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele dag",
+        "Text": "voor de hele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1220,8 +1220,8 @@
             "duration": "86400"
           }
         },
-        "Start": 16,
-        "Length": 11
+        "Start": 11,
+        "Length": 16
       }
     ]
   },
@@ -1233,7 +1233,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele week",
+        "Text": "voor de hele week",
         "Type": "duration",
         "Value": {
           "Timex": "P1W",
@@ -1244,8 +1244,8 @@
             "duration": "604800"
           }
         },
-        "Start": 16,
-        "Length": 12
+        "Start": 11,
+        "Length": 17
       }
     ]
   },
@@ -1257,7 +1257,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de hele maand",
+        "Text": "voor de hele maand",
         "Type": "duration",
         "Value": {
           "Timex": "P1M",
@@ -1268,8 +1268,8 @@
             "duration": "2592000"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -1281,7 +1281,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het hele jaar",
+        "Text": "voor het hele jaar",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y",
@@ -1292,8 +1292,8 @@
             "duration": "31536000"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -1305,7 +1305,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele dag",
+        "Text": "voor de gehele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1316,8 +1316,8 @@
             "duration": "86400"
           }
         },
-        "Start": 16,
-        "Length": 13
+        "Start": 11,
+        "Length": 18
       }
     ]
   },
@@ -1329,7 +1329,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele week",
+        "Text": "voor de gehele week",
         "Type": "duration",
         "Value": {
           "Timex": "P1W",
@@ -1340,8 +1340,8 @@
             "duration": "604800"
           }
         },
-        "Start": 16,
-        "Length": 14
+        "Start": 11,
+        "Length": 19
       }
     ]
   },
@@ -1353,7 +1353,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "de gehele maand",
+        "Text": "voor de gehele maand",
         "Type": "duration",
         "Value": {
           "Timex": "P1M",
@@ -1364,8 +1364,8 @@
             "duration": "2592000"
           }
         },
-        "Start": 16,
-        "Length": 15
+        "Start": 11,
+        "Length": 20
       }
     ]
   },
@@ -1377,7 +1377,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "het gehele jaar",
+        "Text": "voor het gehele jaar",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y",
@@ -1388,8 +1388,8 @@
             "duration": "31536000"
           }
         },
-        "Start": 16,
-        "Length": 15
+        "Start": 11,
+        "Length": 20
       }
     ]
   },
@@ -1425,7 +1425,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "gehele dag",
+        "Text": "voor gehele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1436,8 +1436,8 @@
             "duration": "86400"
           }
         },
-        "Start": 16,
-        "Length": 10
+        "Start": 11,
+        "Length": 15
       }
     ]
   },

--- a/Specs/DateTime/Dutch/TimeExtractor.json
+++ b/Specs/DateTime/Dutch/TimeExtractor.json
@@ -372,13 +372,13 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ga om half zes vanavond",
+    "Input": "Ik ga om half zes 's avonds",
     "Results": [
       {
-        "Text": "half zes vanavond",
+        "Text": "half zes 's avonds",
         "Type": "time",
         "Start": 9,
-        "Length": 17
+        "Length": 18
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"

--- a/Specs/DateTime/Dutch/TimeParser.json
+++ b/Specs/DateTime/Dutch/TimeParser.json
@@ -693,10 +693,10 @@
     "NotSupportedByDesign": "javascript,python,java"
   },
   {
-    "Input": "Ik ben om 7 uur vanavond terug",
+    "Input": "Ik ben om 7 uur 's avonds terug",
     "Results": [
       {
-        "Text": "7 uur vanavond",
+        "Text": "7 uur 's avonds",
         "Type": "time",
         "Value": {
           "Timex": "T19",
@@ -708,7 +708,7 @@
           }
         },
         "Start": 10,
-        "Length": 14
+        "Length": 15
       }
     ],
     "NotSupportedByDesign": "javascript,python,java"

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -11628,7 +11628,7 @@
     "Context": {
       "ReferenceDateTime": "2019-05-23T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "90 s",
@@ -11638,13 +11638,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "1990-01-01",
               "end": "2000-01-01"
             },
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "2090-01-01",
               "end": "2100-01-01"

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -9877,7 +9877,7 @@
     "Context": {
       "ReferenceDateTime": "2019-05-23T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "java, javascript, python",
     "Results": [
       {
         "Text": "90 s",
@@ -9887,13 +9887,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "1990-01-01",
               "end": "2000-01-01"
             },
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "2090-01-01",
               "end": "2100-01-01"

--- a/Specs/DateTime/Hindi/DateTimeModel.json
+++ b/Specs/DateTime/Hindi/DateTimeModel.json
@@ -11521,13 +11521,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "1990-01-01",
               "end": "2000-01-01"
             },
             {
-              "timex": "(XX90-01-01,XX100-01-01,P10Y)",
+              "timex": "(XX90-01-01,XX00-01-01,P10Y)",
               "type": "daterange",
               "start": "2090-01-01",
               "end": "2100-01-01"


### PR DESCRIPTION
352 pass, 29 fail.

Most of the ambiguous test cases with 'voor' have been updated to be resolved as 'before' instead of 'for'. 
Exceptions are: 
- Duration patterns with 'all' (e.g. 'all year') where the 'for' interpretation seems more appropriate (e.g. 'for the whole year' vs 'before the whole year'). In this case 'voor' has been included in the Duration extractions.
- 2 points ranges (still failing) where the 'before' interpretation does not make sense e.g. 'before between 2015 and 2018' ('voor tussen 2015 en 2018').

The resolution of test cases whose meaning does not match the English counterparts has been updated and new test cases have been added to better match the English inputs. 
For example:
- "Ik ben aanstaande september weg" -> "Ik ben deze september weg" (I'll be out this September).
- "Ik zal vertrekken van aanstaande mei tot okt 2020" -> "Ik zal vertrekken van deze mei tot okt 2020" (I will leave from this May to Oct 2020).
- "Heb je een arrangement op aanstaande vrijdag?" -> "Heb je een arrangement op volgende vrijdag?" (Do you have any arrangement on next Friday?). "Aanstaande" is interpreted as "upcoming" and has a different resolution than "next".
- "Gisterenavond verdwenen 26 mensen" -> "Gisterennacht verdwenen 26 mensen" (Last night 26 people disappeared).
- "Regel een Skypegesprek van 15 minuten voor volgende maandag of dinsdag na 13:00 GMT" -> "Regel een Skypegesprek van 15 minuten volgende maandag of dinsdag na 13:00 GMT" (set up a 15 minute skype call next Monday or Tuesday after 1pm GMT.).
- "Ik herinner me  de datum niet, het zou volgende maandag of afgelopen maandag moeten zijn" -> "Ik herinner me  de datum niet, het zou volgende maandag of vorige maandag moeten zijn" (I don't remember the date, it should be next Monday or previous Monday.). "Afgelopen" is interpreted as "past" and has a different resolution than "previous".
- "Ik ga morgenavond terug" -> "Ik ga morgennacht terug" (I'll go back tomorrow night).
- "Laten we over 3 minuten vanaf vandaag beginnen" -> "Laten we 3 minuten vanaf vandaag beginnen" (Let's start 3 minutes from today).
- "Het gebeurde op vorige week dinsdag om 2 uur 's middags" -> "Het gebeurde op vorige week dinsdag tegen 2 uur 's middags" (It happened on previous Tuesday by 2 in the afternoon).
- "laten we dat ergens in de komende weken vastleggen, okay?" -> "laten we dat ergens in de komende paar weken vastleggen, okay?" (let's arrange that over the next couple weeks, ok?).
- "De deur is open vanaf het middaguur vandaag tot het middaguur morgen" -> "De deur is open vanaf middag vandaag tot ochtend morgen" (The door is opened from today pm to tomorrow am.).
- "Cortana kan ons helpen een tijdstip te vinden op maandag 12-4" -> "Cortana kan ons helpen een tijdstip te vinden maandag 12-4" (Cortana can help us find a time Monday 12-4.). "Op maandag 12-4" is interpreted as Date instead of DateTimePeriod (same as "on Monday 12-4").
- "Ik ben 4:00 tot 7 weg" -> "Ik ben weg 4:00 tot 7" (I'll be out 4:00 to 7 oclock). Patters like "4:00 tot 7" that end with a pure number are extracted only if they occur at the end of the sentence.