### PR TITLE
[TimexLib] Months daterange duration resolver fix

### DIFF
--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_helpers.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_helpers.py
@@ -111,7 +111,7 @@ class TimexHelpers:
                     result.month = start.month
                     result.day_of_month = start.day_of_month
                     return result
-            if duration.month:
+            if duration.months:
                 if start.month:
                     result = Timex()
                     result.year = start.year

--- a/Python/tests/datatypes/test_timex_resolver.py
+++ b/Python/tests/datatypes/test_timex_resolver.py
@@ -246,6 +246,16 @@ def test_datatypes_resolver_dateRange_last_three_weeks():
     assert resolution.values[0].end == "2019-05-01"
 
 
+def test_datatypes_resolver_dateRange_last_six_months():
+    today = datetime(2021, 1, 1)
+    resolution = TimexResolver.resolve(["(2021-01-01,2021-07-01,P6M)"], today)
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "(2021-01-01,2021-07-01,P6M)"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2021-01-01"
+    assert resolution.values[0].end == "2021-07-01"
+
+
 def test_datatypes_resolver_dateRange_last_ten_years():
     today = datetime(2021, 1, 1)
     resolution = TimexResolver.resolve(["(2011-01-01,2021-01-01,P10Y)"], today)


### PR DESCRIPTION
* Timex like '(2021-01-01,2021-07-01,P6M)' is now resolved correctly
* Added a testcase for `last 6 months` in test_timex_resolver.py module