### PR TITLE
feat(TimexResolver): fixed first week of the year timex resolution

### DIFF
--- a/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_resolver.py
+++ b/Python/libraries/datatypes-timex-expression/datatypes_timex_expression/timex_resolver.py
@@ -164,7 +164,7 @@ class TimexResolver:
             Constants.DAYS['MONDAY'], date_in_week + timedelta(days=7))
 
         return TimexValue.date_value(Timex(year=start.year, month=start.month, day_of_month=start.day)), TimexValue.date_value(
-            Timex(year=start.year, month=start.month, day_of_month=end.day))
+            Timex(year=end.year, month=end.month, day_of_month=end.day))
 
     @staticmethod
     def resolve_date_range(timex: Timex, date: datetime):

--- a/Python/tests/datatypes/test_timex_resolver.py
+++ b/Python/tests/datatypes/test_timex_resolver.py
@@ -202,6 +202,17 @@ def test_datatypes_resolver_dateRange_winter():
     assert resolution.values[0].end is None
 
 
+def test_datatypes_resolver_dateRange_first_week():
+    today = datetime(2021, 1, 1)
+    resolution = TimexResolver.resolve(["2021-W01"], today)
+
+    assert len(resolution.values) == 1
+    assert resolution.values[0].timex == "2021-W01"
+    assert resolution.values[0].type == "daterange"
+    assert resolution.values[0].start == "2020-12-28"
+    assert resolution.values[0].end == "2021-01-04"
+
+
 def test_datatypes_resolver_dateRange_last_week():
     today = datetime(2017, 4, 30)
     resolution = TimexResolver.resolve(["2019-W17"], today)


### PR DESCRIPTION
- Timex like '2021-W01', '2020-W01' are now resolved correctly
- Added a test case, `test_datatypes_resolver_dateRange_first_week`