### PR TITLE
[.NET] Dutch DateTimeModel refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))))";
       public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag|(maan|dins|woens|donder|vrij|zater|zon)dag)(ochtend|morgen)|^?ochtend))";
       public static readonly string FullDescRegex = $@"({DescRegex}|{AmRegex}|{PmRegexFull})";
-      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b";
+      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:\.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
       public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|zat?|zo)(\.|\b))|((?:maan|dins|woens|donder|vrij|zater|zon)(dag(en)?)?(middag)?)\b)";
       public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr|za)\b(\.)?)|(vrij|zat|zon?)\.(?!$)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater)(dag(en)?)?|(?<=(op|voor)\s+)(vrij|zon?|zat)|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Dutch/DateTimeDefinitions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string PastPrefixRegex = @"((deze\s+)?(verleden|afgelopen))\b";
       public static readonly string PreviousPrefixRegex = $@"((voorgaand[e]|vorige?|verleden|laatste|{PastPrefixRegex})\b|gister(en)?)";
       public const string ThisPrefixRegex = @"(dit|deze|huidige?)\b";
-      public const string RangePrefixRegex = @"(?<desc>van|tussen)";
+      public const string RangePrefixRegex = @"(van|tussen)";
       public const string CenturySuffixRegex = @"(^eeuw|^centennium)\b";
       public const string ReferencePrefixRegex = @"(dezelfde|hetzelfde|dat(zelfde)?|die|overeenkomstige)\b";
       public const string FutureSuffixRegex = @"\b(((in\s+de\s+)?toekomst)|daarna|over|na)\b";
@@ -60,12 +60,12 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string AmDescRegex = $@"(:?{BaseDateTime.BaseAmDescRegex})";
       public static readonly string PmDescRegex = $@"(:?{BaseDateTime.BasePmDescRegex})";
       public static readonly string AmPmDescRegex = $@"(:?{BaseDateTime.BaseAmPmDescRegex})";
-      public static readonly string DescRegex = $@"(:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})";
+      public static readonly string DescRegex = $@"(:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex}))\.?)|{OclockRegex})";
       public static readonly string PmRegex = $@"(?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|dag)";
       public static readonly string PmRegexFull = $@"(?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))))";
-      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))";
+      public static readonly string AmRegex = $@"(?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag|(maan|dins|woens|donder|vrij|zater|zon)dag)(ochtend|morgen)|^?ochtend))";
       public static readonly string FullDescRegex = $@"({DescRegex}|{AmRegex}|{PmRegexFull})";
-      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
+      public static readonly string TwoDigitYearRegex = $@"\b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b";
       public static readonly string YearRegex = $@"({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})";
       public const string WeekDayRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|zat?|zo)(\.|\b))|((?:maan|dins|woens|donder|vrij|zater|zon)(dag(en)?)?(middag)?)\b)";
       public const string SingleWeekDayRegex = @"\b(?<weekday>(((ma|di(ns)?|wo(e(ns)?)?|do|vr|za)\b(\.)?)|(vrij|zat|zon?)\.(?!$)|(((?<!in\s+de\s+)(maan|dins|woens|donder|zater)(dag(en)?)?|(?<=(op|voor)\s+)(vrij|zon?|zat)|vrij(dag(en)?))\b))|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)";
@@ -85,13 +85,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string ForHalfTokenRegex = @"\b(voor\s+half)$";
       public const string FromRegex = @"\b(van(af)?)$";
       public const string BetweenTokenRegex = @"\b(tussen)$";
-      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?(({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})|({DayRegex})\s+((van)\s+)?{MonthSuffixRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string BetweenRegex = $@"\b(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string RelativeYearRegex = $@"({YearRegex}|(?<order>volgende?|komende?|aanstaande?|aankomende?|huidige?|vorige?|afgelopen|dit)\s+jaar)";
       public static readonly string MonthWithYear = $@"\b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*){RelativeYearRegex})|({RelativeYearRegex}(\s*),?(\s*){WrittenMonthRegex}))\b";
-      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
+      public static readonly string OneWordPeriodRegex = $@"\b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar(?!\s+hoger dan))|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b";
       public static readonly string MonthNumWithYear = $@"\b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"\b(?<wom>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week\s+{MonthSuffixRegex}(\s+{BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+year)?)\b";
       public static readonly string WeekOfYearRegex = $@"(\b(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week(\s+van)?\s+({YearRegex}|{RelativeRegex}\s+jaar))\b)|(\b({YearRegex}|{RelativeRegex}\s+jaar)\s(?<woy>(de\s+)?(?<cardinal>eerste|tweede|derde|vierde|vijfde|1e|1ste|2e|2de|3e|3de|4e|4de|5e|5de|laatste)\s+week)\b)";
@@ -109,7 +109,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string MidPrefixRegex = @"\b(?<MidPrefix>(mid(den|-)?|halverwege|op\s+de\s+helft|half)(\s+(in|op|van)(\s+de)?)?)";
       public const string LaterPrefixRegex = @"\b(?<LatePrefix>(laat|(?<RelLate>later)|aan\s+het\s+einde?(\s+van(\s+de)?)?|eind(igend)?|afsluitend)(\s+(in|op|van)(\s+de)?)?)\b";
       public static readonly string PrefixPeriodRegex = $@"({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})";
-      public const string PrefixDayRegex = @"\b(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b";
+      public static readonly string PrefixDayRegex = $@"\b(((?<!{WeekDayRegex}\s+)(?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<!{WeekDayRegex}\s+)(?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b";
       public const string SeasonDescRegex = @"(?<seas>lente|voorjaar|zomer|herfst|najaar|winter)";
       public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}(\s+)?)?({ArticleRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+(in|van)|\s*,\s*)?\s+({YearRegex}|({ArticleRegex}\s+)?({RelativeRegex}\s+)?jaar))?)\b";
       public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
@@ -121,13 +121,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string OnRegex = $@"(?<=\bop\s+)({DayRegex})\b(?!(\.|:)\d+)";
       public const string RelaxedOnRegex = @"\b(?<=op\s+)(?:de\s+)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:(ste|de|e))?\b(?!(\.|:)\d+)";
       public const string PrefixWeekDayRegex = @"(\s*((,?\s*op)|[-—–]))";
-      public static readonly string ThisRegex = $@"\b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
-      public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
+      public static readonly string ThisRegex = $@"\b((deze(\s+week{PrefixWeekDayRegex}?)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b";
+      public static readonly string LastDateRegex = $@"\b({PreviousPrefixRegex}(\s*week{PrefixWeekDayRegex}?)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b";
       public const string WeekDayForNextDateRegex = @"\b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)(\.|\b))|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))";
-      public static readonly string NextDateRegex1 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})";
+      public static readonly string NextDateRegex1 = $@"\b({NextPrefixRegex}(\s*week{PrefixWeekDayRegex}?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})";
       public static readonly string NextDateRegex2 = $@"\b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})";
       public static readonly string NextDateRegex = $@"({NextDateRegex1}|{NextDateRegex2})";
-      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)";
+      public static readonly string SpecialDayRegex = $@"\b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor|erna)|((de\s+)?({RelativeRegex}|mijn)\s+dag)\b|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)";
       public static readonly string SpecialDayWithNumRegex = $@"\b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b";
       public static readonly string RelativeDayRegex = $@"\b(((de\s+)?{RelativeRegex}\s+dag))\b";
       public const string SetWeekDayRegex = @"\b(?<prefix>op\s+({ArticleRegex}\s+)?)?(?<weekday>morgen|ochtend|middag|avond|nacht|zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag)((?<suffix>e)n)\b";
@@ -136,16 +136,16 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string SpecialDate = $@"(?=\b(op\s+)(de\s+)?){DayRegex}\b";
       public const string DatePreposition = @"\b(op(\s+de)?)";
       public static readonly string DateExtractorYearTermRegex = $@"(\s+|\s*[,./-]\s*){DateYearRegex}";
-      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?";
+      public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex}(?!\s*{MonthRegex}))|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}(?!\s*{MonthRegex})\b)?";
       public static readonly string DateExtractor3 = $@"\b({WeekDayRegex}(\s+|\s*,\s*)?(de\s+)?)?(({DayRegex}(\s*dag|\.)?)((\s+|\s*[,/-]\s*|\s+van\s+)?{MonthRegex})((\.)?(\s+|\s*[,/-]\s*|\s+in\s+)?{DateYearRegex})?|{BaseDateTime.FourDigitYearRegex}\s*[,./-]?\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?(\s*dag|\.)?\s*[,./-]?\s*{MonthRegex})\b";
       public static readonly string DateExtractor4 = $@"\b{MonthNumRegex}\s*[/\\\-]\s*{DayRegex}[\.]?\s*[/\\\-]\s*{ApostrofRegex}?{DateYearRegex}";
       public static readonly string DateExtractor5 = $@"\b{DayRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DateYearRegex}(?!\s*[/\\\-\.]\s*\d+)";
       public static readonly string DateExtractor6 = $@"(?<={DatePreposition}\s+)({StrictRelativeRegex}\s+)?({WeekDayRegex}\s+)?{MonthNumRegex}[\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b|(?<={DatePreposition}\s+){MonthNumRegex}[\-\.]{DayRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractor7L = $@"\b({WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{DateExtractorYearTermRegex}(?![%])\b";
       public static readonly string DateExtractor7S = $@"\b((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{MonthNumRegex}\s*/\s*{DayRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
-      public static readonly string DateExtractor8 = $@"((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
+      public static readonly string DateExtractor8 = $@"\b((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?(?<!(morgen|ochtend|middag|avond|nacht)s?\s+){DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractor9L = $@"\b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}((\s+|\s*,\s*|\s+in\s+){DateYearRegex})(?![%])\b";
-      public static readonly string DateExtractor9S = $@"\b(?<!naar\s+)((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}\s*[\-\/.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
+      public static readonly string DateExtractor9S = $@"\b(?<!naar\s+)({WeekDayRegex}\s+)?{DayRegex}\s*(\/|\.)\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b";
       public static readonly string DateExtractorA = $@"\b({WeekDayRegex}\s+)?({BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})";
       public static readonly string OfMonth = $@"(^\s*((van|in)\s+)?)({MonthRegex})";
       public static readonly string MonthEnd = $@"{MonthRegex}(\s+de\s*)?$";
@@ -161,8 +161,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string LessThanOneHour = $@"(?<lth>((een\s+)?((drie\s+)?kwart(ier)?|half(uur)?))|{BaseDateTime.DeltaMinuteRegex}(\s+(minuten|mins|min\.?))?|({DeltaMinuteNumRegex}(\s+(minuten|mins|min\.?))?))";
       public static readonly string WrittenTimeRegex = $@"(?<writtentime>({HourNumRegex}\s+{MinuteNumRegex}|(?<prefix>half)\s+({HourNumRegex})))";
       public static readonly string TimePrefix = $@"(?<prefix>(half|{LessThanOneHour}\s+(over|voor|na)(\s+half)?)|(uur\s+{LessThanOneHour}))";
-      public static readonly string TimeSuffix = $@"(?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})";
-      public static readonly string TimeSuffixFull = $@"(?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})";
+      public static readonly string TimeSuffix = $@"(?<suffix>(({OclockRegex}\s+)?({AmRegex}|{PmRegex}))|{OclockRegex})";
+      public static readonly string TimeSuffixFull = $@"(?<suffix>(({OclockRegex}\s+)?({AmRegex}|{PmRegexFull}))|{OclockRegex})";
       public static readonly string HourDTRegEx = $@"({BaseDateTime.HourRegex})";
       public static readonly string MinuteDTRegEx = $@"({BaseDateTime.MinuteRegex})";
       public static readonly string SecondDTRegEx = $@"({BaseDateTime.SecondRegex})";
@@ -170,7 +170,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string MidnightRegex = $@"(?<midnight>mid\s*(-\s*)?nacht|middernacht|(in\s+)?de nacht(\s+van)?|({ApostrofsRegex}|des)\s*nachts)";
       public const string MidmorningRegex = @"(?<midmorning>mid\s*(-\s*)?(morgen|ochtend)|halverwege de ochtend|het midden van de ochtend)";
       public const string MidafternoonRegex = @"(?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)";
-      public static readonly string MiddayRegex = $@"(?<midday>(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)";
+      public static readonly string MiddayRegex = $@"(?<midday>(?<!gisteren|morgen)(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)";
       public static readonly string MidTimeRegex = $@"(?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))";
       public static readonly string AtRegex = $@"(((?<=\bom\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}(?!\.\d)(\s*((?<iam>a)|(?<ipm>p)))?|{MidTimeRegex}))|{MidTimeRegex})\b";
       public static readonly string IshRegex = $@"\b(tegen\s+{BaseDateTime.HourRegex}(-|——|\s*{ApostrofRegex}\s*)?en|middagloos)\b";
@@ -182,13 +182,13 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string ConnectNumRegex = $@"\b{BaseDateTime.HourRegex}(?<min>00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59)\s*{DescRegex}";
       public static readonly string TimeRegexWithDotConnector = $@"({BaseDateTime.HourRegex}(\s*\.\s*){BaseDateTime.MinuteRegex}(\s*:\s*{BaseDateTime.SecondRegex})?(\s*u\s*)?)";
       public static readonly string TimeRegexFilter = $@"\b((iedere|elke|op)(\s+andere)?\s+)?(week|dag|{SingleWeekDayRegex}|vandaag)\b";
-      public static readonly string TimeRegex1 = $@"\b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|((?<prefix>half)\s+)?(?!een){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)";
+      public static readonly string TimeRegex1 = $@"\b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|(({AroundRegex})\s+){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)";
       public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!(\d|\s*(per|pro)\s*cent|%))((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex3 = $@"(\b{TimePrefix}\s+)?{BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex}(\s*{DescRegex})";
       public static readonly string TimeRegex4 = $@"\b{TimePrefix}\s+{BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b";
       public static readonly string TimeRegex5 = $@"\b({TimePrefix}\s+{BasicTime}|{BasicTime}\s+{TimePrefix})((\s*({DescRegex}|{TimeSuffix}))|\b)";
       public static readonly string TimeRegex6 = $@"{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b";
-      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?(?<!van(avond|nacht)\s+)({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)|({WrittenTimeRegex}|{BasicTime})(\s*{DescRegex})(\s*{TimeSuffixFull})";
+      public static readonly string TimeRegex7 = $@"({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?(?<!van(avond|nacht)\s+){BasicTime})((\s*{DescRegex})|\b)|{BasicTime}(\s*{DescRegex})(\s*{TimeSuffixFull})";
       public static readonly string TimeRegex8 = $@".^";
       public static readonly string TimeRegex9 = $@"\b{PeriodHourNumRegex}\s*{FivesRegex}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex10 = $@"\b({TimePrefix}\s+)?{BaseDateTime.HourRegex}(\s*(u\b|h))(\s*{BaseDateTime.MinuteRegex})?(\s*{DescRegex})?";
@@ -196,7 +196,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeRegex12 = $@"({BaseDateTime.HourRegex}(?=\s+(vandaag|morgen|op)))";
       public static readonly string FirstTimeRegexInTimeRange = $@"\b{TimeRegexWithDotConnector}(?!\s*(per|pro)\s*cent|%|\s+{TimeRegexFilter})(\s*{DescRegex})?";
       public static readonly string PureNumFromToPrefixExcluded = $@"({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
-      public static readonly string PureNumFromToPrefix = $@"(({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
+      public static readonly string PureNumFromToPrefix = $@"(({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s+uur)?(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(\s+uur)?(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?";
       public static readonly string PureNumFromToWithDateBefore = $@"({RangePrefixRegex}\s+)({HourDTRegEx})(\s+(vandaag|morgen)\s+)?(\s*{RangeConnectorRegex}\s*)({HourDTRegEx})";
       public static readonly string PureNumFromToWithDateAfter = $@"({RangePrefixRegex}\s+)({HourDTRegEx})(\s*{RangeConnectorRegex}\s*)({HourDTRegEx}(\s+(vandaag|morgen))?)";
       public static readonly string PureNumFromTo = $@"({PureNumFromToPrefix}|{PureNumFromToPrefixExcluded})";
@@ -226,6 +226,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string PeriodTimeOfDayRegex = $@"((in\s+(de)?\s+)?({EarlyLateRegex}(\s+|-))?(zondag|maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|(eer)?gisteren|morgen)?(?<timeOfDay>ochtend|(na)?middag|avond|nacht))\b";
       public static readonly string PeriodSpecificTimeOfDayRegex = $@"\b(({StrictRelativeRegex}(\s+)?{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b";
       public static readonly string PeriodTimeOfDayWithDateRegex = $@"(({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))\b";
+      public static readonly string PeriodTimeOfDayWithDateRegexWithAnchors = $@"((({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))(?=({MiddlePauseRegex})?\s*$)|(?<=^\s*({MiddlePauseRegex})?){TimeOfDayRegex})";
       public const string LessThanRegex = @"\b((binnen\s+)?minder\s+dan)\b";
       public const string MoreThanRegex = @"\b((meer|langer)\s+dan|ruim)\b";
       public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|(min\.|sec\.)|((?<half>halfuur)|(?<quarter>kwartier\s+uur)|(?<quarter>kwartier)|uur|uren|u|minuten|minuut|mins|min|m|secondes|seconden|secs|sec|s|nacht(en)?)\b)(\s+lang\b)?";
@@ -239,9 +240,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string BeforeEachDayRegex = @"(iedere|elke)\s*dag\s*";
       public static readonly string DurationFollowedUnit = $@"^\s*((?<suffix>(?<unit>(?<suffix_num>(een\s+)?kwartier)))|{SuffixAndRegex}?(\s+|-)?{DurationUnitRegex})";
       public static readonly string NumberCombinedWithDurationUnit = $@"\b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}";
-      public static readonly string AnUnitRegex = $@"\b((?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}";
+      public static readonly string AnUnitRegex = $@"\b((((nog een|een|nog)\s+(?<half>anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}";
       public const string DuringRegex = @"\b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b";
-      public const string AllRegex = @"\b(?<all>(voor\s+)?((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
+      public const string AllRegex = @"\b(?<all>((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b";
       public const string HalfRegex = @"(((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b";
       public const string ConjunctionRegex = @"\b((en(\s+voor)?)|plus)\b";
       public static readonly string HolidayList1 = $@"(?<holiday>goede vrijdag|pasen|((eerste|tweede)\s+)?paasdag|paas(zondag|maandag)|kerst|kerstavond|kerstmis|thanksgiving|halloween|(islamitisch\s+)?nieuwjaar|oud en nieuw|oud & nieuw|pinksteren|oude?jaar|oude?jaarsavond|silvester|silvesteravond|sinterklaas|sinterklaasfeest|sinterklaasavond|pakjesavond|eid al(-|\s+)fitr|eid al(-|\s+)adha)";
@@ -256,8 +257,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string RecentlyTimeRegex = @"\b(kort\s+geleden|eerder)\b";
       public const string AsapTimeRegex = @"\b(zo\s+snel\s+mogelijk|zsm)\b";
       public const string InclusiveModPrepositions = @"(?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))";
+      public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na)|(het\s+)?jaar hoger dan)(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";
       public static readonly string BeforeRegex = $@"(\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>(al\s+)?zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)";
-      public static readonly string AfterRegex = $@"(\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)";
       public const string SinceRegex = @"(\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|(al\s+)?zo\s+vroeg\s+als|(elk|ieder)\s+moment\s+vanaf|een\s+tijdstip\s+vanaf)\b\s*)|(?<!\w|<)(>=)";
       public const string AroundRegex = @"(\b(rond(om)?|ongeveer(\s+om)?)\s*\b)";
       public const string AgoRegex = @"\b(geleden|(voor|eerder\s+dan)\s+(?<day>gisteren|vandaag))\b";
@@ -271,7 +272,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string TodayNowRegex = @"\b(vandaag|nu)\b";
       public static readonly string MorningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+(morgens|ochtends)|in\s+de\s+(na)?(morgen|ochtend)|deze\s+(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+(morgen|ochtend)|{AmDescRegex}|(morgen|ochtend)))|((({ApostrofsRegex}|des)\s+(morgens|ochtends)|deze\s+(morgen|ochtend)|in\s+de\s+(na)?(morgen|ochtend)|(morgen|ochtend)\s+in\s+het\s+begin|(morgen|ochtend)\s+aan\s+het\s+einde?|{AmDescRegex}|(morgen|ochtend))$)";
       public static readonly string AfternoonStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+middags|in\s+de\s+(na)?middag|deze\s+middag|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+middag|{PmDescRegex}))|((({ApostrofsRegex}|des)?\s+middags|in\s+de\s+(na)?middag|deze\s+middag|middag\s+in\s+het\s+begin|middag\s+aan\s+het\s+einde?|{PmDescRegex}|middag)$)";
-      public static readonly string EveningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{{PmDescRegex}}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{{PmDescRegex}}|avond)$)";
+      public static readonly string EveningStartEndRegex = $@"(^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{PmDescRegex}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{PmDescRegex}|avond)$)";
       public static readonly string NightStartEndRegex = $@"(^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)";
       public const string InexactNumberRegex = @"\b((een\s+)?aantal|meerdere|enkele|verscheidene|wat|enige|(?<NumTwoTerm>(een\s+)?paar))\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+({DurationUnitRegex})";
@@ -291,7 +292,8 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public const string RestOfDateRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<duration>week|maand|jaar|decennium)\b";
       public const string RestOfDateTimeRegex = @"\brest\s+(van\s+)?((de|het|mijn|dit|deze|(de\s+)?huidige)\s+)?(?<unit>vandaag|dag)\b";
       public const string MealTimeRegex = @"\b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b";
-      public const string AmbiguousRangeModifierPrefix = @"^[.]";
+      public const string AmbiguousRangeModifierPrefix = @"(voor)";
+      public static readonly string PotentialAmbiguousRangeRegex = $@"\b{AmbiguousRangeModifierPrefix}(.+\b(boven|later|groter|erna|daarna|hoger|(?<!de\s+)({DateUnitRegex}|uur|uren|minuten|minuut|mins|min|secondes|seconden|secs|sec|nacht(en)?)|van(af)?|tussen|tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van|(?<ambiguous>{BaseDateTime.RangeConnectorSymbolRegex}))\b)";
       public static readonly string NumberEndingPattern = $@"^(\s+((?<meeting>vergadering|afspraak|conferentie|telefoontje|skype-gesprek)\s+)?(om|naar)\s+(?<newTime>{PeriodHourNumRegex}|{HourRegex})((\.)?$|(\.,|,|!|\?)))";
       public const string OneOnOneRegex = @"\b(1\s*:\s*1)|(één\s+(op\s)één|één\s*-\s*één|één\s*:\s*één)\b";
       public static readonly string LaterEarlyPeriodRegex = $@"\b({PrefixPeriodRegex})\s*\b\s*(?<suffix>{OneWordPeriodRegex})\b";
@@ -306,9 +308,9 @@ namespace Microsoft.Recognizers.Definitions.Dutch
       public static readonly string TimeBeforeAfterRegex = $@"\b(((?<=\b(voor|niet later dan|na|door)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))|{MidTimeRegex})\b";
       public const string DateNumberConnectorRegex = @"^\s*(?<connector>\s+om)\s*$";
       public const string DecadeRegex = @"(?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|(ee|éé)nentwintigste\s+eeuw))";
-      public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<=\b(de|jaren)\s+)(?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
+      public static readonly string DecadeWithCenturyRegex = $@"\b(de\s+)?(jaren\s+)?((?<!\$)((?<=\b(de|jaren)\s+)(?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?|(?<=\b(de|jaren)\s+)){DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))";
       public static readonly string RelativeDecadeRegex = $@"\b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b";
-      public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna|daarna|hoger)(?!\s+dan))\b";
+      public const string SuffixAfterRegex = @"\b(((bij)\s)?(of|en)\s+(boven|later|groter|erna|daarna|hoger)(?!\s+dan))\b";
       public const string DateAfterRegex = @"\b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b";
       public static readonly string YearPeriodRegex = $@"((((van(af)?|tijdens|gedurende|in)\s+)?{YearRegex}\s*({TillRegex})\s*{YearRegex})|(((tussen)\s+){YearRegex}\s*({RangeConnectorRegex})\s*{YearRegex}))";
       public static readonly string ComplexDatePeriodRegex = $@"(((van(af)?|tijdens|gedurende|in(\s+de)?)\s+)?(?<start>.+)\s*({TillRegex})\s*(?<end>.+)|((tussen)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
@@ -845,7 +847,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         };
       public static readonly Dictionary<string, string> AmbiguityTimeFiltersDict = new Dictionary<string, string>
         {
-            { @"^(\d{1,2}|\p{L}+)\s+uur$", @"(?<LB>(?<!\b(om|is|vanaf|morgen|vandaag|gisteren|\d+)\s+)\b(\d{1,2}|\p{L}+)\s+uur\b)(?(LB)(?!\s+(tot|morgen|vandaag|gisteren|\d+)\b))" }
+            { @"^(\d{1,2}|\p{L}+)\s+uur$", @"(?<LB>(?<!\b(om|is|vanaf|morgen|vandaag|gisteren|\d+)(\s+(\d{1,2}|\p{L}+)\s+uur\s+(of|en))?\s+)\b(\d{1,2}|\p{L}+)\s+uur\b)(?(LB)(?!\s+(tot|morgen|vandaag|gisteren|\d+)\b))" }
         };
       public static readonly IList<string> MorningTermList = new List<string>
         {
@@ -889,6 +891,7 @@ namespace Microsoft.Recognizers.Definitions.Dutch
         {
             @"morgen",
             @"dag na",
+            @"dag erna",
             @"volgende dag",
             @"morgenochtend",
             @"morgenavond"

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string NegativeGroupName = "neg";
         public const string YearCJKGroupName = "yearCJK";
         public const string PluralUnit = "plural";
+        public const string AmbiguousPattern = "ambiguous";
 
         // Include the date mentioned, to make "before" -> "until" or "after" -> "since". Such as "on or earlier than 1/1/2016".
         public const string IncludeGroupName = "include";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchDateTimePeriodExtractorConfiguration.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex HyphenDateRegex =
             new Regex(BaseDateTime.HyphenDateRegex, RegexFlags);
 
+        // Anchors needed to correctly handle patterns when multiple TimeOfDay entities are present.
         public static readonly Regex PeriodTimeOfDayWithDateRegex =
-            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegexWithAnchors, RegexFlags);
 
         public static readonly Regex RelativeTimeUnitRegex =
             new Regex(DateTimeDefinitions.RelativeTimeUnitRegex, RegexFlags);
@@ -135,7 +136,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Regex FollowedUnit => TimeFollowedUnit;
 
-        bool IDateTimePeriodExtractorConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+        // CheckBothBeforeAfter normally gets its value from DateTimeDefinitions.CheckBothBeforeAfter which however for Dutch is false.
+        // It only needs to be true in DateTimePeriod.
+        bool IDateTimePeriodExtractorConfiguration.CheckBothBeforeAfter => true;
 
         Regex IDateTimePeriodExtractorConfiguration.PrefixDayRegex => PrefixDayRegex;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Extractors/DutchMergedExtractorConfiguration.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex UnspecificDatePeriodRegex =
             new Regex(DateTimeDefinitions.UnspecificDatePeriodRegex, RegexFlags);
 
+        public static readonly Regex PotentialAmbiguousRangeRegex =
+            new Regex(DateTimeDefinitions.PotentialAmbiguousRangeRegex, RegexFlags);
+
         public static readonly Regex[] TermFilterRegexes =
         {
             // one on one
@@ -134,9 +137,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         Regex IMergedExtractorConfiguration.PrepositionSuffixRegex => PrepositionSuffixRegex;
 
-        Regex IMergedExtractorConfiguration.AmbiguousRangeModifierPrefix => null;
+        Regex IMergedExtractorConfiguration.AmbiguousRangeModifierPrefix => AmbiguousRangeModifierPrefix;
 
-        Regex IMergedExtractorConfiguration.PotentialAmbiguousRangeRegex => null;
+        Regex IMergedExtractorConfiguration.PotentialAmbiguousRangeRegex => PotentialAmbiguousRangeRegex;
 
         Regex IMergedExtractorConfiguration.NumberEndingPattern => NumberEndingPattern;
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Dutch/Parsers/DutchDateTimePeriodParserConfiguration.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
         public static readonly Regex NightStartEndRegex =
             new Regex(DateTimeDefinitions.NightStartEndRegex, RegexFlags);
 
+        public static readonly Regex PeriodTimeOfDayWithDateRegex =
+            new Regex(DateTimeDefinitions.PeriodTimeOfDayWithDateRegex, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public DutchDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
@@ -51,7 +54,6 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
             FutureSuffixRegex = DutchDatePeriodExtractorConfiguration.FutureSuffixRegex;
             NumberCombinedWithUnitRegex = DutchDateTimePeriodExtractorConfiguration.TimeNumberCombinedWithUnit;
             UnitRegex = DutchTimePeriodExtractorConfiguration.TimeUnitRegex;
-            PeriodTimeOfDayWithDateRegex = DutchDateTimePeriodExtractorConfiguration.PeriodTimeOfDayWithDateRegex;
             RelativeTimeUnitRegex = DutchDateTimePeriodExtractorConfiguration.RelativeTimeUnitRegex;
             RestOfDateTimeRegex = DutchDateTimePeriodExtractorConfiguration.RestOfDateTimeRegex;
             AmDescRegex = DutchDateTimePeriodExtractorConfiguration.AmDescRegex;
@@ -114,7 +116,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Regex UnitRegex { get; }
 
-        public Regex PeriodTimeOfDayWithDateRegex { get; }
+        Regex IDateTimePeriodParserConfiguration.PeriodTimeOfDayWithDateRegex => PeriodTimeOfDayWithDateRegex;
 
         public Regex RelativeTimeUnitRegex { get; }
 
@@ -132,7 +134,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Dutch
 
         public Regex AfterRegex { get; }
 
-        bool IDateTimePeriodParserConfiguration.CheckBothBeforeAfter => DateTimeDefinitions.CheckBothBeforeAfter;
+        // CheckBothBeforeAfter normally gets its value from DateTimeDefinitions.CheckBothBeforeAfter which however for Dutch is false.
+        // It only needs to be true in DateTimePeriod.
+        bool IDateTimePeriodParserConfiguration.CheckBothBeforeAfter => true;
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -593,20 +593,28 @@ namespace Microsoft.Recognizers.Text.DateTime
             var dateResult = this.Config.DateExtractor.Extract(text, referenceTime);
             if (dateResult.Count > 0)
             {
+                DateTimeParseResult pr = new DateTimeParseResult();
                 var beforeString = text.Substring(0, (int)dateResult.Last().Start).TrimEnd();
                 var match = Config.PrefixDayRegex.Match(beforeString);
+                if (match.Success)
+                {
+                    pr = this.Config.DateParser.Parse(dateResult.Last(), referenceTime);
+                }
 
                 // Check also afterString
                 if (!match.Success && this.Config.CheckBothBeforeAfter)
                 {
-                    var afterString = text.Substring((int)(dateResult.Last().Start + dateResult.Last().Length),
-                        text.Length - ((int)(dateResult.Last().Start + dateResult.Last().Length))).TrimStart();
+                    var afterString = text.Substring((int)(dateResult.First().Start + dateResult.First().Length),
+                        text.Length - ((int)(dateResult.First().Start + dateResult.First().Length))).TrimStart();
                     match = Config.PrefixDayRegex.Match(afterString);
+                    if (match.Success)
+                    {
+                        pr = this.Config.DateParser.Parse(dateResult.First(), referenceTime);
+                    }
                 }
 
                 if (match.Success)
                 {
-                    var pr = this.Config.DateParser.Parse(dateResult.Last(), referenceTime);
                     if (pr.Value != null)
                     {
                         var startTime = (DateObject)((DateTimeResolutionResult)pr.Value).FutureValue;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseTimePeriodParser.cs
@@ -292,12 +292,12 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                             if (!string.IsNullOrEmpty(matchAmStr) || rightAmValid)
                             {
-                                if (endHour >= Constants.HalfDayHourCount)
+                                if (endHour > Constants.HalfDayHourCount)
                                 {
                                     endHour -= Constants.HalfDayHourCount;
                                 }
 
-                                if (beginHour >= Constants.HalfDayHourCount && beginHour - Constants.HalfDayHourCount < endHour)
+                                if (beginHour > Constants.HalfDayHourCount && beginHour - Constants.HalfDayHourCount < endHour)
                                 {
                                     beginHour -= Constants.HalfDayHourCount;
                                 }
@@ -312,7 +312,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                             }
                             else if (!string.IsNullOrEmpty(matchPmStr) || rightPmValid)
                             {
-                                if (endHour < Constants.HalfDayHourCount)
+                                if (endHour <= Constants.HalfDayHourCount)
                                 {
                                     endHour += Constants.HalfDayHourCount;
                                 }
@@ -555,7 +555,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                     if (hasRightAm)
                     {
-                        if (endHour >= Constants.HalfDayHourCount)
+                        if (endHour > Constants.HalfDayHourCount)
                         {
                             endDateTime = endDateTime.AddHours(-Constants.HalfDayHourCount);
                         }
@@ -570,7 +570,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     }
                     else if (hasRightPm)
                     {
-                        if (endHour < Constants.HalfDayHourCount)
+                        if (endHour <= Constants.HalfDayHourCount)
                         {
                             endDateTime = endDateTime.AddHours(Constants.HalfDayHourCount);
                         }

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -111,7 +111,7 @@ FullDescRegex: !nestedRegex
 # Exclude cases that include the "Am/Pm" suffix
 # Exclude when preceded by "$" symbol
 TwoDigitYearRegex: !nestedRegex
-  def: \b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b
+  def: \b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:\.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b
   references: [ AmDescRegex, PmDescRegex, ApostrofsRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})

--- a/Patterns/Dutch/Dutch-DateTime.yaml
+++ b/Patterns/Dutch/Dutch-DateTime.yaml
@@ -35,7 +35,7 @@ PreviousPrefixRegex: !nestedRegex
 ThisPrefixRegex: !simpleRegex
   def: (dit|deze|huidige?)\b
 RangePrefixRegex: !simpleRegex
-  def: (?<desc>van|tussen)
+  def: (van|tussen)
 CenturySuffixRegex: !simpleRegex
   def: (^eeuw|^centennium)\b
 ReferencePrefixRegex: !simpleRegex
@@ -94,7 +94,7 @@ AmPmDescRegex: !nestedRegex
   def: (:?{BaseDateTime.BaseAmPmDescRegex})
   references: [BaseDateTime.BaseAmPmDescRegex]
 DescRegex: !nestedRegex
-  def: (:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex})))|{OclockRegex})
+  def: (:?(:?({OclockRegex}\s+)?(?<desc>({AmPmDescRegex}|{AmDescRegex}|{PmDescRegex}|{SpecialDescRegex}))\.?)|{OclockRegex})
   references: [ OclockRegex, AmDescRegex, PmDescRegex, AmPmDescRegex, SpecialDescRegex ]
 PmRegex: !nestedRegex
   def: (?<pm>({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)(((na)?middag|avond|(midder)?nacht|lunchtijd))|dag)
@@ -103,7 +103,7 @@ PmRegexFull: !nestedRegex
   def: (?<pm>(({ApostrofsRegex}|des)\s+(\bmiddags|avonds|nachts)|((in|tegen|op|om|met)\s+(de\s+)?)?(((na)?middag|avond|(midder)?nacht|lunchtijd))))
   references: [ ApostrofsRegex ]
 AmRegex: !nestedRegex
-  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag)(ochtend|morgen)|^?ochtend))
+  def: (?<am>(({ApostrofsRegex}|des)\s+(ochtends|morgens)|((in|tegen|op)\s+de)(\s+(ochtend|morgen))|(?<=gisteren|morgen|vandaag|(maan|dins|woens|donder|vrij|zater|zon)dag)(ochtend|morgen)|^?ochtend))
   references: [ ApostrofsRegex ]
 FullDescRegex: !nestedRegex
   def: ({DescRegex}|{AmRegex}|{PmRegexFull})
@@ -111,8 +111,8 @@ FullDescRegex: !nestedRegex
 # Exclude cases that include the "Am/Pm" suffix
 # Exclude when preceded by "$" symbol
 TwoDigitYearRegex: !nestedRegex
-  def: \b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*((\:\d)|\skeer|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
-  references: [ AmDescRegex, PmDescRegex]
+  def: \b(?<!\$)(?<year>([0-24-9]\d))(?!(\s*(([:.]\d)|keer|uurs?|{AmDescRegex}|{PmDescRegex})))\b
+  references: [ AmDescRegex, PmDescRegex, ApostrofsRegex]
 YearRegex: !nestedRegex
   def: ({BaseDateTime.FourDigitYearRegex}|{FullTextYearRegex})
   references: [ BaseDateTime.FourDigitYearRegex, FullTextYearRegex ]
@@ -151,10 +151,10 @@ FromRegex: !simpleRegex
 BetweenTokenRegex: !simpleRegex
   def: \b(tussen)$
 SimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?({DayRegex}((\s*),?(\s*){MonthSuffixRegex})?)\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex}|{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
+  def: \b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}(\s*),?(\s*){MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex ]
 MonthFrontSimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b
+  def: \b({RangePrefixRegex}\s+)?(({MonthSuffixRegex}\s+((van)\s+)?({DayRegex})|({DayRegex})\s+((van)\s+)?{MonthSuffixRegex})\s*{TillRegex}\s*({DayRegex})|(op\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})\s+{MonthSuffixRegex})((\s+|\s*,\s*){YearRegex})?\b
   references: [ MonthSuffixRegex, DayRegex, TillRegex, YearRegex, RangePrefixRegex ]
 MonthFrontBetweenRegex: !nestedRegex
   def: \b{MonthSuffixRegex}\s+(tussen\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
@@ -169,7 +169,7 @@ MonthWithYear: !nestedRegex
   def: \b(({WrittenMonthRegex}(\.)?(\s*)[/\\\-\.,]?(\s+(van|over|in))?(\s*){RelativeYearRegex})|({RelativeYearRegex}(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, RelativeYearRegex ]
 OneWordPeriodRegex: !nestedRegex
-  def: \b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar)|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
+  def: \b((((de\s+)?maand\s+(van\s+)?)?({StrictRelativeRegex}\s+)?(?<month>januari|februari|maart|april|mei|juni|juli|augustus|september|oktober|november|december|jan\.?|feb\.?|mar\.?|mrt\.?|apr\.?|jun\.?|jul\.?|aug\.?|sep\.?|sept\.?|oct\.?|okt\.?|nov\.?|dec\.?))|(maand|jaar)\s+tot(\s+op)?\s+heden|(({RelativeRegex}\s+)(mijn\s+)?(weekend|week|maand|jaar(?!\s+hoger dan))|({RelativeRegex}\s+)?(mijn\s+)(weekend|week|maand|jaar))(?!((\s+van)?\s+\d+|\s+tot(\s+op)?\s+heden|nu))(\s+{AfterNextSuffixRegex})?)\b
   references: [ StrictRelativeRegex, RelativeRegex, AfterNextSuffixRegex ]
 MonthNumWithYear: !nestedRegex
   def: \b(({BaseDateTime.FourDigitYearRegex}(\s*)[/\-\.](\s*){MonthNumRegex})|({MonthNumRegex}(\s*)[/\-](\s*){BaseDateTime.FourDigitYearRegex}))\b
@@ -217,8 +217,9 @@ LaterPrefixRegex: !simpleRegex
 PrefixPeriodRegex: !nestedRegex
   def: ({EarlyPrefixRegex}|{MidPrefixRegex}|{LaterPrefixRegex})
   references: [EarlyPrefixRegex, MidPrefixRegex, LaterPrefixRegex]
-PrefixDayRegex: !simpleRegex
-  def: \b(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b
+PrefixDayRegex: !nestedRegex
+  def: \b(((?<!{WeekDayRegex}\s+)(?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))?(\s+de\s+dag)?$)|^\s*(((?<!{WeekDayRegex}\s+)(?<EarlyPrefix>eerder|vroeg(er)?|begin|start)|(?<MidPrefix>midden|halverwege|op\s+de\s+helft)|in\s+de|(?<LatePrefix>laat|later))(\s+(in|op|van))(\s+de\s+dag))\b
+  references: [ WeekDayRegex ]
 SeasonDescRegex: !simpleRegex
   def: (?<seas>lente|voorjaar|zomer|herfst|najaar|winter)
 SeasonRegex: !nestedRegex
@@ -249,16 +250,16 @@ RelaxedOnRegex: !simpleRegex
 PrefixWeekDayRegex: !simpleRegex
   def: (\s*((,?\s*op)|[-—–]))
 ThisRegex: !nestedRegex
-  def: \b((deze(\s+week)?(\s+op)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b
-  references: [ WeekDayRegex ]
+  def: \b((deze(\s+week{PrefixWeekDayRegex}?)?\s*){WeekDayRegex})|({WeekDayRegex}((\s+van)?\s*deze\s+week))\b
+  references: [ WeekDayRegex, PrefixWeekDayRegex ]
 LastDateRegex: !nestedRegex
-  def: \b({PreviousPrefixRegex}(\s*week)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b
-  references: [ PreviousPrefixRegex, WeekDayRegex ]
+  def: \b({PreviousPrefixRegex}(\s*week{PrefixWeekDayRegex}?)?\s+{WeekDayRegex})|({WeekDayRegex}(\s+vorige\s+week))\b
+  references: [ PreviousPrefixRegex, WeekDayRegex, PrefixWeekDayRegex ]
 WeekDayForNextDateRegex: !simpleRegex
   def: \b(?<weekday>((ma|di(ns)?|wo(e(ns)?)?|do|vr(ij)?|za(t)?|zo)(\.|\b))|((?:maan(?!den)|dins|woens|donder|vrij|zater|zon)(dag)?))
 NextDateRegex1: !nestedRegex
-  def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})
-  references: [ NextPrefixRegex, WeekDayForNextDateRegex ]
+  def: \b({NextPrefixRegex}(\s*week{PrefixWeekDayRegex}?)?\s+{WeekDayForNextDateRegex}|(op\s+)?{WeekDayForNextDateRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayForNextDateRegex})
+  references: [ NextPrefixRegex, WeekDayForNextDateRegex, PrefixWeekDayRegex ]
 NextDateRegex2: !nestedRegex
   def: \b({NextPrefixRegex}(\s*week(\s*,?\s*op)?)?\s+{WeekDayRegex}|(op\s+)?{WeekDayRegex}\s+((van\s+)?(de\s+)?{NextPrefixRegex})\s*week|(op\s+)?{NextPrefixRegex}\s*week\s+{WeekDayRegex})
   references: [ NextPrefixRegex, WeekDayRegex ]
@@ -266,7 +267,7 @@ NextDateRegex: !nestedRegex
   def: ({NextDateRegex1}|{NextDateRegex2})
   references: [ NextDateRegex1, NextDateRegex2 ]
 SpecialDayRegex: !nestedRegex
-  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor)|((de\s+)?({RelativeRegex}|mijn)\s+dag)|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)
+  def: \b(eergisteren|overmorgen|(de\s+)?dag\s+na\s+morgen|(de\s+)?dag\s+(ervoor|erna)|((de\s+)?({RelativeRegex}|mijn)\s+dag)\b|gisteren|(deze\s+)?morgen|vandaag|morgen(middag))(?!s\b)
   references: [ RelativeRegex ]
 SpecialDayWithNumRegex: !nestedRegex
   def: \b((?<number>{WrittenNumRegex})\s+dag(en)?\s+(gerekend\s+)?(vanaf\s+)(?<day>gisteren|morgen|vandaag))\b
@@ -292,7 +293,7 @@ DateExtractorYearTermRegex: !nestedRegex
   references: [ DateYearRegex ]
 # Maandag, Mei 2
 DateExtractor1: !nestedRegex
-  def: \b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex})|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}\b)?
+  def: \b({WeekDayRegex}\s*[,-]?\s*)?(({MonthRegex}(\.)?\s*[/\\.,-]?\s*{DayRegex}(?!\s*{MonthRegex}))|(\({MonthRegex}\s*[-.]\s*{DayRegex}\))|({DayRegex}(\.)?\s*[/\\.,-]?\s*{MonthRegex}))(\s*\(\s*{WeekDayRegex}\s*\))?({DateExtractorYearTermRegex}(?!\s*{MonthRegex})\b)?
   references: [ WeekDayRegex, MonthRegex, DayRegex, DateExtractorYearTermRegex ]
 # Maandag 2 Mei
 # TODO: add ... van 2019?
@@ -321,13 +322,13 @@ DateExtractor7S: !nestedRegex
 # Only use the long Regex would ignore "11/20" in "11/20, 12/20" and it is hard to exhaust all characters after the "year" as we also have cases like "11/20, 12 of April"
 # Same for DateExtractor9L and DateExtractor9S
 DateExtractor8: !nestedRegex
-  def: ((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
+  def: \b((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?(?<!(morgen|ochtend|middag|avond|nacht)s?\s+){DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
   references: [ DayRegex, MonthNumRegex, WeekDayRegex, DatePreposition, BaseDateTime.CheckDecimalRegex, FullDescRegex ]
 DateExtractor9L: !nestedRegex
   def: \b({WeekDayRegex}\s+)?{DayRegex}\s*[-|\/|.]\s*{MonthNumRegex}((\s+|\s*,\s*|\s+in\s+){DateYearRegex})(?![%])\b
   references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex ]
 DateExtractor9S: !nestedRegex
-  def: \b(?<!naar\s+)((?<=(^|{DatePreposition}\s+)){WeekDayRegex}\s+)?{DayRegex}\s*[\-\/.]\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
+  def: \b(?<!naar\s+)({WeekDayRegex}\s+)?{DayRegex}\s*(\/|\.)\s*{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}(?!([%]|\s*{FullDescRegex}))\b
   references: [ DayRegex, MonthNumRegex, DateYearRegex, WeekDayRegex, BaseDateTime.CheckDecimalRegex, FullDescRegex, DatePreposition ]
 DateExtractorA: !nestedRegex
   def: \b({WeekDayRegex}\s+)?({BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+)|{MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*(de\s*)?(?<day>(?:3[0-1]|[1-2]\d|0?[1-9]))(?:ste|de|e)?|{DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex})
@@ -368,10 +369,10 @@ TimePrefix: !nestedRegex
   def: (?<prefix>(half|{LessThanOneHour}\s+(over|voor|na)(\s+half)?)|(uur\s+{LessThanOneHour}))
   references: [ LessThanOneHour ]
 TimeSuffix: !nestedRegex
-  def: (?<suffix>{AmRegex}|{PmRegex}|{OclockRegex})
+  def: (?<suffix>(({OclockRegex}\s+)?({AmRegex}|{PmRegex}))|{OclockRegex})
   references: [ AmRegex, PmRegex, OclockRegex ]
 TimeSuffixFull: !nestedRegex
-  def: (?<suffix>{AmRegex}|{PmRegexFull}|{OclockRegex})
+  def: (?<suffix>(({OclockRegex}\s+)?({AmRegex}|{PmRegexFull}))|{OclockRegex})
   references: [ AmRegex, PmRegexFull, OclockRegex ]
 HourDTRegEx: !nestedRegex
   def: ({BaseDateTime.HourRegex})
@@ -393,7 +394,7 @@ MidmorningRegex: !simpleRegex
 MidafternoonRegex: !simpleRegex
   def: (?<midafternoon>mid\s*(-\s*)?middag|halverwege de middag|het midden van de middag)
 MiddayRegex: !nestedRegex
-  def: (?<midday>(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)
+  def: (?<midday>(?<!gisteren|morgen)(((rond\s+)?(het|de)|{ApostrofsRegex})\s+)?middag(uur|s|loos)?|namiddag|noen|lunchtijd)
   references: [ ApostrofsRegex ]
 MidTimeRegex: !nestedRegex
   def: (?<mid>({MidnightRegex}|{MidmorningRegex}|{MidafternoonRegex}|{MiddayRegex}))
@@ -425,7 +426,7 @@ TimeRegexFilter: !nestedRegex
   def: \b((iedere|elke|op)(\s+andere)?\s+)?(week|dag|{SingleWeekDayRegex}|vandaag)\b
   references: [ SingleWeekDayRegex ]
 TimeRegex1: !nestedRegex
-  def: \b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|((?<prefix>half)\s+)?(?!een){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)
+  def: \b(({TimePrefix}|{AroundRegex})\s+)?(({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})(\s*{DescRegex})|(({AroundRegex})\s+){HourNumRegex}(?!\s+{SingleWeekDayRegex})\b)
   references: [ TimePrefix, WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, DescRegex, AroundRegex, SingleWeekDayRegex ]
 TimeRegex2: !nestedRegex
   def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?(:|\.)(\s*)?(?<min>[0-5]\d)(?!(\d|\s*(per|pro)\s*cent|%))((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*u)?((\s*{DescRegex})|\b)
@@ -443,7 +444,7 @@ TimeRegex6: !nestedRegex
   def: '{BasicTime}(\s*u\s*)?(\s*{DescRegex})?\s+{TimeSuffix}\b'
   references: [ BasicTime, DescRegex, TimeSuffix ]
 TimeRegex7: !nestedRegex
-  def: ({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?(?<!van(avond|nacht)\s+)({WrittenTimeRegex}|{BasicTime}))((\s*{DescRegex})|\b)|({WrittenTimeRegex}|{BasicTime})(\s*{DescRegex})(\s*{TimeSuffixFull})
+  def: ({TimeSuffixFull}\s+(om\s+)?({TimePrefix}\s+)?(?<!van(avond|nacht)\s+){BasicTime})((\s*{DescRegex})|\b)|{BasicTime}(\s*{DescRegex})(\s*{TimeSuffixFull})
   references: [ TimeSuffixFull, BasicTime, DescRegex, WrittenTimeRegex, TimePrefix ]
 TimeRegex8: !nestedRegex
   def: .^
@@ -467,7 +468,7 @@ PureNumFromToPrefixExcluded: !nestedRegex
   def: ({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{TillRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
   references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, TillRegex, PmRegex, AmRegex ]
 PureNumFromToPrefix: !nestedRegex
-  def: (({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
+  def: (({PmRegexFull}|{AmRegex})\s+)?({RangePrefixRegex}\s+)({HourDTRegEx}|{PeriodHourNumRegex})(\s+uur)?(\s*(?<leftDesc>({PmRegex}|{AmRegex}|{DescRegex})))?\s*{RangeConnectorRegex}\s*({HourDTRegEx}|{PeriodHourNumRegex})(\s+uur)?(?<rightDesc>\s*({PmRegex}|{AmRegex}|{DescRegex}))?
   references: [ HourDTRegEx, PeriodHourNumRegex, DescRegex, RangeConnectorRegex, PmRegex, PmRegexFull, AmRegex, RangePrefixRegex ]
 PureNumFromToWithDateBefore: !nestedRegex
   def: ({RangePrefixRegex}\s+)({HourDTRegEx})(\s+(vandaag|morgen)\s+)?(\s*{RangeConnectorRegex}\s*)({HourDTRegEx})
@@ -542,8 +543,11 @@ PeriodSpecificTimeOfDayRegex: !nestedRegex
   def: \b(({StrictRelativeRegex}(\s+)?{PeriodTimeOfDayRegex})\b|\bvan(nacht|avond|(na)?middag|ochtend))\b
   references: [ PeriodTimeOfDayRegex, StrictRelativeRegex ]
 PeriodTimeOfDayWithDateRegex: !nestedRegex
- def: (({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))\b
- references: [ TimeOfDayRegex ]
+  def: (({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))\b
+  references: [ TimeOfDayRegex ]
+PeriodTimeOfDayWithDateRegexWithAnchors: !nestedRegex
+  def: ((({TimeOfDayRegex}(\s+(om|rond|van|tegen|op(\s+de)?))?))(?=({MiddlePauseRegex})?\s*$)|(?<=^\s*({MiddlePauseRegex})?){TimeOfDayRegex})
+  references: [ TimeOfDayRegex, MiddlePauseRegex ]
 LessThanRegex: !simpleRegex
   def: \b((binnen\s+)?minder\s+dan)\b
 MoreThanRegex: !simpleRegex
@@ -577,12 +581,12 @@ NumberCombinedWithDurationUnit: !nestedRegex
   def: \b(?<num>\d+([.,:]\d*)?)(-)?{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 AnUnitRegex: !nestedRegex
-  def: \b((?<half>((nog een|een|nog)\s+(anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}
+  def: \b((((nog een|een|nog)\s+(?<half>anderhalf|anderhalve|half|halve)?))|andere)\s*{DurationUnitRegex}
   references: [ DurationUnitRegex ]
 DuringRegex: !simpleRegex
   def: \b(voor\s+een|gedurende\s+(het|de))\s+(?<unit>jaar|maand|week|dag)\b
 AllRegex: !simpleRegex
-  def: \b(?<all>(voor\s+)?((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b
+  def: \b(?<all>((de|het|een)\s+)?((ge)?hele|volledige|ganse|heel|volledig|volle)(\s+|-)(?<unit>jaar|maand|week|dag))\b
 HalfRegex: !simpleRegex
   def: (((een)\s*)|\b)(?<half>(half|halve)\s+(?<unit>jaar|maand|week|dag|uur|halfuur)|(?<unit>halfuur))\b
 ConjunctionRegex: !simpleRegex
@@ -618,11 +622,11 @@ AsapTimeRegex: !simpleRegex
   def: \b(zo\s+snel\s+mogelijk|zsm)\b
 InclusiveModPrepositions: !simpleRegex
   def: (?<include>((in|tegen|tijdens|op|om)\s+of\s+)|(\s+of\s+(in|tegen|tijdens|op)))
+AfterRegex: !nestedRegex
+  def: (\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na)|(het\s+)?jaar hoger dan)(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)
+  references: [ InclusiveModPrepositions ]
 BeforeRegex: !nestedRegex
   def: (\b(?<!afspraak\s*){InclusiveModPrepositions}?(voor|vóór|vooraf(gaand?)?\s+aan|(niet\s+later|vroeger|eerder)\s+dan|eindigend\s+(op|met)|tegen|tot(dat)?|uiterlijk|(?<include>(al\s+)?zo\s+laat\s+als)){InclusiveModPrepositions}?\b\s*)|(?<!\w|>)((?<include><=)|<)
-  references: [ InclusiveModPrepositions ]
-AfterRegex: !nestedRegex
-  def: (\b{InclusiveModPrepositions}?((na(\s+afloop\s+van)?|(?<!niet\s+)later\s+dan)|(jaar\s+na))(?!\s+of\s+gelijk\s+aan){InclusiveModPrepositions}?\b\s*)|(?<!\w|<)((?<include>>=)|>)
   references: [ InclusiveModPrepositions ]
 SinceRegex: !simpleRegex
   def: (\b(sinds|na\s+of\s+gelijk\s+aan|(startend|beginnend)\s+(vanaf|op|met)|(al\s+)?zo\s+vroeg\s+als|(elk|ieder)\s+moment\s+vanaf|een\s+tijdstip\s+vanaf)\b\s*)|(?<!\w|<)(>=)
@@ -659,7 +663,7 @@ AfternoonStartEndRegex: !nestedRegex
   references: [ ApostrofsRegex, PmDescRegex ]
 EveningStartEndRegex: !nestedRegex
   def: (^(({ApostrofsRegex}|des)\s+avonds|in\s+de\s+(na)?avond|deze\s+avond|avond\s+in\s+het\s+begin|aan\s+het\s+einde?(\s+van(\s+de)?)?\s+avond|{PmDescRegex}|avond))|((({ApostrofsRegex}|des)?\s+avonds|deze\s+avond|in\s+de\s+(na)?avond|avond\s+in\s+het\s+begin|avond\s+aan\s+het\s+einde?|{PmDescRegex}|avond)$)
-  references: [ ApostrofsRegex ]
+  references: [ ApostrofsRegex, PmDescRegex ]
 NightStartEndRegex: !nestedRegex
   def: (^(gedurende de nacht|vannacht|nacht|({ApostrofsRegex}|des)?\s+nachts))|((gedurende\s+de\s+nacht|vannacht|({ApostrofsRegex}|des)?\s+nachts|nacht\s+in\s+het\s+begin|nacht)$)
   references: [ ApostrofsRegex ]
@@ -708,8 +712,10 @@ RestOfDateTimeRegex: !simpleRegex
 MealTimeRegex: !simpleRegex
   def: \b((tijdens\s+de\s+)?(?<mealTime>lunch)|((om|tegen)\s+)?(?<mealTime>lunchtijd))\b
 AmbiguousRangeModifierPrefix: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: (voor)
+PotentialAmbiguousRangeRegex: !nestedRegex
+  def: \b{AmbiguousRangeModifierPrefix}(.+\b(boven|later|groter|erna|daarna|hoger|(?<!de\s+)({DateUnitRegex}|uur|uren|minuten|minuut|mins|min|secondes|seconden|secs|sec|nacht(en)?)|van(af)?|tussen|tot(dat|\s+en\s+met)?|gedurende|tijdens|ten tijde van|(?<ambiguous>{BaseDateTime.RangeConnectorSymbolRegex}))\b)
+  references: [ AmbiguousRangeModifierPrefix, BaseDateTime.RangeConnectorSymbolRegex, DateUnitRegex ]
 NumberEndingPattern: !nestedRegex
   def: ^(\s+((?<meeting>vergadering|afspraak|conferentie|telefoontje|skype-gesprek)\s+)?(om|naar)\s+(?<newTime>{PeriodHourNumRegex}|{HourRegex})((\.)?$|(\.,|,|!|\?)))
   references: [PeriodHourNumRegex, HourRegex]
@@ -745,13 +751,13 @@ DateNumberConnectorRegex: !simpleRegex
 DecadeRegex: !simpleRegex
   def: (?<decade>(nul|tien|twintig|dertig|veertig|vijftig|zestig|zeventig|tachtig|negentig)|(fifties|sixties|seventies|eighties|nineties|zeroes|tens|tweeduizend|(ee|éé)nentwintigste\s+eeuw))
 DecadeWithCenturyRegex: !nestedRegex
-  def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<=\b(de|jaren)\s+)(?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?)?{DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
+  def: \b(de\s+)?(jaren\s+)?((?<!\$)((?<=\b(de|jaren)\s+)(?<century>1\d|2\d|\d)?({ApostrofRegex})?(?<decade>\d0)({ApostrofRegex})?s?)(?!%)\b|(({CenturyRegex}(\s+|-)?(en\s+)?|(?<=\b(de|jaren)\s+)){DecadeRegex})|({CenturyRegex}(\s+|-)?(en\s+)?(?<decade>tien|honderd)))
   references: [ CenturyRegex, DecadeRegex, ApostrofRegex ]
 RelativeDecadeRegex: !nestedRegex
   def: \b(((de|het)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?decenni(a|um)?)\b
   references: [ RelativeRegex ]
 SuffixAfterRegex: !simpleRegex
-  def: \b(((bij)\s)?(of|en)\s+(boven|na|later|groter|erna|daarna|hoger)(?!\s+dan))\b
+  def: \b(((bij)\s)?(of|en)\s+(boven|later|groter|erna|daarna|hoger)(?!\s+dan))\b
 DateAfterRegex: !simpleRegex
   def: \b((of|en)\s+(hoger|later|groter)(?!\s+dan))\b
 YearPeriodRegex: !nestedRegex
@@ -1304,7 +1310,7 @@ AmbiguityFiltersDict: !dictionary
 AmbiguityTimeFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    '^(\d{1,2}|\p{L}+)\s+uur$': '(?<LB>(?<!\b(om|is|vanaf|morgen|vandaag|gisteren|\d+)\s+)\b(\d{1,2}|\p{L}+)\s+uur\b)(?(LB)(?!\s+(tot|morgen|vandaag|gisteren|\d+)\b))'
+    '^(\d{1,2}|\p{L}+)\s+uur$': '(?<LB>(?<!\b(om|is|vanaf|morgen|vandaag|gisteren|\d+)(\s+(\d{1,2}|\p{L}+)\s+uur\s+(of|en))?\s+)\b(\d{1,2}|\p{L}+)\s+uur\b)(?(LB)(?!\s+(tot|morgen|vandaag|gisteren|\d+)\b))'
 # For TimeOfDay resolution
 MorningTermList: !list
   types: [ string ]
@@ -1349,6 +1355,7 @@ PlusOneDayTerms: !list
   entries:
     - morgen
     - dag na
+    - dag erna
     - volgende dag
     - morgenochtend
     - morgenavond

--- a/Specs/DateTime/Dutch/DateTimeModel.json
+++ b/Specs/DateTime/Dutch/DateTimeModel.json
@@ -1121,15 +1121,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor 3,5 jaar",
-        "Start": 11,
+        "Text": "3,5 jaar",
+        "Start": 16,
         "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3.5Y",
-              "Mod": "before",
               "type": "duration",
               "value": "110376000"
             }
@@ -1146,15 +1145,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor 3 minuten",
-        "Start": 11,
+        "Text": "3 minuten",
+        "Start": 16,
         "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT3M",
-              "Mod": "before",
               "type": "duration",
               "value": "180"
             }
@@ -1171,15 +1169,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor 123,45 sec",
-        "Start": 11,
+        "Text": "123,45 sec",
+        "Start": 16,
         "End": 25,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT123.45S",
-              "Mod": "before",
               "type": "duration",
               "value": "123.45"
             }
@@ -1196,8 +1193,8 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele dag",
-        "Start": 11,
+        "Text": "de hele dag",
+        "Start": 16,
         "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -1220,15 +1217,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor vierentwintig uur",
-        "Start": 11,
+        "Text": "vierentwintig uur",
+        "Start": 16,
         "End": 32,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT24H",
-              "Mod": "before",
               "type": "duration",
               "value": "86400"
             }
@@ -1245,8 +1241,8 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele maand",
-        "Start": 11,
+        "Text": "de hele maand",
+        "Start": 16,
         "End": 28,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
@@ -1269,15 +1265,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor een uur",
-        "Start": 11,
+        "Text": "een uur",
+        "Start": 16,
         "End": 22,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT1H",
-              "Mod": "before",
               "type": "duration",
               "value": "3600"
             }
@@ -1294,15 +1289,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor paar uur",
-        "Start": 11,
+        "Text": "paar uur",
+        "Start": 16,
         "End": 23,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT2H",
-              "Mod": "before",
               "type": "duration",
               "value": "7200"
             }
@@ -1319,15 +1313,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor een paar minuten",
-        "Start": 11,
+        "Text": "een paar minuten",
+        "Start": 16,
         "End": 31,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "PT2M",
-              "Mod": "before",
               "type": "duration",
               "value": "120"
             }
@@ -1344,15 +1337,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor wat dagen",
-        "Start": 11,
+        "Text": "wat dagen",
+        "Start": 16,
         "End": 24,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3D",
-              "Mod": "before",
               "type": "duration",
               "value": "259200"
             }
@@ -1369,15 +1361,14 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor enige weken",
-        "Start": 11,
+        "Text": "enige weken",
+        "Start": 16,
         "End": 26,
         "TypeName": "datetimeV2.duration",
         "Resolution": {
           "values": [
             {
               "timex": "P3W",
-              "Mod": "before",
               "type": "duration",
               "value": "1814400"
             }
@@ -2160,7 +2151,6 @@
     "Context": {
       "ReferenceDateTime": "2017-12-04T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -2181,7 +2171,7 @@
       {
         "Text": "10 uur",
         "Start": 29,
-        "End": 35,
+        "End": 34,
         "TypeName": "datetimeV2.time",
         "Resolution": {
           "values": [
@@ -3087,7 +3077,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-18T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -3169,18 +3158,17 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het jaar",
-        "Start": 29,
+        "Text": "het jaar",
+        "Start": 34,
         "End": 41,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018",
-              "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "end": "2018-01-01"
+              "start": "2018-01-01",
+              "end": "2019-01-01"
             }
           ]
         }
@@ -4058,30 +4046,24 @@
     "Context": {
       "ReferenceDateTime": "2018-06-22T00:00:00"
     },
-    "Comment": "Ambiguity issue of 'voor' that can be interpreted both as 'before' and 'for'",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de 9e van mei",
-        "Start": 28,
+        "Text": "de 9e van mei",
+        "Start": 33,
         "End": 45,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
             {
               "timex": "XXXX-05-09",
-              "Mod": "before",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "end": "2018-05-09"
+              "type": "date",
+              "value": "2018-05-09"
             },
             {
               "timex": "XXXX-05-09",
-              "Mod": "before",
-              "type": "daterange",
-              "sourceEntity": "datetimepoint",
-              "end": "2019-05-09"
+              "type": "date",
+              "value": "2019-05-09"
             }
           ]
         }
@@ -5730,7 +5712,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T10:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5856,7 +5837,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5908,12 +5888,11 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het jaar hoger dan 2012",
-        "Start": 18,
+        "Text": "het jaar hoger dan 2012",
+        "Start": 23,
         "End": 45,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -5922,7 +5901,8 @@
               "timex": "2012",
               "Mod": "after",
               "type": "daterange",
-              "start": "2013-01-01"
+              "start": "2013-01-01",
+              "sourceEntity": "datetimerange"
             }
           ]
         }
@@ -5934,7 +5914,6 @@
     "Context": {
       "ReferenceDateTime": "2018-08-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -5948,6 +5927,7 @@
               "timex": "2012",
               "Mod": "since",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2012-01-01"
             }
           ]
@@ -6152,11 +6132,9 @@
   },
   {
     "Input": "Wat is de verkoop voor tussen 2015 en 2018 of later dan 2020",
-    "Comment": "With 2 points ranges 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6178,7 +6156,7 @@
       {
         "Text": "later dan 2020",
         "Start": 46,
-        "End": 60,
+        "End": 59,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
@@ -6186,6 +6164,7 @@
               "timex": "2020",
               "Mod": "after",
               "type": "daterange",
+              "sourceEntity": "datetimerange",
               "start": "2021-01-01"
             }
           ]
@@ -6321,39 +6300,28 @@
     ]
   },
   {
-    "Input": "hi donderdag 29-3 11 uur 's ochtends is goed",
+    "Input": "hi donderdag 29/3 11 uur 's ochtends is goed",
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "donderdag 29-3 11 uur 's ochtends",
+        "Text": "donderdag 29/3 11 uur 's ochtends",
         "Start": 3,
-        "End": 36,
+        "End": 35,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-03-29T11:00",
+              "timex": "XXXX-03-29T11",
               "type": "datetime",
               "value": "2018-03-29 11:00:00"
             },
             {
-              "timex": "XXXX-03-29T11:00",
+              "timex": "XXXX-03-29T11",
               "type": "datetime",
               "value": "2019-03-29 11:00:00"
-            },
-            {
-              "timex": "XXXX-03-29T23:00",
-              "type": "datetime",
-              "value": "2018-03-29 23:00:00"
-            },
-            {
-              "timex": "XXXX-03-29T23:00",
-              "type": "datetime",
-              "value": "2019-03-29 23:00:00"
             }
           ]
         }
@@ -6365,7 +6333,6 @@
     "Context": {
       "ReferenceDateTime": "2018-09-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6376,16 +6343,16 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-06-04T09:30,XXXX-06-04T16:30,PT7H)",
+              "timex": "(XXXX-04-06T09:30,XXXX-04-06T16:30,PT7H)",
               "type": "datetimerange",
-              "start": "2018-06-04 09:30:00",
-              "end": "2018-06-04 16:30:00"
+              "start": "2018-04-06 09:30:00",
+              "end": "2018-04-06 16:30:00"
             },
             {
-              "timex": "(XXXX-06-04T09:30,XXXX-06-04T16:30,PT7H)",
+              "timex": "(XXXX-04-06T09:30,XXXX-04-06T16:30,PT7H)",
               "type": "datetimerange",
-              "start": "2019-06-04 09:30:00",
-              "end": "2019-06-04 16:30:00"
+              "start": "2019-04-06 09:30:00",
+              "end": "2019-04-06 16:30:00"
             }
           ]
         }
@@ -6830,7 +6797,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -6856,7 +6822,6 @@
     "Context": {
       "ReferenceDateTime": "2018-10-24T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7097,13 +7062,13 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(XXXX-WXX-1T10,XXXX-WXX-1T12,PT2H)",
+              "timex": "(XXXX-WXX-1T10:00,XXXX-WXX-1T12:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-10-29 10:00:00",
               "end": "2018-10-29 12:00:00"
             },
             {
-              "timex": "(XXXX-WXX-1T10,XXXX-WXX-1T12,PT2H)",
+              "timex": "(XXXX-WXX-1T10:00,XXXX-WXX-1T12:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-11-05 10:00:00",
               "end": "2018-11-05 12:00:00"
@@ -7118,7 +7083,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7144,13 +7108,13 @@
               "timex": "(XXXX-WXX-1T22:00,XXXX-WXX-2T00:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-10-29 22:00:00",
-              "end": "2018-10-30 00:00:00"
+              "end": "2018-10-29 00:00:00"
             },
             {
               "timex": "(XXXX-WXX-1T22:00,XXXX-WXX-2T00:00,PT2H)",
               "type": "datetimerange",
               "start": "2018-11-05 22:00:00",
-              "end": "2018-11-06 00:00:00"
+              "end": "2018-11-05 00:00:00"
             }
           ]
         }
@@ -7197,7 +7161,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-10-31T15,2018-10-31T20,PT5H)",
+              "timex": "(2018-10-31T15:00,2018-10-31T20:00,PT5H)",
               "type": "datetimerange",
               "start": "2018-10-31 15:00:00",
               "end": "2018-10-31 20:00:00"
@@ -7212,7 +7176,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7223,7 +7186,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "(2018-10-31T8,2018-10-31T15,PT7H)",
+              "timex": "(2018-10-31T08,2018-10-31T15:00,PT7H)",
               "type": "datetimerange",
               "start": "2018-10-31 08:00:00",
               "end": "2018-10-31 15:00:00"
@@ -7326,12 +7289,6 @@
               "type": "datetimerange",
               "start": "2018-11-05 03:00:00",
               "end": "2018-11-05 08:00:00"
-            },
-            {
-              "timex": "(2018-11-05T15,2018-11-05T20,PT5H)",
-              "type": "datetimerange",
-              "start": "2018-11-05 15:00:00",
-              "end": "2018-11-05 20:00:00"
             }
           ]
         }
@@ -7430,7 +7387,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7445,6 +7401,12 @@
               "type": "datetimerange",
               "start": "2018-11-05 06:00:00",
               "end": "2018-11-05 08:00:00"
+            },
+            {
+              "timex": "(2018-11-05T18,2018-11-05T20,PT2H)",
+              "type": "datetimerange",
+              "start": "2018-11-05 18:00:00",
+              "end": "2018-11-05 20:00:00"
             }
           ]
         }
@@ -7459,18 +7421,17 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor dec-2018",
-        "Start": 15,
+        "Text": "dec-2018",
+        "Start": 20,
         "End": 27,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-12",
-              "Mod": "before",
               "type": "daterange",
-              "sourceEntity": "datetimerange",
-              "end": "2018-12-01"
+              "start": "2018-12-01",
+              "end": "2019-01-01"
             }
           ]
         }
@@ -7531,11 +7492,9 @@
   },
   {
     "Input": "Wat is je plan voor dec/2018-mei/2019",
-    "Comment": "With 2 points ranges, 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2018-11-01T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7585,7 +7544,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-08T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7722,7 +7680,6 @@
     "Context": {
       "ReferenceDateTime": "2018-11-28T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -7973,7 +7930,7 @@
       {
         "Text": "donderdag",
         "Start": 82,
-        "End": 91,
+        "End": 90,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -7993,7 +7950,7 @@
       {
         "Text": "vrijdag",
         "Start": 95,
-        "End": 102,
+        "End": 101,
         "TypeName": "datetimeV2.date",
         "Resolution": {
           "values": [
@@ -8006,6 +7963,34 @@
               "timex": "XXXX-WXX-5",
               "type": "date",
               "value": "2018-11-30"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "tussen 9-6 pt",
+        "Start": 104,
+        "End": 116,
+        "TypeName": "datetimeV2.timerange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(T09,T18,PT9H)",
+              "type": "timerange",
+              "timezone": "UTC-07:00",
+              "timezoneText": "pt",
+              "utcOffsetMins": "-420",
+              "start": "09:00:00",
+              "end": "18:00:00"
+            },
+            {
+              "timex": "(T21,T06,PT9H)",
+              "type": "timerange",
+              "timezone": "UTC-07:00",
+              "timezoneText": "pt",
+              "utcOffsetMins": "-420",
+              "start": "21:00:00",
+              "end": "06:00:00"
             }
           ]
         }
@@ -8393,7 +8378,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-05T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -8426,7 +8410,6 @@
     "Context": {
       "ReferenceDateTime": "2018-12-07T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
@@ -8933,11 +8916,9 @@
   },
   {
     "Input": "Boek een meeting in voor maandag 21 tussen 9:30 en 15:00 pst",
-    "Comment": "With 2 points ranges, 'voor' should be interpreted as 'for' instead of 'before'",
     "Context": {
       "ReferenceDateTime": "2019-02-27T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9365,29 +9346,28 @@
     ]
   },
   {
-    "Input": "Ik ga de 15e, 20:00 terug",
+    "Input": "Ik ga op de 15e, 20:00 terug",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "de 15e, 20:00",
-        "Start": 6,
-        "End": 26,
+        "Start": 9,
+        "End": 21,
         "TypeName": "datetimeV2.datetime",
         "Resolution": {
           "values": [
             {
-              "timex": "XXXX-11-15T20:00",
+              "timex": "XXXX-XX-15T20:00",
               "type": "datetime",
-              "value": "2016-11-15 20:00"
+              "value": "2016-10-15 20:00:00"
             },
             {
-              "timex": "XXXX-11-15T20:00",
+              "timex": "XXXX-XX-15T20:00",
               "type": "datetime",
-              "value": "2017-11-15 20:00"
+              "value": "2016-11-15 20:00:00"
             }
           ]
         }
@@ -9536,25 +9516,30 @@
     ]
   },
   {
-    "Input": "ik ben vandaag weg tussen vijf en zeven",
+    "Input": "ik ben weg vandaag tussen vijf en zeven",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "vandaag weg tussen vijf en zeven",
-        "Start": 7,
+        "Text": "vandaag tussen vijf en zeven",
+        "Start": 11,
         "End": 38,
-        "TypeName": "datetimeV2.daterange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "(2016-11-07T05,2016-11-07T07,PT2H)",
-              "type": "daterange",
+              "type": "datetimerange",
               "start": "2016-11-07 05:00:00",
               "end": "2016-11-07 07:00:00"
+            },
+            {
+              "timex": "(2016-11-07T17,2016-11-07T19,PT2H)",
+              "type": "datetimerange",
+              "start": "2016-11-07 17:00:00",
+              "end": "2016-11-07 19:00:00"
             }
           ]
         }
@@ -9562,45 +9547,42 @@
     ]
   },
   {
-    "Input": "ik ben op 1 januari weg van 5 tot 6",
+    "Input": "ik ben weg op 1 januari van 5 tot 6",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1 januari",
-        "Start": 10,
-        "End": 18,
-        "TypeName": "datetimeV2.date",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "XXXX-01-01",
-              "type": "date",
-              "value": "2016-01-01"
-            },
-            {
-              "timex": "XXXX-01-01",
-              "type": "date",
-              "value": "2017-01-01"
-            }
-          ]
-        }
-      },
-      {
-        "Text": "van 5 tot 6",
-        "Start": 24,
+        "Text": "1 januari van 5 tot 6",
+        "Start": 14,
         "End": 34,
-        "TypeName": "datetimeV2.timerange",
+        "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
-              "type": "daterange",
+              "type": "datetimerange",
+              "start": "2016-01-01 05:00:00",
+              "end": "2016-01-01 06:00:00"
+            },
+            {
+              "timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
+              "type": "datetimerange",
               "start": "2017-01-01 05:00:00",
               "end": "2017-01-01 06:00:00"
+            },
+            {
+              "timex": "(XXXX-01-01T17,XXXX-01-01T18,PT1H)",
+              "type": "datetimerange",
+              "start": "2016-01-01 17:00:00",
+              "end": "2016-01-01 18:00:00"
+            },
+            {
+              "timex": "(XXXX-01-01T17,XXXX-01-01T18,PT1H)",
+              "type": "datetimerange",
+              "start": "2017-01-01 17:00:00",
+              "end": "2017-01-01 18:00:00"
             }
           ]
         }
@@ -9612,7 +9594,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9653,7 +9634,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "morgen",
@@ -9693,7 +9674,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -9719,7 +9699,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "T16,T17,PT1H)",
+              "timex": "(T16,T17,PT1H)",
               "type": "timerange",
               "start": "16:00:00",
               "end": "17:00:00"
@@ -10339,7 +10319,6 @@
     "Context": {
       "ReferenceDateTime": "2018-07-31T12:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -10359,17 +10338,17 @@
         }
       },
       {
-        "Text": "ochtend morgen",
-        "Start": 41,
+        "Text": "tot ochtend morgen",
+        "Start": 37,
         "End": 54,
         "TypeName": "datetimeV2.datetimerange",
         "Resolution": {
           "values": [
             {
               "timex": "2018-08-01TMO",
+              "Mod": "before",
               "type": "datetimerange",
-              "start": "2018-08-01 08:00:00",
-              "end": "2018-08-01 12:00:00"
+              "end": "2018-08-01 08:00:00"
             }
           ]
         }

--- a/Specs/DateTime/Dutch/DateTimePeriodParser.json
+++ b/Specs/DateTime/Dutch/DateTimePeriodParser.json
@@ -1723,14 +1723,14 @@
         "Text": "vrijdag tussen 1 en 4 uur ‘s middags",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(XXXX-WXX-5T01,XXXX-WXX-5T04,PT3H)",
+          "Timex": "(XXXX-WXX-5T13,XXXX-WXX-5T16,PT3H)",
           "FutureResolution": {
-            "startDateTime": "2017-11-10 01:00:00",
-            "endDateTime": "2017-11-10 04:00:00"
+            "startDateTime": "2017-11-10 13:00:00",
+            "endDateTime": "2017-11-10 16:00:00"
           },
           "PastResolution": {
-            "startDateTime": "2017-11-03 01:00:00",
-            "endDateTime": "2017-11-03 04:00:00"
+            "startDateTime": "2017-11-03 13:00:00",
+            "endDateTime": "2017-11-03 16:00:00"
           }
         },
         "Start": 58,

--- a/Specs/DateTime/Dutch/DurationExtractor.json
+++ b/Specs/DateTime/Dutch/DurationExtractor.json
@@ -688,10 +688,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele dag",
+        "Text": "de hele dag",
         "Type": "duration",
-        "Start": 11,
-        "Length": 16
+        "Start": 16,
+        "Length": 11
       }
     ]
   },
@@ -700,10 +700,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele week",
+        "Text": "de hele week",
         "Type": "duration",
-        "Start": 11,
-        "Length": 17
+        "Start": 16,
+        "Length": 12
       }
     ]
   },
@@ -712,10 +712,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele maand",
+        "Text": "de hele maand",
         "Type": "duration",
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -724,10 +724,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het hele jaar",
+        "Text": "het hele jaar",
         "Type": "duration",
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -736,10 +736,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele dag",
+        "Text": "de gehele dag",
         "Type": "duration",
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -748,10 +748,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele week",
+        "Text": "de gehele week",
         "Type": "duration",
-        "Start": 11,
-        "Length": 19
+        "Start": 16,
+        "Length": 14
       }
     ]
   },
@@ -760,10 +760,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele maand",
+        "Text": "de gehele maand",
         "Type": "duration",
-        "Start": 11,
-        "Length": 20
+        "Start": 16,
+        "Length": 15
       }
     ]
   },
@@ -772,10 +772,10 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het gehele jaar",
+        "Text": "het gehele jaar",
         "Type": "duration",
-        "Start": 11,
-        "Length": 20
+        "Start": 16,
+        "Length": 15
       }
     ]
   },

--- a/Specs/DateTime/Dutch/DurationParser.json
+++ b/Specs/DateTime/Dutch/DurationParser.json
@@ -1209,7 +1209,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele dag",
+        "Text": "de hele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1220,8 +1220,8 @@
             "duration": "86400"
           }
         },
-        "Start": 11,
-        "Length": 16
+        "Start": 16,
+        "Length": 11
       }
     ]
   },
@@ -1233,7 +1233,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele week",
+        "Text": "de hele week",
         "Type": "duration",
         "Value": {
           "Timex": "P1W",
@@ -1244,8 +1244,8 @@
             "duration": "604800"
           }
         },
-        "Start": 11,
-        "Length": 17
+        "Start": 16,
+        "Length": 12
       }
     ]
   },
@@ -1257,7 +1257,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de hele maand",
+        "Text": "de hele maand",
         "Type": "duration",
         "Value": {
           "Timex": "P1M",
@@ -1268,8 +1268,8 @@
             "duration": "2592000"
           }
         },
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -1281,7 +1281,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het hele jaar",
+        "Text": "het hele jaar",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y",
@@ -1292,8 +1292,8 @@
             "duration": "31536000"
           }
         },
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -1305,7 +1305,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele dag",
+        "Text": "de gehele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1316,8 +1316,8 @@
             "duration": "86400"
           }
         },
-        "Start": 11,
-        "Length": 18
+        "Start": 16,
+        "Length": 13
       }
     ]
   },
@@ -1329,7 +1329,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele week",
+        "Text": "de gehele week",
         "Type": "duration",
         "Value": {
           "Timex": "P1W",
@@ -1340,8 +1340,8 @@
             "duration": "604800"
           }
         },
-        "Start": 11,
-        "Length": 19
+        "Start": 16,
+        "Length": 14
       }
     ]
   },
@@ -1353,7 +1353,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor de gehele maand",
+        "Text": "de gehele maand",
         "Type": "duration",
         "Value": {
           "Timex": "P1M",
@@ -1364,8 +1364,8 @@
             "duration": "2592000"
           }
         },
-        "Start": 11,
-        "Length": 20
+        "Start": 16,
+        "Length": 15
       }
     ]
   },
@@ -1377,7 +1377,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor het gehele jaar",
+        "Text": "het gehele jaar",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y",
@@ -1388,8 +1388,8 @@
             "duration": "31536000"
           }
         },
-        "Start": 11,
-        "Length": 20
+        "Start": 16,
+        "Length": 15
       }
     ]
   },
@@ -1425,7 +1425,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "voor gehele dag",
+        "Text": "gehele dag",
         "Type": "duration",
         "Value": {
           "Timex": "P1D",
@@ -1436,8 +1436,8 @@
             "duration": "86400"
           }
         },
-        "Start": 11,
-        "Length": 15
+        "Start": 16,
+        "Length": 10
       }
     ]
   },

--- a/Specs/DateTime/Dutch/MergedParser.json
+++ b/Specs/DateTime/Dutch/MergedParser.json
@@ -1050,7 +1050,7 @@
     ]
   },
   {
-    "Input": "Ik zal de afspraak van tien uur 's ochtends naar twintig verzetten!",
+    "Input": "Ik zal de afspraak verzetten van tien uur 's ochtends naar twintig!",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
@@ -1068,7 +1068,7 @@
             }
           ]
         },
-        "Start": 23,
+        "Start": 33,
         "Length": 20
       },
       {
@@ -1083,7 +1083,7 @@
             }
           ]
         },
-        "Start": 49,
+        "Start": 59,
         "Length": 7
       }
     ]
@@ -1128,7 +1128,7 @@
     ]
   },
   {
-    "Input": "Ik zal de afspraak van tien uur 's ochtends naar negen verzetten!",
+    "Input": "Ik zal de afspraak verzetten van tien uur 's ochtends naar negen!",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
@@ -1146,7 +1146,7 @@
             }
           ]
         },
-        "Start": 23,
+        "Start": 33,
         "Length": 20
       },
       {
@@ -1166,7 +1166,7 @@
             }
           ]
         },
-        "Start": 49,
+        "Start": 59,
         "Length": 5
       }
     ]


### PR DESCRIPTION
Original specs: 385 pass, 2 fail.
Total specs: 552 pass, 179 fail.

The 2 failing cases involve time zones which are not supported for now.

PotentialAmbiguousRangeRegex has been enabled and implemented to help disambiguate patterns with 'voor'. 
Consequently, including 'voor' into duration patterns was no longer necessary and it has been reverted.

Handling of cases involving the limit time '12' has been modified in TimePeriod so that expressions like '10 to 12 in the morning' are parsed as (T10,T12) instead of (T22,T00).

Modified test cases:
- "Ik ga de 15e, 20:00 terug" -> "Ik ga op de 15e, 20:00 terug" (I'm going back on the 15th, 20:00), without preposition 'de 15e' cannot be extracted as date (same as in English 'the 15th' -> 'on the 15th').
- "ik ben vandaag weg tussen vijf en zeven" -> "ik ben weg vandaag tussen vijf en zeven" (I'm gone today between five and seven)
- "ik ben op 1 januari weg van 5 tot 6" -> "ik ben weg op 1 januari van 5 tot 6" (I'll be gone on January 1 from 5 to 6)

As in English number ranges can be interpreted as time ranges only when they are contiguous to a date.

In MergedParser:
- "Ik zal de afspraak van tien uur 's ochtends naar twintig verzetten!" -> "Ik zal de afspraak verzetten van tien uur 's ochtends naar twintig!" (I will reschedule the appointment from ten in the morning to twenty!)
- "Ik zal de afspraak van tien uur 's ochtends naar negen verzetten!" -> "Ik zal de afspraak verzetten van tien uur 's ochtends naar negen!" (I will reschedule the appointment from ten in the morning to nine!)

To avoid ambiguity, time ranges ending with pure numbers can be extracted only if not followed by other words.