### PR TITLE
[Number JP] Fix recognizing kanji 零[rei] zero (#2922)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string PercentageRegex = @".+(?=パ\s*ー\s*セ\s*ン\s*ト)|.*(?=[％%])";
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*{RoundNumberIntegerRegex}{{1,2}}(\s*(以上))?";
       public const string FracSplitRegex = @"[はと]|分\s*の";
-      public const string ZeroToNineIntegerRegex = @"[〇一二三四五六七八九]";
+      public const string ZeroToNineIntegerRegex = @"[零〇一二三四五六七八九]";
       public const string HalfUnitRegex = @"半";
       public const string NegativeNumberTermsRegex = @"(マ\s*イ\s*ナ\s*ス)";
       public static readonly string NegativeNumberTermsRegexNum = $@"((?<!(\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)|[-−－])[-−－])";

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -532,7 +532,8 @@ namespace Microsoft.Recognizers.Text.Number
             long roundBefore = -1, roundDefault = 1;
             var isNegative = false;
             var hasPreviousDigits = false;
-            var hasRoundDirectOrZero = intStr.Any(c => Config.RoundDirectList.Contains(c) || c == Config.ZeroChar);
+            var hasRoundDirect = intStr.Any(c => Config.RoundDirectList.Contains(c));
+            var hasRoundDirectOrZero = hasRoundDirect || intStr.Any(c => c == Config.ZeroChar);
 
             var isDozen = false;
             var isPair = false;
@@ -664,7 +665,7 @@ namespace Microsoft.Recognizers.Text.Number
                 // Japanese numbers in the form "一九九九" (1999) must be processed as digit numbers
                 if (Config.CultureInfo.Name.ToLowerInvariant() == Culture.Japanese && !hasPreviousDigits)
                 {
-                    hasPreviousDigits = !hasRoundDirectOrZero && Config.ZeroToNineMap.ContainsKey(intStr[i]);
+                    hasPreviousDigits = !hasRoundDirect && Config.ZeroToNineMap.ContainsKey(intStr[i]) && intStr[i] != Config.ZeroChar;
                 }
 
                 if (Config.RoundDirectList.Contains(intStr[i]))

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -120,7 +120,7 @@ DoubleAndRoundRegex: !nestedRegex
 FracSplitRegex: !simpleRegex
   def: '[はと]|分\s*の'
 ZeroToNineIntegerRegex: !simpleRegex
-  def: '[〇一二三四五六七八九]'
+  def: '[零〇一二三四五六七八九]'
 HalfUnitRegex: !simpleRegex
   def: 半
 NegativeNumberTermsRegex: !simpleRegex

--- a/Specs/Number/Japanese/NumberModel.json
+++ b/Specs/Number/Japanese/NumberModel.json
@@ -12726,5 +12726,167 @@
         "End": 9
       }
     ]
+  },
+  {
+    "Input": "零",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 0
+      }
+    ]
+  },
+  {
+    "Input": "の総和は零となるため二次電流は流れず",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        },
+        "Start": 4,
+        "End": 4
+      }
+    ]
+  },
+  {
+    "Input": "0123",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "0123",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "123"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "〇一二三",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "〇一二三",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "123"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "零一二三",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零一二三",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "123"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": "零零零一二三",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零零零一二三",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "123"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "零 一 二 三",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 0
+      },
+      {
+        "Text": "一",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        },
+        "Start": 2,
+        "End": 2
+      },
+      {
+        "Text": "二",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "2"
+        },
+        "Start": 4,
+        "End": 4
+      },
+      {
+        "Text": "三",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3"
+        },
+        "Start": 6,
+        "End": 6
+      }
+    ]
+  },
+  {
+    "Input": "零十",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零十",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10"
+        },
+        "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "零十三",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "零十三",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "13"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
   }
 ]

--- a/Specs/NumberWithUnit/Japanese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Japanese/CurrencyModel.json
@@ -987,5 +987,22 @@
         "End": 47
       }
     ]
+  },
+  {
+    "Input": "これは 零円です",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "零円",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "JPY",
+          "value": "0",
+          "unit": "Japanese yen"
+        },
+        "Start": 4,
+        "End": 5
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2922.

Test cases added to JP NumberModel and CurrencyModel.