### PR TITLE
[JA Currency] Currency refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
@@ -129,9 +129,9 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string PairRegex = @".*[対膳足]$";
       public const string RoundNumberIntegerRegex = @"(十|百|千|万(?!万)|億|兆)";
       public const string AllowListRegex = @"(。|，|、|（|）|”｜国|週間|時間|時|匹|キロ|トン|年|個|足|本|で|は|\s|$|つ|月|の|と)";
-      public static readonly string NotSingleRegex = $@"(?<!(第|だい))(({RoundNumberIntegerRegex}+(({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex})+|{ZeroToNineFullHalfRegex}+|十)\s*(以上)?))|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*({RoundNumberIntegerRegex}\s*){{1,2}})\s*(([零]?({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*{RoundNumberIntegerRegex}{{0,1}})\s*)*\s*(\s*(以上)?)";
+      public static readonly string NotSingleRegex = $@"(?<!(第|だい))({RoundNumberIntegerRegex}+(({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex})+|{ZeroToNineFullHalfRegex}+|十)(\s*(以上))?)|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){{1,2}})(\s*([零]?({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){{0,1}}))*(\s*(以上)?)";
       public static readonly string SingleRegex = $@"(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(?={AllowListRegex}))";
-      public static readonly string AllIntRegex = $@"(?<!(ダース))((((({ZeroToNineIntegerRegex}|[十百千])\s*{RoundNumberIntegerRegex}*)|(({ZeroToNineFullHalfRegex}\s*{RoundNumberIntegerRegex})|{RoundNumberIntegerRegex})){{1,2}}|({RoundNumberIntegerRegex}+))(\s*[以上]+)?)";
+      public static readonly string AllIntRegex = $@"(?<!(ダース))({NotSingleRegex}|({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+))";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
       public static readonly string NumbersSpecialsChars = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}))+(?=\b|\D)(?!(([\.．]{ZeroToNineFullHalfRegex}+)?\s*{AllMultiplierLookupRegex}))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersWithUnitDefinitions.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Djiboutian franc", @"ジブチ・フラン" },
             { @"CFP franc", @"CFPフラン" },
             { @"Guinean franc", @"ギニア・フラン" },
-            { @"Swiss franc", @"スイス・フラン" },
+            { @"Swiss franc", @"スイス・フラン|スイスフラン" },
             { @"Rwandan franc", @"ルワンダ・フラン" },
             { @"Belgian franc", @"ベルギー・フラン" },
             { @"Rappen", @"Rappen" },
@@ -218,7 +218,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Pound", @"ポンド" },
             { @"Pence", @"ペンス" },
             { @"Shilling", @"シリング" },
-            { @"United States dollar", @"ドル|USドル" },
+            { @"United States dollar", @"米ドル|USドル|ドル" },
             { @"East Caribbean dollar", @"東カリブ・ドル" },
             { @"Australian dollar", @"オーストラリア・ドル|オーストラリアドル" },
             { @"Bahamian dollar", @"バハマ・ドル" },
@@ -235,7 +235,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Guyanese dollar", @"ガイアナ・ドル|ガイアナ・ドル" },
             { @"Hong Kong dollar", @"香港ドル" },
             { @"Macau Pataca", @"マカオ・パタカ|マカオ・パタカ" },
-            { @"New Taiwan dollar", @"ニュー台湾ドル|ニュー台湾ドル" },
+            { @"New Taiwan dollar", @"ニュー台湾ドル|ニュー台湾ドル|台湾ドル" },
             { @"Jamaican dollar", @"ジャマイカ・ドル|ジャマイカドル" },
             { @"Kiribati dollar", @"キリバス・ドル" },
             { @"Liberian dollar", @"リベリア・ドル|リベリアドル" },
@@ -243,7 +243,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Surinamese dollar", @"スリナム・ドル|スリナムドル" },
             { @"Trinidad and Tobago dollar", @"トリニダード・トバゴ・ドル|トリニダードトバゴ・ドル" },
             { @"Tuvaluan dollar", @"ツバル・ドル|ツバルドル" },
-            { @"Chinese yuan", @"人民元" },
+            { @"Chinese yuan", @"人民元|元" },
             { @"Fen", @"分" },
             { @"Jiao", @"角" },
             { @"Finnish markka", @"フィンランド・マルカ" },
@@ -532,7 +532,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Solomon Islands dollar", @"si$|si $" },
             { @"New Taiwan dollar", @"nt$|nt $" },
             { @"Samoan tālā", @"ws$" },
-            { @"Chinese yuan", @"￥" },
+            { @"Chinese yuan", @"￥|人民元" },
             { @"Japanese yen", @"¥|\" },
             { @"Turkish lira", @"₺" },
             { @"Euro", @"€" },
@@ -547,7 +547,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"レク",
             @"プル",
             @"ブル",
-            @"\"
+            @"\",
+            @"元"
         };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -135,14 +135,14 @@ RoundNumberIntegerRegex: !simpleRegex
 AllowListRegex: !simpleRegex
   def: (。|，|、|（|）|”｜国|週間|時間|時|匹|キロ|トン|年|個|足|本|で|は|\s|$|つ|月|の|と)
 NotSingleRegex: !nestedRegex
-  def: (?<!(第|だい))(({RoundNumberIntegerRegex}+(({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex})+|{ZeroToNineFullHalfRegex}+|十)\s*(以上)?))|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*({RoundNumberIntegerRegex}\s*){1,2})\s*(([零]?({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)\s*{RoundNumberIntegerRegex}{0,1})\s*)*\s*(\s*(以上)?)
+  def: (?<!(第|だい))({RoundNumberIntegerRegex}+(({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex})+|{ZeroToNineFullHalfRegex}+|十)(\s*(以上))?)|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){1,2})(\s*([零]?({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){0,1}))*(\s*(以上)?)
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
 SingleRegex: !nestedRegex
   def: (({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(?={AllowListRegex}))
   references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, AllowListRegex]
 AllIntRegex: !nestedRegex
-  def: (?<!(ダース))((((({ZeroToNineIntegerRegex}|[十百千])\s*{RoundNumberIntegerRegex}*)|(({ZeroToNineFullHalfRegex}\s*{RoundNumberIntegerRegex})|{RoundNumberIntegerRegex})){1,2}|({RoundNumberIntegerRegex}+))(\s*[以上]+)?)
-  references: [ZeroToNineIntegerRegex, ZeroToNineFullHalfRegex, RoundNumberIntegerRegex]
+  def: (?<!(ダース))({NotSingleRegex}|({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+))
+  references: [NotSingleRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex]
 PlaceHolderPureNumber: !simpleRegex
   def: \b
 PlaceHolderDefault: !simpleRegex

--- a/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
+++ b/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
@@ -226,7 +226,7 @@ CurrencySuffixList: !dictionary
     Djiboutian franc: ジブチ・フラン
     CFP franc: CFPフラン
     Guinean franc: ギニア・フラン
-    Swiss franc: スイス・フラン
+    Swiss franc: スイス・フラン|スイスフラン
     Rwandan franc: ルワンダ・フラン
     Belgian franc: ベルギー・フラン
     Rappen: Rappen
@@ -280,7 +280,7 @@ CurrencySuffixList: !dictionary
     Pence: ペンス
     Shilling: シリング
 #Dollar
-    United States dollar: ドル|USドル
+    United States dollar: 米ドル|USドル|ドル
     East Caribbean dollar: 東カリブ・ドル
     Australian dollar: オーストラリア・ドル|オーストラリアドル
     Bahamian dollar: バハマ・ドル
@@ -297,7 +297,7 @@ CurrencySuffixList: !dictionary
     Guyanese dollar: ガイアナ・ドル|ガイアナ・ドル
     Hong Kong dollar: 香港ドル
     Macau Pataca: マカオ・パタカ|マカオ・パタカ
-    New Taiwan dollar: ニュー台湾ドル|ニュー台湾ドル
+    New Taiwan dollar: ニュー台湾ドル|ニュー台湾ドル|台湾ドル
     Jamaican dollar: ジャマイカ・ドル|ジャマイカドル
     Kiribati dollar: キリバス・ドル
     Liberian dollar: リベリア・ドル|リベリアドル
@@ -306,7 +306,7 @@ CurrencySuffixList: !dictionary
     Trinidad and Tobago dollar: トリニダード・トバゴ・ドル|トリニダードトバゴ・ドル
     Tuvaluan dollar: ツバル・ドル|ツバルドル
 #Chinese yuan
-    Chinese yuan: 人民元
+    Chinese yuan: 人民元|元
     Fen: 分
     Jiao: 角
 #Additional
@@ -601,7 +601,7 @@ CurrencyPrefixList: !dictionary
     Solomon Islands dollar: si$|si $
     New Taiwan dollar: nt$|nt $
     Samoan tālā: ws$
-    Chinese yuan: ￥
+    Chinese yuan: ￥|人民元
     Japanese yen: ¥|\
     Turkish lira: ₺
     Euro: €
@@ -617,6 +617,7 @@ CurrencyAmbiguousValues: !list
     - プル
     - ブル
     - \
+    - 元
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Specs/NumberWithUnit/Japanese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Japanese/CurrencyModel.json
@@ -502,7 +502,7 @@
   },
   {
     "Input": "十ドル",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "十ドル",
@@ -519,7 +519,7 @@
   },
   {
     "Input": "8億人民元",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "8億人民元",
@@ -535,11 +535,11 @@
     ]
   },
   {
-    "Input": "東芝の再編はもう一万憶が必要、取引銀行に借り入れを申請した。",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Input": "東芝の再編はもう一万億円が必要、取引銀行に借り入れを申請した。",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "一万憶",
+        "Text": "一万億円",
         "TypeName": "currency",
         "Resolution": {
           "isoCurrency": "JPY",
@@ -547,13 +547,13 @@
           "unit": "Japanese yen"
         },
         "Start": 8,
-        "End": 10
+        "End": 11
       }
     ]
   },
   {
     "Input": "その中で、四川省の彩民一口で一千万人民元の基本大賞あたりました。",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "一千万人民元",
@@ -570,7 +570,7 @@
   },
   {
     "Input": "1.0753ドルを交換します",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1.0753ドル",
@@ -586,8 +586,8 @@
     ]
   },
   {
-    "Input": "ある人が江蘇省に15人民元でロト引いてたら1600萬の大あたりました　賞金プールは36.57憶人民元となってます",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Input": "ある人が江蘇省に15人民元でロト引いてたら1600萬の大あたりました　賞金プールは36.57億人民元となってます",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "15人民元",
@@ -599,12 +599,23 @@
         },
         "Start": 8,
         "End": 12
+      },
+	  {
+        "Text": "36.57億人民元",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "CNY",
+          "value": "3657000000",
+          "unit": "Chinese yuan"
+        },
+        "Start": 41,
+        "End": 49
       }
     ]
   },
   {
     "Input": "このスマホケースはお前の5ドルと俺の三人民元かかります",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "5ドル",
@@ -632,7 +643,7 @@
   },
   {
     "Input": "10円5銭",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "10円5銭",
@@ -649,7 +660,7 @@
   },
   {
     "Input": "このパソコンは2ドル3セントとなってます",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2ドル3セント",
@@ -666,6 +677,7 @@
   },
   {
     "Input": "人民元八千元",
+    "Comment": "Currency does not support split units (e.g. '人民元30元')",
     "NotSupported": "dotnet, javascript, python, java",
     "Results": [
       {
@@ -683,7 +695,7 @@
   },
   {
     "Input": "4人民元　5ドル",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "4人民元",
@@ -711,7 +723,7 @@
   },
   {
     "Input": "1.0092スイスフランを交換します",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1.0092スイスフラン",
@@ -727,11 +739,11 @@
     ]
   },
   {
-    "Input": "今回抽選後、賞金プールは36.57憶人民元まで到達",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Input": "今回抽選後、賞金プールは36.57億人民元まで到達",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "36.57憶人民元",
+        "Text": "36.57億人民元",
         "TypeName": "currency",
         "Resolution": {
           "isoCurrency": "CNY",
@@ -744,11 +756,11 @@
     ]
   },
   {
-    "Input": "中国人民銀行の5306憶台湾ドルの預金証書が期限切れになりました",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Input": "中国人民銀行の5306億台湾ドルの預金証書が期限切れになりました",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "5306憶台湾ドル",
+        "Text": "5306億台湾ドル",
         "TypeName": "currency",
         "Resolution": {
           "isoCurrency": "TWD",
@@ -762,7 +774,7 @@
   },
   {
     "Input": "宝安テクノロジーはIPE GROUP LIMITEDの株主15人と買収契約をサインしました。一株あたり1.95香港ドル",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1.95香港ドル",
@@ -779,15 +791,15 @@
   },
   {
     "Input": "千円あります",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "千円",
         "TypeName": "currency",
         "Resolution": {
-          "isoCurrency": "CNY",
+          "isoCurrency": "JPY",
           "value": "1000",
-          "unit": "Chinese yuan"
+          "unit": "Japanese yen"
         },
         "Start": 0,
         "End": 1
@@ -796,7 +808,7 @@
   },
   {
     "Input": "このスマホケースは五元三角で大丈夫です",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "五元三角",
@@ -813,7 +825,7 @@
   },
   {
     "Input": "appleの割引一ドル",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "一ドル",
@@ -830,7 +842,7 @@
   },
   {
     "Input": "人民元　米ドル",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "人民元",
@@ -858,7 +870,7 @@
   },
   {
     "Input": "50元6角3分",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "50元6角3分",
@@ -874,11 +886,11 @@
     ]
   },
   {
-    "Input": "二千十六年、買収などの直接投資において、中国のキャッシュアウトフロー纯额は千二百憶ドルも到達",
-    "NotSupported": "dotnet, javascript, python, java",
+    "Input": "二千十六年、買収などの直接投資において、中国のキャッシュアウトフロー纯额は千二百億ドルも到達",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "千二百憶ドル",
+        "Text": "千二百億ドル",
         "TypeName": "currency",
         "Resolution": {
           "isoCurrency": "USD",
@@ -892,7 +904,7 @@
   },
   {
     "Input": "このパソコンは2ドルとなってます",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2ドル",
@@ -909,7 +921,7 @@
   },
   {
     "Input": "445ナイラ到達で交換できます",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "445ナイラ",
@@ -926,7 +938,7 @@
   },
   {
     "Input": "1ユーロで大丈夫です",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1ユーロ",
@@ -943,6 +955,7 @@
   },
   {
     "Input": "人民元五十元",
+    "Comment": "Currency does not support split units (e.g. '人民元30元')",
     "NotSupported": "dotnet, javascript, python, java",
     "Results": [
       {
@@ -960,6 +973,7 @@
   },
   {
     "Input": "金融市場で運用する資金運用事業を合わせた財投総額も過去最大の同二％減の四十九兆九千五百九十二億円となっている。",
+    "Comment": "Number not correctly recognized",
     "NotSupported": "dotnet, javascript, python, java",
     "Results": [
       {

--- a/Specs/NumberWithUnit/Japanese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Japanese/CurrencyModel.json
@@ -973,15 +973,14 @@
   },
   {
     "Input": "金融市場で運用する資金運用事業を合わせた財投総額も過去最大の同二％減の四十九兆九千五百九十二億円となっている。",
-    "Comment": "Number not correctly recognized",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "四十九兆九千五百九十二億円",
         "TypeName": "currency",
         "Resolution": {
-          "isoCurrency": "CNY",
-          "unit": "Chinese yuan",
+          "isoCurrency": "JPY",
+          "unit": "Japanese yen",
           "value": "49959200000000"
         },
         "Start": 35,


### PR DESCRIPTION
54 cases pass; 3 cases fail.

Failing cases:
- "人民元八千元", "人民元五十元": The unit is split around the number but NumberWihUnitExtractor explicitly prevents to extract both prefix and suffix units for Currency to avoid other issues.
- "金融市場で運用する資金運用事業を合わせた財投総額も過去最大の同二％減の四十九兆九千五百九十二億円となっている。": NumberExtractor does not correctly extract the large number.

Modified cases:
- A typo, '憶' instead of '億' has been corrected in a few inputs.
- "東芝の再編はもう一万憶が必要、取引銀行に借り入れを申請した。"  -> "東芝の再編はもう一万億円が必要、取引銀行に借り入れを申請した。", missing expected unit '円'.