### PR TITLE
[.NET] Japanese TimePeriod support

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -188,21 +188,21 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string TimeQuarterRegex = @"(?<quarter>[一两二三四1-4])\s*(刻钟|刻)";
       public static readonly string TimeCJKTimeRegex = $@"{TimeHourRegex}({TimeQuarterRegex}|{TimeHalfRegex}|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?";
       public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?";
-      public static readonly string TimeDayDescRegex = $@"(?<daydesc>((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(夜明け|朝|早く|午後|夜|午前|日中|未明|白昼))|((夜明け|朝|早く|午後|夜|午前|日中|未明|白昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})))|(正午|深夜|夜中|午前半ば|(昼(食時)?)|真昼))";
+      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
       public const string TimeApproximateDescPreffixRegex = @"(ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|明日の|明日|来週の|来週|昼食時|昼食|真)";
       public const string TimeApproximateDescSuffixRegex = @"(ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)";
       public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?";
       public static readonly string TimeRegexes2 = $@"({TimeApproximateDescPreffixRegex}(の)?)?{TimeDayDescRegex}((の)?{TimeApproximateDescSuffixRegex})?";
       public static readonly string TimeRegexes3 = $@"({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})前((の)?{TimeDayDescRegex})?";
-      public const string TimePeriodTimePeriodConnectWords = @"(起|至|到|–|-|—|~|～)";
-      public static readonly string TimePeriodLeftCJKTimeRegex = $@"(从)?(?<left>{TimeDayDescRegex}?({TimeCJKTimeRegex}))";
-      public static readonly string TimePeriodRightCJKTimeRegex = $@"{TimePeriodTimePeriodConnectWords}(?<right>{TimeDayDescRegex}?{TimeCJKTimeRegex})(之间)?";
-      public static readonly string TimePeriodLeftDigitTimeRegex = $@"(从)?(?<left>{TimeDayDescRegex}?({TimeDigitTimeRegex}))";
-      public static readonly string TimePeriodRightDigitTimeRegex = $@"{TimePeriodTimePeriodConnectWords}(?<right>{TimeDayDescRegex}?{TimeDigitTimeRegex})(之间)?";
-      public static readonly string TimePeriodShortLeftCJKTimeRegex = $@"(从)?(?<left>{TimeDayDescRegex}?({TimeHourCJKRegex}))";
-      public static readonly string TimePeriodShortLeftDigitTimeRegex = $@"(从)?(?<left>{TimeDayDescRegex}?({TimeHourNumRegex}))";
+      public const string TimePeriodTimePeriodConnectWords = @"(まで(の間)?|の間|–|-|—|~|～)";
+      public static readonly string TimePeriodLeftCJKTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeCJKTimeRegex}))(から)?";
+      public static readonly string TimePeriodRightCJKTimeRegex = $@"{TimePeriodTimePeriodConnectWords}?(?<right>{TimeDayDescRegex}?{TimeCJKTimeRegex}){TimePeriodTimePeriodConnectWords}?";
+      public static readonly string TimePeriodLeftDigitTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeDigitTimeRegex}))(から)?";
+      public static readonly string TimePeriodRightDigitTimeRegex = $@"{TimePeriodTimePeriodConnectWords}?(?<right>{TimeDayDescRegex}?{TimeDigitTimeRegex}){TimePeriodTimePeriodConnectWords}?";
+      public static readonly string TimePeriodShortLeftCJKTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeHourCJKRegex}))(から)?";
+      public static readonly string TimePeriodShortLeftDigitTimeRegex = $@"(?<left>{TimeDayDescRegex}?({TimeHourNumRegex}))(から)?";
       public static readonly string TimePeriodRegexes1 = $@"({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})";
-      public static readonly string TimePeriodRegexes2 = $@"({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})";
+      public static readonly string TimePeriodRegexes2 = $@"(((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))";
       public const string FromToRegex = @"^[.]";
       public const string AmbiguousRangeModifierPrefix = @"^[.]";
       public const string ParserConfigurationBefore = @"(之前|以前|前)";
@@ -602,32 +602,42 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"午前半ば", 10 },
             { @"正午", 12 },
             { @"真昼", 12 },
-            { @"昼", 12 },
             { @"夜中", 0 },
             { @"深夜", 0 },
-            { @"昼食時", 11 }
+            { @"昼食時", 11 },
+            { @"夕方に", 12 }
         };
       public const string DefaultLanguageFallback = @"DMY";
       public static readonly IList<string> MorningTermList = new List<string>
         {
             @"午前半ば",
+            @"午前中",
             @"午前",
             @"朝",
-            @"未明"
+            @"未明",
+            @"昼前に",
+            @"昼前",
+            @"早朝に",
+            @"早朝"
         };
       public static readonly IList<string> MidDayTermList = new List<string>
         {
             @"正午",
-            @"真昼",
-            @"昼"
+            @"真昼"
         };
       public static readonly IList<string> AfternoonTermList = new List<string>
         {
             @"午后",
-            @"午後"
+            @"午後",
+            @"午後に",
+            @"夕方前に",
+            @"昼すぎに",
+            @"昼すぎ"
         };
       public static readonly IList<string> EveningTermList = new List<string>
         {
+            @"夕方に",
+            @"夕方",
             @"晚",
             @"晚上",
             @"夜里",
@@ -637,14 +647,33 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly IList<string> DaytimeTermList = new List<string>
         {
             @"日中",
-            @"昼食時"
+            @"昼食時",
+            @"昼"
         };
       public static readonly IList<string> NightTermList = new List<string>
         {
             @"深夜",
+            @"夜に",
             @"夜",
             @"夜中",
             @"夜間"
+        };
+      public static readonly IList<string> BusinessHourTermList = new List<string>
+        {
+            @"営業時間内に",
+            @"営業時間内"
+        };
+      public static readonly IList<string> EarlyHourTermList = new List<string>
+        {
+            @"早朝に",
+            @"早朝",
+            @"昼すぎに",
+            @"昼すぎ"
+        };
+      public static readonly IList<string> LateHourTermList = new List<string>
+        {
+            @"昼前に",
+            @"夕方前に"
         };
       public static readonly Dictionary<string, int> DynastyYearMap = new Dictionary<string, int>
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -128,6 +128,35 @@ namespace Microsoft.Recognizers.Text.DateTime
         // the length of four digits year, e.g., 2018
         public const int FourDigitsYearLength = 4;
 
+        // Times of day begin/end hours
+        public const int EarlyMorningBeginHour = 4;
+        public const int EarlyMorningEndHour = 8;
+        public const int MorningBeginHour = 8;
+        public const int MorningEndHour = 12;
+        public const int MidDayBeginHour = 11;
+        public const int MidDayEndHour = 13;
+        public const int AfternoonBeginHour = 12;
+        public const int AfternoonEndHour = 16;
+        public const int EveningBeginHour = 16;
+        public const int EveningEndHour = 20;
+        public const int DaytimeBeginHour = 8;
+        public const int DaytimeEndHour = 18;
+        public const int NighttimeBeginHour = 0;
+        public const int NighttimeEndHour = 8;
+        public const int BusinessBeginHour = 8;
+        public const int BusinessEndHour = 18;
+        public const int NightBeginHour = 20;
+        public const int NightEndHour = 23;
+        public const int NightEndMin = 59;
+        public const int MealtimeBreakfastBeginHour = 8;
+        public const int MealtimeBreakfastEndHour = 12;
+        public const int MealtimeBrunchBeginHour = 8;
+        public const int MealtimeBrunchEndHour = 12;
+        public const int MealtimeLunchBeginHour = 11;
+        public const int MealtimeLunchEndHour = 13;
+        public const int MealtimeDinnerBeginHour = 16;
+        public const int MealtimeDinnerEndHour = 20;
+
         // specifies the priority interpreting month and day order
         public const string DefaultLanguageFallback_MDY = "MDY";
         public const string DefaultLanguageFallback_DMY = "DMY";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             // Modify time period if "early"/"late" is present
             if (DateTimeDefinitions.EarlyHourTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
             {
-                endHour = beginHour + 2;
+                endHour = beginHour + Constants.HalfMidDayDurationHourCount;
 
                 // Handling special case: night ends with 23:59.
                 if (endMin == 59)
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
             if (DateTimeDefinitions.LateHourTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
             {
-                beginHour = beginHour + 2;
+                beginHour = beginHour + Constants.HalfMidDayDurationHourCount;
             }
 
             return true;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseTimePeriodParserConfiguration.cs
@@ -63,6 +63,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             {
                 timeOfDay = Constants.Night;
             }
+            else if (DateTimeDefinitions.BusinessHourTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            {
+                timeOfDay = Constants.BusinessHour;
+            }
             else
             {
                 timex = null;
@@ -74,6 +78,23 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             beginHour = parseResult.BeginHour;
             endHour = parseResult.EndHour;
             endMin = parseResult.EndMin;
+
+            // Modify time period if "early"/"late" is present
+            if (DateTimeDefinitions.EarlyHourTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            {
+                endHour = beginHour + 2;
+
+                // Handling special case: night ends with 23:59.
+                if (endMin == 59)
+                {
+                    endMin = 0;
+                }
+            }
+
+            if (DateTimeDefinitions.LateHourTermList.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)))
+            {
+                beginHour = beginHour + 2;
+            }
 
             return true;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKTimePeriodParser.cs
@@ -107,12 +107,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             }
 
             // Add "early"/"late" Mod
-            if (endHour == beginHour + 2 && (beginHour == Constants.HalfDayHourCount - 4 || beginHour == Constants.HalfDayHourCount))
+            if (endHour == beginHour + Constants.HalfMidDayDurationHourCount && (beginHour == Constants.MorningBeginHour || beginHour == Constants.AfternoonBeginHour))
             {
                 ret.Comment = Constants.Comment_Early;
                 ret.Mod = Constants.EARLY_MOD;
             }
-            else if (beginHour == endHour - 2 && (endHour == Constants.HalfDayHourCount || endHour == Constants.HalfDayHourCount + 4))
+            else if (beginHour == endHour - Constants.HalfMidDayDurationHourCount && (endHour == Constants.MorningEndHour || endHour == Constants.AfternoonEndHour))
             {
                 ret.Comment = Constants.Comment_Late;
                 ret.Mod = Constants.LATE_MOD;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKTimePeriodParser.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (extra != null)
             {
-                // Handle special case like '上午', '下午'
+                // Handle special case like '上午' (morning), '下午' (afternoon)
                 var parseResult = ParseTimeOfDay(er.Text, referenceTime);
 
                 if (!parseResult.Success)
@@ -106,10 +106,22 @@ namespace Microsoft.Recognizers.Text.DateTime
                 return new DateTimeResolutionResult();
             }
 
+            // Add "early"/"late" Mod
+            if (endHour == beginHour + 2 && (beginHour == Constants.HalfDayHourCount - 4 || beginHour == Constants.HalfDayHourCount))
+            {
+                ret.Comment = Constants.Comment_Early;
+                ret.Mod = Constants.EARLY_MOD;
+            }
+            else if (beginHour == endHour - 2 && (endHour == Constants.HalfDayHourCount || endHour == Constants.HalfDayHourCount + 4))
+            {
+                ret.Comment = Constants.Comment_Late;
+                ret.Mod = Constants.LATE_MOD;
+            }
+
             ret.Timex = timex;
             ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(
                DateObject.MinValue.SafeCreateFromValue(year, month, day, beginHour, 0, 0),
-               DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMinSeg, 0));
+               DateObject.MinValue.SafeCreateFromValue(year, month, day, endHour, endMinSeg, endMinSeg));
             ret.Success = true;
 
             return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -164,7 +164,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             }
 
             var spanTimex = new StringBuilder();
-            spanTimex.Append($"PT{spanHour}H");
+            spanTimex.Append("PT");
+            if (spanHour > 0)
+            {
+                spanTimex.Append($"{spanHour}H");
+            }
 
             if (spanMinute != 0 && spanSecond == 0)
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -50,10 +50,24 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
                 Success = true,
             };
 
+            var spanHour = rightResult.Hour - leftResult.Hour;
+            if (spanHour < 0 || (spanHour == 0 && leftResult.Minute > rightResult.Minute))
+            {
+                spanHour += Constants.DayHourCount;
+            }
+
             // the right side doesn't contain desc while the left side does
-            if (rightResult.LowBound == -1 && leftResult.LowBound != -1 && rightResult.Hour <= leftResult.LowBound)
+            if (rightResult.LowBound == -1 && leftResult.LowBound != -1 && rightResult.Hour <= Constants.HalfDayHourCount &&
+                spanHour > Constants.HalfDayHourCount)
             {
                 rightResult.Hour += Constants.HalfDayHourCount;
+            }
+
+            // the left side doesn't contain desc while the right side does
+            if (leftResult.LowBound == -1 && rightResult.LowBound != -1 && leftResult.Hour <= Constants.HalfDayHourCount &&
+                spanHour > Constants.HalfDayHourCount)
+            {
+                leftResult.Hour += Constants.HalfDayHourCount;
             }
 
             int day = refTime.Day,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -285,69 +285,69 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 case Constants.EarlyMorning:
                     result.Timex = Constants.EarlyMorning;
-                    result.BeginHour = 4;
-                    result.EndHour = 8;
+                    result.BeginHour = Constants.EarlyMorningBeginHour;
+                    result.EndHour = Constants.EarlyMorningEndHour;
                     break;
                 case Constants.Morning:
                     result.Timex = Constants.Morning;
-                    result.BeginHour = 8;
-                    result.EndHour = 12;
+                    result.BeginHour = Constants.MorningBeginHour;
+                    result.EndHour = Constants.MorningEndHour;
                     break;
                 case Constants.MidDay:
                     result.Timex = Constants.MidDay;
-                    result.BeginHour = 11;
-                    result.EndHour = 13;
+                    result.BeginHour = Constants.MidDayBeginHour;
+                    result.EndHour = Constants.MidDayEndHour;
                     break;
                 case Constants.Afternoon:
                     result.Timex = Constants.Afternoon;
-                    result.BeginHour = 12;
-                    result.EndHour = 16;
+                    result.BeginHour = Constants.AfternoonBeginHour;
+                    result.EndHour = Constants.AfternoonEndHour;
                     break;
                 case Constants.Evening:
                     result.Timex = Constants.Evening;
-                    result.BeginHour = 16;
-                    result.EndHour = 20;
+                    result.BeginHour = Constants.EveningBeginHour;
+                    result.EndHour = Constants.EveningEndHour;
                     break;
                 case Constants.Daytime:
                     result.Timex = Constants.Daytime;
-                    result.BeginHour = 8;
-                    result.EndHour = 18;
+                    result.BeginHour = Constants.DaytimeBeginHour;
+                    result.EndHour = Constants.DaytimeEndHour;
                     break;
                 case Constants.Nighttime:
                     result.Timex = Constants.Nighttime;
-                    result.BeginHour = 0;
-                    result.EndHour = 8;
+                    result.BeginHour = Constants.NighttimeBeginHour;
+                    result.EndHour = Constants.NighttimeEndHour;
                     break;
                 case Constants.BusinessHour:
                     result.Timex = Constants.BusinessHour;
-                    result.BeginHour = 8;
-                    result.EndHour = 18;
+                    result.BeginHour = Constants.BusinessBeginHour;
+                    result.EndHour = Constants.BusinessEndHour;
                     break;
                 case Constants.Night:
                     result.Timex = Constants.Night;
-                    result.BeginHour = 20;
-                    result.EndHour = 23;
-                    result.EndMin = 59;
+                    result.BeginHour = Constants.NightBeginHour;
+                    result.EndHour = Constants.NightEndHour;
+                    result.EndMin = Constants.NightEndMin;
                     break;
                 case Constants.MealtimeBreakfast:
                     result.Timex = Constants.MealtimeBreakfast;
-                    result.BeginHour = 8;
-                    result.EndHour = 12;
+                    result.BeginHour = Constants.MealtimeBreakfastBeginHour;
+                    result.EndHour = Constants.MealtimeBreakfastEndHour;
                     break;
                 case Constants.MealtimeBrunch:
                     result.Timex = Constants.MealtimeBrunch;
-                    result.BeginHour = 8;
-                    result.EndHour = 12;
+                    result.BeginHour = Constants.MealtimeBrunchBeginHour;
+                    result.EndHour = Constants.MealtimeBrunchEndHour;
                     break;
                 case Constants.MealtimeLunch:
                     result.Timex = Constants.MealtimeLunch;
-                    result.BeginHour = 11;
-                    result.EndHour = 13;
+                    result.BeginHour = Constants.MealtimeLunchBeginHour;
+                    result.EndHour = Constants.MealtimeLunchEndHour;
                     break;
                 case Constants.MealtimeDinner:
                     result.Timex = Constants.MealtimeDinner;
-                    result.BeginHour = 16;
-                    result.EndHour = 20;
+                    result.BeginHour = Constants.MealtimeDinnerBeginHour;
+                    result.EndHour = Constants.MealtimeDinnerEndHour;
                     break;
                 default:
                     break;

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/timePeriodConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/timePeriodConfiguration.ts
@@ -269,7 +269,10 @@ export class ChineseTimePeriodParser extends BaseTimePeriodParser {
         if (spanHour < 0) {
             spanHour += 24;
         }
-        let spanTimex = `PT${spanHour}H`;
+        let spanTimex = `PT`;
+        if (spanHour > 0 ) {
+            spanTimex = spanTimex + `${spanHour}H`;
+        }
         if (spanMin !== 0 && spanSec === 0) {
             spanTimex = spanTimex + `${spanMin}M`;
         }

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -399,7 +399,7 @@ TimeDigitTimeRegex: !nestedRegex
   def: (?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?
   references: [TimeHourNumRegex, TimeMinuteNumRegex, TimeSecondNumRegex]
 TimeDayDescRegex: !nestedRegex
-  def: (?<daydesc>((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(夜明け|朝|早く|午後|夜|午前|日中|未明|白昼))|((夜明け|朝|早く|午後|夜|午前|日中|未明|白昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})))|(正午|深夜|夜中|午前半ば|(昼(食時)?)|真昼))
+  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
   references: [TimeDigitTimeRegex, TimeCJKTimeRegex]
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|明日の|明日|来週の|来週|昼食時|昼食|真)
@@ -416,31 +416,31 @@ TimeRegexes3: !nestedRegex
   references: [TimeDigitTimeRegex, TimeCJKTimeRegex, TimeDayDescRegex]
 #TimePeriodExtractorCJK
 TimePeriodTimePeriodConnectWords: !simpleRegex
-  def: (起|至|到|–|-|—|~|～)
+  def: (まで(の間)?|の間|–|-|—|~|～)
 TimePeriodLeftCJKTimeRegex: !nestedRegex
-  def: (从)?(?<left>{TimeDayDescRegex}?({TimeCJKTimeRegex}))
+  def: (?<left>{TimeDayDescRegex}?({TimeCJKTimeRegex}))(から)?
   references: [TimeDayDescRegex, TimeCJKTimeRegex]
 TimePeriodRightCJKTimeRegex: !nestedRegex
-  def: '{TimePeriodTimePeriodConnectWords}(?<right>{TimeDayDescRegex}?{TimeCJKTimeRegex})(之间)?'
+  def: '{TimePeriodTimePeriodConnectWords}?(?<right>{TimeDayDescRegex}?{TimeCJKTimeRegex}){TimePeriodTimePeriodConnectWords}?'
   references: [TimePeriodTimePeriodConnectWords, TimeDayDescRegex, TimeCJKTimeRegex]
 TimePeriodLeftDigitTimeRegex: !nestedRegex
-  def: (从)?(?<left>{TimeDayDescRegex}?({TimeDigitTimeRegex}))
+  def: (?<left>{TimeDayDescRegex}?({TimeDigitTimeRegex}))(から)?
   references: [TimeDayDescRegex, TimeDigitTimeRegex]
 TimePeriodRightDigitTimeRegex: !nestedRegex
-  def: '{TimePeriodTimePeriodConnectWords}(?<right>{TimeDayDescRegex}?{TimeDigitTimeRegex})(之间)?'
+  def: '{TimePeriodTimePeriodConnectWords}?(?<right>{TimeDayDescRegex}?{TimeDigitTimeRegex}){TimePeriodTimePeriodConnectWords}?'
   references: [TimePeriodTimePeriodConnectWords, TimeDayDescRegex, TimeDigitTimeRegex]
 TimePeriodShortLeftCJKTimeRegex: !nestedRegex
-  def: (从)?(?<left>{TimeDayDescRegex}?({TimeHourCJKRegex}))
+  def: (?<left>{TimeDayDescRegex}?({TimeHourCJKRegex}))(から)?
   references: [TimeDayDescRegex, TimeHourCJKRegex]
 TimePeriodShortLeftDigitTimeRegex: !nestedRegex
-  def: (从)?(?<left>{TimeDayDescRegex}?({TimeHourNumRegex}))
+  def: (?<left>{TimeDayDescRegex}?({TimeHourNumRegex}))(から)?
   references: [TimeDayDescRegex, TimeHourNumRegex]
 TimePeriodRegexes1: !nestedRegex
   def: ({TimePeriodLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})
   references: [TimePeriodLeftDigitTimeRegex, TimePeriodRightDigitTimeRegex, TimePeriodLeftCJKTimeRegex, TimePeriodRightCJKTimeRegex]
 TimePeriodRegexes2: !nestedRegex
-  def: ({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex})
-  references: [TimePeriodShortLeftDigitTimeRegex, TimePeriodRightDigitTimeRegex, TimePeriodShortLeftCJKTimeRegex, TimePeriodRightCJKTimeRegex]
+  def: (((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)({TimePeriodShortLeftDigitTimeRegex}{TimePeriodRightDigitTimeRegex}|{TimePeriodShortLeftCJKTimeRegex}{TimePeriodRightCJKTimeRegex}))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=((?!({TimeCJKTimeRegex}|{TimeDigitTimeRegex})(から)?)))))
+  references: [TimePeriodShortLeftDigitTimeRegex, TimePeriodRightDigitTimeRegex, TimePeriodShortLeftCJKTimeRegex, TimePeriodRightCJKTimeRegex, TimeCJKTimeRegex, TimeDigitTimeRegex]
 #CJKDateTimeParserConfiguration
 FromToRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Chinese
@@ -863,34 +863,43 @@ TimeLowBoundDesc: !dictionary
     午前半ば: 10
     正午: 12
     真昼: 12
-    昼: 12
     夜中: 0
     深夜: 0
     昼食時: 11
+    夕方に: 12
 DefaultLanguageFallback: DMY
 # For TimeOfDay resolution
-# TODO: modify below dictionaries according to the counterpart in Chinese
 MorningTermList: !list
   types: [ string ]
   entries: 
     - 午前半ば
+    - 午前中
     - 午前
     - 朝
     - 未明
+    - 昼前に
+    - 昼前
+    - 早朝に
+    - 早朝
 MidDayTermList: !list
   types: [ string ]
   entries: 
     - 正午
     - 真昼
-    - 昼
 AfternoonTermList: !list
   types: [ string ]
   entries: 
     - 午后
     - 午後
+    - 午後に
+    - 夕方前に
+    - 昼すぎに
+    - 昼すぎ
 EveningTermList: !list
   types: [ string ]
   entries: 
+    - 夕方に
+    - 夕方
     - 晚
     - 晚上
     - 夜里
@@ -901,13 +910,32 @@ DaytimeTermList: !list
   entries: 
     - 日中
     - 昼食時
+    - 昼
 NightTermList: !list
   types: [ string ]
   entries: 
     - 深夜
+    - 夜に
     - 夜
     - 夜中
     - 夜間
+BusinessHourTermList: !list
+  types: [ string ]
+  entries: 
+    - 営業時間内に
+    - 営業時間内
+EarlyHourTermList: !list
+  types: [ string ]
+  entries: 
+    - 早朝に
+    - 早朝
+    - 昼すぎに
+    - 昼すぎ
+LateHourTermList: !list
+  types: [ string ]
+  entries: 
+    - 昼前に
+    - 夕方前に
 DynastyYearMap: !dictionary
   types: [string, int]
   # TODO: populate dictionary according to the counterpart in Chinese

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/timeperiod_parser.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/chinese/timeperiod_parser.py
@@ -214,7 +214,9 @@ class ChineseTimePeriodParser(BaseTimePeriodParser):
         if span_hour < 0:
             span_hour += 24
 
-        span_timex = f'PT{span_hour}H'
+        span_timex = f'PT'
+        if span_hour != 0:
+            span_timex += f'{span_hour}H'
         if span_min != 0:
             span_timex += f'{span_min}M'
             if span_sec != 0:

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -1462,7 +1462,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:15,T18,PT0H45M)",
+              "timex": "(T17:15,T18,PT45M)",
               "type": "timerange",
               "start": "17:15:00",
               "end": "18:00:00"
@@ -1486,7 +1486,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+              "timex": "(T17:55:23,T18:33:02,PT37M39S)",
               "type": "timerange",
               "start": "17:55:23",
               "end": "18:33:02"
@@ -1510,7 +1510,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+              "timex": "(T17:55:23,T18:33:02,PT37M39S)",
               "type": "timerange",
               "start": "17:55:23",
               "end": "18:33:02"

--- a/Specs/DateTime/Chinese/TimePeriodParser.json
+++ b/Specs/DateTime/Chinese/TimePeriodParser.json
@@ -9,7 +9,7 @@
         "Text": "从五点半到六点",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T05:30,T06,PT0H30M)",
+          "Timex": "(T05:30,T06,PT30M)",
           "FutureResolution": {
             "startTime": "05:30:00",
             "endTime": "06:00:00"
@@ -34,7 +34,7 @@
         "Text": "从下午五点一刻到六点",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:15,T18,PT0H45M)",
+          "Timex": "(T17:15,T18,PT45M)",
           "FutureResolution": {
             "startTime": "17:15:00",
             "endTime": "18:00:00"
@@ -59,7 +59,7 @@
         "Text": "17:55:23-18:33:02",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+          "Timex": "(T17:55:23,T18:33:02,PT37M39S)",
           "FutureResolution": {
             "startTime": "17:55:23",
             "endTime": "18:33:02"
@@ -84,7 +84,7 @@
         "Text": "从17点55分23秒至18点33分02秒",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+          "Timex": "(T17:55:23,T18:33:02,PT37M39S)",
           "FutureResolution": {
             "startTime": "17:55:23",
             "endTime": "18:33:02"

--- a/Specs/DateTime/Japanese/TimePeriodExtractor.json
+++ b/Specs/DateTime/Japanese/TimePeriodExtractor.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "午後5時から6時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -14,7 +13,6 @@
   },
   {
     "Input": "午前5時から7時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "午後5時から6時の間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "午後5時から午後6時の間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "午後4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "午後4時から5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +73,6 @@
   },
   {
     "Input": "4時から7時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -92,7 +85,6 @@
   },
   {
     "Input": "午後3時から7時半まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "午後3時20分から8時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "午後4時から5時半まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "午前3時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +133,6 @@
   },
   {
     "Input": "午後4時から5時半の間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -157,7 +145,6 @@
   },
   {
     "Input": "午前3時から午後5時の間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -170,7 +157,6 @@
   },
   {
     "Input": "午前中に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -183,20 +169,18 @@
   },
   {
     "Input": "午後に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午後",
+        "Text": "午後に",
         "Type": "timerange",
         "Start": 0,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
   {
     "Input": "夜に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -209,7 +193,6 @@
   },
   {
     "Input": "早朝に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,7 +205,6 @@
   },
   {
     "Input": "昼前に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -235,7 +217,6 @@
   },
   {
     "Input": "昼すぎに会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,6 @@
   },
   {
     "Input": "夕方前に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -261,7 +241,6 @@
   },
   {
     "Input": "夕方に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -274,7 +253,6 @@
   },
   {
     "Input": "深夜に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -287,7 +265,6 @@
   },
   {
     "Input": "午後2時から5時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +277,6 @@
   },
   {
     "Input": "午後6時から11時までジャンのパーティー",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -313,20 +289,18 @@
   },
   {
     "Input": "14時から16時30分まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "14時から16時30分",
+        "Text": "14時から16時30分まで",
         "Type": "timerange",
         "Start": 0,
-        "Length": 11
+        "Length": 13
       }
     ]
   },
   {
     "Input": "午後1時から4時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -339,7 +313,6 @@
   },
   {
     "Input": "午後1時30分から4時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -352,13 +325,11 @@
   },
   {
     "Input": "午後1時30分から4人の会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "こんにちはコルタナ。ジェニファーとスカイプ会議の予定を入れてください。私が出発する今週の金曜日午後に30分の会議が必要です。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -371,7 +342,6 @@
   },
   {
     "Input": "1時30分から3時30分まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -384,7 +354,6 @@
   },
   {
     "Input": "午後1時30分から3時30分まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -397,7 +366,6 @@
   },
   {
     "Input": "午後1時30分から午後3時30分まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -410,7 +378,6 @@
   },
   {
     "Input": "1時から3時30分まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -423,7 +390,6 @@
   },
   {
     "Input": "1時30分から3時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -436,7 +402,6 @@
   },
   {
     "Input": "10時から11時30分の間で会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -449,7 +414,6 @@
   },
   {
     "Input": "午前10時10分から12時50分の間で会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -462,7 +426,6 @@
   },
   {
     "Input": "午後10時10分から3時の間で会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -475,7 +438,6 @@
   },
   {
     "Input": "午後10時10分から10時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -488,7 +450,6 @@
   },
   {
     "Input": "午前10時半から23時まで会議を設定して。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -501,7 +462,6 @@
   },
   {
     "Input": "営業時間内に電話をかけてこないで。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -514,7 +474,7 @@
   },
   {
     "Input": "深夜20時～早朝4時",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "深夜20時～早朝4時",
@@ -526,7 +486,7 @@
   },
   {
     "Input": "午後2時～4時",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後2時～4時",
@@ -538,7 +498,7 @@
   },
   {
     "Input": "午後五時から六時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時から六時まで",
@@ -550,7 +510,7 @@
   },
   {
     "Input": "午後5時から6時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後5時から6時まで",
@@ -562,7 +522,7 @@
   },
   {
     "Input": "夜9時30分から午前3時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "夜9時30分から午前3時まで",
@@ -574,7 +534,7 @@
   },
   {
     "Input": "午後",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後",
@@ -586,7 +546,7 @@
   },
   {
     "Input": "深夜12時から未明2時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "深夜12時から未明2時まで",
@@ -598,7 +558,7 @@
   },
   {
     "Input": "午後四時から夜八時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後四時から夜八時まで",
@@ -610,7 +570,7 @@
   },
   {
     "Input": "昼",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "昼",
@@ -622,7 +582,7 @@
   },
   {
     "Input": "午後五時半から六時半まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時半から六時半まで",
@@ -634,7 +594,7 @@
   },
   {
     "Input": "午前",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午前",
@@ -646,7 +606,7 @@
   },
   {
     "Input": "夜",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "夜",
@@ -658,7 +618,7 @@
   },
   {
     "Input": "午前8時45分から9時30分",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午前8時45分から9時30分",
@@ -670,7 +630,7 @@
   },
   {
     "Input": "早朝四時から六時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "早朝四時から六時まで",
@@ -682,7 +642,7 @@
   },
   {
     "Input": "4時から6時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4時から6時まで",
@@ -694,7 +654,7 @@
   },
   {
     "Input": "早朝四時から六時までの間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "早朝四時から六時までの間",

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -31,7 +30,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -58,7 +56,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -85,7 +82,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -112,7 +108,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -139,7 +134,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -166,7 +160,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -193,14 +186,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4時から7時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T04:00,T07,PT3H)",
+          "Timex": "(T04,T07,PT3H)",
           "FutureResolution": {
             "startTime": "04:00:00",
             "endTime": "07:00:00"
@@ -220,7 +212,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -247,7 +238,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -275,7 +265,6 @@
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
     "Comment": "'今日の' shouldn't be annotated by TimePeriodParser",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -302,7 +291,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -329,11 +317,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午後",
+        "Text": "午後に",
         "Type": "timerange",
         "Value": {
           "Timex": "TAF",
@@ -347,7 +334,7 @@
           }
         },
         "Start": 0,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
@@ -356,7 +343,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -383,7 +369,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -391,6 +376,7 @@
         "Type": "timerange",
         "Value": {
           "Timex": "TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startTime": "08:00:00",
             "endTime": "10:00:00"
@@ -410,7 +396,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -418,6 +403,7 @@
         "Type": "timerange",
         "Value": {
           "Timex": "TMO",
+          "Mod": "end",
           "FutureResolution": {
             "startTime": "10:00:00",
             "endTime": "12:00:00"
@@ -437,7 +423,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -445,6 +430,7 @@
         "Type": "timerange",
         "Value": {
           "Timex": "TMO",
+          "Mod": "start",
           "FutureResolution": {
             "startTime": "08:00:00",
             "endTime": "10:00:00"
@@ -464,7 +450,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -472,6 +457,7 @@
         "Type": "timerange",
         "Value": {
           "Timex": "TAF",
+          "Mod": "start",
           "FutureResolution": {
             "startTime": "12:00:00",
             "endTime": "14:00:00"
@@ -491,7 +477,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -499,6 +484,7 @@
         "Type": "timerange",
         "Value": {
           "Timex": "TAF",
+          "Mod": "end",
           "FutureResolution": {
             "startTime": "14:00:00",
             "endTime": "16:00:00"
@@ -518,7 +504,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -528,11 +513,11 @@
           "Timex": "TEV",
           "FutureResolution": {
             "startTime": "16:00:00",
-            "endTime": "18:00:00"
+            "endTime": "20:00:00"
           },
           "PastResolution": {
             "startTime": "16:00:00",
-            "endTime": "18:00:00"
+            "endTime": "20:00:00"
           }
         },
         "Start": 0,
@@ -546,7 +531,6 @@
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
     "Comment": "TBD: Need to find 'early evening' in Japanese. 深夜 is night.",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -556,11 +540,11 @@
           "Timex": "TNI",
           "FutureResolution": {
             "startTime": "20:00:00",
-            "endTime": "23:59:00"
+            "endTime": "23:59:59"
           },
           "PastResolution": {
             "startTime": "20:00:00",
-            "endTime": "23:59:00"
+            "endTime": "23:59:59"
           }
         },
         "Start": 0,
@@ -573,7 +557,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -600,7 +583,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -627,7 +609,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -654,7 +635,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -681,7 +661,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -708,7 +687,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -735,7 +713,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -762,7 +739,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -789,14 +765,13 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午前11時から11時50分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T11,T11:50,PT50M)",
+          "Timex": "(T11,T11:50,PT0H50M)",
           "FutureResolution": {
             "startTime": "11:00:00",
             "endTime": "11:50:00"
@@ -816,7 +791,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -843,7 +817,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -870,14 +843,13 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後3時から午後3時30分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T15,T15:30,PT30M)",
+          "Timex": "(T15,T15:30,PT0H30M)",
           "FutureResolution": {
             "startTime": "15:00:00",
             "endTime": "15:30:00"
@@ -897,7 +869,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -924,14 +895,13 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午前0時1分から1時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T00:01,T01,PT59M)",
+          "Timex": "(T00:01,T01,PT0H59M)",
           "FutureResolution": {
             "startTime": "00:01:00",
             "endTime": "01:00:00"
@@ -951,14 +921,13 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3時から3時30分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T03,T03:30,PT30M)",
+          "Timex": "(T03,T03:30,PT0H30M)",
           "FutureResolution": {
             "startTime": "03:00:00",
             "endTime": "03:30:00"
@@ -978,7 +947,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1005,7 +973,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1032,7 +999,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1059,7 +1025,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1086,7 +1051,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1113,7 +1077,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1140,7 +1103,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1167,7 +1129,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1194,7 +1155,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1221,7 +1181,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1248,7 +1207,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1275,7 +1233,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1302,7 +1259,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-01T13:37:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1329,7 +1285,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "17時55分23秒から18時33分02秒まで",
@@ -1355,13 +1311,13 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時から午前三時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:00,T03:00,PT10H)",
+          "Timex": "(T17,T03,PT10H)",
           "FutureResolution": {
             "startTime": "17:00:00",
             "endTime": "03:00:00"
@@ -1381,20 +1337,20 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "夜",
         "Type": "timerange",
         "Value": {
-          "Timex": "TEV",
+          "Timex": "TNI",
           "FutureResolution": {
-            "startTime": "16:00:00",
-            "endTime": "20:00:00"
+            "startTime": "20:00:00",
+            "endTime": "23:59:59"
           },
           "PastResolution": {
-            "startTime": "16:00:00",
-            "endTime": "20:00:00"
+            "startTime": "20:00:00",
+            "endTime": "23:59:59"
           }
         },
         "Start": 0,
@@ -1407,7 +1363,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時から夜七時半まで",
@@ -1433,20 +1389,20 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "昼",
         "Type": "timerange",
         "Value": {
-          "Timex": "TMI",
+          "Timex": "TDT",
           "FutureResolution": {
-            "startTime": "11:00:00",
-            "endTime": "13:00:00"
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
           },
           "PastResolution": {
-            "startTime": "11:00:00",
-            "endTime": "13:00:00"
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
           }
         },
         "Start": 0,
@@ -1459,13 +1415,13 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時から6時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:00,T18:00,PT1H)",
+          "Timex": "(T17,T18,PT1H)",
           "FutureResolution": {
             "startTime": "17:00:00",
             "endTime": "18:00:00"
@@ -1485,13 +1441,13 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5時から6時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T05:00,T06:00,PT1H)",
+          "Timex": "(T05,T06,PT1H)",
           "FutureResolution": {
             "startTime": "05:00:00",
             "endTime": "06:00:00"
@@ -1511,7 +1467,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "朝五時から六時まで",
@@ -1537,7 +1493,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "五時半から六時まで",
@@ -1563,7 +1519,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "17:55:23から18:33:02まで",
@@ -1589,7 +1545,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後五時十五分から六時まで",
@@ -1615,7 +1571,7 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午前",
@@ -1641,7 +1597,7 @@
     "Context": {
       "ReferenceDateTime": "2018-10-11T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "午後",
@@ -1664,7 +1620,9 @@
   },
   {
     "Input": "日中",
-    "NotSupported": "dotnet",
+    "Context": {
+      "ReferenceDateTime": "2018-10-11T00:00:00"
+    },
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1673,16 +1631,42 @@
         "Value": {
           "Timex": "TDT",
           "FutureResolution": {
-            "startTime": "06:00:00",
+            "startTime": "08:00:00",
             "endTime": "18:00:00"
           },
           "PastResolution": {
-            "startTime": "06:00:00",
+            "startTime": "08:00:00",
             "endTime": "18:00:00"
           }
         },
         "Start": 0,
         "Length": 2
+      }
+    ]
+  },
+  {
+    "Input": "5時から午後6時まで不在にします。",
+    "Context": {
+      "ReferenceDateTime": "2017-03-22T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "5時から午後6時まで",
+        "Type": "timerange",
+        "Value": {
+          "Timex": "(T17,T18,PT1H)",
+          "FutureResolution": {
+            "startTime": "17:00:00",
+            "endTime": "18:00:00"
+          },
+          "PastResolution": {
+            "startTime": "17:00:00",
+            "endTime": "18:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 10
       }
     ]
   }

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -771,7 +771,7 @@
         "Text": "午前11時から11時50分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T11,T11:50,PT0H50M)",
+          "Timex": "(T11,T11:50,PT50M)",
           "FutureResolution": {
             "startTime": "11:00:00",
             "endTime": "11:50:00"
@@ -849,7 +849,7 @@
         "Text": "午後3時から午後3時30分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T15,T15:30,PT0H30M)",
+          "Timex": "(T15,T15:30,PT30M)",
           "FutureResolution": {
             "startTime": "15:00:00",
             "endTime": "15:30:00"
@@ -901,7 +901,7 @@
         "Text": "午前0時1分から1時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T00:01,T01,PT0H59M)",
+          "Timex": "(T00:01,T01,PT59M)",
           "FutureResolution": {
             "startTime": "00:01:00",
             "endTime": "01:00:00"
@@ -927,7 +927,7 @@
         "Text": "3時から3時30分まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T03,T03:30,PT0H30M)",
+          "Timex": "(T03,T03:30,PT30M)",
           "FutureResolution": {
             "startTime": "03:00:00",
             "endTime": "03:30:00"
@@ -1291,7 +1291,7 @@
         "Text": "17時55分23秒から18時33分02秒まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+          "Timex": "(T17:55:23,T18:33:02,PT37M39S)",
           "FutureResolution": {
             "startTime": "17:55:23",
             "endTime": "18:33:02"
@@ -1499,7 +1499,7 @@
         "Text": "五時半から六時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T05:30,T06,PT0H30M)",
+          "Timex": "(T05:30,T06,PT30M)",
           "FutureResolution": {
             "startTime": "05:30:00",
             "endTime": "06:00:00"
@@ -1525,7 +1525,7 @@
         "Text": "17:55:23から18:33:02まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:55:23,T18:33:02,PT0H37M39S)",
+          "Timex": "(T17:55:23,T18:33:02,PT37M39S)",
           "FutureResolution": {
             "startTime": "17:55:23",
             "endTime": "18:33:02"
@@ -1551,7 +1551,7 @@
         "Text": "午後五時十五分から六時まで",
         "Type": "timerange",
         "Value": {
-          "Timex": "(T17:15,T18,PT0H45M)",
+          "Timex": "(T17:15,T18,PT45M)",
           "FutureResolution": {
             "startTime": "17:15:00",
             "endTime": "18:00:00"


### PR DESCRIPTION
Extractor: 56 pass, 0 fail.
Parser: 64 pass, 0 fail.

No input has been modified.

Modified BaseCJKTimePeriodParser to add "start"/"end" mods for cases like "early/late morning" as in standard implementation.
Modified method Handle in TimePeriodFunctions to support patterns like "from 11 to 3 morning" (with desc only in the second term). Originally, only patterns like "from 11 morning to 3" (with desc only in the first term) was supported.