### PR TITLE
[ES DateTimeV2] Minor change to YearSuffix regex

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -233,8 +233,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string RelativeDecadeRegex = $@"\b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b";
       public static readonly string ComplexDatePeriodRegex = $@"(?:((de(sde)?)\s+)?(?<start>.+)\s*({StrictTillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
       public const string AmbiguousPointRangeRegex = @"^(mar\.?)$";
-      public static readonly string YearSuffix = $@"((,|\s(de|del))?\s*({YearRegex}|{FullTextYearRegex}))";
-        public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(el\s+)?año\s*)?{YearSuffix})";
+      public static readonly string YearSuffix = $@"((,|\sdel?)?\s*({YearRegex}|{FullTextYearRegex}))";
+      public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(el\s+)?año\s*)?{YearSuffix})";
       public const string AgoRegex = @"\b(antes\s+de\s+(?<day>hoy|ayer|mañana)|antes|hace)\b";
       public const string LaterRegex = @"\b(despu[eé]s(?!\s+de\b)|desde\s+ahora|a\s+partir\s+de\s+(ahora|(?<day>hoy|ayer|mañana)))\b";
       public const string Tomorrow = @"mañana";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/ChineseDateTime.java
@@ -88,6 +88,8 @@ public class ChineseDateTime {
             .replace("{MonthNumRegex}", MonthNumRegex)
             .replace("{WeekDayRegex}", WeekDayRegex);
 
+    public static final String WeekDayAndDayRegex = "^[.]";
+
     public static final String ThisPrefixRegex = "这个|这一个|这|这一|本|今";
 
     public static final String LastPrefixRegex = "上个|上一个|上|上一|去";

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/resources/SpanishDateTime.java
@@ -737,7 +737,7 @@ public class SpanishDateTime {
 
     public static final String AmbiguousPointRangeRegex = "^(mar\\.?)$";
 
-    public static final String YearSuffix = "((,|\\sde)?\\s*({YearRegex}|{FullTextYearRegex}))"
+    public static final String YearSuffix = "((,|\\sdel?)?\\s*({YearRegex}|{FullTextYearRegex}))"
             .replace("{YearRegex}", YearRegex)
             .replace("{FullTextYearRegex}", FullTextYearRegex);
 

--- a/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/chineseDateTime.ts
@@ -39,6 +39,7 @@ export namespace ChineseDateTime {
     export const SpecialDayRegex = `(最近|前天|后天|昨天|明天|今天|今日|明日|昨日|大后天|大前天|後天|大後天)`;
     export const SpecialDayWithNumRegex = `^[.]`;
     export const WeekDayOfMonthRegex = `(((${MonthRegex}|${MonthNumRegex})的\\s*)(?<cardinal>第一个|第二个|第三个|第四个|第五个|最后一个)\\s*${WeekDayRegex})`;
+    export const WeekDayAndDayRegex = `^[.]`;
     export const ThisPrefixRegex = `这个|这一个|这|这一|本|今`;
     export const LastPrefixRegex = `上个|上一个|上|上一|去`;
     export const NextPrefixRegex = `下个|下一个|下|下一|明`;

--- a/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
+++ b/JavaScript/packages/recognizers-date-time/src/resources/spanishDateTime.ts
@@ -223,7 +223,7 @@ export namespace SpanishDateTime {
     export const RelativeDecadeRegex = `\\b(((el|las?)\\s+)?${RelativeRegex}\\s+(((?<number>[\\d]+)|${WrittenOneToNineRegex})\\s+)?d[eé]cadas?)\\b`;
     export const ComplexDatePeriodRegex = `(?:((de(sde)?)\\s+)?(?<start>.+)\\s*(${StrictTillRegex})\\s*(?<end>.+)|((entre)\\s+)(?<start>.+)\\s*(${RangeConnectorRegex})\\s*(?<end>.+))`;
     export const AmbiguousPointRangeRegex = `^(mar\\.?)$`;
-    export const YearSuffix = `((,|\\sde)?\\s*(${YearRegex}|${FullTextYearRegex}))`;
+    export const YearSuffix = `((,|\\sdel?)?\\s*(${YearRegex}|${FullTextYearRegex}))`;
     export const SinceYearSuffixRegex = `(^\\s*${SinceRegex}(\\s*(el\\s+)?año\\s*)?${YearSuffix})`;
     export const AgoRegex = `\\b(antes\\s+de\\s+(?<day>hoy|ayer|mañana)|antes|hace)\\b`;
     export const LaterRegex = `\\b(despu[eé]s(?!\\s+de\\b)|desde\\s+ahora|a\\s+partir\\s+de\\s+(ahora|(?<day>hoy|ayer|mañana)))\\b`;

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -584,7 +584,7 @@ ComplexDatePeriodRegex: !nestedRegex
 AmbiguousPointRangeRegex: !simpleRegex
   def: ^(mar\.?)$
 YearSuffix: !nestedRegex
-  def: ((,|\sde)?\s*({YearRegex}|{FullTextYearRegex}))
+  def: ((,|\sdel?)?\s*({YearRegex}|{FullTextYearRegex}))
   references: [ YearRegex, FullTextYearRegex ]
 SinceYearSuffixRegex: !nestedRegex
   def: (^\s*{SinceRegex}(\s*(el\s+)?año\s*)?{YearSuffix})

--- a/Patterns/Swedish/Swedish-QuotedText.yaml
+++ b/Patterns/Swedish/Swedish-QuotedText.yaml
@@ -5,7 +5,7 @@ QuotedTextRegex1: !simpleRegex
 QuotedTextRegex2: !simpleRegex
   def: (‘([^‘’]+)’)
 QuotedTextRegex3: !simpleRegex
-  def: (\"([^\"]+)\")
+  def: (""([^""]+)"")
 QuotedTextRegex4: !simpleRegex
   def: (\\'([^\']+)\\')
 QuotedTextRegex5: !simpleRegex

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/chinese_date_time.py
@@ -42,6 +42,7 @@ class ChineseDateTime:
     SpecialDayRegex = f'(最近|前天|后天|昨天|明天|今天|今日|明日|昨日|大后天|大前天|後天|大後天)'
     SpecialDayWithNumRegex = f'^[.]'
     WeekDayOfMonthRegex = f'((({MonthRegex}|{MonthNumRegex})的\\s*)(?<cardinal>第一个|第二个|第三个|第四个|第五个|最后一个)\\s*{WeekDayRegex})'
+    WeekDayAndDayRegex = f'^[.]'
     ThisPrefixRegex = f'这个|这一个|这|这一|本|今'
     LastPrefixRegex = f'上个|上一个|上|上一|去'
     NextPrefixRegex = f'下个|下一个|下|下一|明'

--- a/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
+++ b/Python/libraries/recognizers-date-time/recognizers_date_time/resources/spanish_date_time.py
@@ -226,7 +226,7 @@ class SpanishDateTime:
     RelativeDecadeRegex = f'\\b(((el|las?)\\s+)?{RelativeRegex}\\s+(((?<number>[\\d]+)|{WrittenOneToNineRegex})\\s+)?d[eé]cadas?)\\b'
     ComplexDatePeriodRegex = f'(?:((de(sde)?)\\s+)?(?<start>.+)\\s*({StrictTillRegex})\\s*(?<end>.+)|((entre)\\s+)(?<start>.+)\\s*({RangeConnectorRegex})\\s*(?<end>.+))'
     AmbiguousPointRangeRegex = f'^(mar\\.?)$'
-    YearSuffix = f'((,|\\sde)?\\s*({YearRegex}|{FullTextYearRegex}))'
+    YearSuffix = f'((,|\\sdel?)?\\s*({YearRegex}|{FullTextYearRegex}))'
     SinceYearSuffixRegex = f'(^\\s*{SinceRegex}(\\s*(el\\s+)?año\\s*)?{YearSuffix})'
     AgoRegex = f'\\b(antes\\s+de\\s+(?<day>hoy|ayer|mañana)|antes|hace)\\b'
     LaterRegex = f'\\b(despu[eé]s(?!\\s+de\\b)|desde\\s+ahora|a\\s+partir\\s+de\\s+(ahora|(?<day>hoy|ayer|mañana)))\\b'

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -21938,5 +21938,53 @@
         }
       }
     ]
+  },
+  {
+    "Input": "veintiocho de marzo de mil novecientos noventa y dos",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript,python",
+    "Results": [
+      {
+        "Text": "veintiocho de marzo de mil novecientos noventa y dos",
+        "Start": 0,
+        "End": 51,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1992-03-28",
+              "type": "date",
+              "value": "1992-03-28"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "veintiocho de marzo del mil novecientos noventa y dos",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript,python",
+    "Results": [
+      {
+        "Text": "veintiocho de marzo del mil novecientos noventa y dos",
+        "Start": 0,
+        "End": 52,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "1992-03-28",
+              "type": "date",
+              "value": "1992-03-28"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Minor change in the regex for YearSuffix to accept the word 'del' or 'de', instead of only 'de'.

Related to the issue #2693 