### PR TITLE
[JA DateTimeV2] Set refinements

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Chinese/DateTimeDefinitions.cs
@@ -183,8 +183,10 @@ namespace Microsoft.Recognizers.Definitions.Chinese
       public const string SetUnitRegex = @"(?<unit>年|月|周|星期|日|天|小时|时|分钟|分|秒钟|秒)";
       public static readonly string SetEachUnitRegex = $@"(?<each>(每个|每一|每)\s*{SetUnitRegex})";
       public const string SetEachPrefixRegex = @"(?<each>(每)\s*$)";
+      public const string SetEachSuffixRegex = @"^[.]";
       public const string SetLastRegex = @"(?<last>last|this|next)";
       public const string SetEachDayRegex = @"(每|每一)(天|日)\s*$";
+      public const string SetEachDateUnitRegex = @"^[.]";
       public const string TimeHourNumRegex = @"(00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)";
       public const string TimeMinuteNumRegex = @"(00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";
       public const string TimeSecondNumRegex = @"(00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Japanese/DateTimeDefinitions.cs
@@ -134,7 +134,12 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string TomorrowRegex = @"(?<tomorrow>明日の?(午前|午後|中|夜|朝)?)";
       public const string YesterdayRegex = @"(?<yesterday>昨日の?(午前|午後|中|夜|朝)?)";
       public const string TodayRegex = @"(?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)";
-      public static readonly string TimeOfSpecialDayRegex = $@"(((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?)|((((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))(?<in>で|の?うちに)))";
+      public static readonly string SpecialDayHourRegex = $@"((?<hour>{TimeHourCJKRegex}|{TimeHourNumRegex})(時間?|(:00)))";
+      public static readonly string SpecialDayMinuteRegex = $@"((?<min>{TimeMinuteCJKRegex}|{TimeMinuteNumRegex})分間?)";
+      public static readonly string SpecialDaySecondRegex = $@"((?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex})秒間?)";
+      public const string SpecialDayModRegex = @"((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))";
+      public static readonly string SpecialDayEndOfRegex = $@"((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))";
+      public static readonly string TimeOfSpecialDayRegex = $@"(({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})";
       public const string NowTimeRegex = @"(现在|今)";
       public const string RecentlyTimeRegex = @"(刚刚才?|刚才)";
       public const string AsapTimeRegex = @"(出来る限り早く|立刻|马上)";
@@ -200,11 +205,13 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly string LunarHolidayRegex = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>除夕|春节|旧暦の正月初一|中秋(節|节)?|元宵(节|節)|端午(节|の節句)?|重(阳节|陽節))";
       public static readonly string HolidayRegexList1 = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的|の)?)?(?<holiday>新年|五一|劳动节|国際的な労働者の日|メーデー|元旦节|元旦|大晦日|愚人节|エイプリルフール|圣诞节|クリスマス(の日|イブ)?|感謝祭(の日)?|クリーンマンデイ|父の日|植树节|国庆节|国慶節|情人节|バレンタインデー|教(师节|師の日)|儿童节|妇女节|青年(节|の日)|建军节|建軍節|女生节|光棍节|双十一|清明(节|節)?|キング牧師記念日|旧正月|ガールズデー|(こども|子ども|子供)の日|お正月|植樹祭|シングルデー|シングルズデー|国際婦人デー|ダブル十一|復活祭|イースター)";
       public static readonly string HolidayRegexList2 = $@"(({YearRegex}|{DatePeriodYearInCJKRegex}|(?<yearrel>明年|今年|去年|来年))(的)?)?(?<holiday>母(亲节|の日)|父亲节|感恩节|万圣节|ハロウィン)";
-      public const string SetUnitRegex = @"(?<unit>年|月|周|星期|日|天|小时|时|分钟|分|秒钟|秒)";
-      public static readonly string SetEachUnitRegex = $@"(?<each>(每个|每一|每)\s*{SetUnitRegex})";
-      public const string SetEachPrefixRegex = @"(?<each>(每)\s*$)";
+      public const string SetUnitRegex = @"(?<unit>年|月|隔週|週|日|時|分|秒)";
+      public static readonly string SetEachUnitRegex = $@"((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<=\d)泊|(?<unit>隔週))";
+      public const string SetEachPrefixRegex = @"((?<each>毎|隔|各|ごとに)\s*$)";
+      public const string SetEachSuffixRegex = @"(^\s*(?<each>ごとに))";
       public const string SetLastRegex = @"(?<last>last|this|next)";
-      public const string SetEachDayRegex = @"(每|每一)(天|日)\s*$";
+      public const string SetEachDayRegex = @"(毎|各|毎一)(天|日)\s*$";
+      public const string SetEachDateUnitRegex = @"(毎)(年|月|週)\s*$";
       public const string TimeHourNumRegex = @"([0-1]?\d|2[0-4])";
       public const string TimeMinuteNumRegex = @"([0-5]?\d)";
       public const string TimeSecondNumRegex = @"([0-5]?\d)";
@@ -222,7 +229,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public const string TimeQuarterRegex = @"(?<quarter>[一两二三四1-4])\s*(刻钟|刻)";
       public static readonly string TimeCJKTimeRegex = $@"{TimeHourRegex}({TimeQuarterRegex}|{TimeHalfRegex}|((((过|又)?{TimeMinuteRegex})({TimeSecondRegex})?)|({TimeSecondRegex})))?";
       public static readonly string TimeDigitTimeRegex = $@"(?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?(am|pm)?";
-      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
+      public static readonly string TimeDayDescRegex = $@"(?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))";
       public const string TimeApproximateDescPreffixRegex = @"(ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)";
       public const string TimeApproximateDescSuffixRegex = @"(ごろに|ごろ|過ぎに|過ぎ|丁度に|丁度|きっかりに|きっかり|を過ぎた頃に|を過ぎた頃|ちょっと前に|ちょっと前|近くに|近く|昼食時|昼食|ぐらい|時かっきり|頃|かっきり|以降|まで(の間)?|の間|間で?|間以内)";
       public static readonly string TimeRegexes1 = $@"{TimeApproximateDescPreffixRegex}?({TimeDayDescRegex}(の)?)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex})((の)?{TimeDayDescRegex})?{TimeApproximateDescSuffixRegex}?";
@@ -265,6 +272,7 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"週", @"W" },
             { @"週間", @"W" },
             { @"星期", @"W" },
+            { @"隔週", @"W" },
             { @"个星期", @"W" },
             { @"日", @"D" },
             { @"日間", @"D" },
@@ -695,6 +703,8 @@ namespace Microsoft.Recognizers.Definitions.Japanese
       public static readonly Dictionary<string, int> TimeLowBoundDesc = new Dictionary<string, int>
         {
             { @"夜", 18 },
+            { @"晚", 18 },
+            { @"晩", 18 },
             { @"午後", 12 },
             { @"午后", 12 },
             { @"pm", 12 },
@@ -797,5 +807,10 @@ namespace Microsoft.Recognizers.Definitions.Japanese
             { @"元治", 1864 },
             { @"慶応", 1865 }
         };
+      public const string DayTypeRegex = @"^(天|日)$";
+      public const string WeekTypeRegex = @"^(周|星期|週)$";
+      public const string BiWeekTypeRegex = @"^(隔週)$";
+      public const string MonthTypeRegex = @"^(月)$";
+      public const string YearTypeRegex = @"^(年)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Korean/DateTimeDefinitions.cs
@@ -198,8 +198,10 @@ namespace Microsoft.Recognizers.Definitions.Korean
       public const string SetUnitRegex = @"(?<unit>년|월|달|주일?|일|시간|시|분|초)";
       public static readonly string SetEachUnitRegex = $@"(?<each>{SetUnitRegex}\s?(마다))";
       public const string SetEachPrefixRegex = @"(?<each>(매)\s*$)";
+      public const string SetEachSuffixRegex = @"^[.]";
       public const string SetLastRegex = @"(?<last>last|this|next)";
       public const string SetEachDayRegex = @"(每|每一)(天|日)\s*$";
+      public const string SetEachDateUnitRegex = @"^[.]";
       public const string TimeHourNumRegex = @"(00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)";
       public const string TimeMinuteNumRegex = @"(00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";
       public const string TimeSecondNumRegex = @"(00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|0|1|2|3|4|5|6|7|8|9)";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Extractors/ChineseSetExtractorConfiguration.cs
@@ -17,9 +17,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
 
+        public static readonly Regex EachSuffixRegex = new Regex(DateTimeDefinitions.SetEachSuffixRegex, RegexFlags);
+
         public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
+
+        public static readonly Regex EachDateUnitRegex = new Regex(DateTimeDefinitions.SetEachDateUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -53,10 +57,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
 
         Regex ICJKSetExtractorConfiguration.EachPrefixRegex => EachPrefixRegex;
 
+        Regex ICJKSetExtractorConfiguration.EachSuffixRegex => EachSuffixRegex;
+
         Regex ICJKSetExtractorConfiguration.EachUnitRegex => EachUnitRegex;
 
         Regex ICJKSetExtractorConfiguration.UnitRegex => UnitRegex;
 
         Regex ICJKSetExtractorConfiguration.EachDayRegex => EachDayRegex;
+
+        Regex ICJKSetExtractorConfiguration.EachDateUnitRegex => EachDateUnitRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Chinese/Parsers/ChineseSetParserConfiguration.cs
@@ -17,23 +17,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
             DateExtractor = config.DateExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
 
             DurationParser = config.DurationParser;
             TimeParser = config.TimeParser;
+            TimePeriodParser = config.TimePeriodParser;
             DateParser = config.DateParser;
             DateTimeParser = config.DateTimeParser;
 
             EachPrefixRegex = ChineseSetExtractorConfiguration.EachPrefixRegex;
             EachUnitRegex = ChineseSetExtractorConfiguration.EachUnitRegex;
             EachDayRegex = ChineseSetExtractorConfiguration.EachDayRegex;
+            EachDateUnitRegex = ChineseSetExtractorConfiguration.EachDateUnitRegex;
             UnitMap = config.UnitMap;
         }
 
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
+
+        public IDateTimeExtractor TimePeriodExtractor { get; }
 
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -42,6 +47,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public IDateTimeParser DurationParser { get; }
 
         public IDateTimeParser TimeParser { get; }
+
+        public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DateParser { get; }
 
@@ -52,6 +59,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Chinese
         public Regex EachUnitRegex { get; }
 
         public Regex EachDayRegex { get; }
+
+        public Regex EachDateUnitRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/CJK/ICJKSetExtractorConfiguration.cs
@@ -12,11 +12,15 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         Regex EachPrefixRegex { get; }
 
+        Regex EachSuffixRegex { get; }
+
         Regex EachUnitRegex { get; }
 
         Regex UnitRegex { get; }
 
         Regex EachDayRegex { get; }
+
+        Regex EachDateUnitRegex { get; }
 
         IDateTimeExtractor DurationExtractor { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Extractors/JapaneseSetExtractorConfiguration.cs
@@ -17,9 +17,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
 
+        public static readonly Regex EachSuffixRegex = new Regex(DateTimeDefinitions.SetEachSuffixRegex, RegexFlags);
+
         public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
+
+        public static readonly Regex EachDateUnitRegex = new Regex(DateTimeDefinitions.SetEachDateUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -53,10 +57,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         Regex ICJKSetExtractorConfiguration.EachPrefixRegex => EachPrefixRegex;
 
+        Regex ICJKSetExtractorConfiguration.EachSuffixRegex => EachSuffixRegex;
+
         Regex ICJKSetExtractorConfiguration.EachUnitRegex => EachUnitRegex;
 
         Regex ICJKSetExtractorConfiguration.UnitRegex => UnitRegex;
 
         Regex ICJKSetExtractorConfiguration.EachDayRegex => EachDayRegex;
+
+        Regex ICJKSetExtractorConfiguration.EachDateUnitRegex => EachDateUnitRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Japanese/Parsers/JapaneseSetParserConfiguration.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using Microsoft.Recognizers.Definitions.Japanese;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
 
@@ -12,28 +13,50 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 {
     public class JapaneseSetParserConfiguration : BaseDateTimeOptionsConfiguration, ICJKSetParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+        private static readonly Regex DayTypeRegex =
+            new Regex(DateTimeDefinitions.DayTypeRegex, RegexFlags);
+
+        private static readonly Regex WeekTypeRegex =
+            new Regex(DateTimeDefinitions.WeekTypeRegex, RegexFlags);
+
+        private static readonly Regex BiWeekTypeRegex =
+            new Regex(DateTimeDefinitions.BiWeekTypeRegex, RegexFlags);
+
+        private static readonly Regex MonthTypeRegex =
+            new Regex(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
+
+        private static readonly Regex YearTypeRegex =
+            new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
+
         public JapaneseSetParserConfiguration(ICJKCommonDateTimeParserConfiguration config)
             : base(config)
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
             DateExtractor = config.DateExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
 
             DurationParser = config.DurationParser;
             TimeParser = config.TimeParser;
+            TimePeriodParser = config.TimePeriodParser;
             DateParser = config.DateParser;
             DateTimeParser = config.DateTimeParser;
 
             EachPrefixRegex = JapaneseSetExtractorConfiguration.EachPrefixRegex;
             EachUnitRegex = JapaneseSetExtractorConfiguration.EachUnitRegex;
             EachDayRegex = JapaneseSetExtractorConfiguration.EachDayRegex;
+            EachDateUnitRegex = JapaneseSetExtractorConfiguration.EachDateUnitRegex;
             UnitMap = config.UnitMap;
         }
 
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
+
+        public IDateTimeExtractor TimePeriodExtractor { get; }
 
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -42,6 +65,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
         public IDateTimeParser DurationParser { get; }
 
         public IDateTimeParser TimeParser { get; }
+
+        public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DateParser { get; }
 
@@ -53,28 +78,31 @@ namespace Microsoft.Recognizers.Text.DateTime.Japanese
 
         public Regex EachDayRegex { get; }
 
+        public Regex EachDateUnitRegex { get; }
+
         public IImmutableDictionary<string, string> UnitMap { get; }
 
         public bool GetMatchedUnitTimex(string text, out string timex)
         {
             var trimmedText = text.Trim();
 
-            // @TODO move hardcoded values to resources file
-            if (trimmedText.Equals("天", StringComparison.Ordinal) ||
-                trimmedText.Equals("日", StringComparison.Ordinal))
+            if (DayTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1D";
             }
-            else if (trimmedText.Equals("周", StringComparison.Ordinal) ||
-                     trimmedText.Equals("星期", StringComparison.Ordinal))
+            else if (BiWeekTypeRegex.IsMatch(trimmedText))
+            {
+                timex = "P2W";
+            }
+            else if (WeekTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1W";
             }
-            else if (trimmedText.Equals("月", StringComparison.Ordinal))
+            else if (MonthTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1M";
             }
-            else if (trimmedText.Equals("年", StringComparison.Ordinal))
+            else if (YearTypeRegex.IsMatch(trimmedText))
             {
                 timex = "P1Y";
             }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanSetExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Extractors/KoreanSetExtractorConfiguration.cs
@@ -17,9 +17,13 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         public static readonly Regex EachPrefixRegex = new Regex(DateTimeDefinitions.SetEachPrefixRegex, RegexFlags);
 
+        public static readonly Regex EachSuffixRegex = new Regex(DateTimeDefinitions.SetEachSuffixRegex, RegexFlags);
+
         public static readonly Regex LastRegex = new Regex(DateTimeDefinitions.SetLastRegex, RegexFlags);
 
         public static readonly Regex EachDayRegex = new Regex(DateTimeDefinitions.SetEachDayRegex, RegexFlags);
+
+        public static readonly Regex EachDateUnitRegex = new Regex(DateTimeDefinitions.SetEachDateUnitRegex, RegexFlags);
 
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
@@ -53,10 +57,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
 
         Regex ICJKSetExtractorConfiguration.EachPrefixRegex => EachPrefixRegex;
 
+        Regex ICJKSetExtractorConfiguration.EachSuffixRegex => EachSuffixRegex;
+
         Regex ICJKSetExtractorConfiguration.EachUnitRegex => EachUnitRegex;
 
         Regex ICJKSetExtractorConfiguration.UnitRegex => UnitRegex;
 
         Regex ICJKSetExtractorConfiguration.EachDayRegex => EachDayRegex;
+
+        Regex ICJKSetExtractorConfiguration.EachDateUnitRegex => EachDateUnitRegex;
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Korean/Parsers/KoreanSetParserConfiguration.cs
@@ -17,23 +17,28 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         {
             DurationExtractor = config.DurationExtractor;
             TimeExtractor = config.TimeExtractor;
+            TimePeriodExtractor = config.TimePeriodExtractor;
             DateExtractor = config.DateExtractor;
             DateTimeExtractor = config.DateTimeExtractor;
 
             DurationParser = config.DurationParser;
             TimeParser = config.TimeParser;
+            TimePeriodParser = config.TimePeriodParser;
             DateParser = config.DateParser;
             DateTimeParser = config.DateTimeParser;
 
             EachPrefixRegex = KoreanSetExtractorConfiguration.EachPrefixRegex;
             EachUnitRegex = KoreanSetExtractorConfiguration.EachUnitRegex;
             EachDayRegex = KoreanSetExtractorConfiguration.EachDayRegex;
+            EachDateUnitRegex = KoreanSetExtractorConfiguration.EachDateUnitRegex;
             UnitMap = config.UnitMap;
         }
 
         public IDateTimeExtractor DurationExtractor { get; }
 
         public IDateTimeExtractor TimeExtractor { get; }
+
+        public IDateTimeExtractor TimePeriodExtractor { get; }
 
         public IDateTimeExtractor DateExtractor { get; }
 
@@ -42,6 +47,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public IDateTimeParser DurationParser { get; }
 
         public IDateTimeParser TimeParser { get; }
+
+        public IDateTimeParser TimePeriodParser { get; }
 
         public IDateTimeParser DateParser { get; }
 
@@ -52,6 +59,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Korean
         public Regex EachUnitRegex { get; }
 
         public Regex EachDayRegex { get; }
+
+        public Regex EachDateUnitRegex { get; }
 
         public IImmutableDictionary<string, string> UnitMap { get; }
 

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseSetParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Recognizers.Text.DateTime.Utilities;
 using Microsoft.Recognizers.Text.Utilities;
 using DateObject = System.DateTime;
 
@@ -111,15 +112,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             return candidateResults;
         }
 
-        private DateTimeResolutionResult ResolveSet(ref DateTimeResolutionResult result, string innerTimex)
-        {
-            result.Timex = innerTimex;
-            result.FutureValue = result.PastValue = "Set: " + innerTimex;
-            result.Success = true;
-
-            return result;
-        }
-
         private DateTimeResolutionResult ParseEachDuration(string text, DateObject refDate)
         {
             var ret = new DateTimeResolutionResult();
@@ -136,7 +128,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var pr = this.config.DurationParser.Parse(ers[0], DateObject.Now);
 
-                ret = ResolveSet(ref ret, pr.TimexStr);
+                ret = SetHandler.ResolveSet(ref ret, pr.TimexStr);
             }
 
             return ret;
@@ -156,7 +148,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
 
-                ret = ResolveSet(ref ret, timex);
+                ret = SetHandler.ResolveSet(ref ret, timex);
 
                 return ret;
             }
@@ -186,7 +178,7 @@ namespace Microsoft.Recognizers.Text.DateTime
                         timex = timex.Replace("1", "2");
                     }
 
-                    ret = ResolveSet(ref ret, timex);
+                    ret = SetHandler.ResolveSet(ref ret, timex);
                 }
             }
 
@@ -211,7 +203,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var pr = this.config.TimeParser.Parse(ers[0], DateObject.Now);
 
-                ret = ResolveSet(ref ret, pr.TimexStr);
+                ret = SetHandler.ResolveSet(ref ret, pr.TimexStr);
             }
 
             return ret;
@@ -256,7 +248,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             {
                 var pr = parser.Parse(ers[0], refDate);
 
-                ret = ResolveSet(ref ret, pr.TimexStr);
+                ret = SetHandler.ResolveSet(ref ret, pr.TimexStr);
             }
 
             return ret;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/CJK/ICJKSetParserConfiguration.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Recognizers.Text.DateTime
 
         IDateTimeParser TimeParser { get; }
 
+        IDateTimeExtractor TimePeriodExtractor { get; }
+
+        IDateTimeParser TimePeriodParser { get; }
+
         IDateTimeExtractor DateExtractor { get; }
 
         IDateTimeParser DateParser { get; }
@@ -31,6 +35,8 @@ namespace Microsoft.Recognizers.Text.DateTime
         Regex EachUnitRegex { get; }
 
         Regex EachDayRegex { get; }
+
+        Regex EachDateUnitRegex { get; }
 
         bool GetMatchedUnitTimex(string text, out string timex);
     }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/SetHandler.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/SetHandler.cs
@@ -24,5 +24,14 @@ namespace Microsoft.Recognizers.Text.DateTime.Utilities
             return weekday;
         }
 
+        public static DateTimeResolutionResult ResolveSet(ref DateTimeResolutionResult result, string innerTimex)
+        {
+            result.Timex = innerTimex;
+            result.FutureValue = result.PastValue = "Set: " + innerTimex;
+            result.Success = true;
+
+            return result;
+        }
+
     }
 }

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -96,7 +96,6 @@ AfterRegex: !simpleRegex
   def: 以后|以後|之后|之後|后|後
 TimePeriodLeftRegex: !simpleRegex
   def: ^[.]
-# (农历)?(2016年)?一月三日(星期三)?
 DateRegexList1: !nestedRegex
   def: ({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
   references: [LunarRegex, SimpleYearRegex, DateYearInCJKRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -384,10 +384,14 @@ SetEachUnitRegex: !nestedRegex
   references: [SetUnitRegex]
 SetEachPrefixRegex: !simpleRegex
   def: (?<each>(每)\s*$)
+SetEachSuffixRegex: !simpleRegex
+  def: ^[.]
 SetLastRegex: !simpleRegex
   def: (?<last>last|this|next)
 SetEachDayRegex: !simpleRegex
   def: (每|每一)(天|日)\s*$
+SetEachDateUnitRegex: !simpleRegex
+  def: ^[.]
 #TimeExtractorCJK
 TimeHourNumRegex: !simpleRegex
   def: (00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)

--- a/Patterns/Chinese/Chinese-DateTime.yaml
+++ b/Patterns/Chinese/Chinese-DateTime.yaml
@@ -96,6 +96,7 @@ AfterRegex: !simpleRegex
   def: 以后|以後|之后|之後|后|後
 TimePeriodLeftRegex: !simpleRegex
   def: ^[.]
+# (农历)?(2016年)?一月三日(星期三)?
 DateRegexList1: !nestedRegex
   def: ({LunarRegex}(\s*))?((({SimpleYearRegex}|{DateYearInCJKRegex})年)(\s*))?{MonthRegex}(\s*){DateDayRegexInCJK}((\s*|,|，){WeekDayRegex})?
   references: [LunarRegex, SimpleYearRegex, DateYearInCJKRegex, MonthRegex, DateDayRegexInCJK, WeekDayRegex]

--- a/Patterns/Japanese/Japanese-DateTime.yaml
+++ b/Patterns/Japanese/Japanese-DateTime.yaml
@@ -295,9 +295,23 @@ YesterdayRegex: !simpleRegex
   def: (?<yesterday>昨日の?(午前|午後|中|夜|朝)?)
 TodayRegex: !simpleRegex
   def: (?<today>(今朝の?|今朝の午前|今晩|今晚|今早|今晨|明晚|明早|明晨|昨晚|今夜|昨夜)(的|在)?)
+SpecialDayHourRegex: !nestedRegex
+  def: ((?<hour>{TimeHourCJKRegex}|{TimeHourNumRegex})(時間?|(:00)))
+  references: [TimeHourCJKRegex, TimeHourNumRegex]
+SpecialDayMinuteRegex: !nestedRegex
+  def: ((?<min>{TimeMinuteCJKRegex}|{TimeMinuteNumRegex})分間?)
+  references: [TimeMinuteCJKRegex, TimeMinuteNumRegex]
+SpecialDaySecondRegex: !nestedRegex
+  def: ((?<sec>{TimeSecondCJKRegex}|{TimeSecondNumRegex})秒間?)
+  references: [TimeSecondCJKRegex, TimeSecondNumRegex]
+SpecialDayModRegex: !simpleRegex
+  def: ((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))
+SpecialDayEndOfRegex: !nestedRegex
+  def: ((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり))
+  references: [WeekDayRegex]
 TimeOfSpecialDayRegex: !nestedRegex
-  def: (((?<SpecificEndOf>明日の終わり|({WeekDayRegex}の?終わり))|{WeekDayRegex}|(?<UnspecificEndOf>日の終わり|一日の終わり|その日の終わり)|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))?((?<min>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))分間?)?((?<sec>([二三四五]?十[一二三四五六七八九]?|六十|[零〇一二三四五六七八九])|([0-5]?\d))秒間?)?((?<after>過ぎに)|(?<around>ごろ)|(?<in>で|の?うちに)|(?<less>弱|たらず)|(?<more>以上))?)|((((?<hour>(([零〇一二两三四五六七八九]|二十[一二三四]?|十[一二三四五六七八九]?)(つ)?)|([0-1]?\d|2[0-4]))(時間?|(:00)))(?<in>で|の?うちに)))
-  references: [ TomorrowRegex, YesterdayRegex, TodayRegex, WeekDayRegex ]
+  def: (({SpecialDayEndOfRegex}|{WeekDayRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex})(\d日)?(と)?(({SpecialDayHourRegex}{SpecialDayMinuteRegex}?{SpecialDaySecondRegex}?)|({SpecialDayMinuteRegex}{SpecialDaySecondRegex}?)){SpecialDayModRegex}?)|(({SpecialDayHourRegex}(?<in>で|の?うちに)))|(({SpecialDayEndOfRegex}|{TomorrowRegex}|{YesterdayRegex}|あと|{TodayRegex}){SpecialDayModRegex}?)|({WeekDayRegex}(\d日)?(と)?{SpecialDayModRegex})
+  references: [ TomorrowRegex, YesterdayRegex, TodayRegex, WeekDayRegex, SpecialDayEndOfRegex, SpecialDayHourRegex, SpecialDayMinuteRegex, SpecialDaySecondRegex, SpecialDayModRegex ]
 NowTimeRegex: !simpleRegex
   def: (现在|今)
 RecentlyTimeRegex: !simpleRegex
@@ -416,16 +430,20 @@ HolidayRegexList2: !nestedRegex
   references: [YearRegex, DatePeriodYearInCJKRegex]
 #SetExtractorCJK
 SetUnitRegex: !simpleRegex
-  def: (?<unit>年|月|周|星期|日|天|小时|时|分钟|分|秒钟|秒)
+  def: (?<unit>年|月|隔週|週|日|時|分|秒)
 SetEachUnitRegex: !nestedRegex
-  def: (?<each>(每个|每一|每)\s*{SetUnitRegex})
+  def: ((?<each>(毎个|毎一|毎|各)\s*(?<unit>年|月|週|日|時|分|秒))|(?<=\d)泊|(?<unit>隔週))
   references: [SetUnitRegex]
 SetEachPrefixRegex: !simpleRegex
-  def: (?<each>(每)\s*$)
+  def: ((?<each>毎|隔|各|ごとに)\s*$)
+SetEachSuffixRegex: !simpleRegex
+  def: (^\s*(?<each>ごとに))
 SetLastRegex: !simpleRegex
   def: (?<last>last|this|next)
 SetEachDayRegex: !simpleRegex
-  def: (每|每一)(天|日)\s*$
+  def: (毎|各|毎一)(天|日)\s*$
+SetEachDateUnitRegex: !simpleRegex
+  def: (毎)(年|月|週)\s*$
 #TimeExtractorCJK
 TimeHourNumRegex: !simpleRegex
   def: ([0-1]?\d|2[0-4])
@@ -471,7 +489,7 @@ TimeDigitTimeRegex: !nestedRegex
   def: (?<hour>{TimeHourNumRegex}):(?<min>{TimeMinuteNumRegex})(:(?<sec>{TimeSecondNumRegex}))?(am|pm)?
   references: [TimeHourNumRegex, TimeMinuteNumRegex, TimeSecondNumRegex]
 TimeDayDescRegex: !nestedRegex
-  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
+  def: (?<daydesc>(正午|夜中|午前半ば|(昼食時)|真昼)|((?<=({TimeDigitTimeRegex}|{TimeCJKTimeRegex})(の)?)(早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼))|((早朝(に)?|午後(に)?|晚|晩|(深)?夜(に)?|未明|午前(中)?|日中|白昼|(未|早)?朝(に)?|昼前に|昼すぎに|夕方前に|夕方に|営業時間内に|昼)(?=(の)?({TimeDigitTimeRegex}|{TimeCJKTimeRegex}))))
   references: [TimeDigitTimeRegex, TimeCJKTimeRegex]
 TimeApproximateDescPreffixRegex: !simpleRegex
   def: (ぐらい|おそらく|多分|ほとんど|まもなく|昨日の|昨日|来週の|来週|昼食時|昼食|真)
@@ -553,6 +571,7 @@ ParserConfigurationUnitMap: !dictionary
     週: W
     週間: W
     星期: W
+    隔週: W
     个星期: W
     日: D
     日間: D
@@ -995,6 +1014,8 @@ TimeLowBoundDesc: !dictionary
   types: [string, int]
   entries:
     夜: 18 
+    晚: 18
+    晩: 18
     午後: 12
     午后: 12
     pm: 12
@@ -1098,4 +1119,14 @@ DynastyYearMap: !dictionary
     文久: 1861
     元治: 1864
     慶応: 1865
+DayTypeRegex: !simpleRegex
+  def: ^(天|日)$
+WeekTypeRegex: !simpleRegex
+  def: ^(周|星期|週)$
+BiWeekTypeRegex: !simpleRegex
+  def: ^(隔週)$
+MonthTypeRegex: !simpleRegex
+  def: ^(月)$
+YearTypeRegex: !simpleRegex
+  def: ^(年)$
 ...

--- a/Patterns/Korean/Korean-DateTime.yaml
+++ b/Patterns/Korean/Korean-DateTime.yaml
@@ -399,10 +399,14 @@ SetEachUnitRegex: !nestedRegex
   references: [SetUnitRegex]
 SetEachPrefixRegex: !simpleRegex
   def: (?<each>(매)\s*$)
+SetEachSuffixRegex: !simpleRegex
+  def: ^[.]
 SetLastRegex: !simpleRegex
   def: (?<last>last|this|next)
 SetEachDayRegex: !simpleRegex
   def: (每|每一)(天|日)\s*$
+SetEachDateUnitRegex: !simpleRegex
+  def: ^[.]
 #TimeExtractorCJK
 TimeHourNumRegex: !simpleRegex
   def: (00|01|02|03|04|05|06|07|08|09|0|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|1|2|3|4|5|6|7|8|9)

--- a/Specs/DateTime/Japanese/SetExtractor.json
+++ b/Specs/DateTime/Japanese/SetExtractor.json
@@ -1,7 +1,6 @@
 [
   {
     "Input": "毎週出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -14,7 +13,6 @@
   },
   {
     "Input": "毎日出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -27,7 +25,6 @@
   },
   {
     "Input": "毎月出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -40,7 +37,6 @@
   },
   {
     "Input": "毎年出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -53,7 +49,6 @@
   },
   {
     "Input": "2日ごとに出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -66,7 +61,6 @@
   },
   {
     "Input": "3週間ごとに出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,20 +73,18 @@
   },
   {
     "Input": "毎日午後3時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後3時に",
+        "Text": "毎日午後3時",
         "Type": "set",
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
   {
     "Input": "毎年4月15日に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -105,7 +97,6 @@
   },
   {
     "Input": "毎週月曜日に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -118,7 +109,6 @@
   },
   {
     "Input": "毎週月曜日午後4時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -131,7 +121,6 @@
   },
   {
     "Input": "毎朝出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -144,50 +133,46 @@
   },
   {
     "Input": "毎朝9時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎朝9時に",
+        "Text": "毎朝9時",
         "Type": "set",
         "Start": 0,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
   {
     "Input": "毎日午後4時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後4時に",
+        "Text": "毎日午後4時",
         "Type": "set",
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
   {
     "Input": "毎晩9時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎晩9時に",
+        "Text": "毎晩9時",
         "Type": "set",
         "Start": 0,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
   {
-    "Input": "午前9時に出発する。",
-    "NotSupported": "dotnet",
+    "Input": "各午前9時に出発する。",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午前9時に",
+        "Text": "各午前9時",
         "Type": "set",
         "Start": 0,
         "Length": 5
@@ -196,46 +181,42 @@
   },
   {
     "Input": "毎週日曜日午前9時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週日曜日午前9時に",
+        "Text": "毎週日曜日午前9時",
         "Type": "set",
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
   {
     "Input": "毎週月曜日午前9時に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週月曜日午前9時に",
+        "Text": "毎週月曜日午前9時",
         "Type": "set",
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
   {
     "Input": "毎週日曜日に出発する。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週日曜日に",
+        "Text": "毎週日曜日",
         "Type": "set",
         "Start": 0,
-        "Length": 6
+        "Length": 5
       }
     ]
   },
   {
     "Input": "5月9日から2泊予約できますか。",
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -248,7 +229,7 @@
   },
   {
     "Input": "毎週日曜日午後八時に事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週日曜日午後八時",
@@ -260,7 +241,7 @@
   },
   {
     "Input": "毎週日曜日事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週日曜日",
@@ -272,7 +253,7 @@
   },
   {
     "Input": "毎日事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎日",
@@ -284,7 +265,7 @@
   },
   {
     "Input": "毎週事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週",
@@ -296,7 +277,7 @@
   },
   {
     "Input": "毎月事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎月",
@@ -308,7 +289,7 @@
   },
   {
     "Input": "毎年事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎年",

--- a/Specs/DateTime/Japanese/SetParser.json
+++ b/Specs/DateTime/Japanese/SetParser.json
@@ -4,7 +4,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2744475+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -29,7 +28,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2754476+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -54,7 +52,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2779449+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -79,7 +76,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2794445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -104,7 +100,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2829445+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -129,7 +124,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2844439+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -154,7 +148,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2854444+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -179,7 +172,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2909444+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -204,7 +196,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2959472+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -229,11 +220,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.2989494+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後3時に",
+        "Text": "毎日午後3時",
         "Type": "set",
         "Value": {
           "Timex": "T15",
@@ -245,7 +235,7 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
@@ -254,11 +244,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3039501+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後3時に",
+        "Text": "毎日午後3時",
         "Type": "set",
         "Value": {
           "Timex": "T15",
@@ -270,7 +259,7 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
@@ -279,7 +268,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3109498+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -304,7 +292,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3259514+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -329,7 +316,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3379507+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -354,7 +340,6 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3429518+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
@@ -379,11 +364,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3609535+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎朝9時に",
+        "Text": "毎朝9時",
         "Type": "set",
         "Value": {
           "Timex": "T09",
@@ -395,7 +379,7 @@
           }
         },
         "Start": 0,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
@@ -404,11 +388,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3730732+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎日午後4時に",
+        "Text": "毎日午後4時",
         "Type": "set",
         "Value": {
           "Timex": "T16",
@@ -420,20 +403,19 @@
           }
         },
         "Start": 0,
-        "Length": 7
+        "Length": 6
       }
     ]
   },
   {
-    "Input": "毎晩9時に出発する。",
+    "Input": "各晩9時に出発する。",
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3840706+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎晩9時に",
+        "Text": "各晩9時",
         "Type": "set",
         "Value": {
           "Timex": "T21",
@@ -445,7 +427,7 @@
           }
         },
         "Start": 0,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
@@ -454,11 +436,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.3930718+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎晩9時に",
+        "Text": "毎晩9時",
         "Type": "set",
         "Value": {
           "Timex": "T21",
@@ -470,20 +451,19 @@
           }
         },
         "Start": 0,
-        "Length": 5
+        "Length": 4
       }
     ]
   },
   {
-    "Input": "午前9時に出発する。",
+    "Input": "各午前9時に出発する。",
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4065719+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午前9時に",
+        "Text": "各午前9時",
         "Type": "set",
         "Value": {
           "Timex": "T09",
@@ -500,15 +480,14 @@
     ]
   },
   {
-    "Input": "午前9時に出発する。",
+    "Input": "毎午前9時に出発する。",
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4170727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "午前9時に",
+        "Text": "毎午前9時",
         "Type": "set",
         "Value": {
           "Timex": "T09",
@@ -529,11 +508,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4295727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週日曜日午前9時に",
+        "Text": "毎週日曜日午前9時",
         "Type": "set",
         "Value": {
           "Timex": "XXXX-WXX-7T09",
@@ -545,7 +523,7 @@
           }
         },
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
@@ -554,23 +532,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.438575+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週月曜日午前9時に",
+        "Text": "毎週月曜日午前9時",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-1T09",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-1T09"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-1T09"
           }
         },
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
@@ -579,23 +556,22 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4505726+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週月曜日午前9時に",
+        "Text": "毎週月曜日午前9時",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-7T09",
+          "Timex": "XXXX-WXX-1T09",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-1T09"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-7T09"
+            "set": "Set: XXXX-WXX-1T09"
           }
         },
         "Start": 0,
-        "Length": 10
+        "Length": 9
       }
     ]
   },
@@ -604,11 +580,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4570731+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週月曜日に",
+        "Text": "毎週月曜日",
         "Type": "set",
         "Value": {
           "Timex": "XXXX-WXX-1",
@@ -620,7 +595,7 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 5
       }
     ]
   },
@@ -629,11 +604,10 @@
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4635727+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週日曜日に",
+        "Text": "毎週日曜日",
         "Type": "set",
         "Value": {
           "Timex": "XXXX-WXX-7",
@@ -645,20 +619,19 @@
           }
         },
         "Start": 0,
-        "Length": 6
+        "Length": 5
       }
     ]
   },
   {
-    "Input": "毎週日曜日に出発する。",
+    "Input": "各週日曜日に出発する。",
     "Context": {
       "ReferenceDateTime": "2017-09-27T12:25:54.4710739+03:00"
     },
-    "NotSupported": "dotnet",
     "NotSupportedByDesign": "javascript,python,java",
     "Results": [
       {
-        "Text": "毎週日曜日",
+        "Text": "各週日曜日",
         "Type": "set",
         "Value": {
           "Timex": "XXXX-WXX-7",
@@ -676,18 +649,18 @@
   },
   {
     "Input": "毎週日曜日午後八時に事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週日曜日午後八時",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-1T20",
+          "Timex": "XXXX-WXX-7T20",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-1T20"
+            "set": "Set: XXXX-WXX-7T20"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-1T20"
+            "set": "Set: XXXX-WXX-7T20"
           }
         },
         "Start": 0,
@@ -697,18 +670,18 @@
   },
   {
     "Input": "毎週日曜日事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週日曜日",
         "Type": "set",
         "Value": {
-          "Timex": "XXXX-WXX-1",
+          "Timex": "XXXX-WXX-7",
           "FutureResolution": {
-            "set": "Set: XXXX-WXX-1"
+            "set": "Set: XXXX-WXX-7"
           },
           "PastResolution": {
-            "set": "Set: XXXX-WXX-1"
+            "set": "Set: XXXX-WXX-7"
           }
         },
         "Start": 0,
@@ -718,7 +691,7 @@
   },
   {
     "Input": "毎日事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎日",
@@ -739,7 +712,7 @@
   },
   {
     "Input": "毎週事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎週",
@@ -760,7 +733,7 @@
   },
   {
     "Input": "毎月事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎月",
@@ -781,7 +754,7 @@
   },
   {
     "Input": "毎年事件が起こる",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "毎年",

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -1669,31 +1669,5 @@
         "Length": 10
       }
     ]
-  },
-  {
-    "Input": "日中",
-    "Context": {
-      "ReferenceDateTime": "2018-10-11T00:00:00"
-    },
-    "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "日中",
-        "Type": "timerange",
-        "Value": {
-          "Timex": "TDT",
-          "FutureResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
-          },
-          "PastResolution": {
-            "startTime": "08:00:00",
-            "endTime": "18:00:00"
-          }
-        },
-        "Start": 0,
-        "Length": 2
-      }
-    ]
   }
 ]

--- a/Specs/DateTime/Japanese/TimePeriodParser.json
+++ b/Specs/DateTime/Japanese/TimePeriodParser.json
@@ -1669,5 +1669,31 @@
         "Length": 10
       }
     ]
+  },
+  {
+    "Input": "日中",
+    "Context": {
+      "ReferenceDateTime": "2018-10-11T00:00:00"
+    },
+    "NotSupportedByDesign": "javascript,python,java",
+    "Results": [
+      {
+        "Text": "日中",
+        "Type": "timerange",
+        "Value": {
+          "Timex": "TDT",
+          "FutureResolution": {
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
+          },
+          "PastResolution": {
+            "startTime": "08:00:00",
+            "endTime": "18:00:00"
+          }
+        },
+        "Start": 0,
+        "Length": 2
+      }
+    ]
   }
 ]


### PR DESCRIPTION
All test cases pass.
In DateTimeModel 204 pass, 358 fail.

Modified test cases:
- Japanese does not use plural for days and time of days ("sundays", "mornings"...), so inputs corresponding to these patterns have been corrected to use "each/every":
    - 午前9時に出発する。 -> 各午前9時に出発する。("I'll leave mornings at 9am" -> "I'll leave each mornings at 9am")
    - 午前9時に出発する。 -> 毎午前9時に出発する。("I'll leave on mornings at 9am" -> "I'll leave every mornings at 9am")
    - 毎週日曜日に出発する。 -> 各週日曜日に出発する。("I'll leave on Sundays" -> "I'll leave each Sunday")
- 毎晩9時に出発する。 -> 各晩9時に出発する。("I'll leave every night at 9" -> "I'll leave each night at 9"): duplicate
- Corrected wrong resolution of weekdays in some test cases:
    - 毎週月曜日午前9時 (I'll leave every Monday at 9am): XXXX-WXX-7T09 -> XXXX-WXX-1T09
    - 毎週日曜日午後八時 (I'll leave every Sunday at 8pm): XXXX-WXX-1T20 -> XXXX-WXX-7T20
    - 毎週日曜日事件が起こる (Incidents occur every Sunday):  XXXX-WXX-1 -> XXXX-WXX-7