### PR TITLE
[* Number] Fixed for consistency with Units, "%", "percent", and "percentage" should also be tagged as entity (#2702)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string DoubleWithRoundNumber = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|((?<=\b)(?<!\d+[\.,])))\d+[\.,]\d+\s+{RoundNumberIntegerRegex}(?=\b)";
       public static readonly string DoubleAllFloatRegex = $@"((?<=\b){AllFloatRegex}(?=\b))";
       public const string ConnectorRegex = @"(?<spacer>and)";
-      public static readonly string NumberWithSuffixPercentage = $@"(?<!%)({BaseNumbers.NumberReplaceToken})(\s*)(%(?!{BaseNumbers.NumberReplaceToken})|(per\s*cents?|percentage|cents?)\b)";
+      public static readonly string NumberWithSuffixPercentage = $@"(?<!%({BaseNumbers.NumberReplaceToken})?)({BaseNumbers.NumberReplaceToken}(\s*))?(%(?!{BaseNumbers.NumberReplaceToken})|(per\s*cents?|percentage|cents?)\b)";
       public static readonly string FractionNumberWithSuffixPercentage = $@"(({BaseNumbers.FractionNumberReplaceToken})\s+of)";
       public static readonly string NumberWithPrefixPercentage = $@"(per\s*cents?\s+of)(\s*)({BaseNumbers.NumberReplaceToken})";
       public static readonly string NumberWithPrepositionPercentage = $@"({BaseNumbers.NumberReplaceToken})\s*(in|out\s+of)\s*({BaseNumbers.NumberReplaceToken})";

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BasePercentageParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BasePercentageParser.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Recognizers.Text.Number
                     ((double)ret.Value).ToString("G15", Config.CultureInfo) + "%" :
                     ret.Value + "%";
             }
+            else if (extResult.Data is null)
+            {
+                // for case where only symbol is present
+                ret = new ParseResult(extResult) { Value = "null", ResolutionStr = "null" };
+            }
             else
             {
                 // for case like "one percent" or "1%".

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -146,7 +146,7 @@ ConnectorRegex: !simpleRegex
     def: (?<spacer>and)
 #Percentage Regex
 NumberWithSuffixPercentage: !nestedRegex
-  def: (?<!%)({BaseNumbers.NumberReplaceToken})(\s*)(%(?!{BaseNumbers.NumberReplaceToken})|(per\s*cents?|percentage|cents?)\b)
+  def: (?<!%({BaseNumbers.NumberReplaceToken})?)({BaseNumbers.NumberReplaceToken}(\s*))?(%(?!{BaseNumbers.NumberReplaceToken})|(per\s*cents?|percentage|cents?)\b)
   references: [ BaseNumbers.NumberReplaceToken ]
 FractionNumberWithSuffixPercentage: !nestedRegex
   def: (({BaseNumbers.FractionNumberReplaceToken})\s+of)

--- a/Specs/Number/English/PercentModel.json
+++ b/Specs/Number/English/PercentModel.json
@@ -218,5 +218,50 @@
     "Input": "You can go to https://www.test.com/search?q=30%25%2020%",
     "NotSupported": "javascript",
     "Results": []
+  },
+  {
+    "Input": "Only a small percent attain the top ranks",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "percent",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "null"
+        },
+        "Start": 13,
+        "End": 19
+      }
+    ]
+  },
+  {
+    "Input": "The table shows the % of increase in the last month",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "%",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "null"
+        },
+        "Start": 20,
+        "End": 20
+      }
+    ]
+  },
+  {
+    "Input": "How do I calculate a percentage?",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "percentage",
+        "TypeName": "percentage",
+        "Resolution": {
+          "value": "null"
+        },
+        "Start": 21,
+        "End": 30
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2702 in EN.

Test cases added to PercentModel.