### PR TITLE
[JA Number] Extend number recognition to include Kana along with existing Kanji and Arabic numerals (#2923)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersDefinitions.cs
@@ -101,7 +101,37 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"万万", @"億" },
             { @"億万", @"兆" },
             { @"万億", @"兆" },
-            { @" ", @"" }
+            { @" ", @"" },
+            { @"れい", @"〇" },
+            { @"ゼロ", @"〇" },
+            { @"マル", @"〇" },
+            { @"いち", @"一" },
+            { @"いっ", @"一" },
+            { @"に", @"二" },
+            { @"さん", @"三" },
+            { @"し", @"四" },
+            { @"よん", @"四" },
+            { @"ご", @"五" },
+            { @"ろく", @"六" },
+            { @"ろっ", @"六" },
+            { @"しち", @"七" },
+            { @"なな", @"七" },
+            { @"はち", @"八" },
+            { @"はっ", @"八" },
+            { @"きゅう", @"九" },
+            { @"く", @"九" },
+            { @"じゅう", @"十" },
+            { @"ひゃく", @"百" },
+            { @"ぴゃく", @"百" },
+            { @"びゃく", @"百" },
+            { @"せん", @"千" },
+            { @"ぜん", @"千" },
+            { @"まん", @"万" },
+            { @"ひゃくまん", @"百万" },
+            { @"ぴゃくまん", @"百万" },
+            { @"びゃくまん", @"百万" },
+            { @"せんまん", @"千万" },
+            { @"ぜんまん", @"千万" }
         };
       public static readonly IList<char> RoundDirectList = new List<char>
         {
@@ -114,6 +144,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             '十'
         };
       public const string RoundNumberIntegerRegex = @"(十|百|千|万(?!万)|億|兆)";
+      public const string RoundNumberIntegerHiraganaRegex = @"(じゅう|[ひぴび]ゃく|[せぜ]ん|まん|[ひぴび]ゃくまん|[せぜ]んまん)";
       public static readonly string AllMultiplierLookupRegex = $@"({BaseNumbers.MultiplierLookupRegex}|ミリリットル(入れら)?|キロメートル|メートル|ミリメート)";
       public static readonly string DigitalNumberRegex = $@"((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
       public const string ZeroToNineFullHalfRegex = @"[\d]";
@@ -124,6 +155,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string DoubleAndRoundRegex = $@"{ZeroToNineFullHalfRegex}+(\.{ZeroToNineFullHalfRegex}+)?\s*{RoundNumberIntegerRegex}{{1,2}}(\s*(以上))?";
       public const string FracSplitRegex = @"[はと]|分\s*の";
       public const string ZeroToNineIntegerRegex = @"[零〇一二三四五六七八九]";
+      public const string ZeroToNineIntegerHiraganaRegex = @"(れい|ゼロ|マル|い[ちっ]|に|さん|し|よん|ご|ろ[くっ]|しち|なな|は[ちっ]|きゅう|く)";
       public const string HalfUnitRegex = @"半";
       public const string NegativeNumberTermsRegex = @"(マ\s*イ\s*ナ\s*ス)";
       public static readonly string NegativeNumberTermsRegexNum = $@"((?<!(\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)|[-−－])[-−－])";
@@ -134,6 +166,9 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string NotSingleRegex = $@"(?<!(第|だい))({RoundNumberIntegerRegex}+(({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex})+|{ZeroToNineFullHalfRegex}+|十)(\s*(以上))?)|(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){{1,2}})(\s*([零]?({ZeroToNineIntegerRegex}+|((,\s*){ZeroToNineFullHalfRegex}{{3}})+|{ZeroToNineFullHalfRegex}+|十)(\s*{RoundNumberIntegerRegex}){{0,1}}))*(\s*(以上)?)";
       public static readonly string SingleRegex = $@"(({ZeroToNineIntegerRegex}+|{ZeroToNineFullHalfRegex}+|十)(?={AllowListRegex}))";
       public static readonly string AllIntRegex = $@"(?<!(ダース))({NotSingleRegex}|({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+))";
+      public static readonly string NotSingleHiraganaRegex = $@"(({ZeroToNineIntegerHiraganaRegex}?{RoundNumberIntegerHiraganaRegex})+{ZeroToNineIntegerHiraganaRegex}?)";
+      public static readonly string SingleHiriganaRegex = $@"({ZeroToNineIntegerHiraganaRegex}+)";
+      public static readonly string AllIntHiriganaRegex = $@"\b({NotSingleHiraganaRegex}|{SingleHiriganaRegex})\b";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
       public static readonly string NumbersSpecialsCharsAggressive = $@"((({NegativeNumberTermsRegexNum}|{NegativeNumberTermsRegex})\s*)?({ZeroToNineFullHalfRegex}))+(?=\b|\D)";
@@ -145,8 +180,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string NumbersWithDozen = $@"({AllIntRegex}([と]?{ZeroToNineIntegerRegex})?|{ZeroToNineFullHalfRegex}+)(ダース)";
       public const string PointRegexStr = @"[\.．・]";
       public static readonly string AllFloatRegex = $@"{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[一二三四五六七八九](\s*{ZeroToNineIntegerRegex})*";
-      public static readonly string NumbersWithAllowListRegex = $@"(?<!(離は))({NegativeNumberTermsRegex}?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*([、.]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*{PercentageSymbol}))(?!(\s*{AllMultiplierLookupRegex}))";
-      public static readonly string NumbersAggressiveRegex = $@"(({AllIntRegex})(?!({AllIntRegex}|([、.]{ZeroToNineIntegerRegex})|{AllFloatRegex}|\s*{PercentageSymbol})))";
+      public static readonly string NumbersWithAllowListRegex = $@"(?<!(離は))({NegativeNumberTermsRegex}?({NotSingleRegex}|{SingleRegex}|{AllIntHiriganaRegex})(?!({AllIntRegex}*([、.]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*{PercentageSymbol}))(?!(\s*{AllMultiplierLookupRegex}))";
+      public static readonly string NumbersAggressiveRegex = $@"(({AllIntRegex}|{AllIntHiriganaRegex})(?!({AllIntRegex}|([、.]{ZeroToNineIntegerRegex})|{AllFloatRegex}|\s*{PercentageSymbol})))";
       public static readonly string PointRegex = $@"{PointRegexStr}";
       public static readonly string DoubleSpecialsCharsAggressive = $@"((?<!({ZeroToNineFullHalfRegex}+[\.．]{ZeroToNineFullHalfRegex}*))({NegativeNumberTermsRegexNum}\s*)?{ZeroToNineFullHalfRegex}+[\.．,]{ZeroToNineFullHalfRegex}+(?!({ZeroToNineFullHalfRegex}*[\.．,]{ZeroToNineFullHalfRegex}+)))(?=\b|\D)";
       public static readonly string DoubleSpecialsChars = $@"({DoubleSpecialsCharsAggressive})(?!\s*{AllMultiplierLookupRegex})";
@@ -254,6 +289,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"次のもの", @"current" },
             { @"最後から3番目", @"end" },
             { @"最後から2番目", @"end" }
+        };
+      public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
+        {
+            { @"^に$", @"に" }
         };
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/NumbersWithUnitDefinitions.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"Surinamese dollar", @"スリナム・ドル|スリナムドル" },
             { @"Trinidad and Tobago dollar", @"トリニダード・トバゴ・ドル|トリニダードトバゴ・ドル" },
             { @"Tuvaluan dollar", @"ツバル・ドル|ツバルドル" },
+            { @"Dollar", @"どる|$" },
             { @"Chinese yuan", @"人民元|元" },
             { @"Fen", @"分" },
             { @"Jiao", @"角" },

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Extractors/NumberExtractor.cs
@@ -3,7 +3,8 @@
 
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
-
+using Microsoft.Recognizers.Definitions.Japanese;
+using Microsoft.Recognizers.Definitions.Utilities;
 using Microsoft.Recognizers.Text.Number.Config;
 
 namespace Microsoft.Recognizers.Text.Number.Japanese
@@ -24,9 +25,13 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             builder.AddRange(fracExtract.Regexes);
 
             Regexes = builder.ToImmutable();
+
+            AmbiguityFiltersDict = DefinitionLoader.LoadAmbiguityFilters(NumbersDefinitions.AmbiguityFiltersDict).ToImmutableDictionary();
         }
 
         internal sealed override ImmutableDictionary<Regex, TypeTag> Regexes { get; }
+
+        protected sealed override ImmutableDictionary<Regex, Regex> AmbiguityFiltersDict { get; }
 
         protected sealed override string ExtractType { get; } = Constants.SYS_NUM;
     }

--- a/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Japanese/Parsers/JapaneseNumberParserConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -47,7 +48,9 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
             this.ZeroToNineMap = NumbersDefinitions.ZeroToNineMap.ToImmutableDictionary();
             this.FullToHalfMap = NumbersDefinitions.FullToHalfMap.ToImmutableDictionary();
             this.RoundNumberMapChar = NumbersDefinitions.RoundNumberMapChar.ToImmutableDictionary();
-            this.UnitMap = NumbersDefinitions.UnitMap.ToImmutableSortedDictionary();
+
+            // Sorted by decreasing key length
+            this.UnitMap = NumbersDefinitions.UnitMap.ToImmutableSortedDictionary(new LengthComparer(true));
             this.RoundDirectList = NumbersDefinitions.RoundDirectList.ToImmutableList();
             this.TenChars = NumbersDefinitions.TenChars.ToImmutableList();
 
@@ -116,6 +119,22 @@ namespace Microsoft.Recognizers.Text.Number.Japanese
         public override long ResolveCompositeNumber(string numberStr)
         {
             return 0;
+        }
+
+        private class LengthComparer : IComparer<string>
+        {
+            private bool isReverseOrder;
+
+            public LengthComparer(bool reverseOrder = false)
+            {
+                isReverseOrder = reverseOrder;
+            }
+
+            public int Compare(string x, string y)
+            {
+                int comparison = isReverseOrder ? y.Length.CompareTo(x.Length) : x.Length.CompareTo(y.Length);
+                return comparison == 0 ? x.CompareTo(y) : comparison;
+            }
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.Number/Parsers/BaseCJKNumberParser.cs
@@ -609,6 +609,7 @@ namespace Microsoft.Recognizers.Text.Number
                     }
 
                     roundDefault = roundRecent / 10;
+                    beforeValue = 1;
                 }
                 else if (Config.ZeroToNineMap.ContainsKey(intStr[i]))
                 {

--- a/Patterns/Japanese/Japanese-Numbers.yaml
+++ b/Patterns/Japanese/Japanese-Numbers.yaml
@@ -1,4 +1,4 @@
----
+﻿---
 #ISO 639-2 Code
 LangMarker: Jpn
 #JapaneseNumberParserConfiguration
@@ -85,6 +85,36 @@ UnitMap: !dictionary
     億万: 兆
     万億: 兆
     ' ' : ''
+    れい: 〇
+    ゼロ: 〇
+    マル: 〇
+    いち: 一
+    いっ: 一
+    に: 二
+    さん: 三
+    し: 四
+    よん: 四
+    ご: 五
+    ろく: 六
+    ろっ: 六
+    しち: 七
+    なな: 七
+    はち: 八
+    はっ: 八
+    きゅう: 九
+    く: 九
+    じゅう: 十
+    ひゃく: 百
+    ぴゃく: 百
+    びゃく: 百
+    せん: 千
+    ぜん: 千
+    まん: 万
+    ひゃくまん: 百万
+    ぴゃくまん: 百万
+    びゃくまん: 百万
+    せんまん: 千万
+    ぜんまん: 千万
 RoundDirectList: !list
   types: [char]
   entries:
@@ -97,6 +127,8 @@ TenChars: !list
     - 十
 RoundNumberIntegerRegex: !simpleRegex
   def: '(十|百|千|万(?!万)|億|兆)'
+RoundNumberIntegerHiraganaRegex: !simpleRegex
+  def: (じゅう|[ひぴび]ゃく|[せぜ]ん|まん|[ひぴび]ゃくまん|[せぜ]んまん)
 AllMultiplierLookupRegex: !nestedRegex
   def: ({BaseNumbers.MultiplierLookupRegex}|ミリリットル(入れら)?|キロメートル|メートル|ミリメート)
   references: [BaseNumbers.MultiplierLookupRegex]  
@@ -121,6 +153,8 @@ FracSplitRegex: !simpleRegex
   def: '[はと]|分\s*の'
 ZeroToNineIntegerRegex: !simpleRegex
   def: '[零〇一二三四五六七八九]'
+ZeroToNineIntegerHiraganaRegex: !simpleRegex
+  def: (れい|ゼロ|マル|い[ちっ]|に|さん|し|よん|ご|ろ[くっ]|しち|なな|は[ちっ]|きゅう|く)
 HalfUnitRegex: !simpleRegex
   def: 半
 NegativeNumberTermsRegex: !simpleRegex
@@ -147,6 +181,15 @@ SingleRegex: !nestedRegex
 AllIntRegex: !nestedRegex
   def: (?<!(ダース))({NotSingleRegex}|({ZeroToNineIntegerRegex}+|{RoundNumberIntegerRegex}+))
   references: [NotSingleRegex, ZeroToNineIntegerRegex, RoundNumberIntegerRegex]
+NotSingleHiraganaRegex: !nestedRegex
+  def: (({ZeroToNineIntegerHiraganaRegex}?{RoundNumberIntegerHiraganaRegex})+{ZeroToNineIntegerHiraganaRegex}?)
+  references: [ZeroToNineIntegerHiraganaRegex, RoundNumberIntegerHiraganaRegex]
+SingleHiriganaRegex: !nestedRegex
+  def: ({ZeroToNineIntegerHiraganaRegex}+)
+  references: [ZeroToNineIntegerHiraganaRegex]
+AllIntHiriganaRegex: !nestedRegex
+  def: \b({NotSingleHiraganaRegex}|{SingleHiriganaRegex})\b
+  references: [SingleHiriganaRegex, NotSingleHiraganaRegex]
 PlaceHolderPureNumber: !simpleRegex
   def: \b
 PlaceHolderDefault: !simpleRegex
@@ -178,11 +221,11 @@ AllFloatRegex: !nestedRegex
   def: '{NegativeNumberTermsRegex}?{AllIntRegex}\s*{PointRegexStr}\s*[一二三四五六七八九](\s*{ZeroToNineIntegerRegex})*'
   references: [NegativeNumberTermsRegex, AllIntRegex, PointRegexStr, ZeroToNineIntegerRegex]
 NumbersWithAllowListRegex: !nestedRegex
-  def: '(?<!(離は))({NegativeNumberTermsRegex}?({NotSingleRegex}|{SingleRegex})(?!({AllIntRegex}*([、.]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*{PercentageSymbol}))(?!(\s*{AllMultiplierLookupRegex}))'
-  references: [NegativeNumberTermsRegex, NotSingleRegex, SingleRegex, AllIntRegex, ZeroToNineIntegerRegex, AllFloatRegex, PercentageSymbol, AllMultiplierLookupRegex]
+  def: '(?<!(離は))({NegativeNumberTermsRegex}?({NotSingleRegex}|{SingleRegex}|{AllIntHiriganaRegex})(?!({AllIntRegex}*([、.]{ZeroToNineIntegerRegex}+)*|{AllFloatRegex})*\s*{PercentageSymbol}))(?!(\s*{AllMultiplierLookupRegex}))'
+  references: [NegativeNumberTermsRegex, NotSingleRegex, SingleRegex, AllIntRegex, ZeroToNineIntegerRegex, AllFloatRegex, PercentageSymbol, AllMultiplierLookupRegex, AllIntHiriganaRegex]
 NumbersAggressiveRegex: !nestedRegex
-  def: (({AllIntRegex})(?!({AllIntRegex}|([、.]{ZeroToNineIntegerRegex})|{AllFloatRegex}|\s*{PercentageSymbol})))
-  references: [AllIntRegex, AllFloatRegex, NegativeNumberTermsRegex, ZeroToNineIntegerRegex, PercentageSymbol]
+  def: (({AllIntRegex}|{AllIntHiriganaRegex})(?!({AllIntRegex}|([、.]{ZeroToNineIntegerRegex})|{AllFloatRegex}|\s*{PercentageSymbol})))
+  references: [AllIntRegex, AllFloatRegex, NegativeNumberTermsRegex, ZeroToNineIntegerRegex, PercentageSymbol, AllIntHiriganaRegex]
 #DoubleExtractor
 PointRegex: !nestedRegex
   def: '{PointRegexStr}'
@@ -419,4 +462,8 @@ RelativeReferenceRelativeToMap: !dictionary
     次のもの: current
     最後から3番目: end
     最後から2番目: end
+AmbiguityFiltersDict: !dictionary
+  types: [ string, string ]
+  entries:
+    '^に$': 'に'
 ...

--- a/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
+++ b/Patterns/Japanese/Japanese-NumbersWithUnit.yaml
@@ -305,6 +305,7 @@ CurrencySuffixList: !dictionary
     Surinamese dollar: スリナム・ドル|スリナムドル
     Trinidad and Tobago dollar: トリニダード・トバゴ・ドル|トリニダードトバゴ・ドル
     Tuvaluan dollar: ツバル・ドル|ツバルドル
+    Dollar: どる|$
 #Chinese yuan
     Chinese yuan: 人民元|元
     Fen: 分

--- a/Specs/Number/Japanese/NumberModel.json
+++ b/Specs/Number/Japanese/NumberModel.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Input": "西九条",
     "Results": []
@@ -12886,6 +12886,382 @@
         },
         "Start": 0,
         "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "私 は その 買い物 で あなた に ろく どる 仮 ています",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "ろく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "6"
+        },
+        "Start": 19,
+        "End": 20
+      }
+    ]
+  },
+  {
+    "Input": "にさんよんよんよんよんよんよん の アカウント リセット",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "にさんよんよんよんよんよんよん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "23444444"
+        },
+        "Start": 0,
+        "End": 14
+      }
+    ]
+  },
+  {
+    "Input": "しち",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "しち",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "7"
+        },
+        "Start": 0,
+        "End": 1
+      }
+    ]
+  },
+  {
+    "Input": "にじゅうさん",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "にじゅうさん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "23"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "きゅうじゅうなな",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "きゅうじゅうなな",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "97"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "ひゃくさんじゅうろく",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "ひゃくさんじゅうろく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "136"
+        },
+        "Start": 0,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": "ななひゃくよんじゅうに",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "ななひゃくよんじゅうに",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "742"
+        },
+        "Start": 0,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "せんにひゃくはちじゅうきゅう",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "せんにひゃくはちじゅうきゅう",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1289"
+        },
+        "Start": 0,
+        "End": 13
+      }
+    ]
+  },
+  {
+    "Input": "さんぜんにひゃくじゅうなな",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "さんぜんにひゃくじゅうなな",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3217"
+        },
+        "Start": 0,
+        "End": 12
+      }
+    ]
+  },
+  {
+    "Input": "三千二百十七",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "三千二百十七",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3217"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "にまんごせんさんびゃくよんじゅうはち",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "にまんごせんさんびゃくよんじゅうはち",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "25348"
+        },
+        "Start": 0,
+        "End": 17
+      }
+    ]
+  },
+  {
+    "Input": "はっせんはっぴゃくきゅうじゅうごまんろくせんさんびゃくななじゅう",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "はっせんはっぴゃくきゅうじゅうごまんろくせんさんびゃくななじゅう",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "88956370"
+        },
+        "Start": 0,
+        "End": 31
+      }
+    ]
+  },
+  {
+    "Input": "いっせんまん さんぜんまん はっせんまん",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "いっせんまん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10000000"
+        },
+        "Start": 0,
+        "End": 5
+      },
+      {
+        "Text": "さんぜんまん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "30000000"
+        },
+        "Start": 7,
+        "End": 12
+      },
+      {
+        "Text": "はっせんまん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "80000000"
+        },
+        "Start": 14,
+        "End": 19
+      }
+    ]
+  },
+  {
+    "Input": "さんびゃく ろっぴゃく はっぴゃく",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "さんびゃく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "300"
+        },
+        "Start": 0,
+        "End": 4
+      },
+      {
+        "Text": "ろっぴゃく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "600"
+        },
+        "Start": 6,
+        "End": 10
+      },
+      {
+        "Text": "はっぴゃく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "800"
+        },
+        "Start": 12,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "さんぜん はっせん",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "さんぜん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3000"
+        },
+        "Start": 0,
+        "End": 3
+      },
+      {
+        "Text": "はっせん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "8000"
+        },
+        "Start": 5,
+        "End": 8
+      }
+    ]
+  },
+  {
+    "Input": "ひらがな番号は いち、 に、 さん、 よん、 ご、 ろく、 なな、 はち、 きゅう、 じゅう、 ひゃく、 せん",
+    "Comment": "'に' (2) is not extracted because it is rarely used as number but is common as preposition (to, at, in...)",
+    "NotSupported": "javascript, java, python",
+    "Results": [
+      {
+        "Text": "いち",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1"
+        },
+        "Start": 8,
+        "End": 9
+      },
+      {
+        "Text": "さん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "3"
+        },
+        "Start": 15,
+        "End": 16
+      },
+      {
+        "Text": "よん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "4"
+        },
+        "Start": 19,
+        "End": 20
+      },
+      {
+        "Text": "ご",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "5"
+        },
+        "Start": 23,
+        "End": 23
+      },
+      {
+        "Text": "ろく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "6"
+        },
+        "Start": 26,
+        "End": 27
+      },
+      {
+        "Text": "なな",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "7"
+        },
+        "Start": 30,
+        "End": 31
+      },
+      {
+        "Text": "はち",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "8"
+        },
+        "Start": 34,
+        "End": 35
+      },
+      {
+        "Text": "きゅう",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "9"
+        },
+        "Start": 38,
+        "End": 40
+      },
+      {
+        "Text": "じゅう",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "10"
+        },
+        "Start": 43,
+        "End": 45
+      },
+      {
+        "Text": "ひゃく",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "100"
+        },
+        "Start": 48,
+        "End": 50
+      },
+      {
+        "Text": "せん",
+        "TypeName": "number",
+        "Resolution": {
+          "value": "1000"
+        },
+        "Start": 53,
+        "End": 54
       }
     ]
   }

--- a/Specs/NumberWithUnit/Japanese/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Japanese/CurrencyModel.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Input": "今日の日経平均は2222円13銭です。",
     "NotSupported": "python",
@@ -1002,6 +1002,39 @@
         },
         "Start": 4,
         "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "このパソコンは にせんにひゃくごじゅうろく ドル となってます",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "にせんにひゃくごじゅうろく ドル",
+        "TypeName": "currency",
+        "Resolution": {
+          "isoCurrency": "USD",
+          "value": "2256",
+          "unit": "United States dollar"
+        },
+        "Start": 8,
+        "End": 23
+      }
+    ]
+  },
+  {
+    "Input": "私 は その 買い物 で あなた に ろく どる 仮 ています",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "ろく どる",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "6",
+          "unit": "Dollar"
+        },
+        "Start": 19,
+        "End": 23
       }
     ]
   }


### PR DESCRIPTION
Fix to issue #2923.

Added support for hiragana numbers (integer).

Test cases added to NumberModel and CurrencyModel.