### PR TITLE
[*|EN Currency] Fixed 'ALL' is picked up as a currency (#2858)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -675,6 +675,11 @@ namespace Microsoft.Recognizers.Definitions.English
             @"yer",
             @"yen",
             @"db",
+            @"pen",
+            @"ron",
+            @"mad",
+            @"zar",
+            @"gel",
             @"satoshi",
             @"satoshis"
         };
@@ -894,7 +899,8 @@ namespace Microsoft.Recognizers.Definitions.English
         {
             { @"\bm\b", @"((('|’)\s*m)|(m\s*('|’)))" },
             { @"^\d{5} [cf]$", @"\b([a-z]{2} \d{5} [cf])\b" },
-            { @"\b\d+\s*\p{L}+$", @"((\d+\s*\p{L}+[-—–-]?\d+)|((\p{L}[-—–-]?|\d[-—–-])\d+\s*\p{L}+))" }
+            { @"\b\d+\s*\p{L}+$", @"((\d+\s*\p{L}+[-—–-]?\d+)|((\p{L}[-—–-]?|\d[-—–-])\d+\s*\p{L}+))" },
+            { @"^(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)", @"(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)\s*(\d|\p{L})" }
         };
       public static readonly Dictionary<string, string> TemperatureAmbiguityFiltersDict = new Dictionary<string, string>
         {

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -757,6 +757,11 @@ AmbiguousCurrencyUnitList: !list
     - yer
     - yen
     - db
+    - pen
+    - ron
+    - mad
+    - zar
+    - gel
     - satoshi
     - satoshis
 # DimensionExtractorConfiguration
@@ -990,6 +995,7 @@ AmbiguityFiltersDict: !dictionary
     \bm\b: ((('|’)\s*m)|(m\s*('|’)))
     ^\d{5} [cf]$: \b([a-z]{2} \d{5} [cf])\b
     \b\d+\s*\p{L}+$: ((\d+\s*\p{L}+[-—–-]?\d+)|((\p{L}[-—–-]?|\d[-—–-])\d+\s*\p{L}+))
+    ^(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel): (all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)\s*(\d|\p{L})
 TemperatureAmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2635,5 +2635,33 @@
         "End": 7
       }
     ]
+  },
+  {
+    "Input": "All 70 of us.",
+    "Results": []
+  },
+  {
+    "Input": "ALL 5 solutions are wrong.",
+    "Results": []
+  },
+  {
+    "Input": "All seventeen tests were succesful.",
+    "Results": []
+  },
+  {
+    "Input": "I tried to call Bob 3 times already.",
+    "Results": []
+  },
+  {
+    "Input": "He has lost his pen 7 times since Monday.",
+    "Results": []
+  },
+  {
+    "Input": "Silica gel is used to absorb moisture.",
+    "Results": []
+  },
+  {
+    "Input": "She got really mad when she heard what happened.",
+    "Results": []
   }
 ]


### PR DESCRIPTION
Fix to issue #2858.

Test cases added to CurrencyModel.