### PR TITLE
 [FR DateTimeV2] Fixed misses dates that are surrounded by specific words. (#2708)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/French/DateTimeDefinitions.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Recognizers.Definitions.French
       public const string PreviousPrefixRegex = @".^";
       public static readonly string RelativeDayRegex = $@"\b(((la\s+)?{RelativeRegex}\s+journ[ée]e))\b";
       public const string ConnectorRegex = @"^(,|pour|t|vers|le)$";
-      public const string ConnectorAndRegex = @"\b(et\s*(le|las?)?)\b.+";
+      public const string ConnectorAndRegex = @"\b(et\s*(le|las?)?)\b";
       public const string FromRegex = @"((de|du)?)$";
       public const string FromRegex2 = @"((depuis|de)(\s*las?)?)$";
       public const string FromToRegex = @"\b(du|depuis|des?).+(au|à|a)\b.+";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/French/Extractors/FrenchDateTimePeriodExtractorConfiguration.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Definitions;
 using Microsoft.Recognizers.Definitions.French;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.Utilities;
 
 namespace Microsoft.Recognizers.Text.DateTime.French
 {
@@ -207,7 +208,7 @@ namespace Microsoft.Recognizers.Text.DateTime.French
 
         public bool HasConnectorToken(string text)
         {
-            return ConnectorAndRegex.IsMatch(text);
+            return ConnectorAndRegex.IsExactMatch(text, trim: true);
         }
     }
 }

--- a/Patterns/French/French-DateTime.yaml
+++ b/Patterns/French/French-DateTime.yaml
@@ -505,7 +505,7 @@ RelativeDayRegex: !nestedRegex
 ConnectorRegex: !simpleRegex
   def: ^(,|pour|t|vers|le)$
 ConnectorAndRegex: !simpleRegex
-  def: \b(et\s*(le|las?)?)\b.+
+  def: \b(et\s*(le|las?)?)\b
 FromRegex: !simpleRegex
   def: ((de|du)?)$
 FromRegex2: !simpleRegex

--- a/Specs/DateTime/French/DateTimeModel.json
+++ b/Specs/DateTime/French/DateTimeModel.json
@@ -21234,5 +21234,79 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Avant. JEUDI 3 JUIN 12h55. LUNDI 14 JUIN. Et. Maintenant.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "jeudi 3 juin 12h55",
+        "Start": 7,
+        "End": 24,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-03T12:55",
+              "type": "datetime",
+              "value": "2016-06-03 12:55:00"
+            },
+            {
+              "timex": "XXXX-06-03T12:55",
+              "type": "datetime",
+              "value": "2017-06-03 12:55:00"
+            },
+            {
+              "timex": "XXXX-06-03T00:55",
+              "type": "datetime",
+              "value": "2016-06-03 00:55:00"
+            },
+            {
+              "timex": "XXXX-06-03T00:55",
+              "type": "datetime",
+              "value": "2017-06-03 00:55:00"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "lundi 14 juin",
+        "Start": 27,
+        "End": 39,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-06-14",
+              "type": "date",
+              "value": "2016-06-14"
+            },
+            {
+              "timex": "XXXX-06-14",
+              "type": "date",
+              "value": "2017-06-14"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "maintenant",
+        "Start": 46,
+        "End": 55,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "PRESENT_REF",
+              "type": "datetime",
+              "value": "2016-11-07 00:00:00"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2708

Test case added to French DateTimeModel.