### PR TITLE
Update Portuguese datetime and Numbers with unit regex

### DIFF
--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -935,7 +935,7 @@ YearSuffix: !nestedRegex
   references: [ YearRegex, FullTextYearRegex ]
 SuffixAfterRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: ^\b$
 YearPeriodRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]

--- a/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
+++ b/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
@@ -788,7 +788,7 @@ FractionalUnitNameToCodeMap: !dictionary
     Millibitcoin: MILLIBITCOIN
     Satoshi: SATOSHI
 CompoundUnitConnectorRegex: !simpleRegex
-    def: (?<spacer>e|com)
+    def: \b(?<spacer>e|com)\b
 CurrencyPrefixList: !dictionary
   types: [ string, string ]
   entries:

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/number_with_unit_recognizer.py
@@ -150,12 +150,10 @@ class NumberWithUnitRecognizer(Recognizer[NumberWithUnitOptions]):
         # endregion
 
         # region Portuguese
-        self.register_model('CurrencyModel', Culture.Portuguese, lambda options: CurrencyModel([
-            ExtractorParserModel(
-                NumberWithUnitExtractor(
-                    PortugueseCurrencyExtractorConfiguration()),
-                NumberWithUnitParser(PortugueseCurrencyParserConfiguration()))
-        ]))
+        self.register_model('CurrencyModel', Culture.Portuguese, lambda options: CurrencyModel(
+            [ExtractorParserModel(BaseMergedUnitExtractor(PortugueseCurrencyExtractorConfiguration(
+            )), BaseMergedUnitParser(PortugueseCurrencyParserConfiguration()))]
+        ))
         self.register_model('TemperatureModel', Culture.Portuguese, lambda options: TemperatureModel([
             ExtractorParserModel(
                 NumberWithUnitExtractor(

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/portuguese/parsers.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/portuguese/parsers.py
@@ -46,6 +46,8 @@ class PortugueseCurrencyParserConfiguration(PortugueseNumberWithUnitParserConfig
         super().__init__(culture_info)
         self.add_dict_to_unit_map(PortugueseNumericWithUnit.CurrencySuffixList)
         self.add_dict_to_unit_map(PortugueseNumericWithUnit.CurrencyPrefixList)
+        self.currency_name_to_iso_code_map = PortugueseNumericWithUnit.CurrencyNameToIsoCodeMap
+        self.currency_fraction_code_list = PortugueseNumericWithUnit.FractionalUnitNameToCodeMap
 
 
 class PortugueseDimensionParserConfiguration(PortugueseNumberWithUnitParserConfiguration):

--- a/Specs/DateTime/Portuguese/TimeParser.json
+++ b/Specs/DateTime/Portuguese/TimeParser.json
@@ -922,5 +922,26 @@
         "Length": 8
       }
     ]
+  },
+  {
+    "Input": "Seu vôo está marcado para 11:55.",
+    "NotSupported": "python",
+    "Results": [
+      {
+        "Text": "11:55",
+        "Type": "time",
+        "Value": {
+          "Timex": "T11:55",
+          "FutureResolution": {
+            "time": "11:55:00"
+          },
+          "PastResolution": {
+            "time": "11:55:00"
+          }
+        },
+        "Start": 12,
+        "Length": 8
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1542,7 +1542,7 @@
         "Text": "15 dólares e 15 centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15.15",
+          "value": "15,15",
           "unit": "Dólar"
         },
         "Start": 14,
@@ -1558,7 +1558,7 @@
         "Text": "treze euros e quarenta e cinco centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "13.45",
+          "value": "13,45",
           "unit": "Euro"
         },
         "Start": 14,
@@ -1574,7 +1574,7 @@
         "Text": "15 dólares e 15",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15.15",
+          "value": "15,15",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1590,7 +1590,7 @@
         "Text": "15 dólares 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15.5",
+          "value": "15,5",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1606,7 +1606,7 @@
         "Text": "15 dólares com 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15.5",
+          "value": "15,5",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1622,7 +1622,7 @@
         "Text": "25 euros com 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "25.5",
+          "value": "25,5",
           "unit": "Euro"
         },
         "Start": 13,
@@ -1739,7 +1739,7 @@
         "Text": "15 dólares e 15 centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15.15",
+          "value": "15,15",
           "unit": "Dólar"
         },
         "Start": 0,

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1536,13 +1536,13 @@
   },
   {
     "Input": "custou apenas 15 dólares e 15 centavos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dólares e 15 centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15,15",
+          "value": "15.15",
           "unit": "Dólar"
         },
         "Start": 14,
@@ -1552,13 +1552,13 @@
   },
   {
     "Input": "custou apenas treze euros e quarenta e cinco centavos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "treze euros e quarenta e cinco centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "13,45",
+          "value": "13.45",
           "unit": "Euro"
         },
         "Start": 14,
@@ -1568,13 +1568,13 @@
   },
   {
     "Input": "custa apenas 15 dólares e 15.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dólares e 15",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15,15",
+          "value": "15.15",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1584,13 +1584,13 @@
   },
   {
     "Input": "custa apenas 15 dólares 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dólares 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15,5",
+          "value": "15.5",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1600,13 +1600,13 @@
   },
   {
     "Input": "custa apenas 15 dólares com 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dólares com 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "15,5",
+          "value": "15.5",
           "unit": "Dólar"
         },
         "Start": 13,
@@ -1616,13 +1616,13 @@
   },
   {
     "Input": "custa apenas 25 euros com 50.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "25 euros com 50",
         "TypeName": "currency",
         "Resolution": {
-          "value": "25,5",
+          "value": "25.5",
           "unit": "Euro"
         },
         "Start": 13,
@@ -1632,13 +1632,13 @@
   },
   {
     "Input": "custa apenas 3 euros com 99 centavos.",
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "3 euros com 99 centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "3,99",
+          "value": "3.99",
           "unit": "Euro"
         },
         "Start": 13,
@@ -1728,6 +1728,22 @@
         },
         "Start": 0,
         "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "15 dólares e 15 centavos, por favor",
+    "NotSupported": "javascript, java",
+    "Results": [
+      {
+        "Text": "15 dólares e 15 centavos",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15.15",
+          "unit": "Dólar"
+        },
+        "Start": 0,
+        "End": 23
       }
     ]
   }

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1638,7 +1638,7 @@
         "Text": "3 euros com 99 centavos",
         "TypeName": "currency",
         "Resolution": {
-          "value": "3.99",
+          "value": "3,99",
           "unit": "Euro"
         },
         "Start": 13,


### PR DESCRIPTION
Update Portuguese datetime regex for SuffixAfterRegex, so it does not match on a period at the end of a datetime input. eg "11:55."

Update Portuguese NumbersWithUnit CompoundUnitConnectorRegex, so that compound sentences for currency will resolve eg "15 dólares e 15 centavos, por favor"