### PR TITLE
[KO Number] Korean NumberRange refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
             { @"등", @"" },
             { @"이백십", @"백백십" },
             { @"삼백십", @"백백백십" },
+            { @"십세", @"십" },
             { @" ", @"" }
         };
       public static readonly IList<char> RoundDirectList = new List<char>
@@ -167,7 +168,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string PercentageRegex = @"(?<=백\s*분\s*의).+|.+(?=퍼\s*센\s*트*)|.*(?=[％%])|.+(?=프\s*로*)";
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?{RoundNumberIntegerRegex}{{1,2}}(\s*(이상))?";
       public const string FracSplitRegex = @"(와|과|분\s*의|중)";
-      public const string ZeroToNineIntegerRegex = @"(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
+      public const string ZeroToNineIntegerRegex = @"(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘|른|사|살))이(?!(다|하|상|무|거나))|두|삼|사(?!(이|랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)";
       public static readonly string TenToNinetySinoIntegerRegex = $@"({ZeroToNineIntegerRegex})?십";
       public const string TenToNinetyNativeIntegerRegex = @"(스무|열|스물|서른|마흔|쉰|예순|일흔|여든|아흔)";
       public static readonly string ElevenToNineteenSinoIntegerRegex = $@"십({ZeroToNineIntegerRegex})";
@@ -179,7 +180,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string RoundNumberIntegerRegex = @"(십|백|천|(?<!(큼|\s일|다스|하|하나))만(?![큼|을])|억|조(?!각)(\s번째)?|경|열)";
       public const string AllowListRegex = @"(。|，|、|（|）|“|”|까지|가지|가치|갓|거리|국|[곳|군데]|개|그루|급|기|길|[까풀|꺼풀]|꼭지|닢|다스|대|돈|롤|리|미터|[밀리|미리]|마리|매|모|[면|페이지]|벌|박|배|부|분|살|술|승|쌈|[옴큼|웅큼]|원|일|잎|잔|장|전|점|제곱|주|종|평|평방|척|채|차|첩|켤레|쾌|탕|푼|[연|년]|은|\s|$|/|만)";
       public static readonly string NotSingleRegex = $@"({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)";
-      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(랑|주))|(?<![시])오(?!(월|늘))|육|(?<!며)칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
+      public static readonly string SingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(이|랑|주))|(?<![시])오(?!(월|늘))|육|(?<!며)칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))";
       public static readonly string NativeSingleRegex = $@"(?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})";
       public static readonly string NativeIntRegex = $@"((({ZeroToNineIntegerRegex}\s*)?({RoundNumberIntegerRegex}+\s*)?({TenToNinetyNativeIntegerRegex}\s*)?({ZeroToNineIntegerRegex}))|({TenToNinetyNativeIntegerRegex}))";
       public static readonly string AllIntRegex = $@"(((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|십)\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|[십]|{RoundNumberIntegerRegex}\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))\s*((({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){{1,2}}|영)\s*)*{ZeroToNineIntegerRegex}?|{ZeroToNineIntegerRegex})|{NativeIntRegex}+)";
@@ -226,36 +227,36 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*개\s*백\s*분\s*점";
       public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d)({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})?({AllIntRegex}|{ZeroToNineFullHalfRegex}|{RoundNumberIntegerRegex})+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)([％%]|(퍼\s*센\s*트)|(프\s*로)|(퍼\s*센\s*티\s*지))(?!\d)";
       public const string TillRegex = @"(부터|에서|--|-|—|–|——|~)";
-      public const string MoreRegex = @"(초과|많|높|더많|더높|더크|>|넘는|초과이다|크고|(을 초과하는)|크)";
-      public const string LessRegex = @"(미만|적|낮|작|더적|더낮|더적|이하|이하이다|<|아래|작다)";
-      public const string EqualRegex = @"(동일|같|=|(해당하는)|는|그와 같다)";
-      public const string RangePrefixLessRegex = @"(까지최소|(?<!>|=)<|≤)";
-      public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥)";
+      public const string MoreRegex = @"(넘었(다)?|초과|많|높(고)?|더많|더높|더크|>=|>|넘는(다)?|초과이다|크고|이 넘는|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))";
+      public const string LessRegex = @"(미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)";
+      public const string EqualRegex = @"(동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)";
+      public const string RangePrefixLessRegex = @"(최대|까지최소|(?<!>|=)<|≤)";
+      public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥|>=|개에서 최소|과 같거나 최소|이거나 최소)";
       public static readonly string MoreOrEqual = $@"(({MoreRegex}\s*(거나)?\s*{EqualRegex}))";
       public static readonly string MoreOrEqual2 = $@"(\s*(거나)?\s*(그보다)\s*{MoreRegex})";
-      public const string MoreOrEqualSuffix = @"\s*(이상)";
-      public static readonly string LessOrEqual = $@"(?:(이|보다)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?))";
-      public const string LessOrEqualSuffix = @"\s*(이하|(달하는))";
-      public const string OneNumberRangeMoreSeparateRegex = @"^[.]";
-      public const string OneNumberRangeLessSeparateRegex = @"^[.]";
-      public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))";
+      public const string MoreOrEqualSuffix = @"\s*(이상|세 이상|개 이상|(과 같)?거나 그보다 많다|거나 그보다 크다)";
+      public static readonly string LessOrEqual = $@"(?:(이|보다|과|≤)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?)|≤)";
+      public const string LessOrEqualSuffix = @"\s*((달하는|또는 그 미만|또는 그보다 적게|거나 그보다 작다|또는 그보다 작은|점 이하|이하|이하이다))";
+      public const string OneNumberRangeMoreSeparateRegex = @"(>=|≥|과 같|이거나)";
+      public const string OneNumberRangeLessSeparateRegex = @"같거나|약";
+      public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))";
       public static readonly string OneNumberRangeEqualRegex2 = $@"((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))";
-      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
-      public static readonly string OneNumberRangeMoreRegex2 = $@"(?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)(보다)?\s({MoreRegex})|(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
-      public static readonly string OneNumberRangeMoreRegex3 = $@"({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))";
+      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
+      public static readonly string OneNumberRangeMoreRegex2 = $@"((?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)|(?<number1>(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+))((\s등\s)?보다)?(\s살이)?\s({MoreRegex})|(최소\s*)?(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
+      public static readonly string OneNumberRangeMoreRegex3 = $@"(({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|((과 같거나 최소|이거나 최소)\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))";
       public static readonly string OneNumberRangeMoreRegex4 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?";
       public static readonly string OneNumberRangeMoreRegex5 = $@"(?<number1>((?![,.](?!\d+)).)+)\s*((또는)\s+(그){MoreOrEqualSuffix})";
       public static readonly string OneNumberRangeMoreRegexFraction = $@"((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})";
-      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}";
-      public static readonly string OneNumberRangeLessRegex2 = $@"((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)";
-      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))";
+      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}";
+      public static readonly string TwoNumberRangeRegex = $@"({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?";
+      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((같거나|약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))";
       public static readonly string OneNumberRangeLessRegex4 = $@"(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))";
-      public const string OneNumberRangeLessRegex5 = @"((?<number2>((이분의\s)|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다|보다)?\s*(미만|적게|밑|이하|작다))";
+      public const string OneNumberRangeLessRegex5 = @"((?<number2>((이분의\s|약\s*)|(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는|등)?\s*(살이|그|그보다|(위)?보다(는)?)?\s*(낮다|낮은|미만|마리 미만|적게|밑|(개 )?이하|작다|작거나)(\s?같다?)?)";
       public static readonly string TwoNumberRangeRegex1 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)";
-      public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})";
+      public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(까지)?";
-      public static readonly string TwoNumberRangeRegex5 = $@"(?<number1>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+)\s*{TillRegex}\s*(?<number2>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+)";
+      public static readonly string TwoNumberRangeRegex5 = $@"(?<number1>((마이너스\s?)?([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+)(점)?(\s*)?{TillRegex}(\s*)?(?<number2>((마이너스\s?)?(([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+))(점)?((\s*)?([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+))?((\s)사이)?";
       public static readonly string TwoNumberRangeRegex6 = $@"((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))";
       public static readonly string TwoNumberRangeRegex7 = $@"({OneNumberRangeMoreRegex2}\s*{OneNumberRangeLessRegex5})";
       public const string InexactNumberUnitRegex = @"(몇(?!.+\?)|며|여러)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -227,8 +227,8 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string NumbersFractionPercentageRegex = $@"{ZeroToNineFullHalfRegex}{{1,3}}([,，]{ZeroToNineFullHalfRegex}{{3}})+\s*개\s*백\s*분\s*점";
       public static readonly string SimpleIntegerPercentageRegex = $@"(?<!%|\d)({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})?({AllIntRegex}|{ZeroToNineFullHalfRegex}|{RoundNumberIntegerRegex})+([\.．]{ZeroToNineFullHalfRegex}+)?(\s*)([％%]|(퍼\s*센\s*트)|(프\s*로)|(퍼\s*센\s*티\s*지))(?!\d)";
       public const string TillRegex = @"(부터|에서|--|-|—|–|——|~)";
-      public const string MoreRegex = @"(넘었(다)?|초과|많|높(고)?|더많|더높|더크|>=|>|넘는(다)?|초과이다|크고|이 넘는|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))";
-      public const string LessRegex = @"(미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)";
+      public const string MoreRegex = @"(넘었(다)?|초과|커|많|큽|높(고)?|더많|더높|더크|>=|>|(이\s)?넘는(다)?|초과이다|크고|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))((습)?니다|(아|네|군)?요)?";
+      public const string LessRegex = @"(미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)((네|아|어|군)요|습니다|은|다)?";
       public const string EqualRegex = @"(동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)";
       public const string RangePrefixLessRegex = @"(최대|까지최소|(?<!>|=)<|≤)";
       public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥|>=|개에서 최소|과 같거나 최소|이거나 최소)";
@@ -247,7 +247,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string OneNumberRangeMoreRegex4 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?";
       public static readonly string OneNumberRangeMoreRegex5 = $@"(?<number1>((?![,.](?!\d+)).)+)\s*((또는)\s+(그){MoreOrEqualSuffix})";
       public static readonly string OneNumberRangeMoreRegexFraction = $@"((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})";
-      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}";
+      public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex})|{OneNumberRangeLessRegex5}";
       public static readonly string TwoNumberRangeRegex = $@"({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?";
       public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((같거나|약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))";
       public static readonly string OneNumberRangeLessRegex4 = $@"(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))";

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
@@ -54,8 +54,12 @@ namespace Microsoft.Recognizers.Text.Number
 
                     if (start >= 0 && length > 0)
                     {
-                        // Keep Source Data for extra information
-                        matchSource.Add(new Tuple<int, int>(start, length), collection.Value);
+                        // Add match if not already in matchSource
+                        if (!matchSource.ContainsKey(Tuple.Create(start, length)))
+                        {
+                            // Keep Source Data for extra information
+                            matchSource.Add(new Tuple<int, int>(start, length), collection.Value);
+                        }
                     }
                 }
             }

--- a/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Extractors/BaseNumberRangeExtractor.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Recognizers.Text.Number
 
                     if (start >= 0 && length > 0)
                     {
-                        // Add match if not already in matchSource
+                        // Add match if not already in matchSource (it can happen that a certain pattern is extracted by more than one regex,
+                        // but if the same tuple is added more than once execution breaks).
                         if (!matchSource.ContainsKey(Tuple.Create(start, length)))
                         {
                             // Keep Source Data for extra information

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
@@ -85,8 +85,8 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                     NumberRangeConstants.LESS
                 },
                 {
-                    new Regex(NumbersDefinitions.OneNumberRangeLessRegex2, RegexFlags),
-                    NumberRangeConstants.LESS
+                    new Regex(NumbersDefinitions.TwoNumberRangeRegex, RegexFlags),
+                    NumberRangeConstants.TWONUMCLOSED
                 },
                 {
                     // 까지최소|<|≤...

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -344,9 +344,9 @@ SimpleIntegerPercentageRegex: !nestedRegex
 TillRegex: !simpleRegex
   def: (부터|에서|--|-|—|–|——|~)
 MoreRegex: !simpleRegex
-  def: (넘었(다)?|초과|많|높(고)?|더많|더높|더크|>=|>|넘는(다)?|초과이다|크고|이 넘는|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))
+  def: (넘었(다)?|초과|커|많|큽|높(고)?|더많|더높|더크|>=|>|(이\s)?넘는(다)?|초과이다|크고|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))((습)?니다|(아|네|군)?요)?
 LessRegex: !simpleRegex
-  def: (미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)
+  def: (미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)((네|아|어|군)요|습니다|은|다)?
 EqualRegex: !simpleRegex
   def: (동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)
 RangePrefixLessRegex: !simpleRegex
@@ -395,7 +395,7 @@ OneNumberRangeMoreRegexFraction: !nestedRegex
   def: ((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})
   references: [MoreRegex]
 OneNumberRangeLessRegex1: !nestedRegex
-  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}
+  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex})|{OneNumberRangeLessRegex5}
   references: [LessOrEqual, LessRegex, LessOrEqualSuffix, OneNumberRangeLessRegex5]
 TwoNumberRangeRegex: !nestedRegex
   def: ({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -140,6 +140,7 @@ UnitMap: !dictionary
     등: ''
     이백십: 백백십
     삼백십: 백백백십
+    십세: 십
     ' ' : ''
 RoundDirectList: !list
   types: [char]
@@ -171,7 +172,7 @@ DoubleAndRoundRegex: !nestedRegex
 FracSplitRegex: !simpleRegex
   def: '(와|과|분\s*의|중)'
 ZeroToNineIntegerRegex: !simpleRegex
-  def: '(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘))이(?!다)|두|삼|사(?!(랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)'
+  def: '(영|령|공|(?<!생|주|\d)(?<=십|백|천|만|억|조|\s*)일|(?<!(율|답|둘|른|사|살))이(?!(다|하|상|무|거나))|두|삼|사(?!(이|랑|주))|(?<!시)오(?!(월|늘))|육|(?<!며)칠|팔|구|한(?=\s*)|하나|둘|세|셋|넷|다섯|여섯|일곱|여덟|아홉)'
 TenToNinetySinoIntegerRegex: !nestedRegex
   def: ({ZeroToNineIntegerRegex})?십
   references: [ZeroToNineIntegerRegex]
@@ -200,7 +201,7 @@ NotSingleRegex: !nestedRegex
   def: ({TenToNinetyNativeIntegerRegex})|((({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|[십천백셋])\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|[십천백셋]|{RoundNumberIntegerRegex}\s*((과\s*)?{ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex}|영))((\s*({ZeroToNineIntegerRegex}|{ZeroToNineFullHalfRegex})\s*(\s*{RoundNumberIntegerRegex}){1,2}(와)?|영)\s*)*(\s*{ZeroToNineIntegerRegex})?)
   references: [TenToNinetyNativeIntegerRegex, ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 SingleRegex: !nestedRegex
-  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(랑|주))|(?<![시])오(?!(월|늘))|육|(?<!며)칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))
+  def: (?<!((연필)|(예산)|(사람들)|(년)|(명)))((?<!{ZeroToNineIntegerRegex})(영|령|공|(?<!생)일|두|삼|사(?!(이|랑|주))|(?<![시])오(?!(월|늘))|육|(?<!며)칠|팔|구|세|한(?=(\s*개))|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)(?={AllowListRegex}))
   references: [ZeroToNineIntegerRegex, AllowListRegex]
 NativeSingleRegex: !nestedRegex
   def: (?<!((연필)|(예산)|(사람들)|(년|명|원)))({TenToNinetyNativeIntegerRegex}\s*{ZeroToNineIntegerRegex})
@@ -343,15 +344,15 @@ SimpleIntegerPercentageRegex: !nestedRegex
 TillRegex: !simpleRegex
   def: (부터|에서|--|-|—|–|——|~)
 MoreRegex: !simpleRegex
-  def: (초과|많|높|더많|더높|더크|>|넘는|초과이다|크고|(을 초과하는)|크)
+  def: (넘었(다)?|초과|많|높(고)?|더많|더높|더크|>=|>|넘는(다)?|초과이다|크고|이 넘는|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))
 LessRegex: !simpleRegex
-  def: (미만|적|낮|작|더적|더낮|더적|이하|이하이다|<|아래|작다)
+  def: (미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)
 EqualRegex: !simpleRegex
-  def: (동일|같|=|(해당하는)|는|그와 같다)
+  def: (동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)
 RangePrefixLessRegex: !simpleRegex
-  def: (까지최소|(?<!>|=)<|≤)
+  def: (최대|까지최소|(?<!>|=)<|≤)
 RangePrefixMoreRegex: !simpleRegex
-  def: ((?<!<|=)>|≥)
+  def: ((?<!<|=)>|≥|>=|개에서 최소|과 같거나 최소|이거나 최소)
 MoreOrEqual: !nestedRegex
   def: (({MoreRegex}\s*(거나)?\s*{EqualRegex}))
   references: [ MoreRegex, EqualRegex ]
@@ -359,32 +360,30 @@ MoreOrEqual2: !nestedRegex
   def: (\s*(거나)?\s*(그보다)\s*{MoreRegex})
   references: [ MoreRegex, EqualRegex ]
 MoreOrEqualSuffix: !simpleRegex
-  def: \s*(이상)
-LessOrEqual: !nestedRegex
-  def: (?:(이|보다)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?))
+  def: \s*(이상|세 이상|개 이상|(과 같)?거나 그보다 많다|거나 그보다 크다)
+LessOrEqual: !nestedRegex 
+  def: (?:(이|보다|과|≤)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?)|≤)
   references: [ LessRegex, EqualRegex ]
 LessOrEqualSuffix: !simpleRegex
-  def: \s*(이하|(달하는))
+  def: \s*((달하는|또는 그 미만|또는 그보다 적게|거나 그보다 작다|또는 그보다 작은|점 이하|이하|이하이다))
 OneNumberRangeMoreSeparateRegex: !simpleRegex
-  # TODO: Regex not applicable in Korean, references need to be adjusted
-  def: ^[.]
+  def: (>=|≥|과 같|이거나)
 OneNumberRangeLessSeparateRegex: !simpleRegex
-  # TODO: Regex not applicable in Korean, references need to be adjusted
-  def: ^[.]
+  def: 같거나|약
 OneNumberRangeEqualRegex: !nestedRegex
-  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))
+  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))
   references: [EqualRegex,LessRegex]
 OneNumberRangeEqualRegex2: !nestedRegex
   def: ((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))
   references: [AllIntRegex]
 OneNumberRangeMoreRegex1: !nestedRegex
-  def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
+  def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
   references: [MoreOrEqual, MoreRegex, MoreOrEqualSuffix]
 OneNumberRangeMoreRegex2: !nestedRegex
-  def: (?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)(보다)?\s({MoreRegex})|(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
-  references: [MoreRegex, MoreOrEqualSuffix]
+  def: ((?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)|(?<number1>(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+))((\s등\s)?보다)?(\s살이)?\s({MoreRegex})|(최소\s*)?(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
+  references: [MoreRegex, MoreOrEqualSuffix] 
 OneNumberRangeMoreRegex3: !nestedRegex
-  def: ({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+))
+  def: (({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|((과 같거나 최소|이거나 최소)\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))
   references: [RangePrefixMoreRegex]
 OneNumberRangeMoreRegex4: !nestedRegex
   def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?
@@ -396,24 +395,24 @@ OneNumberRangeMoreRegexFraction: !nestedRegex
   def: ((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})
   references: [MoreRegex]
 OneNumberRangeLessRegex1: !nestedRegex
-  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}
-  references: [LessOrEqual, LessRegex,OneNumberRangeLessRegex5]
-OneNumberRangeLessRegex2: !nestedRegex
-  def: ((?<number2>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에|이)+\s*{EqualRegex}?)(거나)\s*(최소)\s*(\d+)
-  references: [EqualRegex]
+  def: ((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex}(은|다)?)|{OneNumberRangeLessRegex5}
+  references: [LessOrEqual, LessRegex, LessOrEqualSuffix, OneNumberRangeLessRegex5]
+TwoNumberRangeRegex: !nestedRegex
+  def: ({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?
+  references: [RangePrefixLessRegex, RangePrefixMoreRegex] 
 OneNumberRangeLessRegex3: !nestedRegex
-  def: (?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))
+  def: (?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((같거나|약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))
   references: [RangePrefixLessRegex]
 OneNumberRangeLessRegex4: !nestedRegex
   def: (?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))
   references: [LessOrEqualSuffix]
 OneNumberRangeLessRegex5: !simpleRegex
-  def: ((?<number2>((이분의\s)|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는)?\s*(그|그보다|보다)?\s*(미만|적게|밑|이하|작다))
+  def: ((?<number2>((이분의\s|약\s*)|(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는|등)?\s*(살이|그|그보다|(위)?보다(는)?)?\s*(낮다|낮은|미만|마리 미만|적게|밑|(개 )?이하|작다|작거나)(\s?같다?)?)
 TwoNumberRangeRegex1: !nestedRegex
   def: (?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)
   references: [TillRegex]
 TwoNumberRangeRegex2: !nestedRegex
-  def: (({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})
+  def: (({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})
   references: [ OneNumberRangeMoreRegex1, OneNumberRangeMoreRegex2, OneNumberRangeLessRegex1]
 TwoNumberRangeRegex3: !nestedRegex
   def: ({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})
@@ -422,7 +421,7 @@ TwoNumberRangeRegex4: !nestedRegex
   def: (?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(까지)?
   references: [TillRegex]
 TwoNumberRangeRegex5: !nestedRegex
-  def: (?<number1>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+)\s*{TillRegex}\s*(?<number2>([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|칠|팔|구))+)\s*([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+)
+  def: (?<number1>((마이너스\s?)?([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+)(점)?(\s*)?{TillRegex}(\s*)?(?<number2>((마이너스\s?)?(([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+))(점)?((\s*)?([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+))?((\s)사이)?
   references: [TillRegex]
 TwoNumberRangeRegex6: !nestedRegex
   def: ((?<number1>((?!((，(?!\d+))|(,(?!\d+))|。|\D)).)+)\s*{TillRegex}+\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*(까지))

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -269,7 +269,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "서른이 넘는",
+        "Text": "서른이 넘는다",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(30,)"
@@ -1736,7 +1736,7 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5000보다 낮",
+        "Text": "5000보다 낮습니다",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(,5000)"
@@ -1820,6 +1820,26 @@
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(,5000)"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 30과 같 거나 30보다 높다.",
+    "NotSupportedByDesign": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "30과 같",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[30,30]"
+        }
+      },
+      {
+        "Text": "30보다 높다",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(30,)"
         }
       }
     ]

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -1,16 +1,12 @@
 [
   {
     "Input": "1995-01",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "이 숫자는 이십보다 크고 삼십오보다 작거나 같다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "이십보다 크고 삼십오보다 작거나 같다",
@@ -23,10 +19,7 @@
   },
   {
     "Input": "이 숫자는 스물보다 크고 서른다섯보다 작거나 같다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "스물보다 크고 서른다섯보다 작거나 같다",
@@ -39,74 +32,62 @@
   },
   {
     "Input": "이 숫자는 20과 30 사이에 있다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "20과 30 사이",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(20,30)"
+          "value": "[20,30)"
         }
       }
     ]
   },
   {
     "Input": "그는 십등에서 십오등 사이에 위치했다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "십등에서 십오등 사이",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(10,15)"
+          "value": "[10,15)"
         }
       }
     ]
   },
   {
     "Input": "그는 열 번째에서 열다섯 번째 사이에 위치했다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "열 번째에서 열다섯 번째 사이",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(10,15)"
+          "value": "[10,15)"
         }
       }
     ]
   },
   {
     "Input": "그는 마이너스 십점에서 십오점 사이의 점수를 얻었다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "마이너스 십점에서 십오점",
+        "Text": "마이너스 십점에서 십오점 사이",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(-10,15)"
+          "value": "[-10,15)"
         }
       }
     ]
   },
   {
     "Input": "그는 십보다 높고 십오보다 낮은 등수이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "십보다는 높고 십오보다는 낮은",
+        "Text": "십보다 높고 십오보다 낮은",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(10,15)"
@@ -116,10 +97,7 @@
   },
   {
     "Input": "그는 십 등 보다 높고 십오 등 보다 낮다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "십 등 보다 높고 십오 등 보다 낮다",
@@ -132,7 +110,6 @@
   },
   {
     "Input": "이 숫자는 100보다 크고 300보다 작다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -146,10 +123,7 @@
   },
   {
     "Input": "이 숫자는 백보다 크거나 같고, 삼백보다는 작거나 같다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "백보다 크거나 같고, 삼백보다는 작거나 같다",
@@ -162,10 +136,7 @@
   },
   {
     "Input": "최대 100개에서 최소 20개의 사과가 있다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "최대 100개에서 최소 20개",
@@ -178,13 +149,10 @@
   },
   {
     "Input": "사과는 20~100개 이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "20~100개",
+        "Text": "20~100",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[20,100)"
@@ -194,7 +162,6 @@
   },
   {
     "Input": "숫자의 범위는 20부터 100까지 이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -208,10 +175,7 @@
   },
   {
     "Input": "숫자의 범위는 천에서 천오백이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "천에서 천오백",
@@ -224,10 +188,7 @@
   },
   {
     "Input": "숫자는 1000보다 높고 1500보다 낮다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "1000보다 높고 1500보다 낮다",
@@ -240,10 +201,7 @@
   },
   {
     "Input": "숫자는 0.25보다 높고 0.5보다 낮다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "0.25보다 높고 0.5보다 낮다",
@@ -256,10 +214,7 @@
   },
   {
     "Input": "이 숫자는 삼천구백육십오보다 크거나 같다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "삼천구백육십오보다 크거나 같다",
@@ -272,10 +227,7 @@
   },
   {
     "Input": "이 숫자는 4,565보다 크다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "4,565보다 크다",
@@ -288,26 +240,20 @@
   },
   {
     "Input": "그는 삼십 세 이상이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "삼십 세 이상",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(30,)"
+          "value": "[30,)"
         }
       }
     ]
   },
   {
     "Input": "그는 서른 살이 넘는다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "서른 살이 넘는다",
@@ -320,29 +266,23 @@
   },
   {
     "Input": "그의 나이는 서른이 넘는다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "서른이 넘는다",
+        "Text": "서른이 넘는",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "[30,)"
+          "value": "(30,)"
         }
       }
     ]
   },
   {
     "Input": "이 제품은 약 오백 개 이상의 종류가 있다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "약 오백 개 이상",
+        "Text": "오백 개 이상",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[500,)"
@@ -352,13 +292,10 @@
   },
   {
     "Input": "절반이 넘는 사람들이 이곳에 왔다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "절반이 넘는",
+        "Text": "반이 넘는",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(0.5,)"
@@ -368,7 +305,6 @@
   },
   {
     "Input": "100보다 작거나 같은 소수를 찾으시오.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -382,8 +318,6 @@
   },
   {
     "Input": "100과 같거나 작은 소수를 찾으시오.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -397,13 +331,10 @@
   },
   {
     "Input": "이 제품은 약 오백개 이하의 종류가 있다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "약 오백개 이하",
+        "Text": "오백개 이하",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "(,500]"
@@ -412,24 +343,20 @@
     ]
   },
   {
-    "Input": "100 > = 의 소수를 찾으시오.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
+    "Input": "100 >= 의 소수를 찾으시오.",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
-        "Text": "100 > =",
+        "Text": "100 >=",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(,100]"
+          "value": "[100,)"
         }
       }
     ]
   },
   {
     "Input": "그의 신장은 170 미만이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -443,7 +370,6 @@
   },
   {
     "Input": "그의 키는 170 보다 작다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -457,10 +383,7 @@
   },
   {
     "Input": "천 마리 미만의 자이언트 판다가 아직 야생에 살고 있다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "천 마리 미만",
@@ -473,7 +396,6 @@
   },
   {
     "Input": "x는 170과 같다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -487,7 +409,6 @@
   },
   {
     "Input": "x>10 그리고 y<20",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -508,7 +429,6 @@
   },
   {
     "Input": "x는 10보다 크고 20보다 작다. y는 50 이하, 20 이상이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -529,7 +449,6 @@
   },
   {
     "Input": "그 숫자는 20과 같다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -543,10 +462,7 @@
   },
   {
     "Input": "우리 학급의 학생수는 정확히 20명으로 큰 규모는 아니다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "정확히 20",
@@ -559,19 +475,16 @@
   },
   {
     "Input": "+1-222-2222/2222는 전화번호이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "+1-222-2222-2222는 전화번호다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": []
   },
   {
     "Input": "그의 점수는 200 혹은 그 이상이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -585,22 +498,19 @@
   },
   {
     "Input": "그의 점수는 200 혹은 190 이상이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "190 이상",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(190,)"
+          "value": "[190,)"
         }
       }
     ]
   },
   {
     "Input": "그의 점수는 200 이상이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -614,7 +524,6 @@
   },
   {
     "Input": "그의 점수는 30 이하이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -628,7 +537,6 @@
   },
   {
     "Input": "그의 점수는 30 이하다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -642,10 +550,7 @@
   },
   {
     "Input": "그의 점수는 최소 30 이상이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "최소 30 이상",
@@ -658,7 +563,6 @@
   },
   {
     "Input": "그의 점수는 30 이상이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -672,7 +576,6 @@
   },
   {
     "Input": "그의 점수는 5000 이하이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -686,30 +589,19 @@
   },
   {
     "Input": "그의 점수는 5000 혹은 6000 이하이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
-      {
-        "Text": "5000",
-        "TypeName": "numberrange",
-        "Resolution": {
-          "value": "[5000,5000]"
-        }
-      },
       {
         "Text": "6000 이하",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(,6000)"
+          "value": "(,6000]"
         }
       }
     ]
   },
   {
     "Input": "그의 점수는 5000 혹은 그 이상이다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -723,18 +615,8 @@
   },
   {
     "Input": "그의 점수는 5000 이거나 4500 보다 높다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
-      {
-        "Text": "5000",
-        "TypeName": "numberrange",
-        "Resolution": {
-          "value": "[5000,5000]"
-        }
-      },
       {
         "Text": "4500 보다 높다",
         "TypeName": "numberrange",
@@ -746,7 +628,6 @@
   },
   {
     "Input": "그의 점수는 5000 보다 크거나 같다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -760,7 +641,6 @@
   },
   {
     "Input": "그의 점수는 5000 보다 높거나 같다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -774,10 +654,7 @@
   },
   {
     "Input": "그의 점수는 5000 보다 높거나 6000이다.",
-    "IgnoreResolution": true,
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "5000 보다 높거나",
@@ -785,28 +662,13 @@
         "Resolution": {
           "value": "(5000,)"
         }
-      },
-      {
-        "Text": "6000 이다",
-        "TypeName": "numberrange",
-        "Resolution": {
-          "value": "[6000,6000]"
-        }
       }
     ]
   },
   {
     "Input": "그의 점수는 5000과 같거나 5000 보다 작다.",
-    "Comment": "PendingValidation",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
-      {
-        "Text": "5000과 같거나",
-        "TypeName": "numberrange",
-        "Resolution": {
-          "value": "[5000,5000]"
-        }
-      },
       {
         "Text": "5000 보다 작다",
         "TypeName": "numberrange",
@@ -833,7 +695,6 @@
   },
   {
     "Input": "이 숫자는 20과 30 사이에 있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -849,7 +710,6 @@
   },
   {
     "Input": "그는 십위와 십오위 사이에 있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -865,7 +725,6 @@
   },
   {
     "Input": "그는 마이너스 십과 십오 사이에서 득점을 한다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -881,10 +740,7 @@
   },
   {
     "Input": "그는 십위보다 높지만 십오위보다 낮다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "십위보다 높지만 십오위보다 낮다",
@@ -899,7 +755,6 @@
   },
   {
     "Input": "이 숫자는 백 이상, 삼백 이하이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1035,7 +890,6 @@
   },
   {
     "Input": "100 또는 그 미만의 수 중 소수를 찾아라",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1051,7 +905,6 @@
   },
   {
     "Input": "100 또는 그보다 작은 수 중 소수를 찾아라",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1067,7 +920,6 @@
   },
   {
     "Input": "이 제품에는 오백 또는 그 미만이 들어있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1083,7 +935,6 @@
   },
   {
     "Input": "≤100의 소수를 찾아라",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1222,7 +1073,6 @@
   },
   {
     "Input": "그의 점수는 200이거나 그보다 크다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1253,7 +1103,6 @@
   },
   {
     "Input": "그의 점수는 30이거나 그보다 작다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1284,16 +1133,15 @@
   },
   {
     "Input": "그의 점수는 30과 같거나 최소 30이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "30과 같거나 최소 30",
+        "Text": "과 같거나 최소 30",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[30,)"
         },
-        "Start": 7,
+        "Start": 9,
         "End": 19
       }
     ]
@@ -1315,7 +1163,6 @@
   },
   {
     "Input": "그의 점수는 5000과 같거나 그보다 많다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1496,7 +1343,6 @@
   },
   {
     "Input": "아직도 ≥30인 경우인가요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1527,7 +1373,6 @@
   },
   {
     "Input": "아직도 ≤-30인 경우인가요",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1593,10 +1438,7 @@
   },
   {
     "Input": "반이 넘는 사람들이 이곳에 왔다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "반이 넘는",
@@ -1665,14 +1507,13 @@
   },
   {
     "Input": "이 수는 이십보다 크고 삼십오보다 작다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
         "Text": "이십보다 크고 삼십오보다 작다",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(20,35]"
+          "value": "(20,35)"
         },
         "Start": 5,
         "End": 20
@@ -1711,7 +1552,6 @@
   },
   {
     "Input": "이 제품에는 오백 또는 그보다 적게 들어있다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1757,10 +1597,7 @@
   },
   {
     "Input": "x는 10보다 크고 20보다 작다. Y는 50보다 작거나 같고, 20보다 많거나 같다",
-    "IgnoreResolution": true,
-    "Comment": "PendingImplementation",
     "NotSupportedByDesign": "java, javascript, python",
-    "NotSupported": "dotNet",
     "Results": [
       {
         "Text": "10보다 크고 20보다 작다",
@@ -1799,23 +1636,21 @@
   },
   {
     "Input": "그의 점수는 30이거나 최소 30이다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "30이거나 최소 30",
+        "Text": "이거나 최소 30",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[30,)"
         },
-        "Start": 7,
+        "Start": 9,
         "End": 17
       }
     ]
   },
   {
     "Input": "그의 점수는 5000이거나 그보다 많다",
-    "IgnoreResolution": true,
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
@@ -1841,6 +1676,151 @@
         },
         "Start": 0,
         "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수가 5000과 같거나 5000 미만입니다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "같거나 5000 미만",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000]"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "이 제품에는 약 5000개 이하가 있습니다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "약 5000개 이하가",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000]"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그는 서른 살이 넘었다",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "서른 살이 넘었다",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(30,)"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 30점 이하이다",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "30점 이하",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,30]"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "호 점수가 5000보다 낮습니다",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "5000보다 낮",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000)"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 5000과 같 거나 6000 미만이다",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "5000과 같",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,5000]"
+        }
+      },
+      {
+        "Text": "6000 미만",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,6000)"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 4500 보다 높거나 5000과 같다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "4500 보다 높거나",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(4500,)"
+        }
+      },
+      {
+        "Text": "5000과 같다",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,5000]"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 5000 보다 높거나 6000과 같다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "5000 보다 높거나",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(5000,)"
+        }
+      },
+      {
+        "Text": "6000과 같다",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[6000,6000]"
+        }
+      }
+    ]
+  },
+  {
+    "Input": "그의 점수는 5000과 같 거나 5000 미만이다.",
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "5000과 같",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,5000]"
+        }
+      },
+      {
+        "Text": "5000 미만",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000)"
+        }
       }
     ]
   }


### PR DESCRIPTION
All test cases pass.

Some resolutions have been modified because the input meaning differed from the corresponding English spec. New test cases have been added to better match the originals (when not already present).
List of modified test cases:
- "이 숫자는 20과 30 사이에 있다." "(20,30)" -> "[20,30)" (original: "The number is between 20 and 30." "[20,30)")
- "그는 십등에서 십오등 사이에 위치했다." "(10,15)" -> "[10,15)" (original: "He ranks between the tenth and the fifteenth." "[10,15)")
- "그는 열 번째에서 열다섯 번째 사이에 위치했다." "(10,15)" -> "[10,15)" (original: "He ranks between the tenth and the fifteenth." "[10,15)")
- "그는 마이너스 십점에서 십오점 사이의 점수를 얻었다." "(-10,15)" -> "[-10,15)" (original: "He scores between negative ten and fifteen." "[-10,15)")
- "그는 삼십 세 이상이다." "(30,)" -> "[30,)" (original: "His age is no less than thirty." "[30,)")
- "그의 나이는 서른이 넘는다." "[30,)" -> "(30,)" (original: "He is over thirty years old." "(30,)")
- "100 >= 의 소수를 찾으시오." "(,100]" -> "[100,)" (translation: "Find the prime numbers >= 100.")
- "그의 점수는 200 혹은 190 이상이다." "(190,)" -> "[190,)" (translation: "His score is 200 or 190 or higher.")
- "그의 점수는 5000 혹은 6000 이하이다." "(,6000)" -> "(,6000]" and removed expected extraction of "5000" (translates to "His score is 5000 or 6000 or less" but original is "His score is equal to 5000 or less than 6000", added new test case with better translation: "그의 점수는 5000과 같 거나 6000 미만이다")
- "그의 점수는 5000 이거나 4500 보다 높다." removed expected extraction of "5000" (translates to "His score is 5000 or higher than 4500." but original is "His score is equal to 5000 or more than 4500", added new test case with better translation: "그의 점수는 4500 보다 높거나 5000과 같다.")
- "그의 점수는 5000 보다 높거나 6000이다." removed expected extraction of "6000" (translates to "His score is higher than 5000 or 6000." but original is "His score is more than 5000 or equal to 6000", added new test case with better translation: "그의 점수는 5000 보다 높거나 6000과 같다.")
- "그의 점수는 5000과 같거나 5000 보다 작다." removed expected extraction of "5000" (translates to "His score is 5000 or less than 5000" but original is "His score is equal to 5000 or less than 5000", added new test case with better translation: "그의 점수는 5000과 같 거나 5000 미만이다.")
- "이 수는 이십보다 크고 삼십오보다 작다" "(20,35]" -> "(20,35)" (translation: "This number is greater than twenty and less than thirty-five.")
