### PR TITLE
[PT Unit|Currency] Fix bugs reported from Speech (#2882)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -582,7 +582,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dobra", @"db|std" },
-            { @"Dollar", @"$|dollars|dollar" },
+            { @"Dollar", @"$" },
             { @"Brazilian Real", @"R$" },
             { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $|usd$" },
             { @"East Caribbean dollar", @"east caribbean $" },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersWithUnitDefinitions.cs
@@ -578,10 +578,11 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"Satoshi", @"SATOSHI" }
         };
       public const string CompoundUnitConnectorRegex = @"(?<spacer>and)";
+      public const string MultiplierRegex = @"\s*\b(thousand|million|billion|trillion)s?\b";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
             { @"Dobra", @"db|std" },
-            { @"Dollar", @"$" },
+            { @"Dollar", @"$|dollars|dollar" },
             { @"Brazilian Real", @"R$" },
             { @"United States dollar", @"united states $|us$|us $|u.s. $|u.s $|usd$" },
             { @"East Caribbean dollar", @"east caribbean $" },
@@ -899,7 +900,7 @@ namespace Microsoft.Recognizers.Definitions.English
         {
             { @"\bm\b", @"((('|’)\s*m)|(m\s*('|’)))" },
             { @"^\d{5} [cf]$", @"\b([a-z]{2} \d{5} [cf])\b" },
-            { @"\b\d+\s*\p{L}+$", @"((\d+\s*\p{L}+[-—–-]?\d+)|((\p{L}[-—–-]?|\d[-—–-])\d+\s*\p{L}+))" },
+            { @"\b\d+\s*\p{L}+$", @"((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))" },
             { @"^(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)", @"(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)\s*(\d|\p{L})" }
         };
       public static readonly Dictionary<string, string> TemperatureAmbiguityFiltersDict = new Dictionary<string, string>
@@ -908,7 +909,8 @@ namespace Microsoft.Recognizers.Definitions.English
         };
       public static readonly Dictionary<string, string> DimensionAmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"\b(deg(rees?)?|°)$", @"\b((deg(rees?)?|°)\s*(c(elsius|entigrate)?|f(ah?renheit)?)|(temperature)(\s+(\p{L}+|\d+)){0,4}\s*(deg(rees?)?\b|°))" }
+            { @"\b(deg(rees?)?|°)$", @"\b((deg(rees?)?|°)\s*(c(elsius|entigrate)?|f(ah?renheit)?)|(temperature)(\s+(\p{L}+|\d+)){0,4}\s*(deg(rees?)?\b|°))" },
+            { @"\b\d+\s*\p{L}+$", @"((\d+\s*\p{L}+\d+)|(\p{L}\d+\s*\p{L}+))" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersWithUnitDefinitions.cs
@@ -723,7 +723,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { @"Decímetro", @"dm|decimetro|decímetro|decimetros|decímetros" },
             { @"Centímetro", @"cm|centimetro|centímetro|centimetros|centimetros" },
             { @"Milímetro", @"mm|milimetro|milímetro|milimetros|milímetros" },
-            { @"Micrômetro", @"µm|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra" },
+            { @"Micrômetro", @"µm|um|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra" },
             { @"Nanômetro", @"nm|nanometro|nanômetro|nanómetro|nanometros|nanômetros|nanómetros|milimicron|milimícron|milimicrons|milimícrons" },
             { @"Picômetro", @"pm|picometro|picômetro|picómetro|picometros|picômetros|picómetros" },
             { @"Milha", @"mi|milha|milhas" },
@@ -738,7 +738,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             @"milha",
             @"milhas",
             @"""",
-            @"in"
+            @"in",
+            @"um"
         };
       public static readonly Dictionary<string, string> SpeedSuffixList = new Dictionary<string, string>
         {
@@ -825,7 +826,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
         };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"\b\d+\s*\p{L}+$", @"((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))" }
+            { @"\b\d+\s*\p{L}+$", @"((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))" },
+            { @"\bum$", @"\p{L}\s+um\b" }
         };
       public static readonly Dictionary<string, string> TemperatureAmbiguityFiltersDict = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/NumbersWithUnitDefinitions.cs
@@ -633,9 +633,10 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { @"Satoshi", @"SATOSHI" }
         };
       public const string CompoundUnitConnectorRegex = @"\b(?<spacer>e|com)\b";
+      public const string MultiplierRegex = @"\s*\b(mil(h([ãa]o|[õo]es))?|bilh([ãa]o|[õo]es)|trilh([ãa]o|[õo]es)|qua[td]rilh([ãa]o|[õo]es)|quintilh([ãa]o|[õo]es))\b";
       public static readonly Dictionary<string, string> CurrencyPrefixList = new Dictionary<string, string>
         {
-            { @"Dólar", @"$" },
+            { @"Dólar", @"$|dólar|dolar|dólares|dolares" },
             { @"Dólar estadunidense", @"us$|u$d|usd$|usd" },
             { @"Dólar do Caribe Oriental", @"ec$|xcd" },
             { @"Dólar australiano", @"a$|aud" },
@@ -722,7 +723,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { @"Decímetro", @"dm|decimetro|decímetro|decimetros|decímetros" },
             { @"Centímetro", @"cm|centimetro|centímetro|centimetros|centimetros" },
             { @"Milímetro", @"mm|milimetro|milímetro|milimetros|milímetros" },
-            { @"Micrômetro", @"µm|um|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra" },
+            { @"Micrômetro", @"µm|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra" },
             { @"Nanômetro", @"nm|nanometro|nanômetro|nanómetro|nanometros|nanômetros|nanómetros|milimicron|milimícron|milimicrons|milimícrons" },
             { @"Picômetro", @"pm|picometro|picômetro|picómetro|picometros|picômetros|picómetros" },
             { @"Milha", @"mi|milha|milhas" },
@@ -824,7 +825,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
         };
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
-            { @"null", @"null" }
+            { @"\b\d+\s*\p{L}+$", @"((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))" }
         };
       public static readonly Dictionary<string, string> TemperatureAmbiguityFiltersDict = new Dictionary<string, string>
         {

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Chinese/Extractors/ChineseNumberWithUnitExtractorConfiguration.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Chinese
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public abstract string ExtractType { get; }
 
         public CultureInfo CultureInfo { get; }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Dutch/Extractors/DutchNumberWithUnitExtractorConfiguration.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Dutch
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/English/Extractors/EnglishNumberWithUnitExtractorConfiguration.cs
@@ -26,6 +26,9 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
 
+        private static readonly Regex NumberMultiplierRegex =
+            new Regex(NumbersWithUnitDefinitions.MultiplierRegex, RegexFlags);
+
         protected EnglishNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -61,6 +64,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.English
         public Regex NonUnitRegex => NonUnitsRegex;
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+
+        public Regex MultiplierRegex => NumberMultiplierRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/INumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Extractors/INumberWithUnitExtractorConfiguration.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit
 
         Regex NonUnitRegex { get; }
 
+        Regex MultiplierRegex { get; }
+
         Regex AmbiguousUnitNumberMultiplierRegex { get; }
 
         Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/French/Extractors/FrenchNumberWithUnitExtractorConfiguration.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.French
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; }
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/German/Extractors/GermanNumberWithUnitExtractorConfiguration.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.German
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/HindiNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Hindi/Extractors/HindiNumberWithUnitExtractorConfiguration.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Hindi
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Italian/Extractors/ItalianNumberWithUnitExtractorConfiguration.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Italian
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Japanese/Extractors/JapaneseNumberWithUnitExtractorConfiguration.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Japanese
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public IExtractor IntegerExtractor { get; }
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Korean/Extractors/KoreanNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Korean/Extractors/KoreanNumberWithUnitExtractorConfiguration.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Korean
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public abstract string ExtractType { get; }
 
         public CultureInfo CultureInfo { get; }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
         private static readonly Regex NonUnitsRegex =
             new Regex(BaseUnits.PmNonUnitRegex, RegexFlags);
 
+        private static readonly Regex NumberMultiplierRegex =
+            new Regex(NumbersWithUnitDefinitions.MultiplierRegex, RegexFlags);
+
         protected PortugueseNumberWithUnitExtractorConfiguration(CultureInfo ci)
         {
             this.CultureInfo = ci;
@@ -57,6 +60,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
         public Regex NonUnitRegex => NonUnitsRegex;
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
+
+        public Regex MultiplierRegex => NumberMultiplierRegex;
 
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Portuguese/Extractors/PortugueseNumberWithUnitExtractorConfiguration.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Portuguese
             this.BuildSuffix = NumbersWithUnitDefinitions.BuildSuffix;
             this.ConnectorToken = NumbersWithUnitDefinitions.ConnectorToken;
 
+            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.AmbiguityFiltersDict);
             TemperatureAmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.TemperatureAmbiguityFiltersDict);
             DimensionAmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersWithUnitDefinitions.DimensionAmbiguityFiltersDict);
         }

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Spanish/Extractors/SpanishNumberWithUnitExtractorConfiguration.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Spanish
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/SwedishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Swedish/Extractors/SwedishNumberWithUnitExtractorConfiguration.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Swedish
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.NumberWithUnit/Turkish/Extractors/TurkishNumberWithUnitExtractorConfiguration.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Recognizers.Text.NumberWithUnit.Turkish
 
         public virtual Regex AmbiguousUnitNumberMultiplierRegex => null;
 
+        public Regex MultiplierRegex => null;
+
         public Dictionary<Regex, Regex> AmbiguityFiltersDict { get; } = null;
 
         public Dictionary<Regex, Regex> TemperatureAmbiguityFiltersDict { get; } = null;

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -664,7 +664,7 @@ CurrencyPrefixList: !dictionary
   entries:
 # Currency Prefix Symbols/Terms
     Dobra: db|std
-    Dollar: $|dollars|dollar
+    Dollar: $
     Brazilian Real: R$
     United States dollar: united states $|us$|us $|u.s. $|u.s $|usd$
     East Caribbean dollar: east caribbean $

--- a/Patterns/English/English-NumbersWithUnit.yaml
+++ b/Patterns/English/English-NumbersWithUnit.yaml
@@ -657,12 +657,14 @@ FractionalUnitNameToCodeMap: !dictionary
     Satoshi: SATOSHI
 CompoundUnitConnectorRegex: !simpleRegex
     def: (?<spacer>and)
+MultiplierRegex: !simpleRegex
+  def: \s*\b(thousand|million|billion|trillion)s?\b
 CurrencyPrefixList: !dictionary
   types: [ string, string ]
   entries:
 # Currency Prefix Symbols/Terms
     Dobra: db|std
-    Dollar: $
+    Dollar: $|dollars|dollar
     Brazilian Real: R$
     United States dollar: united states $|us$|us $|u.s. $|u.s $|usd$
     East Caribbean dollar: east caribbean $
@@ -994,7 +996,7 @@ AmbiguityFiltersDict: !dictionary
   entries:
     \bm\b: ((('|’)\s*m)|(m\s*('|’)))
     ^\d{5} [cf]$: \b([a-z]{2} \d{5} [cf])\b
-    \b\d+\s*\p{L}+$: ((\d+\s*\p{L}+[-—–-]?\d+)|((\p{L}[-—–-]?|\d[-—–-])\d+\s*\p{L}+))
+    \b\d+\s*\p{L}+$: ((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))
     ^(all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel): (all|bob|pen|cad|cup|cop|sos|ron|mad|mop|zar|gel)\s*(\d|\p{L})
 TemperatureAmbiguityFiltersDict: !dictionary
   types: [ string, string ]
@@ -1004,4 +1006,5 @@ DimensionAmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     \b(deg(rees?)?|°)$: \b((deg(rees?)?|°)\s*(c(elsius|entigrate)?|f(ah?renheit)?)|(temperature)(\s+(\p{L}+|\d+)){0,4}\s*(deg(rees?)?\b|°))
+    \b\d+\s*\p{L}+$: ((\d+\s*\p{L}+\d+)|(\p{L}\d+\s*\p{L}+))
 ...

--- a/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
+++ b/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
@@ -789,10 +789,12 @@ FractionalUnitNameToCodeMap: !dictionary
     Satoshi: SATOSHI
 CompoundUnitConnectorRegex: !simpleRegex
     def: \b(?<spacer>e|com)\b
+MultiplierRegex: !simpleRegex
+  def: \s*\b(mil(h([ãa]o|[õo]es))?|bilh([ãa]o|[õo]es)|trilh([ãa]o|[õo]es)|qua[td]rilh([ãa]o|[õo]es)|quintilh([ãa]o|[õo]es))\b
 CurrencyPrefixList: !dictionary
   types: [ string, string ]
   entries:
-    Dólar: $
+    Dólar: $|dólar|dolar|dólares|dolares
     Dólar estadunidense: us$|u$d|usd$|usd
     Dólar do Caribe Oriental: ec$|xcd
     Dólar australiano: a$|aud
@@ -887,7 +889,7 @@ LengthSuffixList: !dictionary
     Decímetro: dm|decimetro|decímetro|decimetros|decímetros
     Centímetro: cm|centimetro|centímetro|centimetros|centimetros
     Milímetro: mm|milimetro|milímetro|milimetros|milímetros
-    Micrômetro: µm|um|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra
+    Micrômetro: µm|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra
     Nanômetro: nm|nanometro|nanômetro|nanómetro|nanometros|nanômetros|nanómetros|milimicron|milimícron|milimicrons|milimícrons
     Picômetro: pm|picometro|picômetro|picómetro|picometros|picômetros|picómetros
     Milha: mi|milha|milhas
@@ -994,7 +996,7 @@ AmbiguousAngleUnitList: !list
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
-    'null': 'null'
+    \b\d+\s*\p{L}+$: ((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))
 TemperatureAmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
+++ b/Patterns/Portuguese/Portuguese-NumbersWithUnit.yaml
@@ -889,7 +889,7 @@ LengthSuffixList: !dictionary
     Decímetro: dm|decimetro|decímetro|decimetros|decímetros
     Centímetro: cm|centimetro|centímetro|centimetros|centimetros
     Milímetro: mm|milimetro|milímetro|milimetros|milímetros
-    Micrômetro: µm|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra
+    Micrômetro: µm|um|micrometro|micrômetro|micrómetro|micrometros|micrômetros|micrómetros|micron|mícron|microns|mícrons|micra
     Nanômetro: nm|nanometro|nanômetro|nanómetro|nanometros|nanômetros|nanómetros|milimicron|milimícron|milimicrons|milimícrons
     Picômetro: pm|picometro|picômetro|picómetro|picometros|picômetros|picómetros
     Milha: mi|milha|milhas
@@ -905,6 +905,7 @@ AmbiguousLengthUnitList: !list
     - milhas
     - '"'
     - in
+    - um
 #SpeedExtractorConfiguration
 SpeedSuffixList: !dictionary
   types: [ string, string ]
@@ -997,6 +998,7 @@ AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:
     \b\d+\s*\p{L}+$: ((\d+(\s*\p{L}+[-—–-]|\p{L}+)\d+)|(((\p{L}|\d)[-—–-]\d+\s*|\p{L}\d+)\p{L}+))
+    \bum$: \p{L}\s+um\b
 TemperatureAmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   entries:

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/english/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/english/extractors.py
@@ -20,6 +20,10 @@ class EnglishNumberWithUnitExtractorConfiguration(NumberWithUnitExtractorConfigu
     @property
     def ambiguity_filters_dict(self) -> Dict[Pattern, Pattern]:
         return DefinitionLoader.load_ambiguity_filters(EnglishNumericWithUnit.AmbiguityFiltersDict)
+        
+    @property
+    def dimension_ambiguity_filters_dict(self) -> Dict[Pattern, Pattern]:
+        return DefinitionLoader.load_ambiguity_filters(EnglishNumericWithUnit.DimensionAmbiguityFiltersDict)
 
     @property
     def unit_num_extractor(self) -> Extractor:

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/extractors.py
@@ -2,6 +2,7 @@
 #  Licensed under the MIT License.
 
 from abc import ABC, abstractmethod
+from sys import prefix
 from typing import List, Dict, Set, Pattern, Match
 from copy import deepcopy
 from collections import namedtuple
@@ -15,6 +16,7 @@ from recognizers_text.matcher.string_matcher import StringMatcher
 from recognizers_text.matcher.match_strategy import MatchStrategy
 from recognizers_text.matcher.number_with_unit_tokenizer import NumberWithUnitTokenizer
 from recognizers_text.matcher.match_result import MatchResult
+from .utilities import Token
 
 
 PrefixUnitResult = namedtuple('PrefixUnitResult', ['offset', 'unit'])
@@ -172,6 +174,7 @@ class NumberWithUnitExtractor(Extractor):
 
         non_unit_match = None
         numbers = None
+        unit_is_prefix = []
 
         mapping_prefix: Dict[float, PrefixUnitResult] = dict()
         matched = [False] * len(source)
@@ -294,6 +297,7 @@ class NumberWithUnitExtractor(Extractor):
                             continue
 
                         result.append(er)
+                        unit_is_prefix.append(False)
 
                 if prefix_unit and prefix_unit is not None and not prefix_matched:
                     er = ExtractResult()
@@ -306,6 +310,7 @@ class NumberWithUnitExtractor(Extractor):
                     number.start = start - er.start
                     er.data = number
                     result.append(er)
+                    unit_is_prefix.append(True)
 
         # Extract Separate unit
         if self.separate_regex:
@@ -322,6 +327,9 @@ class NumberWithUnitExtractor(Extractor):
             # Remove entity-specific ambiguous case
             if self.config.extract_type == Constants.SYS_UNIT_DIMENSION:
                 result = self._filter_ambiguity(result, source, self.config.dimension_ambiguity_filters_dict)
+
+            if self.config.extract_type == Constants.SYS_UNIT_CURRENCY:
+                result = self._select_candidates(source, result, unit_is_prefix)
 
         # Expand Chinese phrase to the `half` patterns when it follows closely origin phrase.
         self.config.expand_half_suffix(source, result, numbers)
@@ -497,6 +505,70 @@ class NumberWithUnitExtractor(Extractor):
             pass
 
         return ers
+
+    def _select_candidates(self, source: str, ers: List[ExtractResult], unit_is_prefix: List[bool]) -> List[ExtractResult]:
+    
+        total_candidate = len(unit_is_prefix)
+        have_conflict = False
+        for index in range(1, total_candidate):
+            if ers[index -1].end > ers[index].start:
+                have_conflict = True
+
+        if not have_conflict:
+            return ers
+
+        prefix_result: List[ExtractResult] = []
+        suffix_result: List[ExtractResult] = []
+        current_end = -1
+
+        for index in range(total_candidate):
+            if current_end < ers[index].start:
+                current_end = ers[index].end
+                prefix_result.append(ers[index])
+            else:
+                if unit_is_prefix[index]:
+                    prefix_result.pop(-1)
+                    current_end = ers[index].end
+                    prefix_result.append(ers[index])
+
+        current_end = len(source)
+        for index in range(total_candidate -1, -1, -1):
+            if current_end >= ers[index].end:
+                current_end = ers[index].start
+                suffix_result.append(ers[index])
+            else:
+                if not unit_is_prefix[index]:
+                    suffix_result.pop(-1)
+                    current_end = ers[index].start
+                    suffix_result.append(ers[index])
+
+        # Find prefix units with no space, e.g. '$50'.
+        no_space_units: List[Token] = []
+        for prefix in prefix_result:
+            if isinstance(prefix.data, ExtractResult):
+                unit_str = prefix.text[:prefix.data.start]
+                if len(unit_str) > 0 and unit_str == unit_str.rstrip():
+                    no_space_units.append(Token(prefix.start, prefix.start + len(unit_str)))
+
+        # Remove from suffixResult units that are also prefix units with no space,
+        # e.g. in '1 $50', '$' should not be considered a suffix unit.
+        for index in range(len(suffix_result) -1, -1, -1):
+            suffix = suffix_result[index]
+            if (any(suffix.start <= unit.start and suffix.end >= unit.end for unit in no_space_units)):
+                suffix_result.pop(index)
+
+        # Add Separate unit
+        for index in range(total_candidate, len(ers)):
+            prefix_result.append(ers[index])
+            suffix_result.append(ers[index])
+
+        if len(suffix_result) >= len(prefix_result):
+            def sort_by_start(e):
+                return e.start
+            suffix_result.sort(key=sort_by_start)
+            return suffix_result
+
+        return prefix_result
 
 
 class BaseMergedUnitExtractor(Extractor):

--- a/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/utilities.py
+++ b/Python/libraries/recognizers-number-with-unit/recognizers_number_with_unit/number_with_unit/utilities.py
@@ -25,3 +25,30 @@ class DictionaryUtility():
             if not token or token in source_dictionary:
                 continue
             source_dictionary[token] = key
+
+class Token:
+    def __init__(self, start: int, end: int):
+        self._start: int = start
+        self._end: int = end
+
+    @property
+    def length(self) -> int:
+        if self._start > self._end:
+            return 0
+        return self._end - self._start
+
+    @property
+    def start(self) -> int:
+        return self._start
+
+    @start.setter
+    def start(self, value) -> int:
+        self._start = value
+
+    @property
+    def end(self) -> int:
+        return self._end
+
+    @end.setter
+    def end(self, value) -> int:
+        self._end = value

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2683,7 +2683,7 @@
   },
   {
     "Input": "The price starts at dollar 22.5 million.",
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "dotnet, java, javascript, python",
     "Results": [
       {
         "Text": "dollar 22.5 million",

--- a/Specs/NumberWithUnit/English/CurrencyModel.json
+++ b/Specs/NumberWithUnit/English/CurrencyModel.json
@@ -2663,5 +2663,220 @@
   {
     "Input": "She got really mad when she heard what happened.",
     "Results": []
+  },
+  {
+    "Input": "They lost 75 USD million in the past three years.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "75 usd million",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "75000000",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 10,
+        "End": 23
+      }
+    ]
+  },
+  {
+    "Input": "The price starts at dollar 22.5 million.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dollar 22.5 million",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "22500000",
+          "unit": "Dollar"
+        },
+        "Start": 20,
+        "End": 38
+      }
+    ]
+  },
+  {
+    "Input": "The price starts at USD 22.5 million.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "usd 22.5 million",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "22500000",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 20,
+        "End": 35
+      }
+    ]
+  },
+  {
+    "Input": "It costs 15 dollars 50.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "15 dollars 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15.5",
+          "unit": "Dollar"
+        },
+        "Start": 9,
+        "End": 21
+      }
+    ]
+  },
+  {
+    "Input": "It costs 15 dollars and 50.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "15 dollars and 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15.5",
+          "unit": "Dollar"
+        },
+        "Start": 9,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "The subscription will increase to 17 USD 25.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "17 usd 25",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "17.25",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 34,
+        "End": 42
+      }
+    ]
+  },
+  {
+    "Input": "we are giving away 3 USD50 Cards.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "usd50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "50",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 21,
+        "End": 25
+      }
+    ]
+  },
+  {
+    "Input": "They paid 75 USD million but the price was actually 50 million USD. And if they had just 15 USD 50 more, they would have paid 80 USD million.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "75 usd million",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "75000000",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 10,
+        "End": 23
+      },
+      {
+        "Text": "50 million usd",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "50000000",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 52,
+        "End": 65
+      },
+      {
+        "Text": "15 usd 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15.5",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 89,
+        "End": 97
+      },
+      {
+        "Text": "80 usd million",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "80000000",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 126,
+        "End": 139
+      }
+    ]
+  },
+  {
+    "Input": "The cost is 500 USD,100 times more than expected.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "500 usd",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "500",
+          "unit": "United States dollar",
+          "isoCurrency": "USD"
+        },
+        "Start": 12,
+        "End": 18
+      }
+    ]
+  },
+  {
+    "Input": "One is required to pay three thousand dollars two hundred times.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "three thousand dollars",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "3000",
+          "unit": "Dollar"
+        },
+        "Start": 23,
+        "End": 44
+      }
+    ]
+  },
+  {
+    "Input": "I counted the dollars thousand of times.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dollars",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": null,
+          "unit": "Dollar"
+        },
+        "Start": 14,
+        "End": 20
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1765,23 +1765,23 @@
     ]
   },
   {
-    "Input": "Los precios del acuerdo comienzan en dólar 22,5 milhões.",
+    "Input": "Os preços do negócio começam em dólares 22,5 milhões.",
     "NotSupported": "java, javascript, python",
     "Results": [
       {
-        "Text": "dólar 22,5 milhões",
+        "Text": "dólares 22,5 milhões",
         "TypeName": "currency",
         "Resolution": {
           "value": "22500000",
           "unit": "Dólar"
         },
-        "Start": 37,
-        "End": 54
+        "Start": 32,
+        "End": 51
       }
     ]
   },
   {
-    "Input": "Los precios del acuerdo comienzan en dólar 22500000.",
+    "Input": "Os preços do negócio começam em dólar 22500000.",
     "NotSupported": "java, javascript, python",
     "Results": [
       {
@@ -1791,8 +1791,8 @@
           "value": "22500000",
           "unit": "Dólar"
         },
-        "Start": 37,
-        "End": 50
+        "Start": 32,
+        "End": 45
       }
     ]
   },
@@ -1925,6 +1925,22 @@
         },
         "Start": 13,
         "End": 19
+      }
+    ]
+  },
+  {
+    "Input": "O preço era na verdade 50 milhões de dólares.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "50 milhões de dólares",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "50000000",
+          "unit": "Dólar"
+        },
+        "Start": 23,
+        "End": 43
       }
     ]
   }

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1746,5 +1746,186 @@
         "End": 23
       }
     ]
+  },
+  {
+    "Input": "Eles perderam 75 USD milhões nos últimos três anos.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "75 usd milhões",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "75000000",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 14,
+        "End": 27
+      }
+    ]
+  },
+  {
+    "Input": "Los precios del acuerdo comienzan en dólar 22,5 milhões.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dólar 22,5 milhões",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "22500000",
+          "unit": "Dólar"
+        },
+        "Start": 37,
+        "End": 54
+      }
+    ]
+  },
+  {
+    "Input": "Los precios del acuerdo comienzan en dólar 22500000.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dólar 22500000",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "22500000",
+          "unit": "Dólar"
+        },
+        "Start": 37,
+        "End": 50
+      }
+    ]
+  },
+  {
+    "Input": "Por 15 dólares 50 você pode almoçar e jantar",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "15 dólares 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15,5",
+          "unit": "Dólar"
+        },
+        "Start": 4,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "Por 15 USD 50 você pode almoçar e jantar.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "15 usd 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15,5",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 4,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "Eles pagaram 75 USD milhões, mas o preço na verdade foi de 50 milhões USD. E se tivessem mais 15 USD 50, teriam pago 80 USD milhões.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "75 usd milhões",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "75000000",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 13,
+        "End": 26
+      },
+      {
+        "Text": "50 milhões usd",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "50000000",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 59,
+        "End": 72
+      },
+      {
+        "Text": "15 usd 50",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "15,5",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 94,
+        "End": 102
+      },
+      {
+        "Text": "80 usd milhões",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "80000000",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 117,
+        "End": 130
+      }
+    ]
+  },
+  {
+    "Input": "O custo é de 500 USD,100 vezes mais do que o esperado.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "500 usd",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "500",
+          "unit": "Dólar estadunidense",
+          "isoCurrency": "USD"
+        },
+        "Start": 13,
+        "End": 19
+      }
+    ]
+  },
+  {
+    "Input": "Um é obrigado a pagar três mil dólares duzentas vezes.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "três mil dólares",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "3000",
+          "unit": "Dólar"
+        },
+        "Start": 22,
+        "End": 37
+      }
+    ]
+  },
+  {
+    "Input": "Eu contei os dólares milhares de vezes.",
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dólares",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": null,
+          "unit": "Dólar"
+        },
+        "Start": 13,
+        "End": 19
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1584,7 +1584,7 @@
   },
   {
     "Input": "custa apenas 15 dólares 50.",
-    "NotSupported": "javascript, java",
+    "NotSupported": "javascript, java, python",
     "Results": [
       {
         "Text": "15 dólares 50",

--- a/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Portuguese/CurrencyModel.json
@@ -1584,7 +1584,7 @@
   },
   {
     "Input": "custa apenas 15 dólares 50.",
-    "NotSupported": "javascript, java, python",
+    "NotSupported": "javascript, java",
     "Results": [
       {
         "Text": "15 dólares 50",

--- a/Specs/NumberWithUnit/Portuguese/DimensionModel.json
+++ b/Specs/NumberWithUnit/Portuguese/DimensionModel.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Input": "são 180,25ml liquidos",
     "Results": [
@@ -996,5 +996,13 @@
         "End": 20
       }
     ]
+  },
+  {
+    "Input": "vou fazer um dia",
+    "Results": []
+  },
+  {
+    "Input": "lançamento em três dois um...",
+    "Results": []
   }
 ]

--- a/Specs/NumberWithUnit/Portuguese/DimensionModel.json
+++ b/Specs/NumberWithUnit/Portuguese/DimensionModel.json
@@ -1004,5 +1004,21 @@
   {
     "Input": "lançamento em três dois um...",
     "Results": []
+  },
+  {
+    "Input": "o diâmetro é de 23 um.",
+    "Results": [
+      {
+        "Text": "23 um",
+        "TypeName": "dimension",
+        "Resolution": {
+          "value": "23",
+          "unit": "Micrômetro",
+          "subtype": "Length"
+        },
+        "Start": 16,
+        "End": 20
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Portuguese/DimensionModel.json
+++ b/Specs/NumberWithUnit/Portuguese/DimensionModel.json
@@ -999,10 +999,12 @@
   },
   {
     "Input": "vou fazer um dia",
+    "NotSupported": "javascript",
     "Results": []
   },
   {
     "Input": "lançamento em três dois um...",
+    "NotSupported": "javascript",
     "Results": []
   },
   {


### PR DESCRIPTION
Fix to issue #2882

- Modified base code to support “Value Currency Multiplier” (e.g. 75 USD milhoes) in PT and EN
- Modified base code to better handle cases like "15 USD 50" (-> 15.50 USD) and "15 USD50" (-> 50 USD).

Test cases added to DimensionModel and CurrencyModel in PT and EN.