### PR TITLE
[* DateTimeV2] Fixed reference year incorrectly assigned to Timex in DatePeriod patterns (#2586)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -492,7 +492,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                             datePeriodTimexType = DatePeriodTimexType.ByWeek;
                         }
 
-                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd);
+                        // If startResolution and endResolution have fuzzy years, also the combined range timex will use fuzzy years.
+                        if (startResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal) &&
+                            endResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal))
+                        {
+                            ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, UnspecificDateTimeTerms.NonspecificYear);
+                        }
+                        else
+                        {
+                            ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd);
+                        }
 
                         ret.FutureValue = new Tuple<DateObject, DateObject>(futureBegin, futureEnd);
                         ret.PastValue = new Tuple<DateObject, DateObject>(pastBegin, pastEnd);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -492,17 +492,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                             datePeriodTimexType = DatePeriodTimexType.ByWeek;
                         }
 
-                        // If startResolution and endResolution have fuzzy years, also the combined range timex will use fuzzy years.
-                        if (startResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal) &&
-                            endResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal))
-                        {
-                            ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, UnspecificDateTimeTerms.NonspecificYear);
-                        }
-                        else
-                        {
-                            ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd);
-                        }
+                        var hasYear = !startResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal) ||
+                            !endResolution.Timex.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal);
 
+                        // If the year is not specified, the combined range timex will use fuzzy years.
+                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd, hasYear);
                         ret.FutureValue = new Tuple<DateObject, DateObject>(futureBegin, futureEnd);
                         ret.PastValue = new Tuple<DateObject, DateObject>(pastBegin, pastEnd);
                         ret.Success = true;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
@@ -688,9 +688,16 @@ namespace Microsoft.Recognizers.Text.DateTime
                     var endTimex = hasYear || beginYearForPastResolution == endYearForFutureResolution ? DateTimeFormatUtil.LuisDate(endDateForPastResolution, endDateForFutureResolution) :
                         DateTimeFormatUtil.LuisDate(-1, endMonth, 1);*/
 
-                    var beginTimex = DateTimeFormatUtil.LuisDate(beginDateForPastResolution, beginDateForFutureResolution);
-                    var endTimex = DateTimeFormatUtil.LuisDate(endDateForPastResolution, endDateForFutureResolution);
-                    ret.Timex = $"({beginTimex},{endTimex},P{durationMonths}M)";
+                    // If the year is not specified, the combined range timex will use fuzzy years.
+                    if (!hasYear)
+                    {
+                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(beginDateForFutureResolution, endDateForFutureResolution, DatePeriodTimexType.ByMonth, UnspecificDateTimeTerms.NonspecificYear);
+                    }
+                    else
+                    {
+                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(beginDateForFutureResolution, endDateForFutureResolution, DatePeriodTimexType.ByMonth, beginDateForPastResolution, endDateForPastResolution);
+                    }
+
                     ret.PastValue = new Tuple<DateObject, DateObject>(beginDateForPastResolution, endDateForPastResolution);
                     ret.FutureValue = new Tuple<DateObject, DateObject>(beginDateForFutureResolution, endDateForFutureResolution);
                     ret.Success = true;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDatePeriodParser.cs
@@ -689,15 +689,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         DateTimeFormatUtil.LuisDate(-1, endMonth, 1);*/
 
                     // If the year is not specified, the combined range timex will use fuzzy years.
-                    if (!hasYear)
-                    {
-                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(beginDateForFutureResolution, endDateForFutureResolution, DatePeriodTimexType.ByMonth, UnspecificDateTimeTerms.NonspecificYear);
-                    }
-                    else
-                    {
-                        ret.Timex = TimexUtility.GenerateDatePeriodTimex(beginDateForFutureResolution, endDateForFutureResolution, DatePeriodTimexType.ByMonth, beginDateForPastResolution, endDateForPastResolution);
-                    }
-
+                    ret.Timex = TimexUtility.GenerateDatePeriodTimex(beginDateForFutureResolution, endDateForFutureResolution, DatePeriodTimexType.ByMonth, beginDateForPastResolution, endDateForPastResolution, hasYear);
                     ret.PastValue = new Tuple<DateObject, DateObject>(beginDateForPastResolution, endDateForPastResolution);
                     ret.FutureValue = new Tuple<DateObject, DateObject>(beginDateForFutureResolution, endDateForFutureResolution);
                     ret.Success = true;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -60,8 +60,14 @@ namespace Microsoft.Recognizers.Text.DateTime
         }
 
         // TODO: Unify this two methods. This one here detect if "begin/end" have same year, month and day with "alter begin/end" and make them nonspecific.
-        public static string GenerateDatePeriodTimex(DateObject begin, DateObject end, DatePeriodTimexType timexType, DateObject alternativeBegin = default(DateObject), DateObject alternativeEnd = default(DateObject))
+        public static string GenerateDatePeriodTimex(DateObject begin, DateObject end, DatePeriodTimexType timexType, DateObject alternativeBegin = default(DateObject), DateObject alternativeEnd = default(DateObject), bool hasYear = true)
         {
+            // If the year is not specified, the combined range timex will use fuzzy years.
+            if (!hasYear)
+            {
+                return GenerateDatePeriodTimex(begin, end, timexType, UnspecificDateTimeTerms.NonspecificYear);
+            }
+
             var equalDurationLength = (end - begin) == (alternativeEnd - alternativeBegin);
 
             if (alternativeBegin.IsDefaultValue() || alternativeEnd.IsDefaultValue())

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
@@ -205,7 +205,14 @@ public class BaseDatePeriodParser implements IDateTimeParser {
                         datePeriodTimexType = DatePeriodTimexType.ByWeek;
                     }
 
-                    ret.setTimex(TimexUtility.generateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd));
+                    // If startResolution and endResolution have fuzzy years, also the combined
+                    // range timex will use fuzzy years.
+                    if (startResolution.getTimex().startsWith(Constants.TimexFuzzyYear) &&
+                            endResolution.getTimex().startsWith(Constants.TimexFuzzyYear)) {
+                        ret.setTimex(TimexUtility.generateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, TimexUtility.UnspecificDateTimeTerms.NonspecificYear));
+                    } else {
+                        ret.setTimex(TimexUtility.generateDatePeriodTimex(futureBegin, futureEnd, datePeriodTimexType, pastBegin, pastEnd));
+                    }
 
                     ret.setFutureValue(new Pair<>(futureBegin, futureEnd));
                     ret.setPastValue(new Pair<>(pastBegin, pastEnd));

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimexUtility.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/utilities/TimexUtility.java
@@ -27,6 +27,13 @@ public class TimexUtility {
             put(DatePeriodTimexType.ByYear, Constants.TimexYear);
         }
     };
+    
+    public enum UnspecificDateTimeTerms {
+        None,
+        NonspecificYear,
+        NonspecificMonth,
+        NonspecificDay,
+    }
 
     public static String generateCompoundDurationTimex(Map<String, String> unitToTimexComponents, ImmutableMap<String, Long> unitValueMap) {
         List<String> unitList = new ArrayList<>(unitToTimexComponents.keySet());
@@ -59,6 +66,31 @@ public class TimexUtility {
         }
 
         return unitCount;
+    }
+    
+    public static String generateDatePeriodTimex(LocalDateTime begin, LocalDateTime end, DatePeriodTimexType timexType, UnspecificDateTimeTerms terms) {
+        int beginYear = begin.getYear();
+        int endYear = end.getYear();
+        int beginMonth = begin.getMonthValue();
+        int endMonth = end.getMonthValue();
+        int beginDay = begin.getDayOfMonth();
+        int endDay = end.getDayOfMonth();
+        
+        if (terms == UnspecificDateTimeTerms.NonspecificYear) {
+            beginYear = endYear = -1;
+        }
+
+        if (terms == UnspecificDateTimeTerms.NonspecificMonth) {
+            beginMonth = endMonth = -1;
+        }
+
+        if (terms == UnspecificDateTimeTerms.NonspecificDay) {
+            beginDay = endDay = -1;
+        }
+
+        String unitCount = getDatePeriodTimexUnitCount(begin, end, timexType, true);
+        String datePeriodTimex = "P" + unitCount + DatePeriodTimexTypeToTimexSuffix.get(timexType);
+        return "(" + DateTimeFormatUtil.luisDate(beginYear, beginMonth, beginDay) + "," + DateTimeFormatUtil.luisDate(endYear, endMonth, endDay) + "," + datePeriodTimex + ")";
     }
 
     public static String generateDatePeriodTimex(LocalDateTime begin, LocalDateTime end, DatePeriodTimexType timexType) {

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -2474,7 +2474,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-03-01,2018-09-01,P6M)",
+              "timex": "(XXXX-03-01,XXXX-09-01,P6M)",
               "type": "daterange",
               "start": "2018-03-01",
               "end": "2018-09-01"
@@ -2499,7 +2499,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-10-01,P5M)",
+              "timex": "(XXXX-05-01,XXXX-10-01,P5M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-10-01"
@@ -2524,7 +2524,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2019-02-01,P6M)",
+              "timex": "(XXXX-08-01,XXXX-02-01,P6M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2019-02-01"
@@ -2580,13 +2580,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-10-01,XXXX-05-01,P5M)",
+              "timex": "(XXXX-10-01,XXXX-05-01,P7M)",
               "type": "daterange",
               "start": "2017-10-01",
               "end": "2018-05-01"
             },
             {
-              "timex": "(XXXX-10-01,XXXX-05-01,P5M)",
+              "timex": "(XXXX-10-01,XXXX-05-01,P7M)",
               "type": "daterange",
               "start": "2018-10-01",
               "end": "2019-05-01"

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -6438,7 +6438,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -6463,7 +6463,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -6519,7 +6519,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -7408,7 +7408,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -7433,7 +7433,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -7489,7 +7489,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"
@@ -20747,6 +20747,62 @@
               "type": "datetimerange",
               "start": "2016-11-07 12:17:00",
               "end": "2016-11-07 12:30:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out from August to October",
+    "Context": {
+      "ReferenceDateTime": "2016-07-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "from august to october",
+        "Start": 12,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
+              "type": "daterange",
+              "start": "2015-08-01",
+              "end": "2015-10-01"
+            },
+            {
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
+              "type": "daterange",
+              "start": "2016-08-01",
+              "end": "2016-10-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "I'll be out from August to October",
+    "Context": {
+      "ReferenceDateTime": "2016-09-07T00:00:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "from august to october",
+        "Start": 12,
+        "End": 33,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
+              "type": "daterange",
+              "start": "2016-08-01",
+              "end": "2016-10-01"
             }
           ]
         }

--- a/Specs/DateTime/English/DateTimeModelComplexCalendar.json
+++ b/Specs/DateTime/English/DateTimeModelComplexCalendar.json
@@ -6174,7 +6174,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -6199,7 +6199,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -6255,7 +6255,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"

--- a/Specs/DateTime/English/DateTimeModelExperimentalMode.json
+++ b/Specs/DateTime/English/DateTimeModelExperimentalMode.json
@@ -5989,7 +5989,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-11-01,P3M)",
+              "timex": "(XXXX-08-01,XXXX-11-01,P3M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-11-01"
@@ -6014,7 +6014,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-04-01,P11M)",
+              "timex": "(XXXX-05-01,XXXX-04-01,P11M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-04-01"
@@ -6070,7 +6070,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-10-01,P5M)",
+              "timex": "(XXXX-05-01,XXXX-10-01,P5M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-10-01"

--- a/Specs/DateTime/Hindi/DateTimeModel.json
+++ b/Specs/DateTime/Hindi/DateTimeModel.json
@@ -7455,7 +7455,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"

--- a/Specs/DateTime/Japanese/DatePeriodParser.json
+++ b/Specs/DateTime/Japanese/DatePeriodParser.json
@@ -4567,7 +4567,7 @@
         "Text": "08月から12月まで",
         "Type": "daterange",
         "Value": {
-          "Timex": "(2018-08-01,2018-12-01,P4M)",
+          "Timex": "(XXXX-08-01,XXXX-12-01,P4M)",
           "FutureResolution": {
             "startDate": "2018-08-01",
             "endDate": "2018-12-01"

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -9238,7 +9238,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -9263,7 +9263,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -9319,7 +9319,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"

--- a/Specs/DateTime/Turkish/DatePeriodParser.json
+++ b/Specs/DateTime/Turkish/DatePeriodParser.json
@@ -5051,7 +5051,7 @@
         "Text": "Ocak ile Ağustos arası",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-08-01,PXXM)",
+          "Timex": "(XXXX-01-01,XXXX-08-01,P7M)",
           "FutureResolution": {
            "startDate": "2020-01-01",
             "endDate": "2020-08-01"
@@ -5079,7 +5079,7 @@
         "Text": "Ocaktan ağustosa",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-08-01,PXXM)",
+          "Timex": "(XXXX-01-01,XXXX-08-01,P7M)",
           "FutureResolution": {
            "startDate": "2020-01-01",
             "endDate": "2020-08-01"
@@ -5106,7 +5106,7 @@
         "Text": "Ocakla Ağustos arasında",
         "Type": "daterange",
         "Value": {
-          "Timex": "(XXXX-01-01,XXXX-08-01,PXXM)",
+          "Timex": "(XXXX-01-01,XXXX-08-01,P7M)",
           "FutureResolution": {
             "startDate": "2020-01-01",
             "endDate": "2020-08-01"

--- a/Specs/DateTime/Turkish/DateTimeModel.json
+++ b/Specs/DateTime/Turkish/DateTimeModel.json
@@ -6391,7 +6391,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-08-01,2018-10-01,P2M)",
+              "timex": "(XXXX-08-01,XXXX-10-01,P2M)",
               "type": "daterange",
               "start": "2018-08-01",
               "end": "2018-10-01"
@@ -6416,7 +6416,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2019-03-01,P10M)",
+              "timex": "(XXXX-05-01,XXXX-03-01,P10M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2019-03-01"
@@ -6472,7 +6472,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-05-01,2018-09-01,P4M)",
+              "timex": "(XXXX-05-01,XXXX-09-01,P4M)",
               "type": "daterange",
               "start": "2018-05-01",
               "end": "2018-09-01"


### PR DESCRIPTION
Fix to issue #2586.

Updated affected test cases in Chinese, English, Hindi, Japanese, Spanish and Turkish specs.