### PR TITLE
[DE Number] Added "fünfzehn" to German-numbers (TenToNineteenIntegerRegex)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/German/NumbersDefinitions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Recognizers.Definitions.German
       public const string ZeroToNineIntegerRegex = @"(drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|(ein(?!($|\.|,|!|\?)))|eine[rn]?|zwei|zwo|sechs)";
       public const string RoundNumberIntegerRegex = @"((ein)?hundert|tausend|(\s*(million(en)?|mio|milliarden?|mrd|billion(en)?)\s*))";
       public const string AnIntRegex = @"(eine?)(?=\s)";
-      public const string TenToNineteenIntegerRegex = @"(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)";
+      public const string TenToNineteenIntegerRegex = @"(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fünfzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)";
       public const string TensNumberIntegerRegex = @"(siebzig|zwanzig|dreißig|achtzig|neunzig|vierzig|fuenfzig|fünfzig|sechzig|hundert|tausend)";
       public const string NegativeNumberTermsRegex = @"^[.]";
       public static readonly string NegativeNumberSignRegex = $@"^({NegativeNumberTermsRegex}\s+).*";

--- a/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/GermanNumeric.java
+++ b/Java/libraries/recognizers-text-number/src/main/java/com/microsoft/recognizers/text/number/resources/GermanNumeric.java
@@ -31,7 +31,7 @@ public class GermanNumeric {
 
     public static final String AnIntRegex = "(eine?)(?=\\s)";
 
-    public static final String TenToNineteenIntegerRegex = "(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)";
+    public static final String TenToNineteenIntegerRegex = "(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fünfzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)";
 
     public static final String TensNumberIntegerRegex = "(siebzig|zwanzig|dreißig|achtzig|neunzig|vierzig|fuenfzig|fünfzig|sechzig|hundert|tausend)";
 

--- a/Patterns/German/German-Numbers.yaml
+++ b/Patterns/German/German-Numbers.yaml
@@ -13,7 +13,7 @@ RoundNumberIntegerRegex: !simpleRegex
 AnIntRegex: !simpleRegex
   def: (eine?)(?=\s)
 TenToNineteenIntegerRegex: !simpleRegex
-  def: (siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)
+  def: (siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fünfzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)
 TensNumberIntegerRegex: !simpleRegex
   def: (siebzig|zwanzig|dreißig|achtzig|neunzig|vierzig|fuenfzig|fünfzig|sechzig|hundert|tausend)
 NegativeNumberTermsRegex: !simpleRegex

--- a/Python/libraries/recognizers-number/recognizers_number/resources/german_numeric.py
+++ b/Python/libraries/recognizers-number/recognizers_number/resources/german_numeric.py
@@ -20,7 +20,7 @@ class GermanNumeric:
     ZeroToNineIntegerRegex = f'(drei|sieben|acht|vier|fuenf|fünf|null|neun|eins|(ein(?!($|\\.|,|!|\\?)))|eine[rn]?|zwei|zwo|sechs)'
     RoundNumberIntegerRegex = f'((ein)?hundert|tausend|(\\s*(million(en)?|mio|milliarden?|mrd|billion(en)?)\\s*))'
     AnIntRegex = f'(eine?)(?=\\s)'
-    TenToNineteenIntegerRegex = f'(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)'
+    TenToNineteenIntegerRegex = f'(siebzehn|dreizehn|vierzehn|achtzehn|neunzehn|fünfzehn|fuenfzehn|sechzehn|elf|zwoelf|zwölf|zehn)'
     TensNumberIntegerRegex = f'(siebzig|zwanzig|dreißig|achtzig|neunzig|vierzig|fuenfzig|fünfzig|sechzig|hundert|tausend)'
     NegativeNumberTermsRegex = f'^[.]'
     NegativeNumberSignRegex = f'^({NegativeNumberTermsRegex}\\s+).*'

--- a/Specs/Number/German/NumberModel.json
+++ b/Specs/Number/German/NumberModel.json
@@ -910,5 +910,35 @@
         }
       }
     ]
+  },
+  {
+    "Input": "fünfzehn",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "fünfzehn",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "15"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "fünfzehntausend",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "fünfzehntausend",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "15000"
+        },
+        "Start": 0,
+        "End": 14
+      }
+    ]
   }
 ]


### PR DESCRIPTION
"fünfzehn" was added to the `TenToNineteenIntegerRegex` for german. This was used to regenerate constant defintions for C#, Java and Python. Tests for "fünfzehn" as well as ""fünfzehntausend" were added to NumberModel.json.

I tested the "fünfzehn" example in each of the programming languages:
- DotNet: Worked.
- Python: Worked but I needed to [uncomment the German number recognizer in the number_recognizer.py](https://github.com/microsoft/Recognizers-Text/blob/34643228bf91175faeab636f43cb8c4d45c75ff9/Python/libraries/recognizers-number/recognizers_number/number/number_recognizer.py#L55)
- Java: Did not work. In fact, it seems like any number with non-english characters did not work. (including Zwölf and dreißig). Is this a known issue?

closes #2710 