### PR TITLE
[EN .NET] Fix Timex to string conversion of english ordinals 11-13

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
@@ -127,6 +127,17 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
         }
 
+        [TestMethod]
+        public void DataTypes_Timex_FromDateTime_ToString()
+        {
+            var timex = new TimexProperty("2022-03-11");
+            Assert.AreEqual("11th March 2022", timex.ToString());
+            timex = new TimexProperty("2022-03-12");
+            Assert.AreEqual("12th March 2022", timex.ToString());
+            timex = new TimexProperty("2022-03-13");
+            Assert.AreEqual("13th March 2022", timex.ToString());
+        }
+
         private static void Roundtrip(string timex)
         {
             Assert.AreEqual(timex, new TimexProperty(timex).TimexValue);

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConvertEnglish.cs
@@ -97,7 +97,10 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
 
             var date = timex.DayOfMonth.Value.ToString(CultureInfo.InvariantCulture);
-            var abbreviation = TimexConstantsEnglish.DateAbbreviation[int.Parse(date[date.Length - 1].ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture)];
+            var dayOfMonth = int.Parse(date, CultureInfo.InvariantCulture);
+
+            // Ordinals 11 to 13 are special in english as they end in th
+            var abbreviation = TimexConstantsEnglish.DateAbbreviation[(dayOfMonth is > 9 and < 14 ? 9 : dayOfMonth) % 10];
 
             if (timex.Month != null)
             {


### PR DESCRIPTION
The `TimexProperty.ToString()` english conversion of DateTime strings returns the wrong ordinal for days 11-13. In English, ordinals 1 through 3 have special suffixes - 1st, 2nd, 3rd - _except_ on 11-13, where the suffixes are 11th, 12th, 13th.

Fixes #2895