### PR TITLE
[EN .NET] Fix TimexProperty.ToString() to handle DateTimeRanges properly

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
@@ -127,6 +127,13 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
         }
 
+        [TestMethod]
+        public void DataTypes_Timex_FromDateTimeRange_ToString()
+        {
+            var timex = new TimexProperty("(2022-03-15T16,2022-03-15T18,PT2H)");
+            Assert.AreEqual("15th March 2022 4PM", timex.ToString());
+        }
+
         private static void Roundtrip(string timex)
         {
             Assert.AreEqual(timex, new TimexProperty(timex).TimexValue);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Timex_FromDateTimeRange_ToString()
         {
+            // TODO: This test documents a workaround to avoid exceptions when calling TimexProperty.ToString(). Proper fix for date range representation is needed.
             var timex = new TimexProperty("(2022-03-15T16,2022-03-15T18,PT2H)");
             Assert.AreEqual("15th March 2022 4PM", timex.ToString());
         }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -213,9 +214,27 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static string ConvertDateTimeRange(TimexProperty timex)
         {
-            if (timex.Types.Contains(Constants.TimexTypes.TimeRange))
+            var parts = new List<string>();
+
+            var types = timex.Types;
+            if (types.Contains(Constants.TimexTypes.Date))
             {
-                return $"{ConvertDate(timex)} {ConvertTimeRange(timex)}";
+                parts.Add(ConvertDate(timex));
+            }
+
+            if (types.Contains(Constants.TimexTypes.Time))
+            {
+                parts.Add(ConvertTime(timex));
+            }
+
+            if (timex.PartOfDay is not null)
+            {
+                parts.Add(ConvertTimeRange(timex));
+            }
+
+            if (parts.Count > 0)
+            {
+                return string.Join(" ", parts);
             }
 
             // date + time + duration


### PR DESCRIPTION
This fixes the conversion to string of DateTimeRange Timex types such as`"(2022-03-15T16,2022-03-15T18,PT2H)"` to not assume there's a part of day in the `TimexProperty` object when there isn't one.

Fixes #2893