### PR TITLE
[JA DateTimeV2] Duration refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string NextPrefixRegex = @"下个|下一个|下|下一|明|次|来";
       public static readonly string RelativeRegex = $@"(?<order>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex}))";
       public static readonly string SpecialDate = $@"(?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})年)?(の|的)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})(の|的)?月)?(の|的)?{DateDayRegexInCJK}";
-      public const string DateUnitRegex = @"(?<unit>年|个月|月|周|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)";
+      public const string DateUnitRegex = @"(?<unit>年|个月|月|周|時間?|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)";
       public const string BeforeRegex = @"以前|之前|前";
       public const string AfterRegex = @"以内|以后|以後|之后|之後|后|後|先|で(?!す)";
       public static readonly string DateRegexList1 = $@"({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,|，|、)*{WeekDayRegex})?)";
@@ -140,24 +140,24 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string PlusThreeDayRegex = @"大后天|大後天|明日から二日|昨日から4日";
       public const string MinusThreeDayRegex = @"大前天|昨日の2日前|昨日から2日間";
       public const string PlusFourDayRegex = @"今日から4日";
-      public const string DurationAllRegex = @"^[.]";
+      public const string DurationAllRegex = @"(まる(ひと)?)";
       public const string DurationHalfRegex = @"^[.]";
-      public const string DurationRelativeDurationUnitRegex = @"(?<few>数ヶ|数)|(?<ago>前|昨日)|(?<later>後|明日)";
+      public const string DurationRelativeDurationUnitRegex = @"(?<few>数ヶ|数)|(?<ago>前|昨日)|(?<later>後|明日)|(?<another>もう)";
       public const string DurationDuringRegex = @"^[.]";
-      public const string DurationSomeRegex = @"(数ヶ|数)(月|日|週間|年)";
-      public const string DurationMoreOrLessRegex = @"^[.]";
+      public const string DurationSomeRegex = @"(?<few>数(?<unit>((か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)";
+      public const string DurationMoreOrLessRegex = @"(?<less>たらず)|(?<more>以上)";
       public const string DurationYearRegex = @"((\d{3,4})|0\d|两千)\s*年";
       public const string DurationHalfSuffixRegex = @"半";
       public static readonly Dictionary<string, string> DurationSuffixList = new Dictionary<string, string>
         {
-            { @"M", @"分钟" },
-            { @"S", @"秒钟|秒" },
-            { @"H", @"个小时|小时" },
-            { @"D", @"天|日" },
+            { @"M", @"分|分間" },
+            { @"S", @"秒钟|秒|秒間" },
+            { @"H", @"時|時間" },
+            { @"D", @"天|日|日間" },
             { @"BD", @"営業日" },
             { @"W", @"星期|个星期|周|週間|週" },
-            { @"MON", @"个月|か月|月" },
-            { @"Y", @"年" }
+            { @"MON", @"个月|か月|月|月間|か月間|ヶ月|ヶ月間" },
+            { @"Y", @"年|年間" }
         };
       public static readonly IList<string> DurationAmbiguousUnits = new List<string>
         {
@@ -174,7 +174,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"个月",
             @"年"
         };
-      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|分|秒|時間)";
+      public static readonly string DurationUnitRegex = $@"(?<unit>{DateUnitRegex}|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)";
       public const string DurationConnectorRegex = @"^\s*(?<connector>[と]?|,|、)\s*$";
       public static readonly string LunarHolidayRegex = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>除夕|春节|旧暦の正月初一|中秋(節|节)?|元宵(节|節)|端午(节|の節句)?|重(阳节|陽節))";
       public static readonly string HolidayRegexList1 = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)";
@@ -239,14 +239,22 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"星期", @"W" },
             { @"个星期", @"W" },
             { @"日", @"D" },
+            { @"日間", @"D" },
             { @"営業日", @"BD" },
             { @"天", @"D" },
             { @"小时", @"H" },
+            { @"時間", @"H" },
             { @"时", @"H" },
             { @"分钟", @"M" },
             { @"分", @"M" },
             { @"秒钟", @"S" },
-            { @"秒", @"S" }
+            { @"秒", @"S" },
+            { @"まる", @"whole" },
+            { @"まるひと", @"whole" },
+            { @"もう", @"another" },
+            { @"数", @"some" },
+            { @"たらず", @"less" },
+            { @"以上", @"more" }
         };
       public static readonly Dictionary<string, long> ParserConfigurationUnitValueMap = new Dictionary<string, long>
         {
@@ -584,9 +592,15 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"MON", 2592000 },
             { @"W", 604800 },
             { @"D", 86400 },
+            { @"BD", 86400 },
             { @"H", 3600 },
             { @"M", 60 },
-            { @"S", 1 }
+            { @"S", 1 },
+            { @"whole", 1 },
+            { @"another", 1 },
+            { @"some", 2 },
+            { @"more", 3 },
+            { @"less", 4 }
         };
       public static readonly Dictionary<string, string> HolidayNoFixedTimex = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*[万億]{{1,2}}(\s*(以上))?";
       public const string FracSplitRegex = @"[はと]|分\s*の";
       public const string ZeroToNineIntegerRegex = @"[〇一二三四五六七八九]";
+      public const string HalfUnitRegex = @"半";
       public const string NegativeNumberTermsRegex = @"(マ\s*イ\s*ナ\s*ス)";
       public static readonly string NegativeNumberTermsRegexNum = $@"((?<!(\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)|[-−－])[-−－])";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*|^{NegativeNumberTermsRegexNum}.*";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDurationParserConfiguration.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             DurationExtractor = new BaseCJKDurationExtractor(new ChineseDurationExtractorConfiguration(durationConfig), false);
 
             YearRegex = ChineseDurationExtractorConfiguration.YearRegex;
+            SomeRegex = ChineseDurationExtractorConfiguration.SomeRegex;
+            MoreOrLessRegex = ChineseDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = ChineseDurationExtractorConfiguration.DurationUnitRegex;
             DurationConnectorRegex = ChineseDurationExtractorConfiguration.DurationConnectorRegex;
 
@@ -34,6 +36,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public IParser InternalParser { get; }
 
         public Regex YearRegex { get; }
+
+        public Regex SomeRegex { get; }
+
+        public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDurationParserConfiguration.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             DurationExtractor = new BaseCJKDurationExtractor(new JapaneseDurationExtractorConfiguration(durationConfig), false);
 
             YearRegex = JapaneseDurationExtractorConfiguration.YearRegex;
+            SomeRegex = JapaneseDurationExtractorConfiguration.SomeRegex;
+            MoreOrLessRegex = JapaneseDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = JapaneseDurationExtractorConfiguration.DurationUnitRegex;
             DurationConnectorRegex = JapaneseDurationExtractorConfiguration.DurationConnectorRegex;
 
@@ -34,6 +36,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public IParser InternalParser { get; }
 
         public Regex YearRegex { get; }
+
+        public Regex SomeRegex { get; }
+
+        public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDurationParserConfiguration.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             DurationExtractor = new BaseCJKDurationExtractor(new KoreanDurationExtractorConfiguration(durationConfig), false);
 
             YearRegex = KoreanDurationExtractorConfiguration.YearRegex;
+            SomeRegex = KoreanDurationExtractorConfiguration.SomeRegex;
+            MoreOrLessRegex = KoreanDurationExtractorConfiguration.MoreOrLessRegex;
             DurationUnitRegex = KoreanDurationExtractorConfiguration.DurationUnitRegex;
             DurationConnectorRegex = KoreanDurationExtractorConfiguration.DurationConnectorRegex;
 
@@ -34,6 +36,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public IParser InternalParser { get; }
 
         public Regex YearRegex { get; }
+
+        public Regex SomeRegex { get; }
+
+        public Regex MoreOrLessRegex { get; }
 
         public Regex DurationUnitRegex { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDurationParser.cs
@@ -22,13 +22,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             config = configuration;
         }
 
-        public static bool IsLessThanDay(string unit)
-        {
-            return unit.Equals("S", StringComparison.Ordinal) ||
-                   unit.Equals("M", StringComparison.Ordinal) ||
-                   unit.Equals("H", StringComparison.Ordinal);
-        }
-
         public ParseResult Parse(ExtractResult result)
         {
             return this.Parse(result, DateObject.Now);
@@ -139,7 +132,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 return ret;
             }
 
-            if ((ret = ParseInexactNumberUnit(text)).Success)
+            if ((ret = DurationParsingUtil.ParseInexactNumberUnit(text, this.config)).Success)
             {
                 return ret;
             }
@@ -208,7 +201,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         numVal = double.Parse(pr.Value.ToString(), CultureInfo.InvariantCulture) + ParseNumberWithUnitAndSuffix(suffixStr);
                     }
 
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
+                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                     ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
                     ret.Success = true;
                     return ret;
@@ -264,7 +257,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         return ret;
                     }
 
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
+                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                     ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
                     ret.Success = true;
 
@@ -299,47 +292,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     var unitStr = this.config.UnitMap[srcUnit];
 
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
-                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
-                    ret.Success = true;
-                }
-                else if (match.Groups[Constants.BusinessDayGroupName].Success)
-                {
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, Constants.TimexBusinessDay, false);
-
-                    // The line below was containing this.config.UnitValueMap[srcUnit.Split()[1]]
-                    // it was updated to accommodate single word "business day" expressions.
-                    ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit.Split()[srcUnit.Split().Length - 1]];
-                    ret.Success = true;
-                }
-            }
-
-            return ret;
-        }
-
-        private DateTimeResolutionResult ParseInexactNumberUnit(string text)
-        {
-            var ret = new DateTimeResolutionResult();
-
-            var match = config.InexactNumberUnitRegex.Match(text);
-            if (match.Success)
-            {
-                // set the inexact number "few", "some" to 3 for now
-                double numVal = match.Groups["NumTwoTerm"].Success ? 2 : 3;
-                var srcUnit = match.Groups["unit"].Value;
-
-                if (this.config.UnitMap.ContainsKey(srcUnit))
-                {
-                    var unitStr = this.config.UnitMap[srcUnit];
-
-                    if (numVal > 1000 && (unitStr.Equals(Constants.TimexYear, StringComparison.Ordinal) ||
-                                          unitStr.Equals(Constants.TimexMonthFull, StringComparison.Ordinal) ||
-                                          unitStr.Equals(Constants.TimexWeek, StringComparison.Ordinal)))
-                    {
-                        return ret;
-                    }
-
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
+                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                     ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
                     ret.Success = true;
                 }
@@ -405,7 +358,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                                 var unitStr = this.config.UnitMap[srcUnit];
                                 var numVal = double.Parse(numStr, CultureInfo.InvariantCulture);
 
-                                ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
+                                ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                                 ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
                                 ret.Success = true;
                             }
@@ -430,7 +383,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                 {
                     var unitStr = this.config.UnitMap[srcUnit];
                     var numVal = double.Parse(numStr, CultureInfo.InvariantCulture);
-                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, IsLessThanDay(unitStr));
+                    ret.Timex = TimexUtility.GenerateDurationTimex(numVal, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                     ret.FutureValue = ret.PastValue = numVal * this.config.UnitValueMap[srcUnit];
                     ret.Success = true;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/BaseCJKDateParser.cs
@@ -810,7 +810,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     if (this.config.UnitMap.ContainsKey(srcUnit))
                     {
                         unitStr = this.config.UnitMap[srcUnit];
-                        ret.Timex = TimexUtility.GenerateDurationTimex(number, unitStr, BaseDurationParser.IsLessThanDay(unitStr));
+                        ret.Timex = TimexUtility.GenerateDurationTimex(number, unitStr, DurationParsingUtil.IsLessThanDay(unitStr));
                         DateObject date = Constants.InvalidDate;
 
                         var beforeMatch = this.config.BeforeRegex.Match(suffix);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDurationParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDurationParserConfiguration.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex YearRegex { get; }
 
+        Regex SomeRegex { get; }
+
+        Regex MoreOrLessRegex { get; }
+
         Regex DurationUnitRegex { get; }
 
         Regex DurationConnectorRegex { get; }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/IntegerExtractor.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
                 },
                 {
+                    // 半
+                    new Regex(NumbersDefinitions.HalfUnitRegex, RegexFlags),
+                    RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)
+                },
+                {
                     // 一ダース  五十ダース
                     new Regex(NumbersDefinitions.NumbersWithDozen, RegexFlags),
                     RegexTagGenerator.GenerateRegexTag(Constants.INTEGER_PREFIX, Constants.JAPANESE)

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
@@ -13,6 +13,7 @@ using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Chinese;
 using Microsoft.Recognizers.Text.Number.Config;
+using Microsoft.Recognizers.Text.NumberWithUnit.Utilities;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
 {
@@ -79,51 +80,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
         public void ExpandHalfSuffix(string source, ref List<ExtractResult> result, IOrderedEnumerable<ExtractResult> numbers)
         {
             // Expand Chinese phrase to the `half` patterns when it follows closely origin phrase.
-            if (HalfUnitRegex != null && numbers != null)
-            {
-                var match = new List<ExtractResult>();
-                foreach (var number in numbers)
-                {
-                    if (HalfUnitRegex.Matches(number.Text).Count == 1)
-                    {
-                        match.Add(number);
-                    }
-
-                }
-
-                if (match.Count > 0)
-                {
-                    var res = new List<ExtractResult>();
-                    foreach (var er in result)
-                    {
-                        int start = (int)er.Start;
-                        int length = (int)er.Length;
-                        var match_suffix = new List<ExtractResult>();
-                        foreach (var mr in match)
-                        {
-                            if (mr.Start == (start + length))
-                            {
-                                match_suffix.Add(mr);
-                            }
-                        }
-
-                        if (match_suffix.Count == 1)
-                        {
-                            var mr = match_suffix[0];
-                            er.Length += mr.Length;
-                            er.Text += mr.Text;
-                            var tmp = new List<ExtractResult>();
-                            tmp.Add((ExtractResult)er.Data);
-                            tmp.Add(mr);
-                            er.Data = tmp;
-                        }
-
-                        res.Add(er);
-                    }
-
-                    result = res;
-                }
-            }
+            CommonUtils.ExpandHalfSuffix(source, ref result, numbers, HalfUnitRegex);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -13,6 +13,7 @@ using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Config;
 using Microsoft.Recognizers.Text.Number.Japanese;
+using Microsoft.Recognizers.Text.NumberWithUnit.Utilities;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 {
@@ -26,6 +27,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
+
+        private static readonly Regex HalfUnitRegex = new Regex(NumbersWithUnitDefinitions.HalfUnitRegex, RegexFlags);
 
         protected JapaneseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
@@ -76,6 +79,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 
         public void ExpandHalfSuffix(string source, ref List<ExtractResult> result, IOrderedEnumerable<ExtractResult> numbers)
         {
+            // Expand Japanese phrase to the `half` patterns when it follows closely origin phrase.
+            CommonUtils.ExpandHalfSuffix(source, ref result, numbers, HalfUnitRegex);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Korean/Extractors/KoreanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Korean/Extractors/KoreanNumberWithUnitExtractorConfiguration.cs
@@ -13,6 +13,7 @@ using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.Number.Config;
 using Microsoft.Recognizers.Text.Number.Korean;
+using Microsoft.Recognizers.Text.NumberWithUnit.Utilities;
 
 namespace Microsoft.Recognizers.Text.NumberWithUnit.Korean
 {
@@ -79,55 +80,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Korean
         public void ExpandHalfSuffix(string source, ref List<ExtractResult> result, IOrderedEnumerable<ExtractResult> numbers)
         {
             // Expand Korean phrase to the `half` patterns when it follows closely origin phrase.
-            if (HalfUnitRegex != null && numbers != null)
-            {
-                var match = new List<ExtractResult>();
-                foreach (var number in numbers)
-                {
-                    if (HalfUnitRegex.Matches(number.Text).Count == 1)
-                    {
-                        match.Add(number);
-                    }
-
-                }
-
-                if (match.Count > 0)
-                {
-                    var res = new List<ExtractResult>();
-                    foreach (var er in result)
-                    {
-                        int start = (int)er.Start;
-                        int length = (int)er.Length;
-                        var match_suffix = new List<ExtractResult>();
-                        foreach (var mr in match)
-                        {
-                            // Take into account possible whitespaces between result and half unit.
-                            var subLength = (int)mr.Start - (start + length) >= 0 ? (int)mr.Start - (start + length) : 0;
-                            var midStr = source.Substring(start + length, subLength);
-                            if (string.IsNullOrWhiteSpace(midStr) && (int)mr.Start - (start + length) >= 0)
-                            {
-                                match_suffix.Add(mr);
-                            }
-                        }
-
-                        if (match_suffix.Count == 1)
-                        {
-                            var mr = match_suffix[0];
-                            var suffixLength = (int)(mr.Start + mr.Length) - (start + length);
-                            er.Length += suffixLength;
-                            er.Text += source.Substring(start + length, suffixLength);
-                            var tmp = new List<ExtractResult>();
-                            tmp.Add((ExtractResult)er.Data);
-                            tmp.Add(mr);
-                            er.Data = tmp;
-                        }
-
-                        res.Add(er);
-                    }
-
-                    result = res;
-                }
-            }
+            CommonUtils.ExpandHalfSuffix(source, ref result, numbers, HalfUnitRegex);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Utilities/CommonUtils.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Utilities/CommonUtils.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Recognizers.Text.NumberWithUnit.Utilities
+{
+    public static class CommonUtils
+    {
+        // Expand patterns with 'half' suffix in CJK implementation.
+        public static void ExpandHalfSuffix(string source, ref List<ExtractResult> result, IOrderedEnumerable<ExtractResult> numbers, Regex halfUnitRegex)
+        {
+            if (halfUnitRegex != null && numbers != null)
+            {
+                var match = new List<ExtractResult>();
+                foreach (var number in numbers)
+                {
+                    if (halfUnitRegex.Matches(number.Text).Count == 1)
+                    {
+                        match.Add(number);
+                    }
+
+                }
+
+                if (match.Count > 0)
+                {
+                    var res = new List<ExtractResult>();
+                    foreach (var er in result)
+                    {
+                        int start = (int)er.Start;
+                        int length = (int)er.Length;
+                        var match_suffix = new List<ExtractResult>();
+                        foreach (var mr in match)
+                        {
+                            // Take into account possible whitespaces between result and half unit.
+                            var subLength = (int)mr.Start - (start + length) >= 0 ? (int)mr.Start - (start + length) : 0;
+                            var midStr = source.Substring(start + length, subLength);
+                            if (string.IsNullOrWhiteSpace(midStr) && (int)mr.Start - (start + length) >= 0)
+                            {
+                                match_suffix.Add(mr);
+                            }
+                        }
+
+                        if (match_suffix.Count == 1)
+                        {
+                            var mr = match_suffix[0];
+                            var suffixLength = (int)(mr.Start + mr.Length) - (start + length);
+                            er.Length += suffixLength;
+                            er.Text += source.Substring(start + length, suffixLength);
+                            var tmp = new List<ExtractResult>();
+                            tmp.Add((ExtractResult)er.Data);
+                            tmp.Add(mr);
+                            er.Data = tmp;
+                        }
+
+                        res.Add(er);
+                    }
+
+                    result = res;
+                }
+            }
+        }
+    }
+}

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -84,7 +84,7 @@ SpecialDate: !nestedRegex
   def: (?<thisyear>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})年)?(の|的)?(?<thismonth>({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})(の|的)?月)?(の|的)?{DateDayRegexInCJK}
   references: [ThisPrefixRegex, LastPrefixRegex, NextPrefixRegex, DateDayRegexInCJK]
 DateUnitRegex: !simpleRegex
-  def: (?<unit>年|个月|月|周|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)
+  def: (?<unit>年|个月|月|周|時間?|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)
 BeforeRegex: !simpleRegex
   def: 以前|之前|前
 AfterRegex: !simpleRegex
@@ -311,21 +311,19 @@ PlusFourDayRegex: !simpleRegex
   def: 今日から4日
 #DurationExtractorCJK
 DurationAllRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in Korean
-  def: ^[.]
+  def: (まる(ひと)?)
 DurationHalfRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^[.]
 DurationRelativeDurationUnitRegex: !simpleRegex
-  def: (?<few>数ヶ|数)|(?<ago>前|昨日)|(?<later>後|明日)
+  def: (?<few>数ヶ|数)|(?<ago>前|昨日)|(?<later>後|明日)|(?<another>もう)
 DurationDuringRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Korean
   def: ^[.]
 DurationSomeRegex: !simpleRegex
-  def: (数ヶ|数)(月|日|週間|年)
+  def: (?<few>数(?<unit>((か|ヶ)?(時|月|日|週|年|周|週|週|秒|分|営業日|年)間?))(たらず|以上)?)
 DurationMoreOrLessRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in Korean
-  def: ^[.]
+  def: (?<less>たらず)|(?<more>以上)
 DurationYearRegex: !simpleRegex
   def: ((\d{3,4})|0\d|两千)\s*年
 DurationHalfSuffixRegex: !simpleRegex
@@ -333,14 +331,14 @@ DurationHalfSuffixRegex: !simpleRegex
 DurationSuffixList: !dictionary
   types: [string, string]
   entries:
-    M: 分钟
-    S: 秒钟|秒
-    H: 个小时|小时
-    D: 天|日
+    M: 分|分間
+    S: 秒钟|秒|秒間
+    H: 時|時間
+    D: 天|日|日間
     BD: 営業日
     W: 星期|个星期|周|週間|週
-    MON: 个月|か月|月
-    Y: 年
+    MON: 个月|か月|月|月間|か月間|ヶ月|ヶ月間
+    Y: 年|年間
 DurationAmbiguousUnits: !list
   types: [string]
   entries:
@@ -357,7 +355,7 @@ DurationAmbiguousUnits: !list
     - 个月
     - 年
 DurationUnitRegex: !nestedRegex
-  def: (?<unit>{DateUnitRegex}|分|秒|時間)
+  def: (?<unit>{DateUnitRegex}|分|秒|時間|まる(ひと)?|もう|数|以上|たらず)
   references: [DateUnitRegex]
 DurationConnectorRegex: !simpleRegex
   def: ^\s*(?<connector>[と]?|,|、)\s*$
@@ -503,14 +501,22 @@ ParserConfigurationUnitMap: !dictionary
     星期: W
     个星期: W
     日: D
+    日間: D
     営業日: BD
     天: D
     小时: H
+    時間: H 
     时: H
     分钟: M
     分: M
     秒钟: S
     秒: S
+    まる: whole
+    まるひと: whole
+    もう: another
+    数: some
+    たらず: less
+    以上: more
 ParserConfigurationUnitValueMap: !dictionary
   types: [string, long]
   entries:
@@ -858,9 +864,15 @@ DurationUnitValueMap: !dictionary
     MON: 2592000
     W: 604800
     D: 86400
+    BD: 86400
     H: 3600
     M: 60
     S: 1
+    whole: 1
+    another: 1
+    some: 2
+    more: 3
+    less: 4
 HolidayNoFixedTimex: !dictionary
   types: [string, string]
   entries:

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -117,6 +117,8 @@ FracSplitRegex: !simpleRegex
   def: '[はと]|分\s*の'
 ZeroToNineIntegerRegex: !simpleRegex
   def: '[〇一二三四五六七八九]'
+HalfUnitRegex: !simpleRegex
+  def: 半
 NegativeNumberTermsRegex: !simpleRegex
   def: (マ\s*イ\s*ナ\s*ス)
 NegativeNumberTermsRegexNum: !nestedRegex

--- a/Specs/DateTime/Japanese/DurationExtractor.json
+++ b/Specs/DateTime/Japanese/DurationExtractor.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "3時間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -14,7 +13,6 @@
   },
   {
     "Input": "3日間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "3年半不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "3か月不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "3分不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "3秒半不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +73,6 @@
   },
   {
     "Input": "123.45秒不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -92,7 +85,6 @@
   },
   {
     "Input": "2週間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "20分不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "24時間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "まる1日不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +133,6 @@
   },
   {
     "Input": "まる1週間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -157,7 +145,6 @@
   },
   {
     "Input": "まる1か月不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -170,7 +157,6 @@
   },
   {
     "Input": "まる1年不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -183,7 +169,6 @@
   },
   {
     "Input": "まるひと月不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -196,20 +181,18 @@
   },
   {
     "Input": "まる1年間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "まる1年",
+        "Text": "まる1年間",
         "Type": "duration",
         "Start": 0,
-        "Length": 4
+        "Length": 5
       }
     ]
   },
   {
     "Input": "1時間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,20 +205,18 @@
   },
   {
     "Input": "1年間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1年",
+        "Text": "1年間",
         "Type": "duration",
         "Start": 0,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
   {
     "Input": "半年",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,6 @@
   },
   {
     "Input": "30分不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -261,7 +241,6 @@
   },
   {
     "Input": "1時間半不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -274,7 +253,6 @@
   },
   {
     "Input": "2時間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -287,7 +265,6 @@
   },
   {
     "Input": "2時間半不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +277,6 @@
   },
   {
     "Input": "1週間で",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -313,7 +289,6 @@
   },
   {
     "Input": "1日で",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -326,7 +301,6 @@
   },
   {
     "Input": "1時間",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -339,20 +313,18 @@
   },
   {
     "Input": "1か月間",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1か月",
+        "Text": "1か月間",
         "Type": "duration",
         "Start": 0,
-        "Length": 3
+        "Length": 4
       }
     ]
   },
   {
     "Input": "数時間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -365,7 +337,6 @@
   },
   {
     "Input": "数分不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -378,46 +349,42 @@
   },
   {
     "Input": "数日間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "数日",
+        "Text": "数日間",
         "Type": "duration",
         "Start": 0,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
   {
     "Input": "1年1か月と21日間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1年1か月と21日",
+        "Text": "1年1か月と21日間",
         "Type": "duration",
         "Start": 0,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
   {
     "Input": "1か月と2日間、不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1か月と2日",
+        "Text": "1か月と2日間",
         "Type": "duration",
         "Start": 0,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
   {
     "Input": "あなたがもう1週間不在なことに気づきました。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -430,7 +397,6 @@
   },
   {
     "Input": "もう1か月待てますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -443,7 +409,6 @@
   },
   {
     "Input": "もう1営業日待てますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -456,7 +421,6 @@
   },
   {
     "Input": "半営業日不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -469,7 +433,6 @@
   },
   {
     "Input": "20年間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -482,7 +445,7 @@
   },
   {
     "Input": "二年間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "二年間",
@@ -494,7 +457,7 @@
   },
   {
     "Input": "五時間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "五時間",
@@ -506,7 +469,7 @@
   },
   {
     "Input": "三日間半",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "三日間半",
@@ -518,7 +481,7 @@
   },
   {
     "Input": "七週間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "七週間",
@@ -530,7 +493,7 @@
   },
   {
     "Input": "三ヶ月半",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "三ヶ月半",
@@ -542,7 +505,7 @@
   },
   {
     "Input": "三年半",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "三年半",
@@ -554,7 +517,7 @@
   },
   {
     "Input": "六日間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "六日間",

--- a/Specs/DateTime/Japanese/DurationParser.json
+++ b/Specs/DateTime/Japanese/DurationParser.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -54,7 +52,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -104,7 +100,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -129,7 +124,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -154,7 +148,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -179,7 +172,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -204,7 +196,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -229,7 +220,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -254,7 +244,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -279,7 +268,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -304,7 +292,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -329,7 +316,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -354,7 +340,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -379,11 +364,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "まる1年",
+        "Text": "まる1年間",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y",
@@ -395,7 +379,7 @@
           }
         },
         "Start": 0,
-        "Length": 4
+        "Length": 5
       }
     ]
   },
@@ -404,7 +388,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -429,7 +412,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -454,7 +436,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -479,7 +460,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -504,7 +484,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -529,7 +508,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -554,11 +532,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1年1か月と21日",
+        "Text": "1年1か月と21日間",
         "Type": "duration",
         "Value": {
           "Timex": "P1Y1M21D",
@@ -570,7 +547,7 @@
           }
         },
         "Start": 0,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -579,11 +556,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1か月と2日",
+        "Text": "1か月と2日間",
         "Type": "duration",
         "Value": {
           "Timex": "P1M2D",
@@ -595,7 +571,7 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -604,11 +580,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1週間と3日",
+        "Text": "1週間と3日間",
         "Type": "duration",
         "Value": {
           "Timex": "P1W3D",
@@ -620,7 +595,7 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -629,19 +604,18 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "数週間",
         "Type": "duration",
         "Value": {
-          "Timex": "P2W",
+          "Timex": "P3W",
           "FutureResolution": {
-            "duration": "1209600"
+            "duration": "1814400"
           },
           "PastResolution": {
-            "duration": "1209600"
+            "duration": "1814400"
           }
         },
         "Start": 0,
@@ -654,23 +628,22 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "数日",
+        "Text": "数日間",
         "Type": "duration",
         "Value": {
-          "Timex": "P2D",
+          "Timex": "P3D",
           "FutureResolution": {
-            "duration": "172800"
+            "duration": "259200"
           },
           "PastResolution": {
-            "duration": "172800"
+            "duration": "259200"
           }
         },
         "Start": 0,
-        "Length": 2
+        "Length": 3
       }
     ]
   },
@@ -679,7 +652,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -687,12 +659,12 @@
         "Type": "duration",
         "Value": {
           "Mod": "less",
-          "Timex": "P2D",
+          "Timex": "P3D",
           "FutureResolution": {
-            "duration": "172800"
+            "duration": "259200"
           },
           "PastResolution": {
-            "duration": "172800"
+            "duration": "259200"
           }
         },
         "Start": 0,
@@ -705,7 +677,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -731,7 +702,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -756,7 +726,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -781,7 +750,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -806,7 +774,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -828,7 +795,6 @@
   },
   {
     "Input": "20年間不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -853,7 +819,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "15週間",
@@ -877,7 +843,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "３日間",
@@ -901,7 +867,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "３年間半",
@@ -925,7 +891,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "２年間",
@@ -949,7 +915,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "５分間",


### PR DESCRIPTION
All test cases pass.

- Moved common methods IsLessThanDay and ParseInexactNumberUnit from BaseDurationParser to DurationParsingUtil.
- Moved ExpandHalfSuffix (used in CJK languages) from ChineseNumberWithUnitExtractor to CommonUtils in NumberWithUnit.

Changes to specs:
- Added the character '間' to the extracted text when missing (間 indicates a duration and can be translated as 'during').
- Patterns involving 'couple' (e.g. "I'll be away for a couple of days.") are rendered in Japanese using 'few|some' because there is no equivalent of 'couple'. The resolution has therefore been updated accordingly (P2D -> P3D).