### PR TITLE
[.NET Timexlib] Implement missing features of TimexProperty.ToString()

### DIFF
--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimex.cs
@@ -17,133 +17,107 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Timex_FromDateTime()
         {
-            Assert.AreEqual("2017-12-05T23:57:35", TimexProperty.FromDateTime(new System.DateTime(2017, 12, 5, 23, 57, 35)).TimexValue);
+            Assert.AreEqual("2017-12-05T23:57:35",
+                TimexProperty.FromDateTime(new System.DateTime(2017, 12, 5, 23, 57, 35)).TimexValue);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_Date()
+        [DataRow("2017-09-27")]
+        [DataRow("XXXX-WXX-3")]
+        [DataRow("XXXX-12-05")]
+        public void DataTypes_Timex_Roundtrip_Date(string timex)
         {
-            Roundtrip("2017-09-27");
-            Roundtrip("XXXX-WXX-3");
-            Roundtrip("XXXX-12-05");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_Time()
+        [DataRow("T17:30:45")]
+        [DataRow("T05:06:07")]
+        [DataRow("T17:30")]
+        [DataRow("T23")]
+        public void DataTypes_Timex_Roundtrip_Time(string timex)
         {
-            Roundtrip("T17:30:45");
-            Roundtrip("T05:06:07");
-            Roundtrip("T17:30");
-            Roundtrip("T23");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_Duration()
+        [DataRow("P50Y")]
+        [DataRow("P6M")]
+        [DataRow("P3W")]
+        [DataRow("P5D")]
+        [DataRow("PT16H")]
+        [DataRow("PT32M")]
+        [DataRow("PT20S")]
+        public void DataTypes_Timex_Roundtrip_Duration(string timex)
         {
-            Roundtrip("P50Y");
-            Roundtrip("P6M");
-            Roundtrip("P3W");
-            Roundtrip("P5D");
-            Roundtrip("PT16H");
-            Roundtrip("PT32M");
-            Roundtrip("PT20S");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_Now()
+        [DataRow("PRESENT_REF")]
+        public void DataTypes_Timex_Roundtrip_Now(string timex)
         {
-            Roundtrip("PRESENT_REF");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_DateTime()
+        [DataRow("XXXX-WXX-3T04")]
+        [DataRow("2017-09-27T11:41:30")]
+        public void DataTypes_Timex_Roundtrip_DateTime(string timex)
         {
-            Roundtrip("XXXX-WXX-3T04");
-            Roundtrip("2017-09-27T11:41:30");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_DateRange()
+        [DataRow("2017")]
+        [DataRow("SU")]
+        [DataRow("2017-WI")]
+        [DataRow("2017-09")]
+        [DataRow("2017-W37")]
+        [DataRow("2017-W37-WE")]
+        [DataRow("XXXX-05")]
+        public void DataTypes_Timex_Roundtrip_DateRange(string timex)
         {
-            Roundtrip("2017");
-            Roundtrip("SU");
-            Roundtrip("2017-WI");
-            Roundtrip("2017-09");
-            Roundtrip("2017-W37");
-            Roundtrip("2017-W37-WE");
-            Roundtrip("XXXX-05");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_DateRange_Start_End_Duration()
+        [DataRow("(XXXX-WXX-3,XXXX-WXX-6,P3D)")]
+        [DataRow("(XXXX-01-01,XXXX-08-05,P216D)")]
+        [DataRow("(2017-01-01,2017-08-05,P216D)")]
+        [DataRow("(2016-01-01,2016-08-05,P217D)")]
+        public void DataTypes_Timex_Roundtrip_DateRange_Start_End_Duration(string timex)
         {
-            Roundtrip("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
-            Roundtrip("(XXXX-01-01,XXXX-08-05,P216D)");
-            Roundtrip("(2017-01-01,2017-08-05,P216D)");
-            Roundtrip("(2016-01-01,2016-08-05,P217D)");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_TimeRange()
+        [DataRow("TEV")]
+        public void DataTypes_Timex_Roundtrip_TimeRange(string timex)
         {
-            Roundtrip("TEV");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_TimeRange_Start_End_Duration()
+        [DataRow("(T16,T19,PT3H)")]
+        public void DataTypes_Timex_Roundtrip_TimeRange_Start_End_Duration(string timex)
         {
-            Roundtrip("(T16,T19,PT3H)");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_DateTimeRange()
+        [DataRow("2017-09-27TEV")]
+        public void DataTypes_Timex_Roundtrip_DateTimeRange(string timex)
         {
-            Roundtrip("2017-09-27TEV");
+            Roundtrip(timex);
         }
 
         [TestMethod]
-        public void DataTypes_Timex_Roundtrip_DateTimeRange_Start_End_Duration()
+        [DataRow("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)")]
+        [DataRow("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)")]
+        public void DataTypes_Timex_Roundtrip_DateTimeRange_Start_End_Duration(string timex)
         {
-            Roundtrip("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
-            Roundtrip("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)");
-        }
-
-        [TestMethod]
-        public void DataTypes_Timex_ToString()
-        {
-            Assert.AreEqual("5th May", new TimexProperty("XXXX-05-05").ToString());
-        }
-
-        [TestMethod]
-        public void DataTypes_Timex_ToNaturalLanguage()
-        {
-            var today = new System.DateTime(2017, 10, 16);
-            Assert.AreEqual("tomorrow", new TimexProperty("2017-10-17").ToNaturalLanguage(today));
-        }
-
-        [TestMethod]
-        public void DataTypes_Timex_FromTime()
-        {
-            Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
-        }
-
-        [TestMethod]
-        public void DataTypes_Timex_FromDateTime_ToString()
-        {
-            var timex = new TimexProperty("2022-03-11");
-            Assert.AreEqual("11th March 2022", timex.ToString());
-            timex = new TimexProperty("2022-03-12");
-            Assert.AreEqual("12th March 2022", timex.ToString());
-            timex = new TimexProperty("2022-03-13");
-            Assert.AreEqual("13th March 2022", timex.ToString());
-        }
-
-        [TestMethod]
-        public void DataTypes_Timex_FromDateTimeRange_ToString()
-        {
-            // TODO: This test documents a workaround to avoid exceptions when calling TimexProperty.ToString(). Proper fix for date range representation is needed.
-            var timex = new TimexProperty("(2022-03-15T16,2022-03-15T18,PT2H)");
-            Assert.AreEqual("15th March 2022 4PM", timex.ToString());
+            Roundtrip(timex);
         }
 
         private static void Roundtrip(string timex)

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexConvert.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexConvert.cs
@@ -15,276 +15,314 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         }
 
         [TestMethod]
-        public void DataTypes_Convert_MonthAndDayOfMonth()
+        [DataRow("XXXX-01-05", "5th January")]
+        [DataRow("XXXX-02-05", "5th February")]
+        [DataRow("XXXX-03-05", "5th March")]
+        [DataRow("XXXX-04-05", "5th April")]
+        [DataRow("XXXX-05-05", "5th May")]
+        [DataRow("XXXX-06-05", "5th June")]
+        [DataRow("XXXX-07-05", "5th July")]
+        [DataRow("XXXX-08-05", "5th August")]
+        [DataRow("XXXX-09-05", "5th September")]
+        [DataRow("XXXX-10-05", "5th October")]
+        [DataRow("XXXX-11-05", "5th November")]
+        [DataRow("XXXX-12-05", "5th December")]
+        public void DataTypes_Convert_MonthAndDayOfMonth(string timex, string expected)
         {
-            Assert.AreEqual("5th January", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-01-05")));
-            Assert.AreEqual("5th February", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-02-05")));
-            Assert.AreEqual("5th March", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-03-05")));
-            Assert.AreEqual("5th April", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-04-05")));
-            Assert.AreEqual("5th May", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-05-05")));
-            Assert.AreEqual("5th June", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-06-05")));
-            Assert.AreEqual("5th July", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-07-05")));
-            Assert.AreEqual("5th August", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-08-05")));
-            Assert.AreEqual("5th September", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-09-05")));
-            Assert.AreEqual("5th October", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-10-05")));
-            Assert.AreEqual("5th November", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-11-05")));
-            Assert.AreEqual("5th December", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-12-05")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_MonthAndDayOfMonthWithCorrectAbbreviation()
+        [DataRow("XXXX-06-01", "1st June")]
+        [DataRow("XXXX-06-02", "2nd June")]
+        [DataRow("XXXX-06-03", "3rd June")]
+        [DataRow("XXXX-06-04", "4th June")]
+        public void DataTypes_Convert_MonthAndDayOfMonthWithCorrectAbbreviation(string timex, string expected)
         {
-            Assert.AreEqual("1st June", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-06-01")));
-            Assert.AreEqual("2nd June", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-06-02")));
-            Assert.AreEqual("3rd June", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-06-03")));
-            Assert.AreEqual("4th June", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-06-04")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_DayOfWeek()
+        [DataRow("XXXX-WXX-1", "Monday")]
+        [DataRow("XXXX-WXX-2", "Tuesday")]
+        [DataRow("XXXX-WXX-3", "Wednesday")]
+        [DataRow("XXXX-WXX-4", "Thursday")]
+        [DataRow("XXXX-WXX-5", "Friday")]
+        [DataRow("XXXX-WXX-6", "Saturday")]
+        [DataRow("XXXX-WXX-7", "Sunday")]
+        public void DataTypes_Convert_DayOfWeek(string timex, string expected)
         {
-            Assert.AreEqual("Monday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-1")));
-            Assert.AreEqual("Tuesday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-2")));
-            Assert.AreEqual("Wednesday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-3")));
-            Assert.AreEqual("Thursday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-4")));
-            Assert.AreEqual("Friday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-5")));
-            Assert.AreEqual("Saturday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-6")));
-            Assert.AreEqual("Sunday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-7")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Time()
+        [DataRow("T17:30:05", "5:30:05PM")]
+        [DataRow("T02:30:30", "2:30:30AM")]
+        [DataRow("T00:30:30", "12:30:30AM")]
+        [DataRow("T12:30:30", "12:30:30PM")]
+        public void DataTypes_Convert_Time(string timex, string expected)
         {
-            Assert.AreEqual("5:30:05PM", TimexConvert.ConvertTimexToString(new TimexProperty("T17:30:05")));
-            Assert.AreEqual("2:30:30AM", TimexConvert.ConvertTimexToString(new TimexProperty("T02:30:30")));
-            Assert.AreEqual("12:30:30AM", TimexConvert.ConvertTimexToString(new TimexProperty("T00:30:30")));
-            Assert.AreEqual("12:30:30PM", TimexConvert.ConvertTimexToString(new TimexProperty("T12:30:30")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_HourAndMinute()
+        [DataRow("T17:30", "5:30PM")]
+        [DataRow("T17:00", "5PM")]
+        [DataRow("T01:30", "1:30AM")]
+        [DataRow("T01:00", "1AM")]
+        public void DataTypes_Convert_HourAndMinute(string timex, string expected)
         {
-            Assert.AreEqual("5:30PM", TimexConvert.ConvertTimexToString(new TimexProperty("T17:30")));
-            Assert.AreEqual("5PM", TimexConvert.ConvertTimexToString(new TimexProperty("T17:00")));
-            Assert.AreEqual("1:30AM", TimexConvert.ConvertTimexToString(new TimexProperty("T01:30")));
-            Assert.AreEqual("1AM", TimexConvert.ConvertTimexToString(new TimexProperty("T01:00")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Hour()
+        [DataRow("T00", "midnight")]
+        [DataRow("T01", "1AM")]
+        [DataRow("T02", "2AM")]
+        [DataRow("T03", "3AM")]
+        [DataRow("T04", "4AM")]
+        [DataRow("T12", "midday")]
+        [DataRow("T13", "1PM")]
+        [DataRow("T14", "2PM")]
+        [DataRow("T23", "11PM")]
+        public void DataTypes_Convert_Hour(string timex, string expected)
         {
-            Assert.AreEqual("midnight", TimexConvert.ConvertTimexToString(new TimexProperty("T00")));
-            Assert.AreEqual("1AM", TimexConvert.ConvertTimexToString(new TimexProperty("T01")));
-            Assert.AreEqual("2AM", TimexConvert.ConvertTimexToString(new TimexProperty("T02")));
-            Assert.AreEqual("3AM", TimexConvert.ConvertTimexToString(new TimexProperty("T03")));
-            Assert.AreEqual("4AM", TimexConvert.ConvertTimexToString(new TimexProperty("T04")));
-            Assert.AreEqual("midday", TimexConvert.ConvertTimexToString(new TimexProperty("T12")));
-            Assert.AreEqual("1PM", TimexConvert.ConvertTimexToString(new TimexProperty("T13")));
-            Assert.AreEqual("2PM", TimexConvert.ConvertTimexToString(new TimexProperty("T14")));
-            Assert.AreEqual("11PM", TimexConvert.ConvertTimexToString(new TimexProperty("T23")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Now()
+        [DataRow("PRESENT_REF", "now")]
+        public void DataTypes_Convert_Now(string timex, string expected)
         {
-            Assert.AreEqual("now", TimexConvert.ConvertTimexToString(new TimexProperty("PRESENT_REF")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_FullDatetime()
+        [DataRow("1984-01-03T18:30:45", "6:30:45PM 3rd January 1984")]
+        [DataRow("2000-01-01T00", "midnight 1st January 2000")]
+        [DataRow("1967-05-29T19:30:00", "7:30PM 29th May 1967")]
+        public void DataTypes_Convert_FullDatetime(string timex, string expected)
         {
-            Assert.AreEqual("6:30:45PM 3rd January 1984", TimexConvert.ConvertTimexToString(new TimexProperty("1984-01-03T18:30:45")));
-            Assert.AreEqual("midnight 1st January 2000", TimexConvert.ConvertTimexToString(new TimexProperty("2000-01-01T00")));
-            Assert.AreEqual("7:30PM 29th May 1967", TimexConvert.ConvertTimexToString(new TimexProperty("1967-05-29T19:30:00")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_ParicularTimeOnParticularDayOfWeek()
+        [DataRow("XXXX-WXX-3T16", "4PM Wednesday")]
+        [DataRow("XXXX-WXX-5T18:30", "6:30PM Friday")]
+        public void DataTypes_Convert_ParticularTimeOnParticularDayOfWeek(string timex, string expected)
         {
-            Assert.AreEqual("4PM Wednesday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-3T16")));
-            Assert.AreEqual("6:30PM Friday", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-5T18:30")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Year()
+        [DataRow("2016", "2016")]
+        public void DataTypes_Convert_Year(string timex, string expected)
         {
-            Assert.AreEqual("2016", TimexConvert.ConvertTimexToString(new TimexProperty("2016")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_YearSeason()
+        [DataRow("1999-SU", "summer 1999")]
+        public void DataTypes_Convert_YearSeason(string timex, string expected)
         {
-            Assert.AreEqual("summer 1999", TimexConvert.ConvertTimexToString(new TimexProperty("1999-SU")));
-        }
-
-        public void DataTypes_Convert_Season()
-        {
-            Assert.AreEqual("summer", TimexConvert.ConvertTimexToString(new TimexProperty("SU")));
-            Assert.AreEqual("winter", TimexConvert.ConvertTimexToString(new TimexProperty("WI")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Month()
+        [DataRow("SU", "summer")]
+        [DataRow("WI", "winter")]
+        public void DataTypes_Convert_Season(string timex, string expected)
         {
-            Assert.AreEqual("January", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-01")));
-            Assert.AreEqual("May", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-05")));
-            Assert.AreEqual("December", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-12")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_MonthAndYear()
+        [DataRow("XXXX-01", "January")]
+        [DataRow("XXXX-05", "May")]
+        [DataRow("XXXX-12", "December")]
+        public void DataTypes_Convert_Month(string timex, string expected)
         {
-            Assert.AreEqual("May 2018", TimexConvert.ConvertTimexToString(new TimexProperty("2018-05")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_WeekOfMonth()
+        [DataRow("2018-05", "May 2018")]
+        public void DataTypes_Convert_MonthAndYear(string timex, string expected)
         {
-            Assert.AreEqual("first week of January", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-01-W01")));
-            Assert.AreEqual("third week of August", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-08-W03")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_PartOfTheDay()
+        [DataRow("XXXX-01-W01", "first week of January")]
+        [DataRow("XXXX-08-W03", "third week of August")]
+        public void DataTypes_Convert_WeekOfMonth(string timex, string expected)
         {
-            Assert.AreEqual("daytime", TimexConvert.ConvertTimexToString(new TimexProperty("TDT")));
-            Assert.AreEqual("night", TimexConvert.ConvertTimexToString(new TimexProperty("TNI")));
-            Assert.AreEqual("morning", TimexConvert.ConvertTimexToString(new TimexProperty("TMO")));
-            Assert.AreEqual("afternoon", TimexConvert.ConvertTimexToString(new TimexProperty("TAF")));
-            Assert.AreEqual("evening", TimexConvert.ConvertTimexToString(new TimexProperty("TEV")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_FridayEvening()
+        [DataRow("TDT", "daytime")]
+        [DataRow("TNI", "night")]
+        [DataRow("TMO", "morning")]
+        [DataRow("TAF", "afternoon")]
+        [DataRow("TEV", "evening")]
+        public void DataTypes_Convert_PartOfTheDay(string timex, string expected)
         {
-            Assert.AreEqual("Friday evening", TimexConvert.ConvertTimexToString(new TimexProperty("XXXX-WXX-5TEV")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_DateAndPartOfDay()
+        [DataRow("(XXXX-XX-XX,XXXX-XX-XX,P1D)", "1 day")]
+        public void DataTypes_Convert_Period(string timex, string expected)
         {
-            Assert.AreEqual("7th September 2017 night", TimexConvert.ConvertTimexToString(new TimexProperty("2017-09-07TNI")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Last5Minutes()
+        [DataRow("XXXX-WXX-5TEV", "Friday evening")]
+        public void DataTypes_Convert_FridayEvening(string timex, string expected)
         {
-            // date + time + duration
-            var timex = new TimexProperty("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
-
-            // TODO
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_WednesdayToSaturday()
+        [DataRow("2017-09-07TNI", "7th September 2017 night")]
+        public void DataTypes_Convert_DateAndPartOfDay(string timex, string expected)
         {
-            // date + duration
-            var timex = new TimexProperty("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
-
-            // TODO
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Years()
+        [DataRow("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)", "8th September 2017 9:19:29PM to 9:24:29PM")]
+        public void DataTypes_Convert_Last5Minutes(string timex, string expected)
         {
-            Assert.AreEqual("2 years", TimexConvert.ConvertTimexToString(new TimexProperty("P2Y")));
-            Assert.AreEqual("1 year", TimexConvert.ConvertTimexToString(new TimexProperty("P1Y")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Months()
+        [DataRow("(XXXX-WXX-3,XXXX-WXX-6,P3D)", "Wednesday to Saturday")]
+        public void DataTypes_Convert_DateRange(string timex, string expected)
         {
-            Assert.AreEqual("4 months", TimexConvert.ConvertTimexToString(new TimexProperty("P4M")));
-            Assert.AreEqual("1 month", TimexConvert.ConvertTimexToString(new TimexProperty("P1M")));
-            Assert.AreEqual("0 months", TimexConvert.ConvertTimexToString(new TimexProperty("P0M")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Weeks()
+        [DataRow("P2Y", "2 years")]
+        [DataRow("P1Y", "1 year")]
+        public void DataTypes_Convert_Years(string timex, string expected)
         {
-            Assert.AreEqual("6 weeks", TimexConvert.ConvertTimexToString(new TimexProperty("P6W")));
-            Assert.AreEqual("9.5 weeks", TimexConvert.ConvertTimexToString(new TimexProperty("P9.5W")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Days()
+        [DataRow("P4M", "4 months")]
+        [DataRow("P1M", "1 month")]
+        [DataRow("P0M", "0 months")]
+        public void DataTypes_Convert_Months(string timex, string expected)
         {
-            Assert.AreEqual("5 days", TimexConvert.ConvertTimexToString(new TimexProperty("P5D")));
-            Assert.AreEqual("1 day", TimexConvert.ConvertTimexToString(new TimexProperty("P1D")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Hours()
+        [DataRow("P6W", "6 weeks")]
+        [DataRow("P9.5W", "9.5 weeks")]
+        public void DataTypes_Convert_Weeks(string timex, string expected)
         {
-            Assert.AreEqual("5 hours", TimexConvert.ConvertTimexToString(new TimexProperty("PT5H")));
-            Assert.AreEqual("1 hour", TimexConvert.ConvertTimexToString(new TimexProperty("PT1H")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Minutes()
+        [DataRow("P5D", "5 days")]
+        [DataRow("P1D", "1 day")]
+        public void DataTypes_Convert_Days(string timex, string expected)
         {
-            Assert.AreEqual("30 minutes", TimexConvert.ConvertTimexToString(new TimexProperty("PT30M")));
-            Assert.AreEqual("1 minute", TimexConvert.ConvertTimexToString(new TimexProperty("PT1M")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Seconds()
+        [DataRow("PT5H", "5 hours")]
+        [DataRow("PT1H", "1 hour")]
+        public void DataTypes_Convert_Hours(string timex, string expected)
         {
-            Assert.AreEqual("45 seconds", TimexConvert.ConvertTimexToString(new TimexProperty("PT45S")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_Every2Days()
+        [DataRow("PT30M", "30 minutes")]
+        [DataRow("PT1M", "1 minute")]
+        public void DataTypes_Convert_Minutes(string timex, string expected)
         {
-            Assert.AreEqual("every 2 days", TimexConvert.ConvertTimexSetToString(new TimexSet("P2D")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryWeek()
+        [DataRow("PT45S", "45 seconds")]
+        public void DataTypes_Convert_Seconds(string timex, string expected)
         {
-            Assert.AreEqual("every week", TimexConvert.ConvertTimexSetToString(new TimexSet("P1W")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexToString(new TimexProperty(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryOctober()
+        [DataRow("P2D", "every 2 days")]
+        public void DataTypes_Convert_Every2Days(string timex, string expected)
         {
-            Assert.AreEqual("every October", TimexConvert.ConvertTimexSetToString(new TimexSet("XXXX-10")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EverySunday()
+        [DataRow("P1W", "every week")]
+        public void DataTypes_Convert_EveryWeek(string timex, string expected)
         {
-            Assert.AreEqual("every Sunday", TimexConvert.ConvertTimexSetToString(new TimexSet("XXXX-WXX-7")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryDay()
+        [DataRow("XXXX-10", "every October")]
+        public void DataTypes_Convert_EveryOctober(string timex, string expected)
         {
-            Assert.AreEqual("every day", TimexConvert.ConvertTimexSetToString(new TimexSet("P1D")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryYear()
+        [DataRow("XXXX-WXX-7", "every Sunday")]
+        public void DataTypes_Convert_EverySunday(string timex, string expected)
         {
-            Assert.AreEqual("every year", TimexConvert.ConvertTimexSetToString(new TimexSet("P1Y")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EverySpring()
+        [DataRow("P1D", "every day")]
+        public void DataTypes_Convert_EveryDay(string timex, string expected)
         {
-            Assert.AreEqual("every spring", TimexConvert.ConvertTimexSetToString(new TimexSet("SP")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryWinter()
+        [DataRow("P1Y", "every year")]
+        public void DataTypes_Convert_EveryYear(string timex, string expected)
         {
-            Assert.AreEqual("every winter", TimexConvert.ConvertTimexSetToString(new TimexSet("WI")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
 
         [TestMethod]
-        public void DataTypes_Convert_EveryEvening()
+        [DataRow("SP", "every spring")]
+        public void DataTypes_Convert_EverySpring(string timex, string expected)
         {
-            Assert.AreEqual("every evening", TimexConvert.ConvertTimexSetToString(new TimexSet("TEV")));
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
+        }
+
+        [TestMethod]
+        [DataRow("WI", "every winter")]
+        public void DataTypes_Convert_EveryWinter(string timex, string expected)
+        {
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
+        }
+
+        [TestMethod]
+        [DataRow("TEV", "every evening")]
+        public void DataTypes_Convert_EveryEvening(string timex, string expected)
+        {
+            Assert.AreEqual(expected, TimexConvert.ConvertTimexSetToString(new TimexSet(timex)));
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexCreator.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Creator_nextWeek()
         {
-            var start = TimexDateHelpers.DateOfNextDay(DayOfWeek.Monday, System.DateTime.Now);
+            var start = TimexDateHelpers.DateOfNextDay(System.DateTime.Now, DayOfWeek.Monday);
             var t = TimexProperty.FromDate(start);
             t.Days = 7;
             var expected = t.TimexValue;
@@ -128,7 +128,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_Creator_lastWeek()
         {
-            var start = TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, System.DateTime.Now);
+            var start = TimexDateHelpers.DateOfLastDay(System.DateTime.Now, DayOfWeek.Monday);
             start = start.AddDays(-7);
             var t = TimexProperty.FromDate(start);
             t.Days = 7;

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexDateHelpers.cs
@@ -12,74 +12,74 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         [TestMethod]
         public void DataTypes_DateHelpers_tomorrow()
         {
-            Assert.AreEqual(new System.DateTime(2017, 1, 1), TimexDateHelpers.Tomorrow(new System.DateTime(2016, 12, 31)));
-            Assert.AreEqual(new System.DateTime(2017, 1, 2), TimexDateHelpers.Tomorrow(new System.DateTime(2017, 1, 1)));
-            Assert.AreEqual(new System.DateTime(2017, 3, 1), TimexDateHelpers.Tomorrow(new System.DateTime(2017, 2, 28)));
-            Assert.AreEqual(new System.DateTime(2016, 2, 29), TimexDateHelpers.Tomorrow(new System.DateTime(2016, 2, 28)));
+            Assert.AreEqual(new DateTime(2017, 1, 1), new DateTime(2016, 12, 31).Tomorrow());
+            Assert.AreEqual(new DateTime(2017, 1, 2), new DateTime(2017, 1, 1).Tomorrow());
+            Assert.AreEqual(new DateTime(2017, 3, 1), new DateTime(2017, 2, 28).Tomorrow());
+            Assert.AreEqual(new DateTime(2016, 2, 29), new DateTime(2016, 2, 28).Tomorrow());
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_yesterday()
         {
-            Assert.AreEqual(new System.DateTime(2016, 12, 31), TimexDateHelpers.Yesterday(new System.DateTime(2017, 1, 1)));
-            Assert.AreEqual(new System.DateTime(2017, 1, 1), TimexDateHelpers.Yesterday(new System.DateTime(2017, 1, 2)));
-            Assert.AreEqual(new System.DateTime(2017, 2, 28), TimexDateHelpers.Yesterday(new System.DateTime(2017, 3, 1)));
-            Assert.AreEqual(new System.DateTime(2016, 2, 28), TimexDateHelpers.Yesterday(new System.DateTime(2016, 2, 29)));
+            Assert.AreEqual(new DateTime(2016, 12, 31), new DateTime(2017, 1, 1).Yesterday());
+            Assert.AreEqual(new DateTime(2017, 1, 1), new DateTime(2017, 1, 2).Yesterday());
+            Assert.AreEqual(new DateTime(2017, 2, 28), new DateTime(2017, 3, 1).Yesterday());
+            Assert.AreEqual(new DateTime(2016, 2, 28), new DateTime(2016, 2, 29).Yesterday());
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_datePartEquals()
         {
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(new System.DateTime(2017, 5, 29), new System.DateTime(2017, 5, 29)));
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(new System.DateTime(2017, 5, 29, 19, 30, 0), new System.DateTime(2017, 5, 29)));
-            Assert.IsFalse(TimexDateHelpers.DatePartEquals(new System.DateTime(2017, 5, 29), new System.DateTime(2017, 11, 15)));
+            Assert.IsTrue(new DateTime(2017, 5, 29).IsSameDate(new DateTime(2017, 5, 29)));
+            Assert.IsTrue(new DateTime(2017, 5, 29, 19, 30, 0).IsSameDate(new DateTime(2017, 5, 29)));
+            Assert.IsFalse(new DateTime(2017, 5, 29).IsSameDate(new DateTime(2017, 11, 15)));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_isNextWeek()
         {
-            var today = new System.DateTime(2017, 9, 25);
-            Assert.IsTrue(TimexDateHelpers.IsNextWeek(new System.DateTime(2017, 10, 4), today));
-            Assert.IsFalse(TimexDateHelpers.IsNextWeek(new System.DateTime(2017, 9, 27), today));
-            Assert.IsFalse(TimexDateHelpers.IsNextWeek(today, today));
+            var today = new DateTime(2017, 9, 25);
+            Assert.IsTrue(new DateTime(2017, 10, 4).IsNextWeek(today));
+            Assert.IsFalse(new DateTime(2017, 9, 27).IsNextWeek(today));
+            Assert.IsFalse(today.IsNextWeek(today));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_isLastWeek()
         {
-            var today = new System.DateTime(2017, 9, 25);
-            Assert.IsTrue(TimexDateHelpers.IsLastWeek(new System.DateTime(2017, 9, 20), today));
-            Assert.IsFalse(TimexDateHelpers.IsLastWeek(new System.DateTime(2017, 9, 4), today));
-            Assert.IsFalse(TimexDateHelpers.IsLastWeek(today, today));
+            var today = new DateTime(2017, 9, 25);
+            Assert.IsTrue(new DateTime(2017, 9, 20).IsLastWeek(today));
+            Assert.IsFalse(new DateTime(2017, 9, 4).IsLastWeek(today));
+            Assert.IsFalse(today.IsLastWeek(today));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_weekOfyear()
         {
-            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 1)));
-            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 1, 2)));
-            Assert.AreEqual(8, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 2, 23)));
-            Assert.AreEqual(11, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 3, 15)));
-            Assert.AreEqual(39, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 9, 25)));
-            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new System.DateTime(2017, 12, 31)));
-            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 1)));
-            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 2)));
-            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 7)));
-            Assert.AreEqual(2, TimexDateHelpers.WeekOfYear(new System.DateTime(2018, 1, 8)));
+            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new DateTime(2017, 1, 1)));
+            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new DateTime(2017, 1, 2)));
+            Assert.AreEqual(8, TimexDateHelpers.WeekOfYear(new DateTime(2017, 2, 23)));
+            Assert.AreEqual(11, TimexDateHelpers.WeekOfYear(new DateTime(2017, 3, 15)));
+            Assert.AreEqual(39, TimexDateHelpers.WeekOfYear(new DateTime(2017, 9, 25)));
+            Assert.AreEqual(52, TimexDateHelpers.WeekOfYear(new DateTime(2017, 12, 31)));
+            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new DateTime(2018, 1, 1)));
+            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new DateTime(2018, 1, 2)));
+            Assert.AreEqual(1, TimexDateHelpers.WeekOfYear(new DateTime(2018, 1, 7)));
+            Assert.AreEqual(2, TimexDateHelpers.WeekOfYear(new DateTime(2018, 1, 8)));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_invariance()
         {
-            var d = new System.DateTime(2017, 8, 25);
+            var d = new DateTime(2017, 8, 25);
             var before = d;
-            TimexDateHelpers.Tomorrow(d);
-            TimexDateHelpers.Yesterday(d);
-            TimexDateHelpers.DatePartEquals(new System.DateTime(), d);
-            TimexDateHelpers.DatePartEquals(d, new System.DateTime());
-            TimexDateHelpers.IsNextWeek(d, new System.DateTime());
-            TimexDateHelpers.IsNextWeek(new System.DateTime(), d);
-            TimexDateHelpers.IsLastWeek(new System.DateTime(), d);
+            d.Tomorrow();
+            d.Yesterday();
+            new DateTime().IsSameDate(d);
+            d.IsSameDate(new DateTime());
+            d.IsNextWeek(new DateTime());
+            new DateTime().IsNextWeek(d);
+            new DateTime().IsLastWeek(d);
             TimexDateHelpers.WeekOfYear(d);
             var after = d;
             Assert.AreEqual(after, before);
@@ -89,39 +89,47 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_DateHelpers_dateOfLastDay_Friday_last_week()
         {
             var day = DayOfWeek.Friday;
-            var date = new System.DateTime(2017, 9, 28);
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(TimexDateHelpers.DateOfLastDay(day, date), new System.DateTime(2017, 9, 22)));
+            var date = new DateTime(2017, 9, 28);
+            Assert.AreEqual(new DateTime(2017, 9, 22), date.DateOfLastDay(day));
+        }
+
+        [TestMethod]
+        public void DataTypes_DateHelpers_dateOfLastDay_Wednesday_same_week()
+        {
+            var day = DayOfWeek.Wednesday;
+            var date = new DateTime(2022, 3, 17);
+            Assert.AreEqual(date.AddDays(-1), date.DateOfLastDay(day));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_dateOfNextDay_Wednesday_next_week()
         {
             var day = DayOfWeek.Wednesday;
-            var date = new System.DateTime(2017, 9, 28);
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(TimexDateHelpers.DateOfNextDay(day, date), new System.DateTime(2017, 10, 4)));
+            var date = new DateTime(2017, 9, 28);
+            Assert.IsTrue(TimexDateHelpers.DateOfNextDay(date, day).IsSameDate(new DateTime(2017, 10, 4)));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_dateOfNextDay_today()
         {
             var day = DayOfWeek.Thursday;
-            var date = new System.DateTime(2017, 9, 28);
-            Assert.IsFalse(TimexDateHelpers.DatePartEquals(TimexDateHelpers.DateOfNextDay(day, date), date));
+            var date = new DateTime(2017, 9, 28);
+            Assert.IsFalse(TimexDateHelpers.DateOfNextDay(date, day).IsSameDate(date));
         }
 
         [TestMethod]
         public void DataTypes_DateHelpers_datesMatchingDay()
         {
             var day = DayOfWeek.Thursday;
-            var start = new System.DateTime(2017, 3, 1);
-            var end = new System.DateTime(2017, 4, 1);
+            var start = new DateTime(2017, 3, 1);
+            var end = new DateTime(2017, 4, 1);
             var result = TimexDateHelpers.DatesMatchingDay(day, start, end);
             Assert.AreEqual(5, result.Count);
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(result[0], new System.DateTime(2017, 3, 2)));
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(result[1], new System.DateTime(2017, 3, 9)));
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(result[2], new System.DateTime(2017, 3, 16)));
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(result[3], new System.DateTime(2017, 3, 23)));
-            Assert.IsTrue(TimexDateHelpers.DatePartEquals(result[4], new System.DateTime(2017, 3, 30)));
+            Assert.IsTrue(result[0].IsSameDate(new DateTime(2017, 3, 2)));
+            Assert.IsTrue(result[1].IsSameDate(new DateTime(2017, 3, 9)));
+            Assert.IsTrue(result[2].IsSameDate(new DateTime(2017, 3, 16)));
+            Assert.IsTrue(result[3].IsSameDate(new DateTime(2017, 3, 23)));
+            Assert.IsTrue(result[4].IsSameDate(new DateTime(2017, 3, 30)));
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexHelpers.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Helpers_DateFromTimex()
         {
             var timex = new TimexProperty("2017-09-27");
-            var date = TimexHelpers.DateFromTimex(timex);
+            var date = TimexHelpers.DateTimeFromTimex(timex);
             Assert.AreEqual(new System.DateTime(2017, 9, 27), date);
         }
 

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexParsing.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexParsing.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,7 +15,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_CompleteDate()
         {
             var timex = new TimexProperty("2017-05-29");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Definite, Constants.TimexTypes.Date }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Definite, Constants.TimexTypes.Date }, timex.Types.ToList());
 
             Assert.AreEqual(2017, timex.Year);
             Assert.AreEqual(5, timex.Month);
@@ -41,7 +43,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_MonthAndDayOfMonth()
         {
             var timex = new TimexProperty("XXXX-12-05");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.AreEqual(12, timex.Month);
@@ -69,7 +71,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DayOfWeek()
         {
             var timex = new TimexProperty("XXXX-WXX-3");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Date }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -97,7 +99,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_HoursMinutesAndSeconds()
         {
             var timex = new TimexProperty("T17:30:05");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -125,7 +127,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_HoursAndMinutes()
         {
             var timex = new TimexProperty("T17:30");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -153,7 +155,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Hours()
         {
             var timex = new TimexProperty("T17");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Time }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -181,7 +183,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Now()
         {
             var timex = new TimexProperty("PRESENT_REF");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Present,
@@ -216,7 +218,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_FullDatetime()
         {
             var timex = new TimexProperty("1984-01-03T18:30:45");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Definite,
@@ -251,7 +253,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_ParicularTimeOnParticularDayOfWeek()
         {
             var timex = new TimexProperty("XXXX-WXX-3T16");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[] { Constants.TimexTypes.Time, Constants.TimexTypes.Date, Constants.TimexTypes.DateTime }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
@@ -280,7 +282,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Year()
         {
             var timex = new TimexProperty("2016");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.AreEqual(2016, timex.Year);
             Assert.IsNull(timex.Month);
@@ -308,7 +310,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_SummerOf1999()
         {
             var timex = new TimexProperty("1999-SU");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.AreEqual(1999, timex.Year);
             Assert.IsNull(timex.Month);
@@ -336,7 +338,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_YearAndWeek()
         {
             var timex = new TimexProperty("2017-W37");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.AreEqual(2017, timex.Year);
             Assert.IsNull(timex.Month);
@@ -364,7 +366,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_SeasonSummer()
         {
             var timex = new TimexProperty("SU");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -392,7 +394,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_SeasonWinter()
         {
             var timex = new TimexProperty("WI");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -420,7 +422,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_YearAndWeekend()
         {
             var timex = new TimexProperty("2017-W37-WE");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.AreEqual(2017, timex.Year);
             Assert.IsNull(timex.Month);
@@ -448,7 +450,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_May()
         {
             var timex = new TimexProperty("XXXX-05");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.AreEqual(5, timex.Month);
@@ -476,7 +478,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_July2020()
         {
             var timex = new TimexProperty("2020-07");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.AreEqual(2020, timex.Year);
             Assert.AreEqual(7, timex.Month);
@@ -504,7 +506,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_WeekOfMonth()
         {
             var timex = new TimexProperty("XXXX-01-W01");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.DateRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.AreEqual(1, timex.Month);
@@ -532,7 +534,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_WednesdayToSaturday()
         {
             var timex = new TimexProperty("(XXXX-WXX-3,XXXX-WXX-6,P3D)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Date,
@@ -566,7 +568,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Jan1ToAug5()
         {
             var timex = new TimexProperty("(XXXX-01-01,XXXX-08-05,P216D)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Date,
@@ -600,7 +602,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Jan1ToAug5Year2015()
         {
             var timex = new TimexProperty("(2015-01-01,2015-08-05,P216D)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Definite,
@@ -635,7 +637,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DayTime()
         {
             var timex = new TimexProperty("TDT");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -663,7 +665,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_NightTime()
         {
             var timex = new TimexProperty("TNI");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -691,7 +693,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Morning()
         {
             var timex = new TimexProperty("TMO");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -719,7 +721,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Afternoon()
         {
             var timex = new TimexProperty("TAF");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -747,7 +749,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Evening()
         {
             var timex = new TimexProperty("TEV");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.TimeRange }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -775,7 +777,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Timerange430pmTo445pm()
         {
             var timex = new TimexProperty("(T16:30,T16:45,PT15M)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Time,
@@ -809,7 +811,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DateTimeRange()
         {
             var timex = new TimexProperty("XXXX-WXX-5TEV");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Date,
@@ -843,7 +845,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_LastNight()
         {
             var timex = new TimexProperty("2017-09-07TNI");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                 Constants.TimexTypes.Definite,
@@ -878,7 +880,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Last5Minutes()
         {
             var timex = new TimexProperty("(2017-09-08T21:19:29,2017-09-08T21:24:29,PT5M)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                     Constants.TimexTypes.Date,
@@ -917,7 +919,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_Wed4PMToSat3PM()
         {
             var timex = new TimexProperty("(XXXX-WXX-3T16,XXXX-WXX-6T15,PT71H)");
-            CollectionAssert.AreEquivalent(
+            AreEquivalent(
                 new[]
                 {
                     Constants.TimexTypes.Date,
@@ -955,7 +957,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationYears()
         {
             var timex = new TimexProperty("P2Y");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -983,7 +985,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationMonths()
         {
             var timex = new TimexProperty("P4M");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1011,7 +1013,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationWeeks()
         {
             var timex = new TimexProperty("P6W");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1039,7 +1041,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationWeeksFloatingPoint()
         {
             var timex = new TimexProperty("P2.5W");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1067,7 +1069,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationDays()
         {
             var timex = new TimexProperty("P1D");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1095,7 +1097,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationHours()
         {
             var timex = new TimexProperty("PT5H");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1123,7 +1125,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationMinutes()
         {
             var timex = new TimexProperty("PT30M");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1151,7 +1153,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
         public void DataTypes_Parsing_DurationSeconds()
         {
             var timex = new TimexProperty("PT45S");
-            CollectionAssert.AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
+            AreEquivalent(new[] { Constants.TimexTypes.Duration }, timex.Types.ToList());
 
             Assert.IsNull(timex.Year);
             Assert.IsNull(timex.Month);
@@ -1173,6 +1175,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
             Assert.IsNull(timex.Minutes);
             Assert.AreEqual(45, timex.Seconds);
             Assert.IsNull(timex.Now);
+        }
+
+        private static void AreEquivalent(IEnumerable<string> expected, IEnumerable<string> actual)
+        {
+            CollectionAssert.AreEquivalent((ICollection)expected, (ICollection)actual, $"Expected: {string.Join(", ", expected)}, Actual: {string.Join(", ", actual)}");
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexToString.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.DataDrivenTests/TestTimexToString.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression.Tests
+{
+    [TestClass]
+    public class TestTimexToString
+    {
+        [TestMethod]
+        public void DataTypes_Timex_ToNaturalLanguage()
+        {
+            var today = new System.DateTime(2017, 10, 16);
+            Assert.AreEqual("tomorrow", new TimexProperty("2017-10-17").ToNaturalLanguage(today));
+        }
+
+        [TestMethod]
+        public void DataTypes_Timex_FromTime()
+        {
+            Assert.AreEqual("T23:59:30", TimexProperty.FromTime(new Time(23, 59, 30)).TimexValue);
+        }
+
+        [TestMethod]
+        [DataRow("XXXX-05-05", "5th May")]
+        public void DataTypes_Timex_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexProperty(timex).ToString());
+        }
+
+        [TestMethod]
+        [DataRow("2022-03-11", "11th March 2022")]
+        [DataRow("2022-03-12", "12th March 2022")]
+        [DataRow("2022-03-13", "13th March 2022")]
+        public void DataTypes_Timex_FromDateTime_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexProperty(timex).ToString());
+        }
+
+        [TestMethod]
+        [DataRow("(2022-03-15T16,2022-03-15T18,PT2H)", "15th March 2022 4PM to 6PM")]
+
+        [DataRow("(2022-03-15T16,2022-03-17T16,PT50H)", "15th March 2022 4PM to 17th March 2022 6PM")]
+
+        [DataRow("(2022-03-15T16,2022-03-17T16,PT50H)", "15th March 2022 4PM to 17th March 2022 6PM")]
+        public void DataTypes_Timex_FromDateTimeRange_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexProperty(timex).ToString());
+        }
+
+        [TestMethod]
+        [DataRow("(2022-SU,2022-SU,PT3H40M)", "summer 2022 3 hours 40 minutes")]
+        [DataRow("(2022-W02-6,2022-W03-6,P7D)", "Saturday week 2 2022 to Saturday week 3 2022")]
+        [DataRow("(2022-W02-WE,2022-W03-WE,P7D)", "weekend of week 2 2022 to weekend of week 3 2022")]
+        public void DataTypes_Timex_FromDateRange_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexProperty(timex).ToString());
+        }
+
+        [TestMethod]
+        [DataRow("PT2H50M", "2 hours 50 minutes")]
+        public void DataTypes_Timex_FromDuration_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexProperty(timex).ToString());
+        }
+
+        [TestMethod]
+        [DataRow("PT2H50M", "every 2 hours 50 minutes")]
+        [DataRow("P2D", "every 2 days")]
+        [DataRow("(2022-SU,2022-SU,PT3H40M)", "every 3 hours 40 minutes")]
+        public void DataTypes_TimexSet_FromDuration_ToString(string timex, string expected)
+        {
+            Assert.AreEqual(expected, new TimexSet(timex).ToString());
+        }
+    }
+}

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Constants.cs
@@ -43,15 +43,15 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public static class TimexTypes
         {
-            public static readonly string Present = "present";
-            public static readonly string Definite = "definite";
-            public static readonly string Date = "date";
-            public static readonly string DateTime = "datetime";
-            public static readonly string DateRange = "daterange";
-            public static readonly string Duration = "duration";
-            public static readonly string Time = "time";
-            public static readonly string TimeRange = "timerange";
-            public static readonly string DateTimeRange = "datetimerange";
+            public const string Present = "present";
+            public const string Definite = "definite";
+            public const string Date = "date";
+            public const string DateTime = "datetime";
+            public const string DateRange = "daterange";
+            public const string Duration = "duration";
+            public const string Time = "time";
+            public const string TimeRange = "timerange";
+            public const string DateTimeRange = "datetimerange";
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/English/TimexConstantsEnglish.cs
@@ -19,6 +19,10 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public const string This = "this";
         public const string Last = "last";
         public const string Next = "next";
+        public const string To = "to";
+        public const string Week = "week";
+        public const string Of = "of";
+
         public static readonly string[] Days =
         {
             "Monday",
@@ -79,7 +83,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             "first",
             "second",
             "third",
-            "forth",
+            "fourth",
         };
 
         public static readonly IDictionary<string, string> DayParts = new Dictionary<string, string>

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.xml
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/Microsoft.Recognizers.Text.DataTypes.TimexExpression.xml
@@ -4,6 +4,88 @@
         <name>Microsoft.Recognizers.Text.DataTypes.TimexExpression</name>
     </assembly>
     <members>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsSameDate(System.DateTime,System.DateTime)">
+            <summary>
+            Compares the year, month and day of two date objects.
+            </summary>
+            <param name="dateX">The first date to compare.</param>
+            <param name="dateY">The second date to compare.</param>
+            <returns>Whether the date parts of the two date objects match.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsTomorrow(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the day after <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the day after <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsYesterday(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the day before <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the day before <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsNextYear(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the year after <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the year after <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsLastYear(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the year before <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the year before <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsNextMonth(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the month after <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the month after <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsLastMonth(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the month before <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the month before <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsNextWeek(System.DateTime,System.DateTime)">
+            <summary>
+            Check if this is the week after <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the week after <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.IsLastWeek(System.DateTime,System.DateTime)">
+            <summary>
+            Check if the <paramref name="date"/> is the week before <paramref name="referenceDate"/>.
+            </summary>
+            <param name="date">The date to check.</param>
+            <param name="referenceDate">The reference date.</param>
+            <returns>True if <paramref name="date" /> is the week before <paramref name="referenceDate"/>.</returns>
+        </member>
+        <member name="M:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexDateHelpers.DateOfLastDay(System.DateTime,System.DayOfWeek)">
+            <summary>
+            Get the date of <paramref name="day"/> before the <paramref name="referenceDate"/>.
+            For example, if the <paramref name="referenceDate"/> is a Thursday and <paramref name="day"/> is Wednesday, this would return the day before <paramref name="referenceDate"/>.
+            If the <paramref name="referenceDate"/> is a Wednesday and <paramref name="day"/> is Thursday, this would return the thursday of the week before <paramref name="referenceDate"/>.
+            </summary>
+            <param name="referenceDate">The reference date to calculate the day of the week from.</param>
+            <param name="day">The day of the week.</param>
+            <returns>The date corresponding to the day of the week before the reference date.</returns>
+        </member>
         <member name="F:Microsoft.Recognizers.Text.DataTypes.TimexExpression.TimexUnit.Year">
             <summary>
             Year

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexCreator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         {
             var d = (date == default(DateObject)) ? DateObject.Now : date;
             d = d.AddDays(-7);
-            var start = TimexDateHelpers.DateOfNextDay(DayOfWeek.Monday, d);
+            var start = TimexDateHelpers.DateOfNextDay(d, DayOfWeek.Monday);
             var t = TimexProperty.FromDate(start);
             t.Days = 7;
             return t.TimexValue;
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public static string NextWeek(DateObject date = default(DateObject))
         {
             var d = (date == default(DateObject)) ? DateObject.Now : date;
-            var start = TimexDateHelpers.DateOfNextDay(DayOfWeek.Monday, d);
+            var start = TimexDateHelpers.DateOfNextDay(d, DayOfWeek.Monday);
             var t = TimexProperty.FromDate(start);
             t.Days = 7;
             return t.TimexValue;
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
         public static string LastWeek(DateObject date = default(DateObject))
         {
             var d = (date == default(DateObject)) ? DateObject.Now : date;
-            var start = TimexDateHelpers.DateOfLastDay(DayOfWeek.Monday, d);
+            var start = TimexDateHelpers.DateOfLastDay(d, DayOfWeek.Monday);
             start = start.AddDays(-7);
             var t = TimexProperty.FromDate(start);
             t.Days = 7;

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexDateHelpers.cs
@@ -10,62 +10,138 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
     public static class TimexDateHelpers
     {
-        public static DateObject Tomorrow(DateObject date)
+        public static DateObject Tomorrow(this DateObject date)
         {
             return date.AddDays(1);
         }
 
-        public static DateObject Yesterday(DateObject date)
+        public static DateObject Yesterday(this DateObject date)
         {
-            return date.AddDays(-1);
+            return date.TryAddDays(-1, out var ret) ? ret : date;
         }
 
-        public static bool DatePartEquals(DateObject dateX, DateObject dateY)
+        /// <summary>
+        /// Compares the year, month and day of two date objects.
+        /// </summary>
+        /// <param name="dateX">The first date to compare.</param>
+        /// <param name="dateY">The second date to compare.</param>
+        /// <returns>Whether the date parts of the two date objects match.</returns>
+        public static bool IsSameDate(this DateObject dateX, DateObject dateY)
         {
-            return (dateX.Year == dateY.Year) && (dateX.Month == dateY.Month) && (dateX.Day == dateY.Day);
+            return dateX.IsSameYear(dateY) && dateX.DayOfYear == dateY.DayOfYear;
         }
 
-        public static bool IsDateInWeek(DateObject date, DateObject startOfWeek)
+        /// <summary>
+        /// Check if this is the day after <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the day after <paramref name="referenceDate"/>.</returns>
+        public static bool IsTomorrow(this DateObject date, DateObject referenceDate)
         {
-            var d = startOfWeek;
-            for (int i = 0; i < 7; i++)
-            {
-                if (DatePartEquals(date, d))
-                {
-                    return true;
-                }
-
-                d = d.AddDays(1);
-            }
-
-            return false;
+            return referenceDate.Tomorrow().IsSameDate(date);
         }
 
-        public static bool IsThisWeek(DateObject date, DateObject referenceDate)
+        /// <summary>
+        /// Check if this is the day before <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the day before <paramref name="referenceDate"/>.</returns>
+        public static bool IsYesterday(this DateObject date, DateObject referenceDate)
+        {
+            return referenceDate.Yesterday().IsSameDate(date);
+        }
+
+        public static bool IsSameYear(this DateObject dateX, DateObject dateY)
+        {
+            return dateX.Year == dateY.Year;
+        }
+
+        /// <summary>
+        /// Check if this is the year after <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the year after <paramref name="referenceDate"/>.</returns>
+        public static bool IsNextYear(this DateObject date, DateObject referenceDate)
+        {
+            return date.Year == referenceDate.Year + 1;
+        }
+
+        /// <summary>
+        /// Check if this is the year before <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the year before <paramref name="referenceDate"/>.</returns>
+        public static bool IsLastYear(this DateObject date, DateObject referenceDate)
+        {
+            return date.Year == referenceDate.Year - 1;
+        }
+
+        public static bool IsSameMonth(this DateObject dateX, DateObject dateY)
+        {
+            return dateX.IsSameYear(dateY) && dateX.Month == dateY.Month;
+        }
+
+        /// <summary>
+        /// Check if this is the month after <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the month after <paramref name="referenceDate"/>.</returns>
+        public static bool IsNextMonth(this DateObject date, DateObject referenceDate)
+        {
+            return referenceDate.AddMonths(1).IsSameMonth(date);
+        }
+
+        /// <summary>
+        /// Check if this is the month before <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the month before <paramref name="referenceDate"/>.</returns>
+        public static bool IsLastMonth(this DateObject date, DateObject referenceDate)
+        {
+            return referenceDate.TryAddMonths(-1, out referenceDate) && referenceDate.IsSameMonth(date);
+        }
+
+        public static bool IsThisWeek(this DateObject date, DateObject referenceDate)
         {
             // Note ISO 8601 week starts on a Monday
-            var startOfWeek = referenceDate;
-            while (startOfWeek.DayOfWeek > DayOfWeek.Monday)
+            if (!date.TryGetStartOfWeek(out var thisMonday) ||
+                !referenceDate.TryGetStartOfWeek(out var targetMonday))
             {
-                startOfWeek = startOfWeek.AddDays(-1);
+                return false;
             }
 
-            return IsDateInWeek(date, startOfWeek);
+            return thisMonday.IsSameDate(targetMonday);
         }
 
-        public static bool IsNextWeek(DateObject date, DateObject referenceDate)
+        /// <summary>
+        /// Check if this is the week after <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the week after <paramref name="referenceDate"/>.</returns>
+        public static bool IsNextWeek(this DateObject date, DateObject referenceDate)
         {
-            var nextWeekDate = referenceDate.AddDays(7);
-            return IsThisWeek(date, nextWeekDate);
+            return date.IsThisWeek(referenceDate.AddDays(7));
         }
 
-        public static bool IsLastWeek(DateObject date, DateObject referenceDate)
+        /// <summary>
+        /// Check if the <paramref name="date"/> is the week before <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="date">The date to check.</param>
+        /// <param name="referenceDate">The reference date.</param>
+        /// <returns>True if <paramref name="date" /> is the week before <paramref name="referenceDate"/>.</returns>
+        public static bool IsLastWeek(this DateObject date, DateObject referenceDate)
         {
-            var nextWeekDate = referenceDate.AddDays(-7);
-            return IsThisWeek(date, nextWeekDate);
+            return referenceDate.TryAddDays(-7, out referenceDate) && date.IsThisWeek(referenceDate);
         }
 
-        public static int WeekOfYear(DateObject date)
+        public static int WeekOfYear(this DateObject date)
         {
             CultureInfo culture = CultureInfo.InvariantCulture;
 
@@ -87,30 +163,39 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             return n.Value.ToString(CultureInfo.InvariantCulture).PadLeft(size, '0');
         }
 
-        public static DateObject DateOfLastDay(DayOfWeek day, DateObject referenceDate)
+        public static bool TryGetStartOfWeek(this DateObject date, out DateObject ret, DayOfWeek firstDayOfWeek = DayOfWeek.Monday)
         {
-            var result = referenceDate;
-            result = result.AddDays(-1);
-
-            while (result.DayOfWeek != day)
-            {
-                result = result.AddDays(-1);
-            }
-
-            return result;
+            return date.TryAddDays(firstDayOfWeek.Normalize() - date.DayOfWeek.Normalize(), out ret);
         }
 
-        public static DateObject DateOfNextDay(DayOfWeek day, DateObject referenceDate)
+        /// <summary>
+        /// Get the date of <paramref name="day"/> before the <paramref name="referenceDate"/>.
+        /// For example, if the <paramref name="referenceDate"/> is a Thursday and <paramref name="day"/> is Wednesday, this would return the day before <paramref name="referenceDate"/>.
+        /// If the <paramref name="referenceDate"/> is a Wednesday and <paramref name="day"/> is Thursday, this would return the thursday of the week before <paramref name="referenceDate"/>.
+        /// </summary>
+        /// <param name="referenceDate">The reference date to calculate the day of the week from.</param>
+        /// <param name="day">The day of the week.</param>
+        /// <returns>The date corresponding to the day of the week before the reference date.</returns>
+        public static DateObject DateOfLastDay(this DateObject referenceDate, DayOfWeek day)
         {
-            var result = referenceDate;
-            result = result.AddDays(1);
-
-            while (result.DayOfWeek != day)
+            var days = day.Normalize() - referenceDate.DayOfWeek.Normalize();
+            if (referenceDate.TryAddDays(days >= 0 ? days - 7 : days, out var ret))
             {
-                result = result.AddDays(1);
+                return ret;
             }
 
-            return result;
+            return referenceDate;
+        }
+
+        public static DateObject DateOfNextDay(this DateObject referenceDate, DayOfWeek day)
+        {
+            var days = day.Normalize() - referenceDate.DayOfWeek.Normalize();
+            if (referenceDate.TryAddDays(days <= 0 ? 7 - Math.Abs(days) : days, out var ret))
+            {
+                return ret;
+            }
+
+            return referenceDate;
         }
 
         public static List<DateObject> DatesMatchingDay(DayOfWeek day, DateObject start, DateObject end)
@@ -118,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             var result = new List<DateObject>();
             var d = start;
 
-            while (!DatePartEquals(d, end))
+            while (!IsSameDate(d, end))
             {
                 if (d.DayOfWeek == day)
                 {
@@ -129,6 +214,39 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             }
 
             return result;
+        }
+
+        private static bool TryAddMonths(this DateObject date, int shift, out DateObject value)
+        {
+            value = date;
+            try
+            {
+                value = date.AddMonths(shift);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool TryAddDays(this DateObject date, int shift, out DateObject value)
+        {
+            var ret = shift > 0 || date.Year > 1 || date.DayOfYear + shift > 0;
+            value = date;
+            if (ret)
+            {
+                value = date.AddDays(shift);
+            }
+
+            return ret;
+        }
+
+        private static int Normalize(this DayOfWeek day)
+        {
+            var dayNumber = (int)day;
+            return dayNumber < (int)DayOfWeek.Monday ? 7 - dayNumber : dayNumber;
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexFormat.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 {
@@ -11,51 +10,48 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
     {
         public static string Format(TimexProperty timex)
         {
-            var types = timex.Types.Count != 0 ? timex.Types : TimexInference.Infer(timex);
-
-            if (types.Contains(Constants.TimexTypes.Present))
+            if (timex.IsPresent)
             {
                 return "PRESENT_REF";
             }
 
-            if ((types.Contains(Constants.TimexTypes.DateTimeRange) || types.Contains(Constants.TimexTypes.DateRange) ||
-                 types.Contains(Constants.TimexTypes.TimeRange)) && types.Contains(Constants.TimexTypes.Duration))
+            if (timex.IsDuration && (timex.IsDateTimeRange || timex.IsDateRange || timex.IsTimeRange))
             {
                 var range = TimexHelpers.ExpandDateTimeRange(timex);
                 return $"({Format(range.Start)},{Format(range.End)},{Format(range.Duration)})";
             }
 
-            if (types.Contains(Constants.TimexTypes.DateTimeRange))
+            if (timex.IsDateTimeRange)
             {
                 return $"{FormatDate(timex)}{FormatTimeRange(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.DateRange))
+            if (timex.IsDateRange)
             {
                 return $"{FormatDateRange(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.TimeRange))
+            if (timex.IsTimeRange)
             {
                 return $"{FormatTimeRange(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.DateTime))
+            if (timex.IsDateTime)
             {
                 return $"{FormatDate(timex)}{FormatTime(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.Duration))
+            if (timex.IsDuration)
             {
                 return $"{FormatDuration(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.Date))
+            if (timex.IsDate)
             {
                 return $"{FormatDate(timex)}";
             }
 
-            if (types.Contains(Constants.TimexTypes.Time))
+            if (timex.IsTime)
             {
                 return $"{FormatTime(timex)}";
             }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexProperty.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using DateObject = System.DateTime;
 
 namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
@@ -10,6 +12,24 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
     public class TimexProperty
     {
         private Time time;
+        private HashSet<string> types;
+        private bool? now;
+        private decimal? years;
+        private decimal? months;
+        private decimal? weeks;
+        private decimal? days;
+        private decimal? hours;
+        private decimal? minutes;
+        private decimal? seconds;
+        private int? year;
+        private int? month;
+        private int? dayOfMonth;
+        private int? dayOfWeek;
+        private string season;
+        private int? weekOfYear;
+        private bool? weekend;
+        private int? weekOfMonth;
+        private string partOfDay;
 
         public TimexProperty()
         {
@@ -20,41 +40,65 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             TimexParsing.ParseString(timex, this);
         }
 
+        public TimexProperty(TimexProperty other)
+        {
+            now = other.Now;
+            years = other.Years;
+            months = other.Months;
+            weeks = other.Weeks;
+            days = other.Days;
+            hours = other.Hours;
+            minutes = other.Minutes;
+            seconds = other.Seconds;
+            year = other.Year;
+            month = other.Month;
+            dayOfMonth = other.DayOfMonth;
+            dayOfWeek = other.DayOfWeek;
+            season = other.Season;
+            weekOfYear = other.WeekOfYear;
+            weekend = other.Weekend;
+            weekOfMonth = other.WeekOfMonth;
+            partOfDay = other.PartOfDay;
+            time = other.time == null ? null : new Time(other.time.Hour, other.time.Minute, other.time.Second);
+        }
+
+        public static TimexProperty Empty { get; } = new TimexProperty();
+
         public string TimexValue => TimexFormat.Format(this);
 
-        public HashSet<string> Types => TimexInference.Infer(this);
+        public HashSet<string> Types => types?.Count > 0 ? types : types = TimexInference.Infer(this);
 
-        public bool? Now { get; set; }
+        public bool? Now { get => now; set => SetField(v => now = v, value); }
 
-        public decimal? Years { get; set; }
+        public decimal? Years { get => years; set => SetField(v => years = v, value); }
 
-        public decimal? Months { get; set; }
+        public decimal? Months { get => months; set => SetField(v => months = v, value); }
 
-        public decimal? Weeks { get; set; }
+        public decimal? Weeks { get => weeks; set => SetField(v => weeks = v, value); }
 
-        public decimal? Days { get; set; }
+        public decimal? Days { get => days; set => SetField(v => days = v, value); }
 
-        public decimal? Hours { get; set; }
+        public decimal? Hours { get => hours; set => SetField(v => hours = v, value); }
 
-        public decimal? Minutes { get; set; }
+        public decimal? Minutes { get => minutes; set => SetField(v => minutes = v, value); }
 
-        public decimal? Seconds { get; set; }
+        public decimal? Seconds { get => seconds; set => SetField(v => seconds = v, value); }
 
-        public int? Year { get; set; }
+        public int? Year { get => year; set => SetField(v => year = v, value); }
 
-        public int? Month { get; set; }
+        public int? Month { get => month; set => SetField(v => month = v, value); }
 
-        public int? DayOfMonth { get; set; }
+        public int? DayOfMonth { get => dayOfMonth; set => SetField(v => dayOfMonth = v, value); }
 
-        public int? DayOfWeek { get; set; }
+        public int? DayOfWeek { get => dayOfWeek; set => SetField(v => dayOfWeek = v, value); }
 
-        public string Season { get; set; }
+        public string Season { get => season; set => SetField(v => season = v, value); }
 
-        public int? WeekOfYear { get; set; }
+        public int? WeekOfYear { get => weekOfYear; set => SetField(v => weekOfYear = v, value); }
 
-        public bool? Weekend { get; set; }
+        public bool? Weekend { get => weekend; set => SetField(v => weekend = v, value); }
 
-        public int? WeekOfMonth { get; set; }
+        public int? WeekOfMonth { get => weekOfMonth; set => SetField(v => weekOfMonth = v, value); }
 
         public int? Hour
         {
@@ -77,6 +121,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     time = null;
                 }
+
+                types?.Clear();
             }
         }
 
@@ -101,6 +147,8 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     time = null;
                 }
+
+                types?.Clear();
             }
         }
 
@@ -125,10 +173,34 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 {
                     time = null;
                 }
+
+                types?.Clear();
             }
         }
 
-        public string PartOfDay { get; set; }
+        public string PartOfDay { get => partOfDay; set => SetField(v => partOfDay = v, value); }
+
+        public bool IsSeason => Season != null;
+
+        public bool IsPartOfDay => PartOfDay != null;
+
+        public bool IsPresent => Types.Contains(Constants.TimexTypes.Present);
+
+        public bool IsDefinite => Types.Contains(Constants.TimexTypes.Definite);
+
+        public bool IsDateTime => Types.Contains(Constants.TimexTypes.DateTime);
+
+        public bool IsTime => Types.Contains(Constants.TimexTypes.Time);
+
+        public bool IsDate => Types.Contains(Constants.TimexTypes.Date);
+
+        public bool IsTimeRange => Types.Contains(Constants.TimexTypes.TimeRange);
+
+        public bool IsDuration => Types.Contains(Constants.TimexTypes.Duration);
+
+        public bool IsDateRange => Types.Contains(Constants.TimexTypes.DateRange);
+
+        public bool IsDateTimeRange => Types.Contains(Constants.TimexTypes.DateTimeRange);
 
         public static TimexProperty FromDate(DateObject date)
         {
@@ -171,29 +243,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         public TimexProperty Clone()
         {
-            return new TimexProperty
-            {
-                Now = Now,
-                Years = Years,
-                Months = Months,
-                Weeks = Weeks,
-                Days = Days,
-                Hours = Hours,
-                Minutes = Minutes,
-                Seconds = Seconds,
-                Year = Year,
-                Month = Month,
-                DayOfMonth = DayOfMonth,
-                DayOfWeek = DayOfWeek,
-                Season = Season,
-                WeekOfYear = WeekOfYear,
-                Weekend = Weekend,
-                WeekOfMonth = WeekOfMonth,
-                Hour = Hour,
-                Minute = Minute,
-                Second = Second,
-                PartOfDay = PartOfDay,
-            };
+            return new TimexProperty(this);
         }
 
         public void AssignProperties(IDictionary<string, string> source)
@@ -293,6 +343,12 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                     Days = decimal.Parse(source["amount"], CultureInfo.InvariantCulture);
                     break;
             }
+        }
+
+        private void SetField<T>(Action<T> set, T value)
+        {
+            set(value);
+            types?.Clear();
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexRangeResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
     {
         public static List<TimexProperty> Evaluate(IEnumerable<string> candidates, IEnumerable<string> constraints)
         {
-            var timexConstraints = constraints.Select((x) => { return new TimexProperty(x); });
+            var timexConstraints = constraints.Select((x) => { return new TimexProperty(x); }).ToList();
             var candidatesWithDurationsResolved = ResolveDurations(candidates, timexConstraints);
             var candidatesAccordingToDate = ResolveByDateRangeConstraints(candidatesWithDurationsResolved, timexConstraints);
             var candidatesWithAddedTime = ResolveByTimeConstraints(candidatesAccordingToDate, timexConstraints);
@@ -74,7 +74,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 })
                 .Select((timex) =>
                 {
-                    return TimexHelpers.DateRangeFromTimex(timex);
+                    return timex.DateRangeFromTimex();
                 });
 
             var collapsedDateRanges = TimexConstraintsHelper.Collapse(dateRangeconstraints);
@@ -114,7 +114,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 })
                 .Select((timex) =>
                 {
-                    return TimexHelpers.TimeRangeFromTimex(timex);
+                    return timex.TimeRangeFromTimex();
                 });
 
             var collapsedTimeRanges = TimexConstraintsHelper.Collapse(timeRangeConstraints);
@@ -145,7 +145,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static IEnumerable<string> ResolveTimeRange(TimexProperty timex, IEnumerable<TimeRange> constraints)
         {
-            var candidate = TimexHelpers.TimeRangeFromTimex(timex);
+            var candidate = timex.TimeRangeFromTimex();
 
             var result = new List<string>();
             foreach (var constraint in constraints)
@@ -201,7 +201,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static IEnumerable<string> ResolveDefiniteAgainstConstraint(TimexProperty timex, DateRange constraint)
         {
-            var timexDate = TimexHelpers.DateFromTimex(timex);
+            var timexDate = timex.DateTimeFromTimex();
             if (timexDate >= constraint.Start && timexDate < constraint.End)
             {
                 return new[] { timex.TimexValue };
@@ -275,7 +275,7 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 })
                 .Select((timex) =>
                 {
-                    return TimexHelpers.TimeFromTimex(timex);
+                    return timex.TimeFromTimex();
                 });
 
             if (!times.Any())

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexResolver.cs
@@ -26,54 +26,53 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
 
         private static List<Resolution.Entry> ResolveTimex(TimexProperty timex, DateObject date)
         {
-            var types = timex.Types.Count != 0 ? timex.Types : TimexInference.Infer(timex);
-
-            if (types.Contains(Constants.TimexTypes.DateTimeRange))
+            if (timex.IsDateTimeRange)
             {
                 return ResolveDateTimeRange(timex, date);
             }
 
-            if (types.Contains(Constants.TimexTypes.Definite) && types.Contains(Constants.TimexTypes.Time))
+            if (timex.IsDefinite)
             {
-                return ResolveDefiniteTime(timex, date);
+
+                if (timex.IsTime)
+                {
+                    return ResolveDefiniteTime(timex, date);
+                }
+
+                if (timex.IsDateRange)
+                {
+                    return ResolveDefiniteDateRange(timex, date);
+                }
+
+                return ResolveDefinite(timex);
             }
 
-            if (types.Contains(Constants.TimexTypes.Definite) && types.Contains(Constants.TimexTypes.DateRange))
-            {
-                return ResolveDefiniteDateRange(timex, date);
-            }
-
-            if (types.Contains(Constants.TimexTypes.DateRange))
+            if (timex.IsDateRange)
             {
                 return ResolveDateRange(timex, date);
             }
 
-            if (types.Contains(Constants.TimexTypes.Definite))
-            {
-                return ResolveDefinite(timex);
-            }
-
-            if (types.Contains(Constants.TimexTypes.TimeRange))
+            if (timex.IsTimeRange)
             {
                 return ResolveTimeRange(timex, date);
             }
 
-            if (types.Contains(Constants.TimexTypes.DateTime))
+            if (timex.IsDateTime)
             {
                 return ResolveDateTime(timex, date);
             }
 
-            if (types.Contains(Constants.TimexTypes.Duration))
+            if (timex.IsDuration)
             {
                 return ResolveDuration(timex);
             }
 
-            if (types.Contains(Constants.TimexTypes.Date))
+            if (timex.IsDate)
             {
                 return ResolveDate(timex, date);
             }
 
-            if (types.Contains(Constants.TimexTypes.Time))
+            if (timex.IsTime)
             {
                 return ResolveTime(timex, date);
             }
@@ -308,11 +307,11 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
                 var day = timex.DayOfWeek == 7 ? DayOfWeek.Sunday : (DayOfWeek)timex.DayOfWeek;
                 if (isBefore)
                 {
-                    start = TimexDateHelpers.DateOfLastDay(day, date);
+                    start = TimexDateHelpers.DateOfLastDay(date, day);
                 }
                 else
                 {
-                    start = TimexDateHelpers.DateOfNextDay(day, date);
+                    start = TimexDateHelpers.DateOfNextDay(date, day);
                 }
             }
             else

--- a/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexSet.cs
+++ b/.NET/Microsoft.Recognizers.Text.DataTypes.TimexExpression/TimexSet.cs
@@ -10,6 +10,16 @@ namespace Microsoft.Recognizers.Text.DataTypes.TimexExpression
             Timex = new TimexProperty(timex);
         }
 
+        public TimexSet(TimexProperty timex)
+        {
+            Timex = timex;
+        }
+
         public TimexProperty Timex { get; set; }
+
+        public override string ToString()
+        {
+            return TimexConvert.ConvertTimexSetToString(this);
+        }
     }
 }


### PR DESCRIPTION
Following up on PR #2894 , this implements the missing features of TimexProperty.ToString(), adding support for date ranges, date + duration, etc.

This also fixes a bunch of off-by-one bugs when adding days or months to a Timex, where it would not take into account potential month/year overflows.

It also adds caching of the `Types` hashset of the Timex, so that it doesn't recalculate it every time the property is accessed. Instead, `Types` get cleared whenever a meaningful piece of data in the `TimexProperty` is changed.

Some tests have been converted to using `DataRow` instead of inline asserts, so that the test log will show the data being tested. It should also make it easier to see what the tests are doing. I also moved ToString tests to a separate class from the Roundtrip tests so it's easier to follow.

There's a lot of static helper methods that have been made into extension methods, because they're already in static classes so there's no overhead in doing it, and it makes caller code shorter and hopefully simpler to read.