### PR TITLE
[Python] Fix parsed values format in number with unit (es-es)

### DIFF
--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
@@ -177,7 +177,7 @@ class NumberWithUnitRecognizer(Recognizer[NumberWithUnitOptions]):
 
         # region Spanish
         self.register_model('CurrencyModel', Culture.Spanish, lambda options: CurrencyModel(
-            [ExtractorParserModel(BaseMergedUnitParser(SpanishCurrencyExtractorConfiguration(
+            [ExtractorParserModel(BaseMergedUnitExtractor(SpanishCurrencyExtractorConfiguration(
             )), BaseMergedUnitParser(SpanishCurrencyParserConfiguration()))]
         ))
         self.register_model('TemperatureModel', Culture.Spanish, lambda options: TemperatureModel(

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
@@ -177,8 +177,8 @@ class NumberWithUnitRecognizer(Recognizer[NumberWithUnitOptions]):
 
         # region Spanish
         self.register_model('CurrencyModel', Culture.Spanish, lambda options: CurrencyModel(
-            [ExtractorParserModel(NumberWithUnitExtractor(SpanishCurrencyExtractorConfiguration(
-            )), NumberWithUnitParser(SpanishCurrencyParserConfiguration()))]
+            [ExtractorParserModel(BaseMergedUnitParser(SpanishCurrencyExtractorConfiguration(
+            )), BaseMergedUnitParser(SpanishCurrencyParserConfiguration()))]
         ))
         self.register_model('TemperatureModel', Culture.Spanish, lambda options: TemperatureModel(
             [ExtractorParserModel(NumberWithUnitExtractor(SpanishTemperatureExtractorConfiguration(

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/parsers.py
@@ -284,7 +284,8 @@ class BaseCurrencyParser(Parser):
 
     def __get_number_value(self, number_value):
         if number_value:
-            return '{:g}'.format(number_value)
+            return self.config.culture_info.format(number_value) if self.config.culture_info is not None \
+                else repr(number_value)
         else:
             return None
 

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/spanish/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/spanish/parsers.py
@@ -46,6 +46,8 @@ class SpanishCurrencyParserConfiguration(SpanishNumberWithUnitParserConfiguratio
         super().__init__(culture_info)
         self.add_dict_to_unit_map(SpanishNumericWithUnit.CurrencySuffixList)
         self.add_dict_to_unit_map(SpanishNumericWithUnit.CurrencyPrefixList)
+        self.currency_name_to_iso_code_map = SpanishNumericWithUnit.CurrencyNameToIsoCodeMap
+        self.currency_fraction_code_list = SpanishNumericWithUnit.FractionalUnitNameToCodeMap
 
 
 class SpanishDimensionParserConfiguration(SpanishNumberWithUnitParserConfiguration):

--- a/Specs/NumberWithUnit/Spanish/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Spanish/CurrencyModel.json
@@ -1537,7 +1537,7 @@
   },
   {
     "Input": "solo cuesta 15 dolares y 15 centavos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dolares y 15 centavos",
@@ -1553,7 +1553,7 @@
   },
   {
     "Input": "solo cuesta trece euros y cuarenta y cinco céntimos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "trece euros y cuarenta y cinco céntimos",
@@ -1569,7 +1569,7 @@
   },
   {
     "Input": "solo cuesta 15 dolares y 15.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dolares y 15",
@@ -1585,7 +1585,7 @@
   },
   {
     "Input": "solo cuesta 15 dolares 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dolares 50",
@@ -1601,7 +1601,7 @@
   },
   {
     "Input": "solo cuesta 15 dolares con 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dolares con 50",
@@ -1617,7 +1617,7 @@
   },
   {
     "Input": "solo cuesta 25 euros con 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "25 euros con 50",
@@ -1633,7 +1633,7 @@
   },
   {
     "Input": "solo cuesta 3 euros con 99 céntimos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "3 euros con 99 céntimos",


### PR DESCRIPTION
- Using BaseMergedUnitParser and BaseMergedUnitExtractor for es-es CurrencyModel.
- Update __get_number_value to return number_value in format based on culture instead of general format.
- 
 
With this change, CurrencyModel for es-es will use **_BaseCurrencyParser_** and **___merged_compound_units_** (for extraction) 
and be able to resolve fractional units like "15 dolares y 15 centavos por favor" , "Son 25 dolares 50 por libra"

Resolved value is formatted to culture-based format with changes to function **___get_number_value_**