### PR TITLE
 [ZH Number] Fixed negative decimal such as "负1.1" 、"负0.2千米"、"负3.9%" can't be recognized (#2667)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/NumbersDefinitions.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string HalfUnitRegex = @"半";
       public const string NegativeNumberTermsRegex = @"[负負]";
       public static readonly string NegativeNumberTermsRegexNum = $@"((?<!(\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)|[-－])[-－])";
+      public static readonly string NegativeNumberTermsRegexAll = $@"({NegativeNumberTermsRegex}|{NegativeNumberTermsRegexNum})";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*";
       public static readonly string SpeGetNumberRegex = $@"{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[十拾半对對]";
       public const string PairRegex = @".*[双对雙對]$";
@@ -195,14 +196,14 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string NumbersWithAllowListRegex = $@"(?<![百佰]\s*分\s*之\s*({AllIntRegex}[点點]*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*([点點]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*[个個]\s*[百佰]\s*分\s*[点點])";
       public static readonly string NumbersAggressiveRegex = $@"(?<![百佰]\s*分\s*之\s*({AllIntRegex}[点點]*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*([点點]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*[个個]\s*[百佰]\s*分\s*[点點])";
       public static readonly string PointRegex = $@"{PointRegexStr}";
-      public static readonly string DoubleSpecialsChars = $@"(?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)";
-      public static readonly string DoubleSpecialsCharsWithNegatives = $@"(?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))";
-      public static readonly string SimpleDoubleSpecialsChars = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+";
-      public static readonly string DoubleWithMultiplierRegex = $@"({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}";
+      public static readonly string DoubleSpecialsChars = $@"(?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)";
+      public static readonly string DoubleSpecialsCharsWithNegatives = $@"(?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexAll}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))";
+      public static readonly string SimpleDoubleSpecialsChars = $@"({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+";
+      public static readonly string DoubleWithMultiplierRegex = $@"({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}";
       public static readonly string DoubleWithThousandsRegex = $@"{NegativeNumberTermsRegex}?(({ZeroToNineFullHalfRegex}+)|({ZeroToNineFullHalfRegex}{{1,3}}(,{ZeroToNineFullHalfRegex}{{3}})+))([\.．]{ZeroToNineFullHalfRegex}+)?\s*[多几幾余]?[万亿萬億]{{1,2}}";
       public static readonly string DoubleAllFloatRegex = $@"(?<![百佰]\s*分\s*之\s*(({AllIntRegex}[点點]*)|{AllFloatRegex})*){AllFloatRegex}(?!{ZeroToNineIntegerRegex}*\s*[个個]\s*[百佰]\s*分\s*[点點])";
-      public static readonly string DoubleExponentialNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)|0(?!{ZeroToNineFullHalfRegex}+))";
-      public static readonly string DoubleScientificNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)";
+      public static readonly string DoubleExponentialNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)|0(?!{ZeroToNineFullHalfRegex}+))";
+      public static readonly string DoubleScientificNotationRegex = $@"(?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexAll}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)";
       public static readonly string OrdinalRegex = $@"第{AllIntRegex}";
       public static readonly string OrdinalNumbersRegex = $@"第{ZeroToNineFullHalfRegex}+";
       public static readonly string AllFractionNumber = $@"{NegativeNumberTermsRegex}?(({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*又\s*)?{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})\s*分\s*之\s*{NegativeNumberTermsRegex}?({ZeroToNineFullHalfRegex}+|{AllIntRegex})({PointRegexStr}{AllIntRegex}*)?";
@@ -222,7 +223,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string IntegerPercentageRegex = $@"{ZeroToNineFullHalfRegex}+\s*[个個]\s*{RoundNumberIntegerRegex}{{1,3}}\s*分\s*[点點]";
       public static readonly string IntegerPercentageWithMultiplierRegex = $@"{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}\s*[个個]\s*{RoundNumberIntegerRegex}{{1,3}}\s*分\s*[点點]";
       public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*[个個]\s*{RoundNumberIntegerRegex}{{1,3}}\s*分\s*[点點]";
-      public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)";
+      public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d){NegativeNumberTermsRegexAll}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)";
       public static readonly string NumbersFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*折";
       public static readonly string FoldsPercentageRegex = $@"{ZeroToNineIntegerRegex}(\s*[点點]?\s*{ZeroToNineIntegerRegex})?\s*折";
       public static readonly string SimpleFoldsPercentageRegex = $@"{ZeroToNineFullHalfRegex}\s*成(\s*(半|{ZeroToNineFullHalfRegex}))?";

--- a/Patterns/Chinese/Chinese-Numbers.yaml
+++ b/Patterns/Chinese/Chinese-Numbers.yaml
@@ -169,6 +169,9 @@ NegativeNumberTermsRegex: !simpleRegex
 NegativeNumberTermsRegexNum: !nestedRegex
   def: ((?<!(\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)|[-－])[-－])
   references: [BaseNumbers.NumberMultiplierRegex]
+NegativeNumberTermsRegexAll: !nestedRegex
+  def: ({NegativeNumberTermsRegex}|{NegativeNumberTermsRegexNum})
+  references: [NegativeNumberTermsRegex, NegativeNumberTermsRegexNum]
 NegativeNumberSignRegex: !nestedRegex
   def: ^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*
   references: [NegativeNumberTermsRegex, NegativeNumberTermsRegexNum]
@@ -239,17 +242,17 @@ PointRegex: !nestedRegex
   def: '{PointRegexStr}'
   references: [PointRegexStr]
 DoubleSpecialsChars: !nestedRegex
-  def: (?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)
-  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
+  def: (?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)
+  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexAll]
 DoubleSpecialsCharsWithNegatives: !nestedRegex
-  def: (?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))
-  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
+  def: (?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexAll}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+))
+  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexAll]
 SimpleDoubleSpecialsChars: !nestedRegex
-  def: ({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+
-  references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
+  def: ({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+
+  references: [NegativeNumberTermsRegexAll, ZeroToNineFullHalfRegex]
 DoubleWithMultiplierRegex: !nestedRegex
-  def: ({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}
-  references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, BaseNumbers.NumberMultiplierRegex]
+  def: ({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex}
+  references: [NegativeNumberTermsRegexAll, ZeroToNineFullHalfRegex, BaseNumbers.NumberMultiplierRegex]
 DoubleWithThousandsRegex: !nestedRegex
   def: '{NegativeNumberTermsRegex}?(({ZeroToNineFullHalfRegex}+)|({ZeroToNineFullHalfRegex}{1,3}(,{ZeroToNineFullHalfRegex}{3})+))([\.．]{ZeroToNineFullHalfRegex}+)?\s*[多几幾余]?[万亿萬億]{1,2}'
   references: [NegativeNumberTermsRegex, ZeroToNineFullHalfRegex]
@@ -257,11 +260,11 @@ DoubleAllFloatRegex: !nestedRegex
   def: (?<![百佰]\s*分\s*之\s*(({AllIntRegex}[点點]*)|{AllFloatRegex})*){AllFloatRegex}(?!{ZeroToNineIntegerRegex}*\s*[个個]\s*[百佰]\s*分\s*[点點])
   references: [AllIntRegex, AllFloatRegex, ZeroToNineIntegerRegex]
 DoubleExponentialNotationRegex: !nestedRegex
-  def: (?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)|0(?!{ZeroToNineFullHalfRegex}+))
-  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
+  def: (?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexAll}\s*)?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?e(([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)|0(?!{ZeroToNineFullHalfRegex}+))
+  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexAll]
 DoubleScientificNotationRegex: !nestedRegex
-  def: (?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexNum}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)
-  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
+  def: (?<!{ZeroToNineFullHalfRegex}+[\.．])({NegativeNumberTermsRegexAll}\s*)?({ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?)\^([-－+＋]*[1-9]{ZeroToNineFullHalfRegex}*)
+  references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexAll]
 #OrdinalExtractor
 OrdinalRegex: !nestedRegex
   def: 第{AllIntRegex}
@@ -323,8 +326,8 @@ NumbersFractionPercentageRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+\s*[个個]\s*{RoundNumberIntegerRegex}{1,3}\s*分\s*[点點]'
   references: [ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 SimpleIntegerPercentageRegex: !nestedRegex
-  def: '(?<!%|\d){NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)'
-  references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
+  def: '(?<!%|\d){NegativeNumberTermsRegexAll}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)[％%](?!\d)'
+  references: [NegativeNumberTermsRegexAll, ZeroToNineFullHalfRegex]
 NumbersFoldsPercentageRegex: !nestedRegex
   def: '{ZeroToNineFullHalfRegex}(([\.．]?|\s*){ZeroToNineFullHalfRegex})?\s*折'
   references: [ZeroToNineFullHalfRegex]

--- a/Specs/Number/Chinese/NumberModel.json
+++ b/Specs/Number/Chinese/NumberModel.json
@@ -5227,5 +5227,33 @@
         "End": 45
       }
     ]
+  },
+  {
+    "Input": "负1.1",
+    "Results": [
+      {
+        "Text": "负1.1",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-1.1"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "负0.2",
+    "Results": [
+      {
+        "Text": "负0.2",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "-0.2"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
   }
 ]

--- a/Specs/Number/Chinese/PercentModel.json
+++ b/Specs/Number/Chinese/PercentModel.json
@@ -2185,5 +2185,33 @@
         }
       }
     ]
+  },
+  {
+    "Input": "负3.9%",
+    "Results": [
+      {
+        "Text": "负3.9%",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "-3.9%"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "负40%",
+    "Results": [
+      {
+        "Text": "负40%",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "-40%"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Chinese/DimensionModel.json
+++ b/Specs/NumberWithUnit/Chinese/DimensionModel.json
@@ -476,5 +476,35 @@
         "End": 4
       }
     ]
+  },
+  {
+    "Input": "负0.2千米",
+    "Results": [
+      {
+        "Text": "负0.2千米",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "-0.2",
+          "unit": "Kilometer"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "负13.5千米",
+    "Results": [
+      {
+        "Text": "负13.5千米",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "-13.5",
+          "unit": "Kilometer"
+        },
+        "Start": 0,
+        "End": 6
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2667 (following python [solution](https://github.com/17000cyh/Recognizers-Text/commit/6b6ea617c42eba3d82a471d3cd090d3151f50db1) by @17000cyh).

Test cases added to NumberModel, PercentModel, DimensionModel.