### PR TITLE
[.NET TimexLib] Fixed ISO week number erros (#2744)

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_DateHelpers_weekOfyear()
         {
-            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 1)));
-            Assert.AreEqual(2, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 2)));
-            Assert.AreEqual(9, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 2, 23)));
-            Assert.AreEqual(12, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 3, 15)));
-            Assert.AreEqual(40, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 9, 25)));
-            Assert.AreEqual(53, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 12, 31)));
+            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 1)));
+            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 2)));
+            Assert.AreEqual(8, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 2, 23)));
+            Assert.AreEqual(11, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 3, 15)));
+            Assert.AreEqual(39, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 9, 25)));
+            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 12, 31)));
             Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 1)));
             Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 2)));
             Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 7)));

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexRelativeConvert.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_this_week()
         {
-            var timex = new TimexProperty("2017-W40");
+            var timex = new TimexProperty("2017-W39");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("this week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -155,7 +155,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_next_week()
         {
-            var timex = new TimexProperty("2017-W41");
+            var timex = new TimexProperty("2017-W40");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -163,7 +163,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_last_week()
         {
-            var timex = new TimexProperty("2017-W39");
+            var timex = new TimexProperty("2017-W38");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("last week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -171,7 +171,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_this_week_2()
         {
-            var timex = new TimexProperty("2017-W41");
+            var timex = new TimexProperty("2017-W40");
             var today = new System.DateTime(2017, 10, 4);
             Assert.AreEqual("this week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -179,7 +179,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_next_week_2()
         {
-            var timex = new TimexProperty("2017-W42");
+            var timex = new TimexProperty("2017-W41");
             var today = new System.DateTime(2017, 10, 4);
             Assert.AreEqual("next week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_DateRange_last_week_2()
         {
-            var timex = new TimexProperty("2017-W40");
+            var timex = new TimexProperty("2017-W39");
             var today = new System.DateTime(2017, 10, 4);
             Assert.AreEqual("last week", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -195,7 +195,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_Weekend_this_weekend()
         {
-            var timex = new TimexProperty("2017-W40-WE");
+            var timex = new TimexProperty("2017-W39-WE");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("this weekend", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -203,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_Weekend_next_weekend()
         {
-            var timex = new TimexProperty("2017-W41-WE");
+            var timex = new TimexProperty("2017-W40-WE");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("next weekend", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }
@@ -211,7 +211,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_RelativeConvert_Weekend_last_weekend()
         {
-            var timex = new TimexProperty("2017-W39-WE");
+            var timex = new TimexProperty("2017-W38-WE");
             var today = new System.DateTime(2017, 9, 25);
             Assert.AreEqual("last weekend", TimexRelativeConvert.ConvertTimexToStringRelative(timex, today));
         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexResolver.cs
@@ -533,7 +533,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Resolver_DateRange_Demaical_Period_EN()
         {
             var sourceLanguage = CultureInfo.CurrentCulture;
-            var testLanguage = new CultureInfo("en-En", false);
+            var testLanguage = new CultureInfo("en-US", false);
             CultureInfo.CurrentCulture = testLanguage;
             var today = new System.DateTime(2019, 4, 30);
             var resolution = TimexResolver.Resolve(new[] { "(2019-04-05,XXXX-04-11,P5.54701493625231D)" }, today);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -66,29 +67,24 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static int WeekOfYear(DateObject date)
         {
-            var ds = new DateObject(date.Year, 1, 1);
-            var de = new DateObject(date.Year, date.Month, date.Day);
-            int weeks = 1;
+            CultureInfo culture = CultureInfo.InvariantCulture;
 
-            while (ds < de)
+            // Workaround to get ISO 8601 week number.
+            // (A better solution would be to use ISOWeek.GetWeekOfYear but it seems currently unsupported)
+            DayOfWeek day = culture.Calendar.GetDayOfWeek(date);
+            if (day >= DayOfWeek.Monday && day <= DayOfWeek.Wednesday)
             {
-                var dayOfWeek = ds.DayOfWeek;
-
-                var isoDayOfWeek = (dayOfWeek == 0) ? 7 : (int)dayOfWeek;
-                if (isoDayOfWeek == 7)
-                {
-                    weeks++;
-                }
-
-                ds = ds.AddDays(1);
+                date = date.AddDays(3);
             }
+
+            int weeks = culture.Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
 
             return weeks;
         }
 
         public static string FixedFormatNumber(int? n, int size)
         {
-            return n.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).PadLeft(size, '0');
+            return n.Value.ToString(CultureInfo.InvariantCulture).PadLeft(size, '0');
         }
 
         public static DateObject DateOfLastDay(DayOfWeek day, DateObject referenceDate)


### PR DESCRIPTION
Fix to issue #2744.

As commented in the code, a better solution would be to use ISOWeek.GetWeekOfYear, 
but it seems unavailable (even if it is supported in .NET Core 3.1 and .NET Standard 2.1).