### PR TITLE
[EN DateTimeV2] "last week of this month" resolving to previous month

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1817,7 +1817,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             int month;
             if (string.IsNullOrEmpty(monthStr))
             {
-                var monthText = !string.IsNullOrEmpty(match.Groups["relmonth"].Value) ? match.Groups["relmonth"].Value : trimmedText;
+                var relMonthValue = match.Groups["relmonth"].Value;
+                var monthText = !string.IsNullOrEmpty(relMonthValue) ? relMonthValue : trimmedText;
                 var swift = this.config.GetSwiftDayOrMonth(monthText);
 
                 month = referenceDate.AddMonths(swift).Month;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1817,7 +1817,8 @@ namespace Microsoft.Recognizers.Text.DateTime
             int month;
             if (string.IsNullOrEmpty(monthStr))
             {
-                var swift = this.config.GetSwiftDayOrMonth(trimmedText);
+                var monthText = !string.IsNullOrEmpty(match.Groups["relmonth"].Value) ? match.Groups["relmonth"].Value : trimmedText;
+                var swift = this.config.GetSwiftDayOrMonth(monthText);
 
                 month = referenceDate.AddMonths(swift).Month;
                 year = referenceDate.AddMonths(swift).Year;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/parsers/BaseDatePeriodParser.java
@@ -1303,7 +1303,9 @@ public class BaseDatePeriodParser implements IDateTimeParser {
 
         int month;
         if (StringUtility.isNullOrEmpty(monthStr)) {
-            int swift = this.config.getSwiftDayOrMonth(trimmedText);
+            String relMonth = match.getMatch().get().getGroup("relmonth").value;
+            String monthText = !StringUtility.isNullOrEmpty(relMonth) ? relMonth : trimmedText;
+            int swift = this.config.getSwiftDayOrMonth(monthText);
 
             month = referenceDate.plusMonths(swift).getMonthValue();
             year = referenceDate.plusMonths(swift).getYear();

--- a/Java/samples/simple-console/src/main/java/com/microsoft/recognizers/text/samples/simpleconsole/Sample.java
+++ b/Java/samples/simple-console/src/main/java/com/microsoft/recognizers/text/samples/simpleconsole/Sample.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class Sample {
 
-    private static final String defaultCulture = Culture.Spanish;
+    private static final String defaultCulture = Culture.English;
 
     public static void main(String[] args) throws Exception {
         showIntro();

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -983,7 +983,10 @@ export class BaseDatePeriodParser implements IDateTimeParser {
         let cardinal = this.config.isLastCardinal(cardinalStr) ? 5
             : this.config.cardinalMap.get(cardinalStr);
         if (StringUtility.isNullOrEmpty(monthStr)) {
-            let swift = this.config.getSwiftDayOrMonth(source);
+            let relMonthValue = match.groups('relmonth').value;
+            let monthStr =  !StringUtility.isNullOrEmpty(relMonthValue) ? relMonthValue : source;
+
+            let swift = this.config.getSwiftDayOrMonth(monthStr);
             let tempDate = new Date(referenceDate);
             tempDate.setMonth(referenceDate.getMonth() + swift);
             month = tempDate.getMonth();

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseDatePeriod.ts
@@ -1002,6 +1002,8 @@ export class BaseDatePeriodParser implements IDateTimeParser {
     protected getWeekOfMonth(cardinal: number, month: number, year: number, referenceDate: Date, noYear: boolean): DateTimeResolutionResult {
         let result = new DateTimeResolutionResult();
         let seedDate = this.computeDate(cardinal, 1, month, year);
+        let isLastCardinal = cardinal == 5;
+
         if (seedDate.getMonth() !== month) {
             cardinal--;
             seedDate.setDate(seedDate.getDate() - 7);
@@ -1020,9 +1022,11 @@ export class BaseDatePeriodParser implements IDateTimeParser {
                 pastDate.setDate(pastDate.getDate() - 7);
             }
         }
+
+        let adjustedCardinal = isLastCardinal ? 5 : cardinal;
         result.timex = noYear ?
-            `XXXX-${DateTimeFormatUtil.toString(month + 1, 2)}-W${DateTimeFormatUtil.toString(cardinal, 2)}` :
-            `${DateTimeFormatUtil.toString(year, 4)}-${DateTimeFormatUtil.toString(month + 1, 2)}-W${DateTimeFormatUtil.toString(cardinal, 2)}`;
+            `XXXX-${DateTimeFormatUtil.toString(month + 1, 2)}-W${DateTimeFormatUtil.toString(adjustedCardinal, 2)}` :
+            `${DateTimeFormatUtil.toString(year, 4)}-${DateTimeFormatUtil.toString(month + 1, 2)}-W${DateTimeFormatUtil.toString(adjustedCardinal, 2)}`;
         result.futureValue = [futureDate, DateUtils.addDays(futureDate, this.inclusiveEndPeriod ? 6 : 7)];
         result.pastValue = [pastDate, DateUtils.addDays(pastDate, this.inclusiveEndPeriod ? 6 : 7)];
         result.success = true;

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1810,7 +1810,7 @@ class BaseDatePeriodParser(DateTimeParser):
         if not month_str:
             rel_month_text = RegExpUtility.get_group(match, Constants.REL_MONTH)
             month_text = rel_month_text
-            
+
             if not rel_month_text:
                 month_text = source
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1808,7 +1808,13 @@ class BaseDatePeriodParser(DateTimeParser):
         cardinal = 5 if self.config.is_last_cardinal(cardinal_str) else self.config.cardinal_map.get(cardinal_str)
 
         if not month_str:
-            swift = self.config.get_swift_day_or_month(source)
+            rel_month_text = RegExpUtility.get_group(match, Constants.REL_MONTH)
+            month_text = rel_month_text
+            
+            if not rel_month_text:
+                month_text = source
+
+            swift = self.config.get_swift_day_or_month(month_text)
             temp_data = reference + datedelta(months=swift)
             year, month = temp_data.year, temp_data.month
 

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/date_time/base_dateperiod.py
@@ -1827,6 +1827,7 @@ class BaseDatePeriodParser(DateTimeParser):
     def _get_week_of_month(self, cardinal, month, year, reference, no_year) -> DateTimeResolutionResult:
         result = DateTimeResolutionResult()
         seed_date = self._compute_date(cardinal, 1, month, year)
+        is_last_cardinal = cardinal == 5
 
         if not seed_date.month == month:
             cardinal -= 1
@@ -1849,7 +1850,9 @@ class BaseDatePeriodParser(DateTimeParser):
         # the StartDate and EndDate of the resolution would always be correct (following ISO week definition).
         # But week number for "last week" might be inconsistent with the resolution as we only have one Timex,
         # but we may have past and future resolutions which may have different week numbers
-        result.timex = ('XXXX' if no_year else f'{year:04d}') + f'-{month:02d}-W{cardinal:02d}'
+        adjustedCardinal = 5 if is_last_cardinal else cardinal
+        result.timex = ('XXXX' if no_year else f'{year:04d}') + f'-{month:02d}-W{adjustedCardinal:02d}'
+
         days_to_add = 6 if self._inclusive_end_period else 7
         result.future_value = [future_date, future_date + datedelta(days=days_to_add)]
         result.past_value = [past_date, past_date + datedelta(days=days_to_add)]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -21123,6 +21123,56 @@
     ]
   },
   {
+    "Input": "show statistics from the last week of this month",
+    "Context": {
+      "ReferenceDateTime": "2021-10-10T12:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "the last week of this month",
+        "Start": 21,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2021-10-W05",
+              "type": "daterange",
+              "start": "2021-10-25",
+              "end": "2021-11-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "show statistics from the last week of last month",
+    "Context": {
+      "ReferenceDateTime": "2021-10-10T12:00:00"
+    },
+    "NotSupported": "javascript, python",
+    "Results": [
+      {
+        "Text": "the last week of last month",
+        "Start": 21,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2021-09-W05",
+              "type": "daterange",
+              "start": "2021-09-27",
+              "end": "2021-10-04"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
     "Input": "dates which are greater than or equals to date 1",
     "Context": {
         "ReferenceDateTime": "2021-06-18T18:00:00"


### PR DESCRIPTION
There are two issues that can be identified in #2689 for the inputs "last week of this month" and "last week of the month". 

- Firstly, the resolution timex refers to the week 'W05', which the issue states is an "invalid" week. However, when going through the code, this seems to be an intentional design decision where any "last" week of the month will always return with a W05. This is stated in the [following docstring](https://github.com/microsoft/Recognizers-Text/blob/bf8eb3c78146e4559e1b3189073691dab897cda8/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs#L2211). 
  - However, I noticed that this behavior is not consistent in Python and JavaScript (the output is W04). We should decide on which behavior is correct and ensure consistency (perhaps as a separate issue). 

- The date would resolve to last month's dates instead of this month. This has been fixed for all 4 languages. Examples tested include: "last week of this month", "last week of the month", "last week of last month",  and "last week of next month".
