### PR TITLE
[JA DateTimeV2] DateTimePeriod refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string DateUnitRegex = @"(?<unit>年|个月|周|週|日|天)";
       public const string BeforeRegex = @"以前|之前|前";
       public const string AfterRegex = @"以后|以後|之后|之後|后|後";
+      public const string TimePeriodLeftRegex = @"^[.]";
       public static readonly string DateRegexList1 = $@"({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?";
       public static readonly string DateRegexList2 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?";
       public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?({LunarRegex}(\s*))?{MonthRegex}(\s*)({DayRegexNumInCJK}|{DayRegex})((\s*|,|，){WeekDayRegex})?";
@@ -95,6 +96,7 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public static readonly string WeekOfYearRegex = $@"(?<woy>({YearRegex}|{RelativeRegex}年)的(?<cardinal>第一|第二|第三|第四|第五|最后一)\s*周\s*)";
       public const string WeekOfDateRegex = @"^[.]";
       public const string MonthOfDateRegex = @"^[.]";
+      public const string RestOfDateRegex = @"^[.]";
       public const string UnitRegex = @"(?<unit>年|(?<uoy>(个)?月|周|週|日|天))";
       public static readonly string FollowedUnit = $@"^\s*{UnitRegex}";
       public static readonly string NumberCombinedWithUnit = $@"(?<num>\d+(\.\d*)?){UnitRegex}";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string DateUnitRegex = @"(?<unit>年|个月|月|周|時間?|(?<business>営業)日|(?<!(明|昨|今))日|天|週間?|星期|个星期|か月)";
       public const string BeforeRegex = @"以前|之前|前|先";
       public const string AfterRegex = @"過ぎ|以内|以后|以後|之后|之後|后|後|で(?!す)|あと";
+      public const string TimePeriodLeftRegex = @"あと";
       public static readonly string DateRegexList1 = $@"({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,)*{WeekDayRegex})?)";
       public static readonly string DateRegexList2 = $@"(({SimpleYearRegex}|{DateYearInCJKRegex}){MonthRegexForPeriod}\s*)";
       public static readonly string DateRegexList3 = $@"((({SimpleYearRegex}|{DateYearInCJKRegex})年)(的|の|\s)*)?({LunarRegex}(的|の|\s)*)?{MonthRegex}(\s*)({DateDayRegexInCJK}|{DayRegex})((\s|,)*{WeekDayRegex})?({BeforeRegex}|{AfterRegex})?";
@@ -101,6 +102,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string WeekOfYearRegex = $@"({DateRangePrepositions})(?<woy>({YearRegex}|{RelativeRegex}年)(的|の)(?<cardinal>第一|第二|第三|第四|第五|最后一|第\d|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex})?\s*の?(週|周)\s*)";
       public static readonly string WeekOfDateRegex = $@"(({DateRangePrepositions})({MonthSuffixRegex}({DayRegex})(的|の))第?\s*の?(週|周)s*)|({DayRegex}日の?(週(間)?))";
       public static readonly string MonthOfDateRegex = $@"({DateRangePrepositions})({MonthSuffixRegex}({DayRegex})(的|の))第?\s*の?(月)s*";
+      public const string RestOfDateRegex = @"((当|この|今)(?<unit>日)の)?(?<restof>残りの?)(?<duration>時間|日|週|月|年)";
       public const string UnitRegex = @"(?<unit>ヶ?(年|(个)?月|周|週間|日|天))";
       public static readonly string FollowedUnit = $@"^\s*{UnitRegex}";
       public static readonly string NumberCombinedWithUnit = $@"(?<num>\d+(\.\d*)?){UnitRegex}";
@@ -114,8 +116,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string DayToDay = $@"({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?(({SpecialMonthRegex}|{MonthRegex})の?)?(({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})から(({SpecialMonthRegex}|{MonthRegex})の?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?((今月|来月|{MonthRegex})の?)?({SpecialDayRegex}|{DayRegex}|{WeekDayRegex})(までの間|まで|の間))|{SpecialDayRegex}";
       public static readonly string FirstLastOfYearRegex = $@"(({DatePeriodYearInCJKRegex}|{YearRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))的?)((?<first>前)|(?<last>(最后|最後|最終)))";
       public static readonly string ComplexDatePeriodRegex = $@"({DateRangePrepositions})(?<start>(第{ZeroToNineIntegerRegexCJK}+|第\d+|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex}|(({YearNumRegex}|{DayRegexForPeriod}|{DateDayRegexInCJK}|{MonthRegex}|{MonthNumRegex})(?!((\d+)?(分|秒|時))))|{RelativeRegex}).+)(から)(?<end>.+)(までの間|まで|の間)";
-      public const string PastRegex = @"(?<past>(この|前|上|之前|近|过去|去|過去)(の)?)";
-      public const string FutureRegex = @"(?<future>((?<within>以内に)|後に|向こう|后|次の|今後|これからの|後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))";
+      public const string PastRegex = @"(?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|過去)(の)?)";
+      public const string FutureRegex = @"(?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これからの|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))";
       public const string SeasonRegex = @"(?<season>春|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?";
       public const string WhichWeekRegex = @"第(?<number>5[0-3]|[1-4]\d|0?[1-9])週";
       public static readonly string SeasonWithYear = $@"({DateRangePrepositions})(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>再来年|翌年|来年|今年|去年))(的|の)?)?({ThisPrefixRegex}|{LastPrefixRegex}|{NextPrefixRegex})?{SeasonRegex}";
@@ -130,27 +132,28 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string NowRegex = @"(?<now>出来る限り早く|できるだけ早く|现在|马上|立刻|刚刚才|刚刚|刚才|今日中|今(すぐ)?)";
       public const string NightRegex = @"(?<night>早|晚|夜)";
       public const string TomorrowRegex = @"(?<tomorrow>明日の?(午前|午後|中|夜|朝)?)";
-      public const string TodayRegex = @"(?<today>(今朝の?|今朝の午前|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)";
-      public static readonly string TimeOfSpecialDayRegex = $@"((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに?)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?";
+      public const string YesterdayRegex = @"(?<yesterday>昨日の?(午前|午後|中|夜|朝)?)";
+      public const string TodayRegex = @"(?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)";
+      public static readonly string TimeOfSpecialDayRegex = $@"(((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?)|((((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))(?<in>で|の?うちに)))";
       public const string NowTimeRegex = @"(现在|今)";
       public const string RecentlyTimeRegex = @"(刚刚才?|刚才)";
       public const string AsapTimeRegex = @"(出来る限り早く|立刻|马上)";
-      public const string DateTimePeriodTillRegex = @"(?<till>到|直到|--|-|—|——)";
-      public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*(的|の)|在\s*$)";
+      public const string DateTimePeriodTillRegex = @"(?<till> 到|至|から|--|-|—|——|~)";
+      public const string DateTimePeriodPrepositionRegex = @"(?<prep>^\s*(的|の(?!午))|在\s*$)";
       public static readonly string HourRegex = $@"\b{BaseDateTime.HourRegex}";
       public const string HourNumRegex = @"(?<hour>[零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)";
       public const string ZhijianRegex = @"^\s*(之间|之内|期间|中间|间)";
-      public const string DateTimePeriodThisRegex = @"这个|这一个|这|这一";
-      public const string DateTimePeriodLastRegex = @"上个|上一个|上|上一";
+      public const string DateTimePeriodThisRegex = @"这个|这一个|这|这一|今後|今から|これから";
+      public const string DateTimePeriodLastRegex = @"上个|上一个|上|上一|昨";
       public const string DateTimePeriodNextRegex = @"下个|下一个|下|下一";
       public const string AmPmDescRegex = @"(?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))";
-      public const string TimeOfDayRegex = @"(?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晚)";
-      public static readonly string SpecificTimeOfDayRegex = $@"((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})\s+{TimeOfDayRegex})|(今晚|今早|今晨|明晚|明早|明晨|昨晚))";
-      public const string DateTimePeriodUnitRegex = @"(个)?(?<unit>(小时|分钟|秒钟|时|分|秒))";
+      public const string TimeOfDayRegex = @"(?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|日|号)晩(?!上))";
+      public static readonly string SpecificTimeOfDayRegex = $@"((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))";
+      public const string DateTimePeriodUnitRegex = @"(?<unit>(時|分|秒)間?)";
       public static readonly string DateTimePeriodFollowedUnit = $@"^\s*{DateTimePeriodUnitRegex}";
       public static readonly string DateTimePeriodNumberCombinedWithUnit = $@"\b(?<num>\d+(\.\d*)?){DateTimePeriodUnitRegex}";
       public const string PlusOneDayRegex = @"あす|あした|明日|来|次";
-      public const string MinusOneDayRegex = @"きのう|最後の日|前日|昨";
+      public const string MinusOneDayRegex = @"きのう|最後の日|前日|昨|昨日の?";
       public const string PlusTwoDayRegex = @"后天|後天|明後日|あさって|今日から二日";
       public const string MinusTwoDayRegex = @"前天|一昨日|二日前|おととい";
       public const string PlusThreeDayRegex = @"大后天|大後天|明日から二日|昨日から4日";
@@ -221,7 +224,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?(am|pm)?";
       public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
       public const string TimeApproximateDescPreffixRegex = @"(ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)";
-      public const string TimeApproximateDescSuffixRegex = @"(ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)";
+      public const string TimeApproximateDescSuffixRegex = @"(ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり|以降|まで(の間)?|の間|間で?|間以内)";
       public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?";
       public static readonly string TimeRegexes2 = $@"({TimeApproximateDescPreffixRegex}(の)?)?{TimeDayDescRegex}((の)?{TimeApproximateDescSuffixRegex})?";
       public static readonly string TimeRegexes3 = $@"({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})前((の)?{TimeDayDescRegex})?";
@@ -271,6 +274,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"時間", @"H" },
             { @"时", @"H" },
             { @"分钟", @"M" },
+            { @"分間", @"M" },
             { @"分", @"M" },
             { @"秒钟", @"S" },
             { @"秒", @"S" },
@@ -628,12 +632,12 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"09月", 9 }
         };
       public const string DateTimeSimpleAmRegex = @"(?<am>早|晨|am)";
-      public const string DateTimeSimplePmRegex = @"(?<pm>晚|pm)";
-      public const string DateTimePeriodMORegex = @"(凌晨|清晨|早上|早|上午)";
+      public const string DateTimeSimplePmRegex = @"(?<pm>晚|晩|pm)";
+      public const string DateTimePeriodMORegex = @"(朝|凌晨|清晨|早上|早|上午)";
       public const string DateTimePeriodMIRegex = @"^[.]";
       public const string DateTimePeriodAFRegex = @"(中午|下午|午后|傍晚)";
-      public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚)";
-      public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜)";
+      public const string DateTimePeriodEVRegex = @"(晚上|夜里|夜晚|晚|晩)";
+      public const string DateTimePeriodNIRegex = @"(半夜|夜间|深夜|夜)";
       public static readonly Dictionary<string, string> AmbiguityFiltersDict = new Dictionary<string, string>
         {
             { @"早", @"(?<!今|明|日|号)早(?!上)" }
@@ -718,7 +722,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly IList<string> MidDayTermList = new List<string>
         {
             @"正午",
-            @"真昼"
+            @"真昼",
+            @"昼"
         };
       public static readonly IList<string> AfternoonTermList = new List<string>
         {
@@ -734,6 +739,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             @"夕方に",
             @"夕方",
             @"晚",
+            @"晩",
             @"晚上",
             @"夜里",
             @"傍晚",

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string DateUnitRegex = @"(?<unit>년|개?월|주|(?<!내)일)";
       public const string BeforeRegex = @"이?전|之前|前";
       public const string AfterRegex = @"이?후|후에";
+      public const string TimePeriodLeftRegex = @"^[.]";
       public static readonly string DateRegexList1 = $@"({RelativeRegex}\s*)?({SimpleYearRegex}년\s*)?({LunarRegex}\s*)?({MonthRegex}\s*)?{DateDayRegexInCJK}(\s*(,\s*)?{WeekDayRegex})?(\s*(,\s*)?{SimpleYearRegex})?";
       public static readonly string DateRegexList2 = $@"({WeekDayRegex},?\s*)?({MonthRegex}\s*[/\\\-\.]?\s*{DateDayRegexInCJK})(\s*{WeekDayRegex})?(\s*(,\s*)?({SimpleYearRegex}|{DateYearInCJKRegex})년?)?";
       public static readonly string DateRegexList3 = $@"(({SpecialDayRegex}으?로?부터)\s((\d+\s*주간?(\s*{WeekDayRegex})?)|({DateDayRegexInCJK}|{SpecialDayRegex})\s[전후]))|((\d+년\s*)?(((한|두|세|네|다섯|여섯|일곱|여덟|아홉|열|열한|열두)\s?달\s*)|(\d+개월\s*))?(((,\s*)|(\s*하고\s*))?{DateDayRegexInCJK}|{SpecialDayRegex})\s(전|후|지나서))|(((그\s)?(다음날|전날))|([그이] 날)|(지난 날)|(새해\s첫\s?날))|({DayRegex}일\s*{MonthNumRegex}월\s*{SimpleYearRegex}년)|(((앞으로\s+)|({SpecialDayRegex}으?로?부터\s+))?\d+\s*주\s(후|동안)\s+{WeekDayRegex})|(나의 하루)|(몇\s*[달일] 전)";
@@ -97,6 +98,7 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public static readonly string WeekOfYearRegex = $@"(?<woy>(?<yearrel>내년|금년|작년|((다음|올)\s*해)|{YearRegex})의?\s+(?<cardinal>첫\s?번?째|두\s?번?째|둘째|세\s?번?째|셋째|네\s?번?째|넷째|마지막)\s*주\s*)";
       public const string WeekOfDateRegex = @"^[.]";
       public const string MonthOfDateRegex = @"^[.]";
+      public const string RestOfDateRegex = @"^[.]";
       public const string UnitRegex = @"(?<unit>년|(개)?월(\s달)?|달|주|일)";
       public static readonly string FollowedUnit = $@"^\s*{UnitRegex}";
       public static readonly string NumberCombinedWithUnit = $@"(?<num>\d+(\.\d*)?){UnitRegex}";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseDateTimePeriodExtractorConfiguration.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
+
+        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+
+        public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -91,6 +97,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         Regex ICJKDateTimePeriodExtractorConfiguration.PastRegex => PastRegex;
 
         Regex ICJKDateTimePeriodExtractorConfiguration.FutureRegex => FutureRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex => TimePeriodLeftRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseDateTimePeriodParserConfiguration.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             TimeParser = config.TimeParser;
             DateTimeParser = config.DateTimeParser;
             TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
 
             SpecificTimeOfDayRegex = ChineseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex;
             TimeOfDayRegex = ChineseDateTimePeriodExtractorConfiguration.TimeOfDayRegex;
@@ -63,7 +64,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
             LastRegex = ChineseDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = ChineseDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = ChineseDateTimePeriodExtractorConfiguration.FutureRegex;
+            TimePeriodLeftRegex = ChineseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = ChineseDateTimePeriodExtractorConfiguration.UnitRegex;
+            RestOfDateRegex = ChineseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -89,6 +92,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public IDateTimeParser TimePeriodParser { get; }
 
+        public IDateTimeParser DurationParser { get; }
+
         public Regex SpecificTimeOfDayRegex { get; }
 
         public Regex TimeOfDayRegex { get; }
@@ -101,7 +106,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public Regex FutureRegex { get; }
 
+        public Regex TimePeriodLeftRegex { get; }
+
         public Regex UnitRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -213,6 +213,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string NumGroupName = "num";
         public const string FirstGroupName = "first";
         public const string LastGroupName = "last";
+        public const string LatestGroupName = "latest";
         public const string AfterGroupName = "after";
         public const string RelEarlyGroupName = "RelEarly";
         public const string RelLateGroupName = "RelLate";
@@ -311,5 +312,6 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         // Timex non-constant
         public static readonly string[] DatePeriodTimexSplitter = { ",", "(", ")" };
+        public static readonly char[] DurationUnitChar = { 'D', 'W', 'M', 'Y', 'B' };
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKDateTimePeriodExtractorConfiguration.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex FutureRegex { get; }
 
+        Regex TimePeriodLeftRegex { get; }
+
+        Regex RelativeRegex { get; }
+
+        Regex RestOfDateRegex { get; }
+
+        Regex ThisRegex { get; }
+
         IExtractor CardinalExtractor { get; }
 
         IDateTimeExtractor SingleDateExtractor { get; }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseDateTimePeriodExtractorConfiguration.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
+
+        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+
+        public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -91,6 +97,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         Regex ICJKDateTimePeriodExtractorConfiguration.PastRegex => PastRegex;
 
         Regex ICJKDateTimePeriodExtractorConfiguration.FutureRegex => FutureRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex => TimePeriodLeftRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseDateTimePeriodParserConfiguration.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             TimeParser = config.TimeParser;
             DateTimeParser = config.DateTimeParser;
             TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
 
             SpecificTimeOfDayRegex = JapaneseDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex;
             TimeOfDayRegex = JapaneseDateTimePeriodExtractorConfiguration.TimeOfDayRegex;
@@ -63,7 +64,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
             LastRegex = JapaneseDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = JapaneseDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = JapaneseDateTimePeriodExtractorConfiguration.FutureRegex;
+            TimePeriodLeftRegex = JapaneseDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = JapaneseDateTimePeriodExtractorConfiguration.UnitRegex;
+            RestOfDateRegex = JapaneseDateTimePeriodExtractorConfiguration.RestOfDateRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -89,6 +92,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public IDateTimeParser TimePeriodParser { get; }
 
+        public IDateTimeParser DurationParser { get; }
+
         public Regex SpecificTimeOfDayRegex { get; }
 
         public Regex TimeOfDayRegex { get; }
@@ -101,7 +106,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public Regex FutureRegex { get; }
 
+        public Regex TimePeriodLeftRegex { get; }
+
         public Regex UnitRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanDateTimePeriodExtractorConfiguration.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex FutureRegex = new Regex(DateTimeDefinitions.FutureRegex, RegexFlags);
 
+        public static readonly Regex TimePeriodLeftRegex = new Regex(DateTimeDefinitions.TimePeriodLeftRegex, RegexFlags);
+
+        public static readonly Regex RelativeRegex = new Regex(DateTimeDefinitions.RelativeRegex, RegexFlags);
+
+        public static readonly Regex RestOfDateRegex = new Regex(DateTimeDefinitions.RestOfDateRegex, RegexFlags);
+
         public static readonly Regex HourRegex = new Regex(DateTimeDefinitions.HourRegex, RegexFlags);
         public static readonly Regex HourNumRegex = new Regex(DateTimeDefinitions.HourNumRegex, RegexFlags);
         public static readonly Regex ThisRegex = new Regex(DateTimeDefinitions.DateTimePeriodThisRegex, RegexFlags);
@@ -91,6 +97,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         Regex ICJKDateTimePeriodExtractorConfiguration.PastRegex => PastRegex;
 
         Regex ICJKDateTimePeriodExtractorConfiguration.FutureRegex => FutureRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex => TimePeriodLeftRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RelativeRegex => RelativeRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.RestOfDateRegex => RestOfDateRegex;
+
+        Regex ICJKDateTimePeriodExtractorConfiguration.ThisRegex => ThisRegex;
 
         public bool GetFromTokenIndex(string text, out int index)
         {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanDateTimePeriodParserConfiguration.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             TimeParser = config.TimeParser;
             DateTimeParser = config.DateTimeParser;
             TimePeriodParser = config.TimePeriodParser;
+            DurationParser = config.DurationParser;
 
             SpecificTimeOfDayRegex = KoreanDateTimePeriodExtractorConfiguration.SpecificTimeOfDayRegex;
             TimeOfDayRegex = KoreanDateTimePeriodExtractorConfiguration.TimeOfDayRegex;
@@ -63,7 +64,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
             LastRegex = KoreanDateTimePeriodExtractorConfiguration.LastRegex;
             PastRegex = KoreanDateTimePeriodExtractorConfiguration.PastRegex;
             FutureRegex = KoreanDateTimePeriodExtractorConfiguration.FutureRegex;
+            TimePeriodLeftRegex = KoreanDateTimePeriodExtractorConfiguration.TimePeriodLeftRegex;
             UnitRegex = KoreanDateTimePeriodExtractorConfiguration.UnitRegex;
+            RestOfDateRegex = KoreanDateTimePeriodExtractorConfiguration.RestOfDateRegex;
             UnitMap = config.UnitMap;
         }
 
@@ -89,6 +92,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public IDateTimeParser TimePeriodParser { get; }
 
+        public IDateTimeParser DurationParser { get; }
+
         public Regex SpecificTimeOfDayRegex { get; }
 
         public Regex TimeOfDayRegex { get; }
@@ -101,7 +106,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public Regex FutureRegex { get; }
 
+        public Regex TimePeriodLeftRegex { get; }
+
         public Regex UnitRegex { get; }
+
+        public Regex RestOfDateRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDateTimePeriodParser.cs
@@ -1318,42 +1318,13 @@ namespace Microsoft.Recognizers.Text.DateTime
 
                 DateObject beginTime;
                 var endTime = beginTime = referenceTime;
-                var sufixPtTimex = string.Empty;
 
                 if (Config.UnitMap.ContainsKey(srcUnit))
                 {
-                    switch (unitStr)
-                    {
-                        case "D":
-                            endTime = DateObject.MinValue.SafeCreateFromValue(beginTime.Year, beginTime.Month, beginTime.Day);
-                            endTime = endTime.AddDays(1).AddSeconds(-1);
-                            sufixPtTimex = "PT" + (endTime - beginTime).TotalSeconds + "S";
-                            break;
-                        case "H":
-                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddHours(swiftValue);
-                            endTime = swiftValue > 0 ? referenceTime.AddHours(swiftValue) : endTime;
-                            sufixPtTimex = "PT1H";
-                            break;
-                        case "M":
-                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddMinutes(swiftValue);
-                            endTime = swiftValue > 0 ? referenceTime.AddMinutes(swiftValue) : endTime;
-                            sufixPtTimex = "PT1M";
-                            break;
-                        case "S":
-                            beginTime = swiftValue > 0 ? beginTime : referenceTime.AddSeconds(swiftValue);
-                            endTime = swiftValue > 0 ? referenceTime.AddSeconds(swiftValue) : endTime;
-                            sufixPtTimex = "PT1S";
-                            break;
-                        default:
-                            return ret;
-                    }
-
-                    ret.Timex =
-                            $"({DateTimeFormatUtil.LuisDate(beginTime)}T{DateTimeFormatUtil.LuisTime(beginTime)}," +
-                            $"{DateTimeFormatUtil.LuisDate(endTime)}T{DateTimeFormatUtil.LuisTime(endTime)},{sufixPtTimex})";
+                    ret.Timex = TimexUtility.GenerateRelativeUnitDateTimePeriodTimex(ref beginTime, ref endTime, referenceTime, unitStr, swiftValue);
 
                     ret.FutureValue = ret.PastValue = new Tuple<DateObject, DateObject>(beginTime, endTime);
-                    ret.Success = true;
+                    ret.Success = !string.IsNullOrEmpty(ret.Timex);
 
                     return ret;
                 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKDateTimePeriodParserConfiguration.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeExtractor DurationExtractor { get; }
 
+        IDateTimeParser DurationParser { get; }
+
         IExtractor CardinalExtractor { get; }
 
         IParser CardinalParser { get; }
@@ -42,7 +44,11 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex FutureRegex { get; }
 
+        Regex TimePeriodLeftRegex { get; }
+
         Regex UnitRegex { get; }
+
+        Regex RestOfDateRegex { get; }
 
         IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimePeriodFunctions.cs
@@ -73,6 +73,22 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
                 leftResult.Hour += Constants.HalfDayHourCount;
             }
 
+            // No 'am' or 'pm' indicator
+            if (leftResult.LowBound == -1 && rightResult.LowBound == -1 && leftResult.Hour <= Constants.HalfDayHourCount && rightResult.Hour <= Constants.HalfDayHourCount && spanHour > Constants.HalfDayHourCount)
+            {
+                if (leftResult.Hour > rightResult.Hour)
+                {
+                    if (leftResult.Hour == Constants.HalfDayHourCount)
+                    {
+                        leftResult.Hour -= Constants.HalfDayHourCount;
+                    }
+                    else
+                    {
+                        rightResult.Hour += Constants.HalfDayHourCount;
+                    }
+                }
+            }
+
             int day = refTime.Day,
                 month = refTime.Month,
                 year = refTime.Year;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/TimexUtility.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     break;
             }
 
-            var durationTimex = "P" + diff + Constants.TimexDay;
+            var durationTimex = Constants.GeneralPeriodPrefix + diff + Constants.TimexDay;
             return $"({DateTimeFormatUtil.LuisDate(beginDate)},{DateTimeFormatUtil.LuisDate(endDate)},{durationTimex})";
         }
 
@@ -225,6 +225,22 @@ namespace Microsoft.Recognizers.Text.DateTime
             return Constants.GeneralPeriodPrefix +
                    (isLessThanDay ? Constants.TimeTimexPrefix : string.Empty) +
                    number.ToString(CultureInfo.InvariantCulture) + unitStr;
+        }
+
+        public static string GenerateDurationTimex(DateObject beginDateTime, DateObject endDateTime)
+        {
+            var duration = endDateTime - beginDateTime;
+            var days = duration.Days;
+            var hours = duration.Hours;
+            var mins = duration.Minutes;
+            var secs = duration.Seconds;
+
+            return Constants.GeneralPeriodPrefix +
+                   (days > 0 ? days.ToString(CultureInfo.InvariantCulture) + Constants.TimexDay : string.Empty) +
+                   (hours > 0 || mins > 0 || secs > 0 ? Constants.TimeTimexPrefix : string.Empty) +
+                   (hours > 0 ? hours.ToString(CultureInfo.InvariantCulture) + Constants.TimexHour : string.Empty) +
+                   (mins > 0 ? mins.ToString(CultureInfo.InvariantCulture) + Constants.TimexMinute : string.Empty) +
+                   (secs > 0 ? secs.ToString(CultureInfo.InvariantCulture) + Constants.TimexSecond : string.Empty);
         }
 
         public static DatePeriodTimexType GetDatePeriodTimexType(string durationTimex)
@@ -447,6 +463,69 @@ namespace Microsoft.Recognizers.Text.DateTime
             return $"({beginTimex},{endTimex},{durationTimex})";
         }
 
+        public static string GenerateDateTimePeriodTimex(DateObject beginDateTime, DateObject endDateTime, string durationTimex)
+        {
+            return GenerateDateTimePeriodTimex(DateTimeFormatUtil.LuisDateTime(beginDateTime),
+                DateTimeFormatUtil.LuisDateTime(endDateTime), durationTimex);
+        }
+
+        public static string GenerateDateTimePeriodTimex(DateObject beginDateTime, DateObject endDateTime)
+        {
+            var durationTimex = GenerateDurationTimex(beginDateTime, endDateTime);
+
+            return GenerateDateTimePeriodTimex(beginDateTime, endDateTime, durationTimex);
+        }
+
+        public static string GenerateRelativeUnitDateTimePeriodTimex(ref DateObject beginDateTime, ref DateObject endDateTime, DateObject referenceTime, string unitStr, int swift)
+        {
+            string prefix = Constants.GeneralPeriodPrefix + Constants.TimeTimexPrefix;
+            string durationTimex = string.Empty;
+            switch (unitStr)
+            {
+                case Constants.TimexDay:
+                    endDateTime = DateObject.MinValue.SafeCreateFromValue(beginDateTime.Year, beginDateTime.Month, beginDateTime.Day);
+                    endDateTime = endDateTime.AddDays(1).AddSeconds(-1);
+                    durationTimex = prefix + (endDateTime - beginDateTime).TotalSeconds + Constants.TimexSecond;
+                    break;
+                case Constants.TimexHour:
+                    beginDateTime = swift > 0 ? beginDateTime : referenceTime.AddHours(swift);
+                    endDateTime = swift > 0 ? referenceTime.AddHours(swift) : endDateTime;
+                    durationTimex = prefix + "1" + Constants.TimexHour;
+                    break;
+                case Constants.TimexMinute:
+                    beginDateTime = swift > 0 ? beginDateTime : referenceTime.AddMinutes(swift);
+                    endDateTime = swift > 0 ? referenceTime.AddMinutes(swift) : endDateTime;
+                    durationTimex = prefix + "1" + Constants.TimexMinute;
+                    break;
+                case Constants.TimexSecond:
+                    beginDateTime = swift > 0 ? beginDateTime : referenceTime.AddSeconds(swift);
+                    endDateTime = swift > 0 ? referenceTime.AddSeconds(swift) : endDateTime;
+                    durationTimex = prefix + "1" + Constants.TimexSecond;
+                    break;
+                default:
+                    return string.Empty;
+            }
+
+            return GenerateDateTimePeriodTimex(beginDateTime, endDateTime, durationTimex);
+        }
+
+        public static string GenerateSplitDateTimePeriodTimex(string dateTimex, string timeRangeTimex)
+        {
+            var split = timeRangeTimex.Split(Constants.TimeTimexPrefix[0]);
+            string timex = null;
+            if (split.Length == 4)
+            {
+                timex = split[0] + dateTimex + Constants.TimeTimexPrefix + split[1] + dateTimex +
+                    Constants.TimeTimexPrefix + split[2] + Constants.TimeTimexPrefix + split[3];
+            }
+            else if (split.Length == 2)
+            {
+                timex = dateTimex + timeRangeTimex;
+            }
+
+            return timex;
+        }
+
         public static RangeTimexComponents GetRangeTimexComponents(string rangeTimex)
         {
             rangeTimex = rangeTimex.Replace("(", string.Empty).Replace(")", string.Empty);
@@ -486,8 +565,7 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         public static float ParseNumberFromDurationTimex(string timex)
         {
-            char[] unitChar = new char[] { 'D', 'W', 'M', 'Y', 'B' };
-            var numberStr = timex.Substring(timex.IndexOf('P') + 1, timex.IndexOfAny(unitChar) - 1);
+            var numberStr = timex.Substring(timex.IndexOf(Constants.GeneralPeriodPrefix) + 1, timex.IndexOfAny(Constants.DurationUnitChar) - 1);
             return float.Parse(numberStr);
         }
 

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -94,7 +94,8 @@ BeforeRegex: !simpleRegex
   def: 以前|之前|前
 AfterRegex: !simpleRegex
   def: 以后|以後|之后|之後|后|後
-# (农历)?(2016年)?一月三日(星期三)?
+TimePeriodLeftRegex: !simpleRegex
+  def: ^[.]
 DateRegexList1: !nestedRegex
   def: ({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
   references: [LunarRegex, SimpleYearRegex, DateYearInCJKRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]
@@ -198,6 +199,8 @@ WeekOfDateRegex: !simpleRegex
   def: ^[.]
 MonthOfDateRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
+RestOfDateRegex: !simpleRegex
   def: ^[.]
 UnitRegex: !simpleRegex
   def: (?<unit>年|(?<uoy>(个)?月|周|週|日|天))

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -96,6 +96,7 @@ AfterRegex: !simpleRegex
   def: 以后|以後|之后|之後|后|後
 TimePeriodLeftRegex: !simpleRegex
   def: ^[.]
+# (农历)?(2016年)?一月三日(星期三)?
 DateRegexList1: !nestedRegex
   def: ({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
   references: [LunarRegex, SimpleYearRegex, DateYearInCJKRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -94,6 +94,8 @@ BeforeRegex: !simpleRegex
   def: 以前|之前|前|先
 AfterRegex: !simpleRegex
   def: 過ぎ|以内|以后|以後|之后|之後|后|後|で(?!す)|あと
+TimePeriodLeftRegex: !simpleRegex
+  def: あと
 DateRegexList1: !nestedRegex
   # ２０１６年１２月１日
   def: ({LunarRegex}(的|の|\s)*)?(({SimpleYearRegex}|{DateYearInCJKRegex})[/\\\-の的]?(\s*{MonthRegex})[/\\\-の的]?(\s*{DayRegexForPeriod})((\s|,)*{WeekDayRegex})?)
@@ -211,6 +213,8 @@ WeekOfDateRegex: !nestedRegex
 MonthOfDateRegex: !nestedRegex
   def: ({DateRangePrepositions})({MonthSuffixRegex}({DayRegex})(的|の))第?\s*の?(月)s*
   references: [DayRegex, DateRangePrepositions, MonthSuffixRegex]
+RestOfDateRegex: !simpleRegex
+  def: ((当|この|今)(?<unit>日)の)?(?<restof>残りの?)(?<duration>時間|日|週|月|年)
 UnitRegex: !simpleRegex
   def: (?<unit>ヶ?(年|(个)?月|周|週間|日|天))
 FollowedUnit: !nestedRegex
@@ -250,9 +254,9 @@ ComplexDatePeriodRegex: !nestedRegex
   def: ({DateRangePrepositions})(?<start>(第{ZeroToNineIntegerRegexCJK}+|第\d+|{DatePeriodThisRegex}|{DatePeriodLastRegex}|{DatePeriodNextRegex}|(({YearNumRegex}|{DayRegexForPeriod}|{DateDayRegexInCJK}|{MonthRegex}|{MonthNumRegex})(?!((\d+)?(分|秒|時))))|{RelativeRegex}).+)(から)(?<end>.+)(までの間|まで|の間)
   references: [ DatePeriodThisRegex, DatePeriodLastRegex, DatePeriodNextRegex, ZeroToNineIntegerRegexCJK, DateRangePrepositions, YearNumRegex, DayRegexForPeriod, WeekDayRegex, MonthRegex, MonthNumRegex, RelativeRegex, DateDayRegexInCJK ]
 PastRegex: !simpleRegex
-  def: (?<past>(この|前|上|之前|近|过去|去|過去)(の)?)
+  def: (?<past>(この|時前|(?<!午)前|最後|上|之前|近|过去|去|過去)(の)?)
 FutureRegex: !simpleRegex
-  def: (?<future>((?<within>以内に)|後に|向こう|后|次の|今後|これからの|後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))
+  def: (?<future>((?<within>以内に)|後に|向こう|后|次の|今後|今日の午後|これからの|(?<!午)後|(?<![一两几]\s*)下|之后|之後|未来(的|の)?))
 SeasonRegex: !simpleRegex
   def: (?<season>春|夏|秋|冬)(天|季)?(の)?((?<MidPrefix>半ば)|(?<EarlyPrefix>初め|のはじめ)|(?<LatePrefix>終わり(ごろ)?|末|下旬))?
 WhichWeekRegex: !simpleRegex
@@ -287,11 +291,13 @@ NightRegex: !simpleRegex
   def: (?<night>早|晚|夜)
 TomorrowRegex: !simpleRegex
   def: (?<tomorrow>明日の?(午前|午後|中|夜|朝)?)
+YesterdayRegex: !simpleRegex
+  def: (?<yesterday>昨日の?(午前|午後|中|夜|朝)?)
 TodayRegex: !simpleRegex
-  def: (?<today>(今朝の?|今朝の午前|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)
+  def: (?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)
 TimeOfSpecialDayRegex: !nestedRegex
-  def: ((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに?)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?
-  references: [ TomorrowRegex, TodayRegex, WeekDayRegex ]
+  def: (((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?)|((((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))(?<in>で|の?うちに)))
+  references: [ TomorrowRegex, YesterdayRegex, TodayRegex, WeekDayRegex ]
 NowTimeRegex: !simpleRegex
   def: (现在|今)
 RecentlyTimeRegex: !simpleRegex
@@ -300,9 +306,9 @@ AsapTimeRegex: !simpleRegex
   def: (出来る限り早く|立刻|马上)
 #DateTimePeriodExtractorCJK
 DateTimePeriodTillRegex: !simpleRegex
-  def: (?<till>到|直到|--|-|—|——)
+  def: (?<till> 到|至|から|--|-|—|——|~)
 DateTimePeriodPrepositionRegex: !simpleRegex
-  def: (?<prep>^\s*(的|の)|在\s*$)
+  def: (?<prep>^\s*(的|の(?!午))|在\s*$)
 HourRegex: !nestedRegex
   def: \b{BaseDateTime.HourRegex}
   references: [ BaseDateTime.HourRegex ]
@@ -311,20 +317,20 @@ HourNumRegex: !simpleRegex
 ZhijianRegex: !simpleRegex
   def: ^\s*(之间|之内|期间|中间|间)
 DateTimePeriodThisRegex: !simpleRegex
-  def: 这个|这一个|这|这一
+  def: 这个|这一个|这|这一|今後|今から|これから
 DateTimePeriodLastRegex: !simpleRegex
-  def: 上个|上一个|上|上一
+  def: 上个|上一个|上|上一|昨
 DateTimePeriodNextRegex: !simpleRegex
   def: 下个|下一个|下|下一
 AmPmDescRegex: !simpleRegex
   def: (?<daydesc>(am|a\.m\.|a m|a\. m\.|a\.m|a\. m|a m|pm|p\.m\.|p m|p\. m\.|p\.m|p\. m|p m))
 TimeOfDayRegex: !simpleRegex
-  def: (?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晚)
+  def: (?<timeOfDay>凌晨|清晨|早上|早|上午|中午|下午|午后|晚上|夜里|夜晚|半夜|夜间|深夜|傍晚|晩|夜|((?<!今|明|昨|傍|夜|日|号)朝(?!上))|(?<!今|明|昨|傍|夜|日|号)晚(?!上)|(?<!今|明|昨|傍|夜|日|号)晩(?!上))
 SpecificTimeOfDayRegex: !nestedRegex
-  def: ((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})\s+{TimeOfDayRegex})|(今晚|今早|今晨|明晚|明早|明晨|昨晚))
-  references: [DateTimePeriodThisRegex, DateTimePeriodNextRegex, DateTimePeriodLastRegex, TimeOfDayRegex]
+  def: ((({DateTimePeriodThisRegex}|{DateTimePeriodNextRegex}|{DateTimePeriodLastRegex})の?{TimeOfDayRegex})|(?<latest>ぎりぎり)|(今夜|今晩|今朝|今早|今晨|明晚|明早|明晨|昨晚)|(({FutureRegex}|{PastRegex})(?<weekday>(日|月|火|水|木|金|土)曜日?)の(午前|午後|中|夜|朝)((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))時間?)((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?まで)|(({FutureRegex}|{PastRegex})の?(?<few>数)((時|分|秒)間?)))
+  references: [DateTimePeriodThisRegex, DateTimePeriodNextRegex, DateTimePeriodLastRegex, TimeOfDayRegex, FutureRegex, PastRegex]
 DateTimePeriodUnitRegex: !simpleRegex
-  def: (个)?(?<unit>(小时|分钟|秒钟|时|分|秒))
+  def: (?<unit>(時|分|秒)間?)
 DateTimePeriodFollowedUnit: !nestedRegex
   def: ^\s*{DateTimePeriodUnitRegex}
   references: [DateTimePeriodUnitRegex]
@@ -334,7 +340,7 @@ DateTimePeriodNumberCombinedWithUnit: !nestedRegex
 PlusOneDayRegex: !simpleRegex
   def: あす|あした|明日|来|次
 MinusOneDayRegex: !simpleRegex
-  def: きのう|最後の日|前日|昨
+  def: きのう|最後の日|前日|昨|昨日の?
 PlusTwoDayRegex: !simpleRegex
   def: 后天|後天|明後日|あさって|今日から二日
 MinusTwoDayRegex: !simpleRegex
@@ -470,7 +476,7 @@ TimeDayDescRegex: !nestedRegex
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)
 TimeApproximateDescSuffixRegex: !simpleRegex
-  def: (ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり)
+  def: (ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり|以降|まで(の間)?|の間|間で?|間以内)
 TimeRegexes1: !nestedRegex
   def: '{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?'
   references: [TimeApproximateDescPreffixRegex, TimeDayDescRegex, TimeDigitTimeRegex, TimeCJKTimeRegex, TimeApproximateDescSuffixRegex]
@@ -556,6 +562,7 @@ ParserConfigurationUnitMap: !dictionary
     時間: H 
     时: H
     分钟: M
+    分間: M
     分: M
     秒钟: S
     秒: S
@@ -915,18 +922,18 @@ ParserConfigurationMonthOfYear: !dictionary
 DateTimeSimpleAmRegex: !simpleRegex
   def: (?<am>早|晨|am)
 DateTimeSimplePmRegex: !simpleRegex
-  def: (?<pm>晚|pm)
+  def: (?<pm>晚|晩|pm)
 DateTimePeriodMORegex: !simpleRegex
-  def: (凌晨|清晨|早上|早|上午)
+  def: (朝|凌晨|清晨|早上|早|上午)
 DateTimePeriodMIRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Chinese
   def: ^[.]
 DateTimePeriodAFRegex: !simpleRegex
   def: (中午|下午|午后|傍晚)
 DateTimePeriodEVRegex: !simpleRegex
-  def: (晚上|夜里|夜晚|晚)
+  def: (晚上|夜里|夜晚|晚|晩)
 DateTimePeriodNIRegex: !simpleRegex
-  def: (半夜|夜间|深夜)
+  def: (半夜|夜间|深夜|夜)
 AmbiguityFiltersDict: !dictionary
   types: [ string, string ]
   # TODO: populate dictionary according to the counterpart in Chinese
@@ -1017,6 +1024,7 @@ MidDayTermList: !list
   entries: 
     - 正午
     - 真昼
+    - 昼
 AfternoonTermList: !list
   types: [ string ]
   entries: 
@@ -1032,6 +1040,7 @@ EveningTermList: !list
     - 夕方に
     - 夕方
     - 晚
+    - 晩
     - 晚上
     - 夜里
     - 傍晚

--- a/Patterns/Korean/Korean-DateTime.yaml
+++ b/Patterns/Korean/Korean-DateTime.yaml
@@ -90,6 +90,8 @@ BeforeRegex: !simpleRegex
   def: 이?전|之前|前
 AfterRegex: !simpleRegex
   def: 이?후|후에
+TimePeriodLeftRegex: !simpleRegex
+  def: ^[.]
 DateRegexList1: !nestedRegex
   def: ({RelativeRegex}\s*)?({SimpleYearRegex}년\s*)?({LunarRegex}\s*)?({MonthRegex}\s*)?{DateDayRegexInCJK}(\s*(,\s*)?{WeekDayRegex})?(\s*(,\s*)?{SimpleYearRegex})?
   references: [RelativeRegex, LunarRegex, SimpleYearRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]
@@ -198,6 +200,8 @@ WeekOfDateRegex: !simpleRegex
   def: ^[.]
 MonthOfDateRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in Japanese
+  def: ^[.]
+RestOfDateRegex: !simpleRegex
   def: ^[.]
 UnitRegex: !simpleRegex
   def: (?<unit>년|(개)?월(\s달)?|달|주|일)

--- a/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
+++ b/Specs/DateTime/Japanese/DateTimePeriodExtractor.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "今日の5時から7時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -14,7 +13,6 @@
   },
   {
     "Input": "明日の5時から7時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "来週の日曜日5時から6時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "来週の日曜日5時から午後6時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "今日の午後4時から5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "今日の午後4時から明日の午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +73,6 @@
   },
   {
     "Input": "明日の午後4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -92,7 +85,6 @@
   },
   {
     "Input": "2017年6月6日の午後4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "2018年5月5日午後4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "2018年5月5日4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "2016年1月1日の午後4時から今日午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,7 +133,6 @@
   },
   {
     "Input": "2016年2月21日午後2時から2016年4月23日3時32分まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -157,7 +145,6 @@
   },
   {
     "Input": "今日4時から来週の水曜日5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -170,7 +157,6 @@
   },
   {
     "Input": "今日午後4時から午後5時まで不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -183,7 +169,6 @@
   },
   {
     "Input": "2016年1月1日午後4時から今日午後5時の間は不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -196,7 +181,6 @@
   },
   {
     "Input": "今夜戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -209,7 +193,6 @@
   },
   {
     "Input": "今晩戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -222,7 +205,6 @@
   },
   {
     "Input": "今朝戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -235,7 +217,6 @@
   },
   {
     "Input": "今日の午後戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,6 @@
   },
   {
     "Input": "明日の夜戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -261,7 +241,6 @@
   },
   {
     "Input": "来週月曜日の午後戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -274,7 +253,6 @@
   },
   {
     "Input": "5月5日の夜戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -287,7 +265,6 @@
   },
   {
     "Input": "最後の3分に戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -300,7 +277,6 @@
   },
   {
     "Input": "この3分戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -313,7 +289,6 @@
   },
   {
     "Input": "前の3分戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -325,21 +300,19 @@
     ]
   },
   {
-    "Input": "今から5時間で戻ります。",
-    "NotSupported": "dotnet",
+    "Input": "今から5時間以内に戻ります。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今から5時間",
+        "Text": "今から5時間以内に",
         "Type": "datetimerange",
         "Start": 0,
-        "Length": 6
+        "Length": 9
       }
     ]
   },
   {
     "Input": "ぎりぎりに戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -351,25 +324,23 @@
     ]
   },
   {
-    "Input": "1時間で戻ります。",
-    "NotSupported": "dotnet",
+    "Input": "1時間以内に戻ります。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1時間で",
+        "Text": "1時間以内に",
         "Type": "datetimerange",
         "Start": 0,
-        "Length": 4
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "この数分間戻ります。",
-    "NotSupported": "dotnet",
+    "Input": "最後の数分はいません。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "この数分間",
+        "Text": "最後の数分",
         "Type": "datetimerange",
         "Start": 0,
         "Length": 5
@@ -378,7 +349,6 @@
   },
   {
     "Input": "火曜日の午前中に戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -391,7 +361,6 @@
   },
   {
     "Input": "火曜日の午後戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -404,7 +373,6 @@
   },
   {
     "Input": "火曜日の夜戻ります。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -417,7 +385,6 @@
   },
   {
     "Input": "火曜日の早朝に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -430,7 +397,6 @@
   },
   {
     "Input": "火曜日の昼前に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -443,7 +409,6 @@
   },
   {
     "Input": "火曜日の昼すぎに会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -456,7 +421,6 @@
   },
   {
     "Input": "火曜日の夕方前に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -469,7 +433,6 @@
   },
   {
     "Input": "火曜日の夕方に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -482,7 +445,6 @@
   },
   {
     "Input": "火曜日の深夜に会いましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -495,20 +457,18 @@
   },
   {
     "Input": "今日の残りの時間は不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "残りの時間",
+        "Text": "今日の残りの時間",
         "Type": "datetimerange",
-        "Start": 3,
-        "Length": 5
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
   {
     "Input": "この日の残りの時間は不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -521,7 +481,6 @@
   },
   {
     "Input": "当日の残りの時間は不在にします。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -534,7 +493,6 @@
   },
   {
     "Input": "コルタナ、金曜日の午後1時から午後4時の間にウェインとスカイプでビジネス会議の予定を入れてください。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -547,7 +505,6 @@
   },
   {
     "Input": "明日の午前8時から午後2時の間で私たちの予定を組んでもらえますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -560,7 +517,6 @@
   },
   {
     "Input": "12月9日の午前8時から午後2時の間で私たちの予定を組んでもらえますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -573,46 +529,42 @@
   },
   {
     "Input": "こんにちはコルタナ。ジェニファーとスカイプ会議の予定を入れてください。今週の金曜日の午後に30分の会議が必要です。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の金曜日の午後",
+        "Text": "今週の金曜日の午後に",
         "Type": "datetimerange",
         "Start": 35,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
   {
     "Input": "2015年9月23日の午後1時から4時までで私たちの予定を組んでもらえますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2015年9月23日の午後1時から4時",
+        "Text": "2015年9月23日の午後1時から4時まで",
         "Type": "datetimerange",
         "Start": 0,
-        "Length": 19
+        "Length": 21
       }
     ]
   },
   {
     "Input": "2015年9月23日の午後1時30分から4時までで私たちの予定を組んでもらえますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2015年9月23日の午後1時30分から4時",
+        "Text": "2015年9月23日の午後1時30分から4時まで",
         "Type": "datetimerange",
         "Start": 0,
-        "Length": 22
+        "Length": 24
       }
     ]
   },
   {
     "Input": "それは今後2時間のうちに起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -625,7 +577,6 @@
   },
   {
     "Input": "それは2015年1月1日の10時から11時30分の間に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -638,7 +589,6 @@
   },
   {
     "Input": "それは2015年1月1日の10時30分から3時に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -651,7 +601,6 @@
   },
   {
     "Input": "それは2015年1月1日の3時から5時の間に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -664,7 +613,6 @@
   },
   {
     "Input": "それは2015年1月1日の3時30分から5時55分の間に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -677,7 +625,6 @@
   },
   {
     "Input": "それは2015年1月1日の2時以降に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -690,7 +637,6 @@
   },
   {
     "Input": "それは今日の午後4時前に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -703,7 +649,6 @@
   },
   {
     "Input": "それは来週の水曜日の午前10時以降に起きるでしょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -716,7 +661,6 @@
   },
   {
     "Input": "それは前の火曜日の午後2時までに起きた。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -729,7 +673,6 @@
   },
   {
     "Input": "2月1日の6時までには行きましょう。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -742,7 +685,7 @@
   },
   {
     "Input": "7月25日の朝の中小企業株式公告のまとめ",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7月25日の朝",
@@ -754,7 +697,7 @@
   },
   {
     "Input": "2019年7月25日の朝の糧油相場の簡単な分析",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2019年7月25日の朝",
@@ -766,7 +709,7 @@
   },
   {
     "Input": "あと5分間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "あと5分間",
@@ -778,7 +721,7 @@
   },
   {
     "Input": "昨日の午後2時から明日の4時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の午後2時から明日の4時まで",
@@ -790,7 +733,7 @@
   },
   {
     "Input": "昨日の午後2時から4時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の午後2時から4時まで",
@@ -802,7 +745,7 @@
   },
   {
     "Input": "2時-明日の4時",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2時-明日の4時",
@@ -814,7 +757,7 @@
   },
   {
     "Input": "前の3時間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の3時間",
@@ -826,7 +769,7 @@
   },
   {
     "Input": "昨夜",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨夜",
@@ -841,7 +784,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7月25日の朝",
@@ -859,7 +802,7 @@
   },
   {
     "Input": "昨日5:00-6:00",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日5:00-6:00",
@@ -871,7 +814,7 @@
   },
   {
     "Input": "昨日の夜",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の夜",
@@ -883,7 +826,7 @@
   },
   {
     "Input": "前の一時間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の一時間",
@@ -895,7 +838,7 @@
   },
   {
     "Input": "明日の午前",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の午前",
@@ -907,7 +850,7 @@
   },
   {
     "Input": "明日の2時から4時まで",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の2時から4時まで",
@@ -919,7 +862,7 @@
   },
   {
     "Input": "1月15日の4時から2月3日の9時までの間",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1月15日の4時から2月3日の9時までの間",

--- a/Specs/DateTime/Japanese/DateTimePeriodParser.json
+++ b/Specs/DateTime/Japanese/DateTimePeriodParser.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -31,7 +30,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -58,7 +56,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -85,7 +82,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -112,17 +108,16 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016年1月1日の5時から6時まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(XXXX-01-01T05,XXXX-01-01T06,PT1H)",
+          "Timex": "(2016-01-01T05,2016-01-01T06,PT1H)",
           "FutureResolution": {
-            "startDateTime": "2017-01-01 05:00:00",
-            "endDateTime": "2017-01-01 06:00:00"
+            "startDateTime": "2016-01-01 05:00:00",
+            "endDateTime": "2016-01-01 06:00:00"
           },
           "PastResolution": {
             "startDateTime": "2016-01-01 05:00:00",
@@ -139,7 +134,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -166,14 +160,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "明日の3時から4時まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-08T03:00,2016-11-08T04:00,PT1H)",
+          "Timex": "(2016-11-08T03,2016-11-08T04,PT1H)",
           "FutureResolution": {
             "startDateTime": "2016-11-08 03:00:00",
             "endDateTime": "2016-11-08 04:00:00"
@@ -193,7 +186,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -220,14 +212,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "今日の午後4時から明日の午後5時まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-11-07T16,2016-11-08T17,PT25H)",
+          "Timex": "(2016-11-07T16:00:00,2016-11-08T17:00:00,PT25H)",
           "FutureResolution": {
             "startDateTime": "2016-11-07 16:00:00",
             "endDateTime": "2016-11-08 17:00:00"
@@ -247,14 +238,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016年2月21日の午後2時から2016年4月23日3時32分まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
+          "Timex": "(2016-02-21T14:00:00,2016-04-23T03:32:00,PT1478H)",
           "FutureResolution": {
             "startDateTime": "2016-02-21 14:00:00",
             "endDateTime": "2016-04-23 03:32:00"
@@ -274,7 +264,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -301,14 +290,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016年1月1日の午後4時から今日の午後5時まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-01-01T16,2016-11-07T17,PT7465H)",
+          "Timex": "(2016-01-01T16:00:00,2016-11-07T17:00:00,PT7465H)",
           "FutureResolution": {
             "startDateTime": "2016-01-01 16:00:00",
             "endDateTime": "2016-11-07 17:00:00"
@@ -328,7 +316,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -355,7 +342,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -382,7 +368,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -409,7 +394,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -436,7 +420,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -463,7 +446,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -490,7 +472,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -517,7 +498,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -544,7 +524,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -571,7 +550,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -594,15 +572,14 @@
     ]
   },
   {
-    "Input": "今から5時間で戻ります。",
+    "Input": "今から5時間以内に戻ります。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今から5時間",
+        "Text": "今から5時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
@@ -616,7 +593,7 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 9
       }
     ]
   },
@@ -625,11 +602,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "",
+        "Text": "ぎりぎり",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:11:00,2016-11-07T16:12:00,PT1M)",
@@ -643,20 +619,19 @@
           }
         },
         "Start": 0,
-        "Length": 0
+        "Length": 4
       }
     ]
   },
   {
-    "Input": "1時間で戻ります。",
+    "Input": "1時間以内に戻ります。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1時間で",
+        "Text": "1時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T17:12:00,PT1H)",
@@ -670,20 +645,19 @@
           }
         },
         "Start": 0,
-        "Length": 4
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "これから数時間で戻ります。",
+    "Input": "これから数時間以内に戻ります。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "これから数時間",
+        "Text": "これから数時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T19:12:00,PT3H)",
@@ -697,7 +671,7 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 10
       }
     ]
   },
@@ -706,7 +680,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -733,7 +706,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -760,7 +732,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -787,7 +758,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -814,21 +784,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "火曜日の夜",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TEV",
+          "Timex": "XXXX-WXX-2TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 16:00:00",
-            "endDateTime": "2016-11-08 20:00:00"
+            "startDateTime": "2016-11-08 20:00:00",
+            "endDateTime": "2016-11-08 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 16:00:00",
-            "endDateTime": "2016-11-01 20:00:00"
+            "startDateTime": "2016-11-01 20:00:00",
+            "endDateTime": "2016-11-01 23:59:59"
           }
         },
         "Start": 0,
@@ -841,7 +810,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -868,7 +836,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -895,7 +862,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -922,7 +888,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -949,7 +914,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -959,11 +923,11 @@
           "Timex": "XXXX-WXX-2TEV",
           "FutureResolution": {
             "startDateTime": "2016-11-08 16:00:00",
-            "endDateTime": "2016-11-08 18:00:00"
+            "endDateTime": "2016-11-08 20:00:00"
           },
           "PastResolution": {
             "startDateTime": "2016-11-01 16:00:00",
-            "endDateTime": "2016-11-01 18:00:00"
+            "endDateTime": "2016-11-01 20:00:00"
           }
         },
         "Start": 0,
@@ -976,21 +940,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "火曜日の深夜に",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-WXX-2TEV",
+          "Timex": "XXXX-WXX-2TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-08 18:00:00",
-            "endDateTime": "2016-11-08 20:00:00"
+            "startDateTime": "2016-11-08 20:00:00",
+            "endDateTime": "2016-11-08 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-01 18:00:00",
-            "endDateTime": "2016-11-01 20:00:00"
+            "startDateTime": "2016-11-01 20:00:00",
+            "endDateTime": "2016-11-01 23:59:59"
           }
         },
         "Start": 0,
@@ -1003,11 +966,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "残りの時間",
+        "Text": "今日の残りの時間",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T23:59:59,PT28079S)",
@@ -1020,8 +982,8 @@
             "endDateTime": "2016-11-07 23:59:59"
           }
         },
-        "Start": 3,
-        "Length": 5
+        "Start": 0,
+        "Length": 8
       }
     ]
   },
@@ -1030,7 +992,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1057,7 +1018,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1084,14 +1044,13 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
         "Text": "2016年2月21日午後2時から2016年4月23日3時32分まで",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "(2016-02-21T14:00,2016-04-23T03:32,PT1478H)",
+          "Timex": "(2016-02-21T14:00:00,2016-04-23T03:32:00,PT1478H)",
           "FutureResolution": {
             "startDateTime": "2016-02-21 14:00:00",
             "endDateTime": "2016-04-23 03:32:00"
@@ -1111,7 +1070,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1138,7 +1096,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1165,7 +1122,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-09T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1192,11 +1148,10 @@
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の金曜日の午後",
+        "Text": "今週の金曜日の午後に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2017-11-17TAF",
@@ -1210,7 +1165,7 @@
           }
         },
         "Start": 35,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -1219,11 +1174,10 @@
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今週の金曜日の午後",
+        "Text": "今週の金曜日の午後に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2017-11-17TAF",
@@ -1237,7 +1191,7 @@
           }
         },
         "Start": 35,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -1246,11 +1200,10 @@
     "Context": {
       "ReferenceDateTime": "2017-11-13T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "来週の金曜日の午後",
+        "Text": "来週の金曜日の午後に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "2017-11-24TAF",
@@ -1264,7 +1217,7 @@
           }
         },
         "Start": 35,
-        "Length": 9
+        "Length": 10
       }
     ]
   },
@@ -1273,7 +1226,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-14T19:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1300,7 +1252,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-17T19:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1327,7 +1278,6 @@
     "Context": {
       "ReferenceDateTime": "2017-11-17T19:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1354,7 +1304,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1377,15 +1326,14 @@
     ]
   },
   {
-    "Input": "それは今後2時間のうちに起きるでしょう。",
+    "Input": "それは今後2時間以内に起きるでしょう。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今後2時間",
+        "Text": "今後2時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T18:12:00,PT2H)",
@@ -1399,20 +1347,19 @@
           }
         },
         "Start": 3,
-        "Length": 5
+        "Length": 8
       }
     ]
   },
   {
-    "Input": "15秒で戻ってきます。",
+    "Input": "15秒以内に戻ってきます。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "15秒で",
+        "Text": "15秒以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T16:12:15,PT15S)",
@@ -1426,20 +1373,19 @@
           }
         },
         "Start": 0,
-        "Length": 4
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "5分で戻ってきます。",
+    "Input": "5分以内に戻ってきます。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5分で",
+        "Text": "5分以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T16:17:00,PT5M)",
@@ -1453,20 +1399,19 @@
           }
         },
         "Start": 0,
-        "Length": 3
+        "Length": 5
       }
     ]
   },
   {
-    "Input": "5時間で戻ってきます。",
+    "Input": "5時間以内に戻ってきます。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "5時間で",
+        "Text": "5時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
@@ -1480,20 +1425,19 @@
           }
         },
         "Start": 0,
-        "Length": 4
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "1日と5時間で戻ってきます。",
+    "Input": "1日と5時間以内に戻ってきます。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "1日と5時間で",
+        "Text": "1日と5時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-08T21:12:00,P1DT5H)",
@@ -1507,20 +1451,19 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 9
       }
     ]
   },
   {
-    "Input": "この仕事は2日と1時間5分30秒で完了するでしょう。",
+    "Input": "この仕事は2日と1時間5分30秒以内に完了するでしょう。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "2日と1時間5分30秒で",
+        "Text": "2日と1時間5分30秒以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
@@ -1534,20 +1477,19 @@
           }
         },
         "Start": 5,
-        "Length": 12
+        "Length": 14
       }
     ]
   },
   {
-    "Input": "この仕事は今から2日と1時間5分30秒で完了するでしょう。",
+    "Input": "この仕事は今から2日と1時間5分30秒以内に完了するでしょう。",
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今から2日と1時間5分30秒で",
+        "Text": "今から2日と1時間5分30秒以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-09T17:17:30,P2DT1H5M30S)",
@@ -1561,7 +1503,7 @@
           }
         },
         "Start": 5,
-        "Length": 15
+        "Length": 17
       }
     ]
   },
@@ -1570,11 +1512,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "今から5時間以内",
+        "Text": "今から5時間以内に",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T21:12:00,PT5H)",
@@ -1588,7 +1529,7 @@
           }
         },
         "Start": 0,
-        "Length": 8
+        "Length": 9
       }
     ]
   },
@@ -1597,7 +1538,6 @@
     "Context": {
       "ReferenceDateTime": "2018-04-19T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1624,11 +1564,10 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "月曜日の12時から4時",
+        "Text": "月曜日の12時から4時の間",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-WXX-1T00,XXXX-WXX-1T04,PT4H)",
@@ -1642,7 +1581,7 @@
           }
         },
         "Start": 5,
-        "Length": 11
+        "Length": 13
       }
     ]
   },
@@ -1651,11 +1590,10 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "月曜日の11時から4時",
+        "Text": "月曜日の11時から4時の間",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(XXXX-WXX-1T11,XXXX-WXX-1T16,PT5H)",
@@ -1669,7 +1607,7 @@
           }
         },
         "Start": 5,
-        "Length": 11
+        "Length": 13
       }
     ]
   },
@@ -1678,7 +1616,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1705,7 +1642,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1732,7 +1668,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1759,7 +1694,6 @@
     "Context": {
       "ReferenceDateTime": "2018-05-16T08:12:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -1786,7 +1720,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "8月7日の朝",
@@ -1812,7 +1746,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の昼",
@@ -1838,7 +1772,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2時-明日の4時",
@@ -1864,7 +1798,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日5:00-6:00",
@@ -1890,7 +1824,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の朝",
@@ -1916,7 +1850,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今夜7時から7時30分まで",
@@ -1942,7 +1876,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-09T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7月5日朝",
@@ -1968,7 +1902,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日の午前",
@@ -1994,24 +1928,24 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "8月7日の夜",
+        "Text": "8月7日の夜に",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-08-07TEV",
+          "Timex": "XXXX-08-07TNI",
           "FutureResolution": {
-            "startDateTime": "2020-08-07 16:00:00",
-            "endDateTime": "2020-08-07 20:00:00"
+            "startDateTime": "2020-08-07 20:00:00",
+            "endDateTime": "2020-08-07 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2019-08-07 16:00:00",
-            "endDateTime": "2019-08-07 20:00:00"
+            "startDateTime": "2019-08-07 20:00:00",
+            "endDateTime": "2019-08-07 23:59:59"
           }
         },
         "Start": 6,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -2020,7 +1954,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今夜8時から9時まで",
@@ -2046,7 +1980,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の3時間",
@@ -2072,20 +2006,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の夜",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-06TEV",
+          "Timex": "2016-11-06TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-06 16:00:00",
-            "endDateTime": "2016-11-06 20:00:00"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-06 16:00:00",
-            "endDateTime": "2016-11-06 20:00:00"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           }
         },
         "Start": 0,
@@ -2098,7 +2032,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "今から8時まで",
@@ -2124,20 +2058,20 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨夜",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "2016-11-06TEV",
+          "Timex": "2016-11-06TNI",
           "FutureResolution": {
-            "startDateTime": "2016-11-06 16:00:00",
-            "endDateTime": "2016-11-06 20:00:00"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2016-11-06 16:00:00",
-            "endDateTime": "2016-11-06 20:00:00"
+            "startDateTime": "2016-11-06 20:00:00",
+            "endDateTime": "2016-11-06 23:59:59"
           }
         },
         "Start": 0,
@@ -2150,24 +2084,24 @@
     "Context": {
       "ReferenceDateTime": "2019-08-09T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "7月5日の夜",
+        "Text": "7月5日の夜に",
         "Type": "datetimerange",
         "Value": {
-          "Timex": "XXXX-07-05TEV",
+          "Timex": "XXXX-07-05TNI",
           "FutureResolution": {
-            "startDateTime": "2020-07-05 16:00:00",
-            "endDateTime": "2020-07-05 20:00:00"
+            "startDateTime": "2020-07-05 20:00:00",
+            "endDateTime": "2020-07-05 23:59:59"
           },
           "PastResolution": {
-            "startDateTime": "2019-07-05 16:00:00",
-            "endDateTime": "2019-07-05 20:00:00"
+            "startDateTime": "2019-07-05 20:00:00",
+            "endDateTime": "2019-07-05 23:59:59"
           }
         },
         "Start": 3,
-        "Length": 6
+        "Length": 7
       }
     ]
   },
@@ -2176,7 +2110,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "1月15日の4時から2月3日の9時までの間",
@@ -2199,7 +2133,7 @@
   },
   {
     "Input": "2019年7月25日の朝の糧油相場の簡単な分析",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "2019年7月25日の朝",
@@ -2225,7 +2159,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7月25日の午前中",
@@ -2268,7 +2202,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "前の一時間",
@@ -2294,10 +2228,10 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "未来の3時間に",
+        "Text": "未来の3時間",
         "Type": "datetimerange",
         "Value": {
           "Timex": "(2016-11-07T16:12:00,2016-11-07T19:12:00,PT3H)",
@@ -2311,7 +2245,7 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
@@ -2320,7 +2254,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-09T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "明日朝",
@@ -2346,7 +2280,7 @@
     "Context": {
       "ReferenceDateTime": "2019-08-19T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "7月25日の午前中",
@@ -2372,7 +2306,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の午後2時から明日4時まで",
@@ -2398,7 +2332,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "あと5分間",
@@ -2424,7 +2358,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T16:12:00"
     },
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "昨日の午後2時から4時まで",
@@ -2442,6 +2376,84 @@
         },
         "Start": 0,
         "Length": 13
+      }
+    ]
+  },
+  {
+    "Input": "昨日の晩",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "昨日の晩",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "2016-11-06TEV",
+          "FutureResolution": {
+            "startDateTime": "2016-11-06 16:00:00",
+            "endDateTime": "2016-11-06 20:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-06 16:00:00",
+            "endDateTime": "2016-11-06 20:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 4
+      }
+    ]
+  },
+  {
+    "Input": "火曜日の晩戻ります。",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T16:12:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "火曜日の晩",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-WXX-2TEV",
+          "FutureResolution": {
+            "startDateTime": "2016-11-08 16:00:00",
+            "endDateTime": "2016-11-08 20:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2016-11-01 16:00:00",
+            "endDateTime": "2016-11-01 20:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 5
+      }
+    ]
+  },
+  {
+    "Input": "台風は7月5日の晩に通過します。",
+    "Context": {
+      "ReferenceDateTime": "2019-08-09T16:12:00"
+    },
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "7月5日の晩",
+        "Type": "datetimerange",
+        "Value": {
+          "Timex": "XXXX-07-05TEV",
+          "FutureResolution": {
+            "startDateTime": "2020-07-05 16:00:00",
+            "endDateTime": "2020-07-05 20:00:00"
+          },
+          "PastResolution": {
+            "startDateTime": "2019-07-05 16:00:00",
+            "endDateTime": "2019-07-05 20:00:00"
+          }
+        },
+        "Start": 3,
+        "Length": 6
       }
     ]
   }

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -1669,31 +1669,5 @@
         "Length": 10
       }
     ]
-  },
-  {
-    "Input": "日中",
-    "Context": {
-      "ReferenceDateTime": "2018-10-11T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "日中",
-        "Type": "timerange",
-        "Value": {
-          "Timex": "TDT",
-          "FutureResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
-          },
-          "PastResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
-          }
-        },
-        "Start": 0,
-        "Length": 2
-      }
-    ]
   }
 ]

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -1395,14 +1395,14 @@
         "Text": "昼",
         "Type": "timerange",
         "Value": {
-          "Timex": "TDT",
+          "Timex": "TMI",
           "FutureResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
+            "startTime": "11:00:00",
+            "endTime": "13:00:00"
           },
           "PastResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
+            "startTime": "11:00:00",
+            "endTime": "13:00:00"
           }
         },
         "Start": 0,
@@ -1667,6 +1667,32 @@
         },
         "Start": 0,
         "Length": 10
+      }
+    ]
+  },
+  {
+    "Input": "日中",
+    "Context": {
+      "ReferenceDateTime": "2018-10-11T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "日中",
+        "Type": "timerange",
+        "Value": {
+          "Timex": "TDT",
+          "FutureResolution": {
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
+          },
+          "PastResolution": {
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 2
       }
     ]
   }


### PR DESCRIPTION
All test cases pass.
In DateTimeModel 192 pass, 370 fail.

Modified test cases:
- Cases using 'で' (in) (which indicates a specific date/time point) have been corrected to use '以内に' (within) in order to represent a date/time period as in the English counterpart:
     - 今から5時間で戻ります。 -> 今から5時間以内に戻ります  (I will be back within 5 hours)
     - 1時間で戻ります。 -> 1時間以内に戻ります。 (I'll go back next hour)
     - これから数時間で戻ります。 -> これから数時間以内に戻ります。 (I'll go back next few hours)
     - それは今後2時間のうちに起きるでしょう。 -> それは今後2時間以内に起きるでしょう。 (It will happen 2 hours in the future)
     - 15秒で戻ってきます。 -> 15秒以内に戻ってきます。 (I will be back within 15 seconds)
     - 5分で戻ってきます。 -> 5分以内に戻ってきます。 (I will be back within 5 minutes)
     - 5時間で戻ってきます。 -> 5時間以内に戻ってきます。 (I will be back within 5 hours)
     - 1日と5時間で戻ってきます。 -> 1日と5時間以内に戻ってきます。 (I will be back within 1 day and 5 hours)
     - この仕事は2日と1時間5分30秒で完了するでしょう。 -> この仕事は2日と1時間5分30秒以内に完了するでしょう。 (This task would complete within 2 days 1 hour 5 minutes 30 seconds)
     - この仕事は今から2日と1時間5分30秒で完了するでしょう。 -> この仕事は今から2日と1時間5分30秒以内に完了するで しょう。 (This task would complete within next 2 days 1 hour 5 minutes 30 seconds)
- この数分間戻ります。-> 最後の数分はいません。(I'll go back last few minutes): corrected expression for 'last few minutes' (originally it meant 'these few minutes').
- Patterns containing '夜' (night) were wrongly resolved to 'evening' and have been updated. New test cases containing 'の晩' (evening) have been added:
     - 火曜日の夜戻ります。 -> 火曜日の晩戻ります。
     - 火曜日の深夜に会いましょう。
     - タキシードは8月7日の夜にお宅に送ります。
     - 昨日の夜 -> 昨日の晩
     - 昨夜
     - 台風は7月5日の夜に通過します。 -> 台風は7月5日の晩に通過します。