### PR TITLE
[KO Number] Korean Number refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -119,12 +119,33 @@ namespace Microsoft.Recognizers.Definitions.Korean
         };
       public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
         {
+            { @"여섯", @"육" },
+            { @"하나", @"일" },
+            { @"둘", @"이" },
+            { @"셋", @"삼" },
+            { @"넷", @"사" },
+            { @"다섯", @"오" },
+            { @"일곱", @"칠" },
+            { @"여덟", @"팔" },
+            { @"아홉", @"구" },
+            { @"스물", @"이십" },
+            { @"서른", @"삼십" },
+            { @"마흔", @"사십" },
+            { @"쉰", @"오십" },
+            { @"예순", @"육십" },
+            { @"일흔", @"칠십" },
+            { @"여든", @"팔십" },
+            { @"아흔", @"구십" },
+            { @"온", @"백" },
+            { @"즈믄", @"천" },
+            { @"다스", @"십이" },
             { @" ", @"" }
         };
       public static readonly IList<char> RoundDirectList = new List<char>
         {
             '빵',
-            '열'
+            '열',
+            '조'
         };
       public static readonly IList<char> TenChars = new List<char>
         {
@@ -135,7 +156,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string DigitNumRegex = $@"{ZeroToNineFullHalfRegex}+|반";
       public const string DozenRegex = @".*타$";
       public const string PercentageRegex = @"(?<=백\s*분\s*의).+|.+(?=퍼\s*센\s*트)|.*(?=[％%])";
-      public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[만억]{{1,2}}(\s*(이상))?";
+      public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?{RoundNumberIntegerRegex}{{1,2}}(\s*(이상))?";
       public const string FracSplitRegex = @"(와|과|분\s*의|중)";
       public const string ZeroToNineIntegerRegex = @"(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
       public static readonly string TenToNinetySinoIntegerRegex = $@"({ZeroToNineIntegerRegex})?십";
@@ -146,8 +167,8 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}|^{NegativeNumberTermsRegexNum}";
       public static readonly string SpeGetNumberRegex = $@"{ZeroToNineFullHalfRegex}|{ZeroToNineIntegerRegex}|[십반]";
       public const string PairRegex = @".*[쌍짝]$";
-      public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)|경|열)";
-      public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/|만)";
+      public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)(\s번째)?|경|열)";
+      public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|은|\s|$|/|만)";
       public static readonly string NotSingleRegex = $@"({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)";
       public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(랑|주))|(?<![시])오(?!(월|늘))|육|(?<!며)칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
       public static readonly string NativeSingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})";
@@ -155,19 +176,19 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string AllIntRegex = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex})|{NativeIntRegex}+)";
       public static readonly string NativeCumKoreanRegex = $@"({ZeroToNineFullHalfRegex}+)\s*(({RoundNumberIntegerRegex}+)({ZeroToNineFullHalfRegex}+))+";
       public static readonly string NumbersWithDozen = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex}))?(다스)(?!{AllIntRegex})";
-      public static readonly string NumbersSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))";
-      public static readonly string NumbersSpecialsCharsWithSuffix = $@"({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))";
+      public static readonly string NumbersSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m|월|미터)))";
+      public static readonly string NumbersSpecialsCharsWithSuffix = $@"({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m|월|미터)))";
       public static readonly string ZeroToNineIntegerSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*){ZeroToNineIntegerRegex}+)";
-      public static readonly string DottedNumbersSpecialsChar = $@"{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+";
+      public static readonly string DottedNumbersSpecialsChar = $@"({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{{1,3}}(([,，\s]{ZeroToNineFullHalfRegex}{{3}})(?!{ZeroToNineFullHalfRegex}))+)";
       public const string PointRegexStr = @"[점\.．]";
       public static readonly string AllFloatRegex = $@"{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[일이삼사오육칠팔구영](\s*{ZeroToNineIntegerRegex})*";
-      public static readonly string NumbersWithAllowListRegex = $@"((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(((?<!사)(과\s*))(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+";
+      public static readonly string NumbersWithAllowListRegex = $@"((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+";
       public static readonly string NumbersAggressiveRegex = $@"(?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점)";
       public static readonly string PointRegex = $@"{PointRegexStr}";
       public static readonly string DoubleSpecialsChars = $@"((?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
       public static readonly string DoubleRoundNumberSpecialsChars = $@"(?<!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*))(({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+[\.．점]\s?({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+(?!(({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})*[\.．점]({ZeroToNineIntegerRegex}|{RoundNumberIntegerRegex})+))";
       public static readonly string DoubleSpecialsCharsWithNegatives = $@"((?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
-      public static readonly string SimpleDoubleSpecialsChars = $@"(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+)";
+      public static readonly string SimpleDoubleSpecialsChars = $@"(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{{1,3}}([,，\s]{ZeroToNineFullHalfRegex}{{3}})+[\.．]{ZeroToNineFullHalfRegex}+)";
       public static readonly string DoubleWithMultiplierRegex = $@"(({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex})(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))";
       public static readonly string DoubleWithThousandsRegex = $@"{NegativeNumberTermsRegex}?{ZeroToNineFullHalfRegex}+([\.．]{ZeroToNineFullHalfRegex}+)?\s*?[백천만억]{{1,2}}";
       public static readonly string DoubleAllFloatRegex = $@"(?<!백\s*분\s*의\s*(({AllIntRegex}점*)|{AllFloatRegex})*){AllFloatRegex}(?!{ZeroToNineIntegerRegex}*\s*개\s*백\s*분\s*점)";

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/DoubleExtractor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                 },
                 {
                     new Regex(NumbersDefinitions.DoubleRoundNumberSpecialsChars, RegexFlags),
-                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.NUMBER_SUFFIX)
+                    RegexTagGenerator.GenerateRegexTag(Constants.DOUBLE_PREFIX, Constants.KOREAN)
                 },
                 {
                     // (-).2

--- a/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Models/AbstractNumberModel.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Recognizers.Text.Number
             Constants.PORTUGUESE,
             Constants.SPANISH,
             Constants.SWEDISH,
+            Constants.KOREAN,
 
             // TODO: Temporarily disabled as existing TestSpec not supporting
             // Constants.JAPANESE_SUBS,

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -139,7 +139,13 @@ namespace Microsoft.Recognizers.Text.Number
             var splitResult = Config.FracSplitRegex.Split(resultText);
             string intPart = string.Empty, demoPart = string.Empty, numPart = string.Empty;
 
-            if (splitResult.Length == 3)
+            if (splitResult.Length == 4)
+            {
+                intPart = splitResult[0] + splitResult[1];
+                demoPart = splitResult[2];
+                numPart = splitResult[3];
+            }
+            else if (splitResult.Length == 3)
             {
                 intPart = splitResult[0];
                 demoPart = splitResult[1];

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -111,12 +111,34 @@ FullToHalfMap: !dictionary
 UnitMap: !dictionary
   types: [string, string]
   entries:
+    여섯: 육
+    하나: 일
+    둘: 이
+    셋: 삼
+    넷: 사
+    다섯: 오
+    여섯: 육 
+    일곱: 칠
+    여덟: 팔
+    아홉: 구
+    스물: 이십
+    서른: 삼십
+    마흔: 사십
+    쉰: 오십
+    예순: 육십
+    일흔: 칠십
+    여든: 팔십
+    아흔: 구십
+    온: 백
+    즈믄: 천
+    다스: 십이
     ' ' : ''
 RoundDirectList: !list
   types: [char]
   entries:
     - 빵
     - 열
+    - 조
 # TODO: modify below list according to the counterpart in Chinese
 TenChars: !list
   types: [char]
@@ -135,12 +157,12 @@ DozenRegex: !simpleRegex
 PercentageRegex: !simpleRegex
   def: (?<=백\s*분\s*의).+|.+(?=퍼\s*센\s*트)|.*(?=[％%])
 DoubleAndRoundRegex: !nestedRegex
-  def: '{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[만억]{1,2}(\s*(이상))?'
-  references: [ZeroToNineFullHalfRegex]
+  def: '{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?{RoundNumberIntegerRegex}{1,2}(\s*(이상))?'
+  references: [ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 FracSplitRegex: !simpleRegex
   def: '(와|과|분\s*의|중)'
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)
+  def: '(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)'
 TenToNinetySinoIntegerRegex: !nestedRegex
   def: ({ZeroToNineIntegerRegex})?십
   references: [ZeroToNineIntegerRegex]
@@ -162,9 +184,9 @@ SpeGetNumberRegex: !nestedRegex
 PairRegex: .*[쌍짝]$
 #IntegerExtractor
 RoundNumberIntegerRegex: !simpleRegex
-  def: (십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)|경|열)
+  def: (십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)(\s번째)?|경|열)
 AllowListRegex: !simpleRegex
-  def: (。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|월|일|은|\s|$|/|만)
+  def: (。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|은|\s|$|/|만)
 NotSingleRegex: !nestedRegex
   def: ({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)
   references: [TenToNinetyNativeIntegerRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
@@ -187,16 +209,16 @@ NumbersWithDozen: !nestedRegex
   def: '(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){1,2}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex}))?(다스)(?!{AllIntRegex})'
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex, AllIntRegex]
 NumbersSpecialsChars: !nestedRegex
-  def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))
+  def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}+))(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m|월|미터)))
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, NegativeNumberTermsRegex]
 NumbersSpecialsCharsWithSuffix: !nestedRegex
-  def: '({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m)))'
+  def: '({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}+(\s*{BaseNumbers.NumberMultiplierRegex}+)?)(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?(k|mil|t|g|b|km|ml|m|월|미터)))'
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex, BaseNumbers.NumberMultiplierRegex]
 ZeroToNineIntegerSpecialsChars: !nestedRegex
   def: ((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*){ZeroToNineIntegerRegex}+)
   references: [NegativeNumberTermsRegexNum, ZeroToNineIntegerRegex, NegativeNumberTermsRegex]
 DottedNumbersSpecialsChar: !nestedRegex
-  def: '{NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+'
+  def: ({NegativeNumberTermsRegexNum}?{ZeroToNineFullHalfRegex}{1,3}(([,，\s]{ZeroToNineFullHalfRegex}{3})(?!{ZeroToNineFullHalfRegex}))+)
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
 PointRegexStr: !simpleRegex
   def: '[점\.．]'
@@ -204,7 +226,7 @@ AllFloatRegex: !nestedRegex
   def: '{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[일이삼사오육칠팔구영](\s*{ZeroToNineIntegerRegex})*'
   references: [NegativeNumberTermsRegex, AllIntRegex, PointRegexStr, ZeroToNineIntegerRegex]
 NumbersWithAllowListRegex: !nestedRegex
-  def: ((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?(((?<!사)(과\s*))(?!{ZeroToNineFullHalfRegex}))?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+
+  def: ((?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?({RoundNumberIntegerRegex})?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점))+
   references: [AllIntRegex, AllFloatRegex, NegativeNumberTermsRegex, NotSingleRegex, SingleRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 NumbersAggressiveRegex: !nestedRegex
   def: (?<!백\s*분\s*의\s*({AllIntRegex}점*|{AllFloatRegex})*){NegativeNumberTermsRegex}?{AllIntRegex}(?!({AllIntRegex}*(점{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*개\s*백\s*분\s*점)
@@ -223,7 +245,7 @@ DoubleSpecialsCharsWithNegatives: !nestedRegex
   def: ((?<!({ZeroToNineFullHalfRegex}+|\.\.|．．))({NegativeNumberTermsRegexNum}\s*)?[\.．]{ZeroToNineFullHalfRegex}+(?!{ZeroToNineFullHalfRegex}*([\.．]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))
   references: [ZeroToNineFullHalfRegex, NegativeNumberTermsRegexNum]
 SimpleDoubleSpecialsChars: !nestedRegex
-  def: (({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+)
+  def: (({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}{1,3}([,，\s]{ZeroToNineFullHalfRegex}{3})+[\.．]{ZeroToNineFullHalfRegex}+)
   references: [NegativeNumberTermsRegexNum, ZeroToNineFullHalfRegex]
 DoubleWithMultiplierRegex: !nestedRegex
   def: (({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}+\s*{BaseNumbers.NumberMultiplierRegex})(?=\b|\D)(?!(k|mil|t|g|b|km|ml|m))

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -4044,21 +4044,25 @@
         "Resolution": {
           "subtype": "fraction",
           "value": "1E-12"
-        }
+        },
+        "Start": 0,
+        "End": 4
       }
     ]
   },
   {
-    "Input": "일백조 번째분의일",
+    "Input": "일백조 분의 일",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "일백조 번째분의일",
+        "Text": "일백조 분의 일",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "1E-14"
-        }
+        },
+        "Start": 0,
+        "End": 7
       }
     ]
   }

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -4065,5 +4065,71 @@
         "End": 7
       }
     ]
+  },
+  {
+    "Input": "423 0000는 두 개의 숫자이다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "423",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "423"
+        }
+      },
+      {
+        "Text": "0000",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        }
+      },
+      {
+        "Text": "두",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "423 0000은 두개의 수로 인식될 것이다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "423",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "423"
+        },
+        "Start": 0,
+        "End": 2
+      },
+      {
+        "Text": "0000",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        },
+        "Start": 4,
+        "End": 7
+      },
+      {
+        "Text": "두",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 10,
+        "End": 10
+      }
+    ]
   }
 ]

--- a/Specs/Number/Korean/NumberModel.json
+++ b/Specs/Number/Korean/NumberModel.json
@@ -1,13 +1,13 @@
 [
   {
     "Input": "마이너스일만",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "마이너스일만",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-10000"
         }
       }
@@ -15,13 +15,13 @@
   },
   {
     "Input": "192.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "192",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "192"
         }
       }
@@ -29,13 +29,13 @@
   },
   {
     "Input": "192.168.1.2",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "192",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "192"
         }
       },
@@ -43,6 +43,7 @@
         "Text": "168",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "168"
         }
       },
@@ -50,6 +51,7 @@
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         }
       },
@@ -57,51 +59,49 @@
         "Text": "2",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2"
         }
       }
     ]
   },
   {
-    "Input": "180.25ml의 액체",
-    "Comment": "PendingValidation, incorrect result set",
+    "Input": "180.25 ml의 액체",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "180.25",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "180.25"
         }
       }
     ]
   },
   {
-    "Input": "180ml의 액체",
-    "Comment": "PendingValidation, incorrect result set",
+    "Input": "180 ml 의 액체",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "180",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "180"
         }
       }
     ]
   },
   {
-    "Input": "29km의 길",
-    "Comment": "PendingValidation",
+    "Input": "29 km의 길",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "29",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "29"
         }
       }
@@ -109,36 +109,18 @@
   },
   {
     "Input": "5월 4일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
-    "Results": [
-      {
-        "Text": "5",
-        "TypeName": "number",
-        "Resolution": {
-          "value": "5"
-        }
-      },
-      {
-        "Text": "4",
-        "TypeName": "number",
-        "Resolution": {
-          "value": "4"
-        }
-      }
-    ]
+    "Results": []
   },
   {
-    "Input": ".25ml의 액체",
-    "Comment": "PendingValidation, incorrect result set",
+    "Input": ".25 ml의 액체",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": ".25",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "0.25"
         }
       }
@@ -146,13 +128,13 @@
   },
   {
     "Input": ".08",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": ".08",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "0.08"
         }
       }
@@ -160,13 +142,13 @@
   },
   {
     "Input": ".23456000",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": ".23456000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "0.23456"
         }
       }
@@ -174,13 +156,13 @@
   },
   {
     "Input": "4.800",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "4.800",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "4.8"
         }
       }
@@ -188,13 +170,13 @@
   },
   {
     "Input": "일백삼과 삼분의 이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백삼과 삼분의 이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "103.666666666667"
         }
       }
@@ -202,13 +184,13 @@
   },
   {
     "Input": "십육",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "십육",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "16"
         }
       }
@@ -216,13 +198,13 @@
   },
   {
     "Input": "삼분의 이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼분의 이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.666666666666667"
         }
       }
@@ -230,13 +212,13 @@
   },
   {
     "Input": "일백십육",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백십육",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "116"
         }
       }
@@ -244,13 +226,13 @@
   },
   {
     "Input": "일백육",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백육",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "106"
         }
       }
@@ -258,57 +240,55 @@
   },
   {
     "Input": "일백육십일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백육십일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "161"
         }
       }
     ]
   },
   {
-    "Input": "조 번째",
-    "Comment": "PendingValidation",
+    "Input": "일조 번째",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
-        "Text": "조 번째",
+        "Text": "일조 번째",
         "TypeName": "number",
         "Resolution": {
-          "value": "1E-12"
+          "subtype": "integer",
+          "value": "1000000000000"
         }
       }
     ]
   },
   {
     "Input": "일백조 번째",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "일백조 번째",
         "TypeName": "number",
         "Resolution": {
-          "value": "1E-10"
+          "subtype": "integer",
+          "value": "100000000000000"
         }
       }
     ]
   },
   {
     "Input": "1,234,567",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1,234,567",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1234567"
         }
       }
@@ -316,13 +296,13 @@
   },
   {
     "Input": "1, 234, 567",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         }
       },
@@ -330,6 +310,7 @@
         "Text": "234",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "234"
         }
       },
@@ -337,6 +318,7 @@
         "Text": "567",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "567"
         }
       }
@@ -344,13 +326,13 @@
   },
   {
     "Input": "9.2321312",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "9.2321312",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "9.2321312"
         }
       }
@@ -358,13 +340,13 @@
   },
   {
     "Input": "-9.2321312",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-9.2321312",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "-9.2321312"
         }
       }
@@ -372,13 +354,13 @@
   },
   {
     "Input": "-1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-1"
         }
       }
@@ -386,13 +368,13 @@
   },
   {
     "Input": "-4/5",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-4/5",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-0.8"
         }
       }
@@ -400,13 +382,13 @@
   },
   {
     "Input": "- 1 4/5",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "- 1 4/5",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-1.8"
         }
       }
@@ -414,13 +396,13 @@
   },
   {
     "Input": "삼",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3"
         }
       }
@@ -428,13 +410,13 @@
   },
   {
     "Input": " 123456789101231",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "123456789101231"
         }
       }
@@ -442,13 +424,13 @@
   },
   {
     "Input": "-123456789101231",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-123456789101231"
         }
       }
@@ -456,13 +438,13 @@
   },
   {
     "Input": " -123456789101231",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-123456789101231",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-123456789101231"
         }
       }
@@ -470,13 +452,13 @@
   },
   {
     "Input": "1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         }
       }
@@ -484,13 +466,13 @@
   },
   {
     "Input": "일만",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일만",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "10000"
         }
       }
@@ -498,13 +480,13 @@
   },
   {
     "Input": "일백억",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백억",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "10000000000"
         }
       }
@@ -512,13 +494,13 @@
   },
   {
     "Input": "이백만",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이백만",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2000000"
         }
       }
@@ -526,13 +508,13 @@
   },
   {
     "Input": "1조",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1조",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000000000000"
         }
       }
@@ -540,13 +522,13 @@
   },
   {
     "Input": " 삼 ",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "3"
         }
       }
@@ -554,13 +536,13 @@
   },
   {
     "Input": "일조",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일조",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1000000000000"
         }
       }
@@ -568,13 +550,13 @@
   },
   {
     "Input": "이십일조",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일조",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "21000000000000"
         }
       }
@@ -582,13 +564,13 @@
   },
   {
     "Input": "이십일조 삼백",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일조 삼백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "21000000000300"
         }
       }
@@ -596,13 +578,13 @@
   },
   {
     "Input": "오십 이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오십 이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "52"
         }
       }
@@ -610,13 +592,13 @@
   },
   {
     "Input": "오십  이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오십  이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "52"
         }
       }
@@ -624,13 +606,13 @@
   },
   {
     "Input": "삼백  삼십  일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼백  삼십  일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "331"
         }
       }
@@ -638,13 +620,13 @@
   },
   {
     "Input": "이십만 이천",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십만 이천",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "202000"
         }
       }
@@ -652,13 +634,13 @@
   },
   {
     "Input": "이천  이백",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이천  이백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2200"
         }
       }
@@ -666,13 +648,13 @@
   },
   {
     "Input": "1e10",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1e10",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "10000000000"
         }
       }
@@ -680,13 +662,13 @@
   },
   {
     "Input": "1.1^23",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1.1^23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "8.95430243255239"
         }
       }
@@ -694,13 +676,13 @@
   },
   {
     "Input": "칠십",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "칠십",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "70"
         }
       }
@@ -708,13 +690,13 @@
   },
   {
     "Input": "2  1/4",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2  1/4",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "2.25"
         }
       }
@@ -722,13 +704,13 @@
   },
   {
     "Input": "3/4",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3/4",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.75"
         }
       }
@@ -736,13 +718,13 @@
   },
   {
     "Input": "팔분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "팔분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.125"
         }
       }
@@ -750,13 +732,13 @@
   },
   {
     "Input": "팔분의 오",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "팔분의 오",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.625"
         }
       }
@@ -764,14 +746,13 @@
   },
   {
     "Input": "반",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "반",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.5"
         }
       }
@@ -779,13 +760,13 @@
   },
   {
     "Input": "이십삼과 오분의 삼",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십삼과 오분의 삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "23.6"
         }
       }
@@ -793,13 +774,13 @@
   },
   {
     "Input": "일과 이분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일과 이분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1.5"
         }
       }
@@ -807,13 +788,13 @@
   },
   {
     "Input": "일과 사분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일과 사분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1.25"
         }
       }
@@ -821,13 +802,13 @@
   },
   {
     "Input": "오와 사분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오와 사분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "5.25"
         }
       }
@@ -835,13 +816,13 @@
   },
   {
     "Input": "일백과 사분의 삼",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백과 사분의 삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "100.75"
         }
       }
@@ -849,13 +830,13 @@
   },
   {
     "Input": "백분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "백분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.01"
         }
       }
@@ -863,13 +844,13 @@
   },
   {
     "Input": "1.1^+23",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1.1^+23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "8.95430243255239"
         }
       }
@@ -877,13 +858,13 @@
   },
   {
     "Input": "2.5^-1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2.5^-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "0.4"
         }
       }
@@ -891,13 +872,13 @@
   },
   {
     "Input": "-2500^-1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-2500^-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-0.0004"
         }
       }
@@ -905,13 +886,13 @@
   },
   {
     "Input": "-1.1^+23",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-1.1^+23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-8.95430243255239"
         }
       }
@@ -919,13 +900,13 @@
   },
   {
     "Input": "-2.5^-1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-2.5^-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-0.4"
         }
       }
@@ -933,13 +914,13 @@
   },
   {
     "Input": "-1.1^--23",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-1.1^--23",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-8.95430243255239"
         }
       }
@@ -947,13 +928,13 @@
   },
   {
     "Input": "-127.32e13",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-127.32e13",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-1.2732E+15"
         }
       }
@@ -961,13 +942,13 @@
   },
   {
     "Input": "12.32e+14",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "12.32e+14",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "1.232E+15"
         }
       }
@@ -975,13 +956,13 @@
   },
   {
     "Input": "-12e-1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "-12e-1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "power",
           "value": "-1.2"
         }
       }
@@ -989,13 +970,13 @@
   },
   {
     "Input": "십이억",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "십이억",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1200000000"
         }
       }
@@ -1003,13 +984,13 @@
   },
   {
     "Input": "오분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.2"
         }
       }
@@ -1017,13 +998,13 @@
   },
   {
     "Input": "삼과 오분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼과 오분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "3.2"
         }
       }
@@ -1031,13 +1012,13 @@
   },
   {
     "Input": "이십일분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.0476190476190476"
         }
       }
@@ -1045,13 +1026,13 @@
   },
   {
     "Input": "이십오분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십오분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.04"
         }
       }
@@ -1059,13 +1040,13 @@
   },
   {
     "Input": "이십일분의 삼",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일분의 삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.142857142857143"
         }
       }
@@ -1073,13 +1054,13 @@
   },
   {
     "Input": "이십일 분의 삼",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십일 분의 삼",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.142857142857143"
         }
       }
@@ -1087,13 +1068,13 @@
   },
   {
     "Input": "이십오분의 이십",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십오분의 이십",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.8"
         }
       }
@@ -1101,13 +1082,13 @@
   },
   {
     "Input": "일백과 오분의 삼십",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백과 오분의 삼십",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "106"
         }
       }
@@ -1115,13 +1096,13 @@
   },
   {
     "Input": "삼십오분의 일백",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼십오분의 일백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "2.85714285714286"
         }
       }
@@ -1129,13 +1110,13 @@
   },
   {
     "Input": "오분의 일백삼십이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오분의 일백삼십이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "26.4"
         }
       }
@@ -1143,13 +1124,13 @@
   },
   {
     "Input": "일백삼십과 오분의 이",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백삼십과 오분의 이",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "130.4"
         }
       }
@@ -1157,13 +1138,13 @@
   },
   {
     "Input": "일백오분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백오분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.00952380952380952"
         }
       }
@@ -1171,13 +1152,13 @@
   },
   {
     "Input": "백오분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "백오분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.00952380952380952"
         }
       }
@@ -1185,13 +1166,13 @@
   },
   {
     "Input": "일천오분의 일백",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일천오분의 일백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.0995024875621891"
         }
       }
@@ -1199,13 +1180,13 @@
   },
   {
     "Input": "삼분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.333333333333333"
         }
       }
@@ -1213,13 +1194,13 @@
   },
   {
     "Input": "일백이십일분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백이십일분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.00826446280991736"
         }
       }
@@ -1227,13 +1208,13 @@
   },
   {
     "Input": "삼 분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼 분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.333333333333333"
         }
       }
@@ -1241,13 +1222,13 @@
   },
   {
     "Input": "3분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "3분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.333333333333333"
         }
       }
@@ -1255,13 +1236,13 @@
   },
   {
     "Input": "삼분의 1",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "삼분의 1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.333333333333333"
         }
       }
@@ -1269,13 +1250,13 @@
   },
   {
     "Input": "20분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "20분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.05"
         }
       }
@@ -1283,13 +1264,13 @@
   },
   {
     "Input": "이십분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "이십분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.05"
         }
       }
@@ -1297,13 +1278,13 @@
   },
   {
     "Input": "일백분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.01"
         }
       }
@@ -1311,13 +1292,13 @@
   },
   {
     "Input": "일백이십팔분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "일백이십팔분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.0078125"
         }
       }
@@ -1325,13 +1306,13 @@
   },
   {
     "Input": "정답은 음수 일천구백입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "음수 일천구백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-1900"
         }
       }
@@ -1339,13 +1320,13 @@
   },
   {
     "Input": "정답은 마이너스 일천구백입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "마이너스 일천구백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-1900"
         }
       }
@@ -1353,13 +1334,13 @@
   },
   {
     "Input": "정답은 마이너스 일입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "마이너스 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "-1"
         }
       }
@@ -1367,13 +1348,13 @@
   },
   {
     "Input": "정답은 마이너스 삼십오분의 일백입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "마이너스 삼십오분의 일백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-2.85714285714286"
         }
       }
@@ -1381,13 +1362,13 @@
   },
   {
     "Input": "정답은 음수 이십분의 일입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "음수 이십분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "-0.05"
         }
       }
@@ -1395,28 +1376,27 @@
   },
   {
     "Input": "정답은 마이너스 오 점 오입니다.",
-    "Comment": "PendingValidation",
-    "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
-    "Results": [
-      {
-        "Text": "마이너스 오 점 오",
-        "TypeName": "number",
-        "Resolution": {
-          "value": "-5.5"
-        }
-      }
-    ]
-  },
-  {
-    "Input": "정답은 마이너스 오입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "마이너스 오",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
+          "value": "-5"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "정답은 마이너스 오입니다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "마이너스 오",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
           "value": "-5"
         }
       }
@@ -1424,13 +1404,13 @@
   },
   {
     "Input": "사분의 일",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "사분의 일",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "0.25"
         }
       }
@@ -1438,13 +1418,13 @@
   },
   {
     "Input": "오분의 구천오백",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "오분의 구천오백",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "fraction",
           "value": "1900"
         }
       }
@@ -1452,29 +1432,29 @@
   },
   {
     "Input": "1 234 567",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "1 234 567",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1234567"
-        }
+        },
+        "Start": 0,
+        "End": 8
       }
     ]
   },
   {
     "Input": "40 000 은 40 000과 같다",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "40 000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "40000"
         }
       },
@@ -1482,6 +1462,7 @@
         "Text": "40 000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "40000"
         }
       }
@@ -1489,29 +1470,27 @@
   },
   {
     "Input": "현재 중국의 인구수는 1 414 021 100이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "1 414 021 100",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1414021100"
         }
       }
     ]
   },
   {
-    "Input": "423 0000는 두 개의 숫자이다.",
-    "Comment": "PendingValidation",
+    "Input": "423 0000 는 두 개의 숫자이다.",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "423",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "423"
         }
       },
@@ -1519,6 +1498,7 @@
         "Text": "0000",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "0"
         }
       },
@@ -1526,6 +1506,7 @@
         "Text": "두",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2"
         }
       }
@@ -1533,14 +1514,13 @@
   },
   {
     "Input": "1 234 567.89는 유효한 숫자 형식이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotnet",
     "Results": [
       {
         "Text": "1 234 567.89",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "decimal",
           "value": "1234567.89"
         }
       }
@@ -1548,13 +1528,13 @@
   },
   {
     "Input": "0은 영이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "0",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "0"
         }
       },
@@ -1562,6 +1542,7 @@
         "Text": "영",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "0"
         }
       }
@@ -1569,13 +1550,13 @@
   },
   {
     "Input": "5/17/2018에 만날까요?",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "5",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "5"
         }
       },
@@ -1583,6 +1564,7 @@
         "Text": "17",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "17"
         }
       },
@@ -1590,6 +1572,7 @@
         "Text": "2018",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2018"
         }
       }
@@ -1597,13 +1580,13 @@
   },
   {
     "Input": "내 전화번호는 +1-222-2222/2222입니다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "1",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "1"
         }
       },
@@ -1611,6 +1594,7 @@
         "Text": "222",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "222"
         }
       },
@@ -1618,6 +1602,7 @@
         "Text": "2222",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2222"
         }
       },
@@ -1625,6 +1610,7 @@
         "Text": "2222",
         "TypeName": "number",
         "Resolution": {
+          "subtype": "integer",
           "value": "2222"
         }
       }
@@ -1632,7 +1618,6 @@
   },
   {
     "Input": "그 나무는 192살입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1649,7 +1634,6 @@
   },
   {
     "Input": "내 IP 주소는 192.168.1.2입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1696,7 +1680,6 @@
   },
   {
     "Input": "내 학생번호는 십육입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1713,7 +1696,6 @@
   },
   {
     "Input": "백십육 자루의 연필이 있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1730,7 +1712,6 @@
   },
   {
     "Input": "백육은 나에게 특별한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1747,7 +1728,6 @@
   },
   {
     "Input": "내가 사는 곳은 백육십일 호입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1764,7 +1744,6 @@
   },
   {
     "Input": "십만 달러",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1781,7 +1760,6 @@
   },
   {
     "Input": "1,234,567은 큰 숫자인가?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1798,7 +1776,6 @@
   },
   {
     "Input": "이 가방의 가격은 1, 234, 567원이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1835,7 +1812,6 @@
   },
   {
     "Input": "-1은 음수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1852,7 +1828,6 @@
   },
   {
     "Input": "삼은 자연수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1869,7 +1844,6 @@
   },
   {
     "Input": "숫자 1",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1886,7 +1860,6 @@
   },
   {
     "Input": "나의 월급은 2백만원입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1903,7 +1876,6 @@
   },
   {
     "Input": "1조원이 넘는 정부의 예산이 사라졌다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1920,7 +1892,6 @@
   },
   {
     "Input": "삼은 소수입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1937,7 +1908,6 @@
   },
   {
     "Input": "일조원의 정부 예산이 사라졌다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1954,7 +1924,6 @@
   },
   {
     "Input": "이십일조원은 큰 돈이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1971,7 +1940,6 @@
   },
   {
     "Input": "삼성의 연 매출은 이십일조 삼백에 달한다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1988,7 +1956,6 @@
   },
   {
     "Input": "이십일조와 삼백은 다른 수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2005,7 +1972,6 @@
   },
   {
     "Input": "오십이명의 사람들이 참석했다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2022,7 +1988,6 @@
   },
   {
     "Input": "삼백삼십일일이 지났다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2039,24 +2004,32 @@
   },
   {
     "Input": "이백과 이천은 다른 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "이백과 이천",
+        "Text": "이백",
         "TypeName": "number",
         "Resolution": {
           "subtype": "integer",
-          "value": "202000"
+          "value": "200"
         },
         "Start": 0,
+        "End": 1
+      },
+      {
+        "Text": "이천",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2000"
+        },
+        "Start": 4,
         "End": 5
       }
     ]
   },
   {
     "Input": "이천이백년이 지났다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2073,7 +2046,6 @@
   },
   {
     "Input": "322백은 유효하지 않은 수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2090,7 +2062,6 @@
   },
   {
     "Input": "칠십척의 배가 있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2107,7 +2078,6 @@
   },
   {
     "Input": "답은 마이너스 일입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2124,7 +2094,6 @@
   },
   {
     "Input": "답은 마이너스 5이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2141,7 +2110,6 @@
   },
   {
     "Input": "1,234,567 은 자연수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2158,7 +2126,6 @@
   },
   {
     "Input": "40,000은 40,000이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2185,7 +2152,6 @@
   },
   {
     "Input": "현재 중국의 인구는 1,414,021,100 명이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2201,8 +2167,7 @@
     ]
   },
   {
-    "Input": "423 0000은 두개의 수로 인식될 것이다",
-    "IgnoreResolution": true,
+    "Input": "423 0000 은 두개의 수로 인식될 것이다",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2232,14 +2197,13 @@
           "subtype": "integer",
           "value": "2"
         },
-        "Start": 10,
-        "End": 10
+        "Start": 11,
+        "End": 11
       }
     ]
   },
   {
     "Input": "영은 0이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2266,7 +2230,6 @@
   },
   {
     "Input": "2018/5/17에 시간 있어?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2303,7 +2266,6 @@
   },
   {
     "Input": "내 전화번호는 국가번호 +1-222-2222/2222입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2350,7 +2312,6 @@
   },
   {
     "Input": "나는 너에게 3백21 위안을 줄 수 있어",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2367,7 +2328,6 @@
   },
   {
     "Input": "4천3백21은 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2384,7 +2344,6 @@
   },
   {
     "Input": "4천 3백과 0은 두개의 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2421,7 +2380,6 @@
   },
   {
     "Input": "4000 3백21은 두개의 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2458,7 +2416,6 @@
   },
   {
     "Input": "3백과 2백은 두개의 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2495,7 +2452,6 @@
   },
   {
     "Input": "3백일은 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2512,7 +2468,6 @@
   },
   {
     "Input": "테키만에서 일어난 사고에서 스물여섯명이 죽다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2529,7 +2484,6 @@
   },
   {
     "Input": "나는 3년 안에 10000$를 벌고 싶다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2556,7 +2510,6 @@
   },
   {
     "Input": "나는 3년 동안 2000$를 벌고싶다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2583,7 +2536,6 @@
   },
   {
     "Input": "내 한달 용돈은 20$이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2600,7 +2552,6 @@
   },
   {
     "Input": "계란 한 다스만 사주시겠어요?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2617,7 +2568,6 @@
   },
   {
     "Input": "3백과 마이너스 일은 두개의 유효한 숫자입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2654,9 +2604,7 @@
   },
   {
     "Input": "3백과 2.12백은 두개의 유효한 숫자이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Comment": "Point value parser need to be refactored",
     "Results": [
       {
@@ -2693,7 +2641,6 @@
   },
   {
     "Input": "0.08 밀리그램을 더 넣어주세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2710,7 +2657,6 @@
   },
   {
     "Input": "0.23456000은 경미한 수치이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2727,7 +2673,6 @@
   },
   {
     "Input": "4.800점의 부분점수를 받았다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2744,7 +2689,6 @@
   },
   {
     "Input": "9.2321312은 짝수인가?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2761,7 +2705,6 @@
   },
   {
     "Input": " -9.2321312은 홀수인가?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2778,7 +2721,6 @@
   },
   {
     "Input": "이백점 영삼점을 획득했습니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2795,7 +2737,6 @@
   },
   {
     "Input": "그녀의 프리스케이팅 점수는 이백점 칠일이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2812,7 +2753,6 @@
   },
   {
     "Input": "답은 마이너스 오점 오이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2829,7 +2769,6 @@
   },
   {
     "Input": "1,234,567.89 는 유효한 숫자 형식이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2846,7 +2785,6 @@
   },
   {
     "Input": "1.1^23을 해보세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2863,7 +2801,6 @@
   },
   {
     "Input": "2.5^-1을 계산하여 소수로 나타내시오",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2880,7 +2817,6 @@
   },
   {
     "Input": "모든 값을 더하면 백삼과 삼분의 이가 나온다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2897,7 +2833,6 @@
   },
   {
     "Input": "케이크의 삼분의 이를 먹어치웠다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2914,7 +2849,6 @@
   },
   {
     "Input": "일조분의 일만큼만 사랑해",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2931,7 +2865,6 @@
   },
   {
     "Input": "백억분의 일만 주세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2948,7 +2881,6 @@
   },
   {
     "Input": "-4/5 를 좌표에 표시하세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2965,7 +2897,6 @@
   },
   {
     "Input": "-1 4/5는 이 함수에서 상수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2982,7 +2913,6 @@
   },
   {
     "Input": "2  1/4 조각을 동생에게 주어라",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -2999,7 +2929,6 @@
   },
   {
     "Input": "동생은 피자의 3/4를 먹어치웠다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3016,7 +2945,6 @@
   },
   {
     "Input": "팔분의 일조각을 남겨주세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3033,10 +2961,7 @@
   },
   {
     "Input": "반을 떼어주세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Extraction done. Parser does not support half (반).",
     "Results": [
       {
         "Text": "반",
@@ -3052,7 +2977,6 @@
   },
   {
     "Input": "이 케이크의 사분의 삼은 내 것이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3069,7 +2993,6 @@
   },
   {
     "Input": "이십과 오분의 삼은 대분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3086,7 +3009,6 @@
   },
   {
     "Input": "오분의 이십삼은 가분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3103,7 +3025,6 @@
   },
   {
     "Input": "이십과 삼과 오분의 삼은 각각 자연수와 분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3120,7 +3041,6 @@
   },
   {
     "Input": "오분의 백만이천이백삼은 가분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3137,7 +3057,6 @@
   },
   {
     "Input": "일과 이분의 일은 대분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3154,7 +3073,6 @@
   },
   {
     "Input": "일과 사분의 일만큼 더 가져가세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3171,7 +3089,6 @@
   },
   {
     "Input": "오와 사분의 일을 소수로 표현하시오",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3188,7 +3105,6 @@
   },
   {
     "Input": "계산했더니 답이 백과 사분의 삼으로 나왔다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3205,7 +3121,6 @@
   },
   {
     "Input": "당첨될 확률은 백분의 일이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3222,7 +3137,6 @@
   },
   {
     "Input": "천만분의 일 확률이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3239,7 +3153,6 @@
   },
   {
     "Input": "투자 금액의 오분의 일만을 돌려받았다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3256,7 +3169,6 @@
   },
   {
     "Input": "호두파이의 오분의 삼조각만 먹었다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3273,7 +3185,6 @@
   },
   {
     "Input": "오분의 이십을 계산하면 자연수가 나온다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3290,7 +3201,6 @@
   },
   {
     "Input": "삼과 오분의 일은 대분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3307,7 +3217,6 @@
   },
   {
     "Input": "오분의 이십일은 나누어 떨어지지 않는다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3324,7 +3233,6 @@
   },
   {
     "Input": "이십오분의 일의 확률로 이 병에 걸린다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3341,7 +3249,6 @@
   },
   {
     "Input": "재산의 이십일분의 삼은 기부할 것이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3358,7 +3265,6 @@
   },
   {
     "Input": "이 학교에 입학할 확률은 이십일분의 삼이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3375,7 +3281,6 @@
   },
   {
     "Input": "출산율이 이십오분의 이십으로 떨어졌다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3392,7 +3297,6 @@
   },
   {
     "Input": "오분의 백삼십은 나누어 떨어진다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3409,7 +3313,6 @@
   },
   {
     "Input": "삼십오분의 백은 나누어 떨어지지 않는다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3426,7 +3329,6 @@
   },
   {
     "Input": "오분의 백삼십이를 계산하면 나머지가 존재한다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3443,7 +3345,6 @@
   },
   {
     "Input": "백삼십과 오분의 이는 오답이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3460,7 +3361,6 @@
   },
   {
     "Input": "현재의 값에서 백오분의 일 을 빼세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3477,7 +3377,6 @@
   },
   {
     "Input": "백오분의 일을 추가로 빼세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3494,7 +3393,6 @@
   },
   {
     "Input": "천오분의 백을 소수로 표현하시오",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3511,7 +3409,6 @@
   },
   {
     "Input": "삼분의 일조각을 잘라줘",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3528,7 +3425,6 @@
   },
   {
     "Input": "백이십일분의 1은 분수이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3545,7 +3441,6 @@
   },
   {
     "Input": "삼분의 1조각을 잘라줘",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3562,7 +3457,6 @@
   },
   {
     "Input": "3분의 1조각만 잘라줘",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3579,7 +3473,6 @@
   },
   {
     "Input": "3분의 일만 줘",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3596,7 +3489,6 @@
   },
   {
     "Input": "20분의 일은 내 몫이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3613,7 +3505,6 @@
   },
   {
     "Input": "이십분의 일은 네 몫이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3630,7 +3521,6 @@
   },
   {
     "Input": "한국 사람의 백분의 일",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3647,7 +3537,6 @@
   },
   {
     "Input": "이 생물이 생존할 확률은 백이십오분의 일이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3664,7 +3553,6 @@
   },
   {
     "Input": "오분의 구천오백은 얼마입니까?",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3681,7 +3569,6 @@
   },
   {
     "Input": "답은 오분의 마이너스 구천오백이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3698,7 +3585,6 @@
   },
   {
     "Input": "답은 삼십오분의 마이너스 백입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3715,7 +3601,6 @@
   },
   {
     "Input": "답은 20분의 마이너스 일이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3732,7 +3617,6 @@
   },
   {
     "Input": "사분의 일 조각만 남겨줘",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3749,7 +3633,6 @@
   },
   {
     "Input": "팔분의 일은 네 몫이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3766,7 +3649,6 @@
   },
   {
     "Input": "서울 시민의 팔분의 오는 여당을 지지한다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3783,7 +3665,6 @@
   },
   {
     "Input": "셋 중 하나는 진짜 샤넬이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3800,7 +3681,6 @@
   },
   {
     "Input": "이십일 분의 1의 확률이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3817,7 +3697,6 @@
   },
   {
     "Input": "케이크의 팔분의 오",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3834,10 +3713,7 @@
   },
   {
     "Input": "반이 넘는 사람들이 이곳에 왔다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
-    "Comment": "Extraction done. Parser does not support half (반).",
     "Results": [
       {
         "Text": "반",
@@ -3853,7 +3729,6 @@
   },
   {
     "Input": "3분의 2000을 계산하시오",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3901,7 +3776,6 @@
   {
     "Input": "1미터는 숫자가 아닙니다",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotnet",
     "Comment": "Need more research by language expert",
     "Results": []
   },
@@ -3922,7 +3796,6 @@
   },
   {
     "Input": "그녀는 열여섯 살입니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3939,7 +3812,6 @@
   },
   {
     "Input": "셋에 출발하시면 됩니다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3956,7 +3828,6 @@
   },
   {
     "Input": "하나만 주세요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3973,7 +3844,6 @@
   },
   {
     "Input": "쉰둘이 넘는 사람들이 모였다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -3990,7 +3860,6 @@
   },
   {
     "Input": "일흔 살",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -4007,7 +3876,6 @@
   },
   {
     "Input": "내가 가장 좋아하는 숫자는 이십육이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -4024,7 +3892,6 @@
   },
   {
     "Input": "사과 세개",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -4041,7 +3908,6 @@
   },
   {
     "Input": "사과 한 개",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -4058,7 +3924,6 @@
   },
   {
     "Input": "쉰두살",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -4075,8 +3940,7 @@
   },
   {
     "Input": "천삼백",
-    "IgnoreResolution": true,
-    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "천삼백",
@@ -4086,14 +3950,13 @@
           "value": "1300"
         },
         "Start": 0,
-        "End": 3
+        "End": 2
       }
     ]
   },
   {
     "Input": "천삼",
-    "IgnoreResolution": true,
-    "NotSupportedByDesign": "dotnet, java, javascript, python",
+    "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "천삼",
@@ -4103,7 +3966,99 @@
           "value": "1003"
         },
         "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "이십만이천은 다른 숫자이다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "이십만이천",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "202000"
+        },
+        "Start": 0,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "사십구은유효한 숫자입니다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "사십구",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "49"
+        },
+        "Start": 0,
         "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "쉰일곱",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "쉰일곱",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "57"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "그는 일흔일곱 세입니다",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "일흔일곱",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "77"
+        },
+        "Start": 3,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "일조분의일",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "일조분의일",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "1E-12"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "일백조 번째분의일",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "일백조 번째분의일",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "1E-14"
+        }
       }
     ]
   }


### PR DESCRIPTION
All test cases pass.

A few inputs have been modified e.g. 
- "조 번째" -> "일조 번째" (one trillion). "조 번째" alone does not mean "trillion" it needs to be preceded by a number.
- "180.25ml의 액체", "180ml 의 액체", "29km의 길". A space has been added between the number and the unit in order to reproduce the behavior of the corresponding English cases.