### PR TITLE
[EN Number] Fixed "a current" or similar phrases determined as ordinal detected as a number fraction (#2826)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string RoundNumberOrdinalRegex = @"(?:hundredth|thousandth|millionth|billionth|trillionth)";
       public const string NumberOrdinalRegex = @"(?:first|second|third|fourth|fifth|sixth|seventh|eighth|nine?th|tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth)";
       public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>(next|previous|current)\s+one|(the\s+second|next)\s+to\s+last|the\s+one\s+before\s+the\s+last(\s+one)?|the\s+last\s+but\s+one|(ante)?penultimate|last|next|previous|current)";
-      public static readonly string BasicOrdinalRegex = $@"({NumberOrdinalRegex}|{RelativeOrdinalRegex})";
-      public static readonly string SuffixBasicOrdinalRegex = $@"(?:(((({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})+)\s+(and\s+)?)*({TensNumberIntegerRegex}(\s+|\s*-\s*))?{BasicOrdinalRegex})";
+      public static readonly string SuffixBasicOrdinalRegex = $@"(?:(((({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})+)\s+(and\s+)?)*({TensNumberIntegerRegex}(\s+|\s*-\s*))?{NumberOrdinalRegex})";
       public static readonly string SuffixRoundNumberOrdinalRegex = $@"(?:({AllIntRegex}\s+){RoundNumberOrdinalRegex})";
-      public static readonly string AllOrdinalRegex = $@"(?:{SuffixBasicOrdinalRegex}|{SuffixRoundNumberOrdinalRegex})";
+      public static readonly string AllOrdinalNumberRegex = $@"(?:{SuffixBasicOrdinalRegex}|{SuffixRoundNumberOrdinalRegex})";
+      public static readonly string AllOrdinalRegex = $@"(?:{AllOrdinalNumberRegex}|{RelativeOrdinalRegex})";
       public const string OrdinalSuffixRegex = @"(?<=\b)(?:(\d*(1st|2nd|3rd|[4-90]th))|(1[1-2]th))(?=\b)";
       public const string OrdinalNumericRegex = @"(?<=\b)(?:\d{1,3}(\s*,\s*\d{3})*\s*th)(?=\b)";
       public static readonly string OrdinalRoundNumberRegex = $@"(?<!an?\s+){RoundNumberOrdinalRegex}";
@@ -66,8 +66,8 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string FractionMultiplierRegex = $@"(?<fracMultiplier>\s+and\s+(a|one|{TwoToNineIntegerRegex})\s+(half|quarter|third|fourth|fifth|sixth|seventh|eighth|nine?th|tenth)s?)";
       public static readonly string RoundMultiplierWithFraction = $@"(?<=(?<!{RoundNumberIntegerRegex}){FractionMultiplierRegex}\s+)?(?<multiplier>(?:million|mln|billion|bln|trillion|tln)s?)(?={FractionMultiplierRegex}?$)";
       public static readonly string RoundMultiplierRegex = $@"\b\s*((of\s+)?a\s+)?({RoundMultiplierWithFraction}|(?<multiplier>(?:hundred|thousand|lakh|crore)s?)$)";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(((({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)";
+      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalNumberRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(((({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalNumberRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string FractionPrepositionWithinPercentModeRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+over\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{SeparaIntRegex}))";

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -70,18 +70,18 @@ NumberOrdinalRegex: !simpleRegex
   def: (?:first|second|third|fourth|fifth|sixth|seventh|eighth|nine?th|tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth)
 RelativeOrdinalRegex: !simpleRegex
   def: (?<relativeOrdinal>(next|previous|current)\s+one|(the\s+second|next)\s+to\s+last|the\s+one\s+before\s+the\s+last(\s+one)?|the\s+last\s+but\s+one|(ante)?penultimate|last|next|previous|current)
-BasicOrdinalRegex: !nestedRegex
-  def: ({NumberOrdinalRegex}|{RelativeOrdinalRegex})
-  references: [ NumberOrdinalRegex, RelativeOrdinalRegex ]
 SuffixBasicOrdinalRegex: !nestedRegex
-  def: (?:(((({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})+)\s+(and\s+)?)*({TensNumberIntegerRegex}(\s+|\s*-\s*))?{BasicOrdinalRegex})
-  references: [ TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, BasicOrdinalRegex ]
+  def: (?:(((({TensNumberIntegerRegex}(\s+(and\s+)?|\s*-\s*){ZeroToNineIntegerRegex})|{TensNumberIntegerRegex}|{ZeroToNineIntegerRegex}|{AnIntRegex})(\s+{RoundNumberIntegerRegex})+)\s+(and\s+)?)*({TensNumberIntegerRegex}(\s+|\s*-\s*))?{NumberOrdinalRegex})
+  references: [ TensNumberIntegerRegex, ZeroToNineIntegerRegex, AnIntRegex, RoundNumberIntegerRegex, NumberOrdinalRegex ]
 SuffixRoundNumberOrdinalRegex: !nestedRegex
   def: (?:({AllIntRegex}\s+){RoundNumberOrdinalRegex})
   references: [ AllIntRegex, RoundNumberOrdinalRegex ]
-AllOrdinalRegex: !nestedRegex
+AllOrdinalNumberRegex: !nestedRegex
   def: (?:{SuffixBasicOrdinalRegex}|{SuffixRoundNumberOrdinalRegex})
   references: [ SuffixBasicOrdinalRegex, SuffixRoundNumberOrdinalRegex ]
+AllOrdinalRegex: !nestedRegex
+  def: (?:{AllOrdinalNumberRegex}|{RelativeOrdinalRegex})
+  references: [ AllOrdinalNumberRegex, RelativeOrdinalRegex ]
 OrdinalSuffixRegex: !simpleRegex
   def: (?<=\b)(?:(\d*(1st|2nd|3rd|[4-90]th))|(1[1-2]th))(?=\b)
 OrdinalNumericRegex: !simpleRegex
@@ -108,11 +108,11 @@ RoundMultiplierRegex: !nestedRegex
   def: \b\s*((of\s+)?a\s+)?({RoundMultiplierWithFraction}|(?<multiplier>(?:hundred|thousand|lakh|crore)s?)$)
   references: [ RoundMultiplierWithFraction ]
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex ]
+  def: (?<=\b)({AllIntRegex}\s+(and\s+)?)?(({AllIntRegex})(\s+|\s*-\s*)((({AllOrdinalNumberRegex})|({RoundNumberOrdinalRegex}))s|halves|quarters)((\s+of\s+a)?\s+{RoundNumberIntegerRegex})?|(half(\s+a)?|quarter(\s+of\s+a)?)\s+{RoundNumberIntegerRegex})(?=\b)
+  references: [ AllIntRegex, AllOrdinalNumberRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)(((({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)
-  references: [ AllIntRegex, AllOrdinalRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex, RoundNumberIntegerRegexWithLocks ]
+  def: (?<=\b)(((({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(and\s+)?)?(an?|one)(\s+|\s*-\s*)(?!\bfirst\b|\bsecond\b)(({AllOrdinalNumberRegex})|({RoundNumberOrdinalRegex})|(half|quarter)(((\s+of)?\s+a)?\s+{RoundNumberIntegerRegex})?))|(half))(?=\b)
+  references: [ AllIntRegex, AllOrdinalNumberRegex, RoundNumberOrdinalRegex, RoundNumberIntegerRegex, RoundNumberIntegerRegexWithLocks ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<![\.,])\d+))\s+(over|(?<ambiguousSeparator>in|out\s+of))\s+(?<denominator>({AllIntRegex})|(\d+)(?![\.,]))(?=\b)
   references: [ AllIntRegex, BaseNumbers.CommonCurrencySymbol ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -3478,5 +3478,36 @@
         "End": 23
       }
     ]
+  },
+  {
+    "Input": "Let's try one last time",
+    "Results": [
+      {
+        "Text": "one",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "1"
+        },
+        "Start": 10,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "I was a current student last semester",
+    "Results": []
+  },
+  {
+    "Input": "He was looking for a next of kin",
+    "Results": []
+  },
+  {
+    "Input": "you can restore a previous version",
+    "Results": []
+  },
+  {
+    "Input": "we'll try this new medication as a last resort.",
+    "Results": []
   }
 ]

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -3509,5 +3509,58 @@
   {
     "Input": "we'll try this new medication as a last resort.",
     "Results": []
+  },
+  {
+    "Input": "placeholder name is a next generation service for translation",
+    "NotSupported": "javascript, java, python",
+    "Results": []
+  },
+  {
+    "Input": "The measurement has a value of forty two and a third",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "forty two and a third",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "42.3333333333333"
+        },
+        "Start": 31,
+        "End": 51
+      }
+    ]
+  },
+  {
+    "Input": "The measurement has a value of two hundred thirty two and a thirtieth",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two hundred thirty two and a thirtieth",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "232.033333333333"
+        },
+        "Start": 31,
+        "End": 68
+      }
+    ]
+  },
+  {
+    "Input": "we will be working on releasing version two and a previous version will still be maintained",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "two",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 40,
+        "End": 42
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/OrdinalModel.json
+++ b/Specs/Number/English/OrdinalModel.json
@@ -763,5 +763,169 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Let's try one last time",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "last",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 14,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "I was a current student last semester",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "current",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "current",
+          "value": "current+0"
+        },
+        "Start": 8,
+        "End": 14
+      },
+      {
+        "Text": "last",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 24,
+        "End": 27
+      }
+    ]
+  },
+  {
+    "Input": "He was looking for a next of kin",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "next",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 21,
+        "End": 24
+      }
+    ]
+  },
+  {
+    "Input": "you can restore a previous version",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "previous",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "current",
+          "value": "current-1"
+        },
+        "Start": 18,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "we'll try this new medication as a last resort.",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "last",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "0",
+          "relativeTo": "end",
+          "value": "end+0"
+        },
+        "Start": 35,
+        "End": 38
+      }
+    ]
+  },
+  {
+    "Input": "placeholder name is a next generation service for translation",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "next",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "1",
+          "relativeTo": "current",
+          "value": "current+1"
+        },
+        "Start": 22,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "The measurement has a value of forty two and a third",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "third",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "3",
+          "relativeTo": "start",
+          "value": "3"
+        },
+        "Start": 47,
+        "End": 51
+      }
+    ]
+  },
+  {
+    "Input": "The measurement has a value of two hundred thirty two and a thirtieth",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "thirtieth",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "30",
+          "relativeTo": "start",
+          "value": "30"
+        },
+        "Start": 60,
+        "End": 68
+      }
+    ]
+  },
+  {
+    "Input": "we will be working on releasing version two and a previous version will still be maintained",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "previous",
+        "TypeName": "ordinal.relative",
+        "Resolution": {
+          "offset": "-1",
+          "relativeTo": "current",
+          "value": "current-1"
+        },
+        "Start": 50,
+        "End": 57
+      }
+    ]
   }
 ]

--- a/Specs/Number/English/OrdinalModelSuppressExtendedTypes.json
+++ b/Specs/Number/English/OrdinalModelSuppressExtendedTypes.json
@@ -149,5 +149,74 @@
     "Input": "Look at the current page",
     "NotSupported": "javascript, python, java",
     "Results": []
+  },
+  {
+    "Input": "Let's try one last time",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "I was a current student last semester",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "He was looking for a next of kin",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "you can restore a previous version",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "we'll try this new medication as a last resort.",
+    "NotSupported": "javascript, python, java",
+    "Results": []
+  },
+  {
+    "Input": "placeholder name is a next generation service for translation",
+    "NotSupported": "javascript, java, python",
+    "Results": []
+  },
+  {
+    "Input": "The measurement has a value of forty two and a third",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "third",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "3",
+          "relativeTo": "start",
+          "value": "3"
+        },
+        "Start": 47,
+        "End": 51
+      }
+    ]
+  },
+  {
+    "Input": "The measurement has a value of two hundred thirty two and a thirtieth",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "thirtieth",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "offset": "30",
+          "relativeTo": "start",
+          "value": "30"
+        },
+        "Start": 60,
+        "End": 68
+      }
+    ]
+  },
+  {
+    "Input": "we will be working on releasing version two and a previous version will still be maintained",
+    "NotSupported": "javascript, java, python",
+    "Results": []
   }
 ]


### PR DESCRIPTION
Fix to issue #2826 and #2690.

Test cases added to NumberModel.