### PR TITLE
[KO Number] Korean NumberRange fixed extraction of pattern 'is 30 or at least 30'

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -231,8 +231,8 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string LessRegex = @"(미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)((네|아|어|군)요|습니다|은|다)?";
       public const string EqualRegex = @"(동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)";
       public const string RangePrefixLessRegex = @"(최대|까지최소|(?<!>|=)<|≤)";
-      public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥|>=|개에서 최소|과 같거나 최소|이거나 최소)";
-      public static readonly string MoreOrEqual = $@"(({MoreRegex}\s*(거나)?\s*{EqualRegex}))";
+      public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥|>=|개에서 최소)";
+      public static readonly string MoreOrEqual = $@"(({MoreRegex}\s*(거나)?\s*{EqualRegex})|최소)";
       public static readonly string MoreOrEqual2 = $@"(\s*(거나)?\s*(그보다)\s*{MoreRegex})";
       public const string MoreOrEqualSuffix = @"\s*(이상|세 이상|개 이상|(과 같)?거나 그보다 많다|거나 그보다 크다)";
       public static readonly string LessOrEqual = $@"(?:(이|보다|과|≤)?)?\s*(({LessRegex}\s*(거나)?\s*{EqualRegex}(은|다)?)|≤)";
@@ -241,9 +241,9 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string OneNumberRangeLessSeparateRegex = @"같거나|약";
       public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))";
       public static readonly string OneNumberRangeEqualRegex2 = $@"((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))";
-      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
+      public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
       public static readonly string OneNumberRangeMoreRegex2 = $@"((?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)|(?<number1>(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+))((\s등\s)?보다)?(\s살이)?\s({MoreRegex})|(최소\s*)?(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
-      public static readonly string OneNumberRangeMoreRegex3 = $@"(({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|((과 같거나 최소|이거나 최소)\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))";
+      public static readonly string OneNumberRangeMoreRegex3 = $@"(({RangePrefixMoreRegex}|{MoreOrEqual})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|(최소\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))";
       public static readonly string OneNumberRangeMoreRegex4 = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?";
       public static readonly string OneNumberRangeMoreRegex5 = $@"(?<number1>((?![,.](?!\d+)).)+)\s*((또는)\s+(그){MoreOrEqualSuffix})";
       public static readonly string OneNumberRangeMoreRegexFraction = $@"((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/NumbersDefinitions.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string TillRegex = @"(부터|에서|--|-|—|–|——|~)";
       public const string MoreRegex = @"(넘었(다)?|초과|커|많|큽|높(고)?|더많|더높|더크|>=|>|(이\s)?넘는(다)?|초과이다|크고|(살)?이 넘는다|크고|보다 크다|보다 높(거나)?|(을 초과하는)|크(거나(\s같(다|고)?)?))((습)?니다|(아|네|군)?요)?";
       public const string LessRegex = @"(미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)((네|아|어|군)요|습니다|은|다)?";
-      public const string EqualRegex = @"(동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)";
+      public const string EqualRegex = @"(동일|같(고)?|=|(해당하는)|작은|그와 같다)";
       public const string RangePrefixLessRegex = @"(최대|까지최소|(?<!>|=)<|≤)";
       public const string RangePrefixMoreRegex = @"((?<!<|=)>|≥|>=|개에서 최소)";
       public static readonly string MoreOrEqual = $@"(({MoreRegex}\s*(거나)?\s*{EqualRegex})|최소)";
@@ -239,7 +239,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string LessOrEqualSuffix = @"\s*((달하는|또는 그 미만|또는 그보다 적게|거나 그보다 작다|또는 그보다 작은|점 이하|이하|이하이다))";
       public const string OneNumberRangeMoreSeparateRegex = @"(>=|≥|과 같|이거나)";
       public const string OneNumberRangeLessSeparateRegex = @"같거나|약";
-      public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))";
+      public static readonly string OneNumberRangeEqualRegex = $@"((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(다|개)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))";
       public static readonly string OneNumberRangeEqualRegex2 = $@"((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))";
       public static readonly string OneNumberRangeMoreRegex1 = $@"((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)";
       public static readonly string OneNumberRangeMoreRegex2 = $@"((?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)|(?<number1>(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+))((\s등\s)?보다)?(\s살이)?\s({MoreRegex})|(최소\s*)?(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})";
@@ -249,11 +249,11 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string OneNumberRangeMoreRegexFraction = $@"((?<number1>(((\d+)[/／]).)+)(이)\s*{MoreRegex})";
       public static readonly string OneNumberRangeLessRegex1 = $@"((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+)\s*({LessOrEqual}|{LessOrEqualSuffix}|{LessRegex}))|((?<number2>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*{LessRegex})|{OneNumberRangeLessRegex5}";
       public static readonly string TwoNumberRangeRegex = $@"({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?";
-      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((같거나|약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))";
+      public static readonly string OneNumberRangeLessRegex3 = $@"(?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))";
       public static readonly string OneNumberRangeLessRegex4 = $@"(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))";
       public const string OneNumberRangeLessRegex5 = @"((?<number2>((이분의\s|약\s*)|(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+|[영령공일이두삼사오육칠팔구]+|[십백천만억조경열]+)+)\s*(또는|등)?\s*(살이|그|그보다|(위)?보다(는)?)?\s*(낮다|낮은|미만|마리 미만|적게|밑|(개 )?이하|작다|작거나)(\s?같다?)?)";
       public static readonly string TwoNumberRangeRegex1 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)";
-      public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})";
+      public static readonly string TwoNumberRangeRegex2 = $@"(({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))";
       public static readonly string TwoNumberRangeRegex3 = $@"({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})";
       public static readonly string TwoNumberRangeRegex4 = $@"(?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)\s*{TillRegex}\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(까지)?";
       public static readonly string TwoNumberRangeRegex5 = $@"(?<number1>((마이너스\s?)?([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+)(점)?(\s*)?{TillRegex}(\s*)?(?<number2>((마이너스\s?)?(([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구)))+))(점)?((\s*)?([십백천만억조경열]|((미만|적|낮|작|더적|더낮|더적|이하이다|까지|아래))+))?((\s)사이)?";

--- a/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Korean/Extractors/NumberRangeExtractor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Recognizers.Text.Number.Korean
                 },
                 {
                     new Regex(NumbersDefinitions.OneNumberRangeMoreRegex4, RegexFlags),
-                    NumberRangeConstants.EQUAL
+                    NumberRangeConstants.MORE
                 },
                 {
                     // 700에 달하는

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -348,7 +348,7 @@ MoreRegex: !simpleRegex
 LessRegex: !simpleRegex
   def: (미만|마리|적|낮|작|더적|더낮|더적|<|아래|작다|같)((네|아|어|군)요|습니다|은|다)?
 EqualRegex: !simpleRegex
-  def: (동일|같(고)?|=|(해당하는)|작은|그와 같다)(?!거나)
+  def: (동일|같(고)?|=|(해당하는)|작은|그와 같다)
 RangePrefixLessRegex: !simpleRegex
   def: (최대|까지최소|(?<!>|=)<|≤)
 RangePrefixMoreRegex: !simpleRegex
@@ -371,8 +371,8 @@ OneNumberRangeMoreSeparateRegex: !simpleRegex
 OneNumberRangeLessSeparateRegex: !simpleRegex
   def: 같거나|약
 OneNumberRangeEqualRegex: !nestedRegex
-  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(거나|다|개)?(\s*({LessRegex})(은)?)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))
-  references: [EqualRegex,LessRegex]
+  def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex})(다|개)?|((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(년에)\s*(\d+)(은|이다))|(정확히|같음|평등|그냥|저스트)(?<number1>\s*[+-]?(\d+[\.,]?\d+))
+  references: [EqualRegex]
 OneNumberRangeEqualRegex2: !nestedRegex
   def: ((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))
   references: [AllIntRegex]
@@ -401,7 +401,7 @@ TwoNumberRangeRegex: !nestedRegex
   def: ({RangePrefixLessRegex})\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*({RangePrefixMoreRegex}\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))(개)?
   references: [RangePrefixLessRegex, RangePrefixMoreRegex] 
 OneNumberRangeLessRegex3: !nestedRegex
-  def: (?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((같거나|약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))
+  def: (?:({RangePrefixLessRegex}))\s*(?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))|((약)(?<number1>\s*[+-]?(\d+[\.,]?\d+))\s*(미만|개 이하가))
   references: [RangePrefixLessRegex]
 OneNumberRangeLessRegex4: !nestedRegex
   def: (?<number2>(((?!((\s(?!\d+))|((,)(?!\d+))|。)).)+))\s*(에)(?:({LessOrEqualSuffix}))
@@ -412,7 +412,7 @@ TwoNumberRangeRegex1: !nestedRegex
   def: (?<number1>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(과|와|{TillRegex})\s*(?<number2>((?!((，(?!\d+))|(,(?!\d+))|。)).)+)(위?)\s*(사이)
   references: [TillRegex]
 TwoNumberRangeRegex2: !nestedRegex
-  def: (({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))|({OneNumberRangeLessRegex1}|{OneNumberRangeMoreRegex2})
+  def: (({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})\s*(과|지만|또는|，|、|,)?\s*({OneNumberRangeLessRegex1}))
   references: [ OneNumberRangeMoreRegex1, OneNumberRangeMoreRegex2, OneNumberRangeLessRegex1]
 TwoNumberRangeRegex3: !nestedRegex
   def: ({OneNumberRangeLessRegex1})\s*(과|또는|，|、|,)?\s*({OneNumberRangeMoreRegex1}|{OneNumberRangeMoreRegex2})

--- a/Patterns/Korean/Korean-Numbers.yaml
+++ b/Patterns/Korean/Korean-Numbers.yaml
@@ -352,9 +352,9 @@ EqualRegex: !simpleRegex
 RangePrefixLessRegex: !simpleRegex
   def: (최대|까지최소|(?<!>|=)<|≤)
 RangePrefixMoreRegex: !simpleRegex
-  def: ((?<!<|=)>|≥|>=|개에서 최소|과 같거나 최소|이거나 최소)
+  def: ((?<!<|=)>|≥|>=|개에서 최소)
 MoreOrEqual: !nestedRegex
-  def: (({MoreRegex}\s*(거나)?\s*{EqualRegex}))
+  def: (({MoreRegex}\s*(거나)?\s*{EqualRegex})|최소)
   references: [ MoreRegex, EqualRegex ]
 MoreOrEqual2: !nestedRegex
   def: (\s*(거나)?\s*(그보다)\s*{MoreRegex})
@@ -377,14 +377,14 @@ OneNumberRangeEqualRegex2: !nestedRegex
   def: ((?<number1>(((?!((\s(?!\d+))|(,(?!\d+))|。)))(?<=((는\s+))))([\d]|{AllIntRegex})+)(이다))
   references: [AllIntRegex]
 OneNumberRangeMoreRegex1: !nestedRegex
-  def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다|거나|또는)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
+  def: ((?<number1>((?!(((?!\d+))|((,)(?!\d+))|。)).)+[\.,]?(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)?)\s*(이|보다)+\s*(그|그보다)?\s*({MoreOrEqual}|{MoreRegex}|{MoreOrEqualSuffix})(은|다)?)
   references: [MoreOrEqual, MoreRegex, MoreOrEqualSuffix]
 OneNumberRangeMoreRegex2: !nestedRegex
   def: ((?<number1>(((?!(((?!([십백천만억조경열]|(영|령|공|일|이(?!다)|두|삼|사|오|육|(?<!며)칠|팔|구))+))))|(사분의\s)).)+)|(?<number1>(스물|서른|마흔|쉰|예순|일흔|여든|아흔|온|즈믄|다스|스무|이십오일)|(첫|처음|여섯|하나|둘|셋|넷|다섯|여섯|일곱|여덟|아홉)+))((\s등\s)?보다)?(\s살이)?\s({MoreRegex})|(최소\s*)?(?<number1>((?!((、(?!\d+))|(、(?!\d+))|。))|(?!\s+).)+)\s*(((혹은\s*그)?){MoreRegex}|((혹은\s*그)?){MoreOrEqualSuffix})
   references: [MoreRegex, MoreOrEqualSuffix] 
 OneNumberRangeMoreRegex3: !nestedRegex
-  def: (({RangePrefixMoreRegex})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|((과 같거나 최소|이거나 최소)\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))
-  references: [RangePrefixMoreRegex]
+  def: (({RangePrefixMoreRegex}|{MoreOrEqual})\s*(?<number1>(((?!(((?!\d+))|((,)(?!\d+))|。)).)+)))|(최소\s*(?<number1>\s*[+-]?(\d+[\.,]?\d+)))
+  references: [RangePrefixMoreRegex, MoreOrEqual]
 OneNumberRangeMoreRegex4: !nestedRegex
   def: ((?<number1>((?!((\s(?!\d+))|(,(?!\d+))|。)).)+)\s*(과|에)+\s*{EqualRegex}){MoreOrEqual2}(다)?
   references: [MoreOrEqual2,EqualRegex]

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -670,6 +670,13 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
+        "Text": "5000과 같",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[5000,5000]"
+        }
+      },
+      {
         "Text": "5000 보다 작다",
         "TypeName": "numberrange",
         "Resolution": {
@@ -1135,6 +1142,15 @@
     "Input": "그의 점수는 30과 같거나 최소 30이다",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
+      {
+        "Text": "30과 같",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "[30,30]"
+        },
+        "Start": 7,
+        "End": 11
+      },
       {
         "Text": "최소 30",
         "TypeName": "numberrange",
@@ -1684,10 +1700,17 @@
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "같거나 5000 미만",
+        "Text": "5000과 같",
         "TypeName": "numberrange",
         "Resolution": {
-          "value": "(,5000]"
+          "value": "[5000,5000]"
+        }
+      },
+      {
+        "Text": "5000 미만",
+        "TypeName": "numberrange",
+        "Resolution": {
+          "value": "(,5000)"
         }
       }
     ]

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -1140,6 +1140,7 @@
   },
   {
     "Input": "그의 점수는 30과 같거나 최소 30이다",
+    "Comment": "The pattern 'X과 같거나 최소 Y' is ambiguous and can be translated as either 'is X or at least Y' or 'is equal to X or at least Y'. Here the second interpretation is used and '30과 같' (equal to 30) is extracted.",
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {

--- a/Specs/Number/Korean/NumberRangeModel.json
+++ b/Specs/Number/Korean/NumberRangeModel.json
@@ -1136,12 +1136,12 @@
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "과 같거나 최소 30",
+        "Text": "최소 30",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[30,)"
         },
-        "Start": 9,
+        "Start": 15,
         "End": 19
       }
     ]
@@ -1639,12 +1639,12 @@
     "NotSupportedByDesign": "java, javascript, python",
     "Results": [
       {
-        "Text": "이거나 최소 30",
+        "Text": "최소 30",
         "TypeName": "numberrange",
         "Resolution": {
           "value": "[30,)"
         },
-        "Start": 9,
+        "Start": 13,
         "End": 17
       }
     ]


### PR DESCRIPTION
"X 과 같거나 최소 Y" can be translated to "is X or at least Y" or "is equal to X or at least Y". 
In English, "is X or at least Y" returns one result, "at least Y", and "is equal to X or at least Y" returns 2 results, "equal to X" and "at least Y".
Now in Korean, "X 과 같거나 최소 Y" also returns 2 results: "X 과 같" (equal to X) and "최소 Y" (at least Y).
