### PR TITLE
[SV Currency] Fix ATT recognized as a currency unit in the wrong context (#2891)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/Swedish/NumbersWithUnitDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Swedish/NumbersWithUnitDefinitions.cs
@@ -740,6 +740,7 @@ namespace Microsoft.Recognizers.Definitions.Swedish
         };
       public static readonly IList<string> AmbiguousCurrencyUnitList = new List<string>
         {
+            @"att",
             @"din.",
             @"kiwi",
             @"kina",

--- a/Patterns/Swedish/Swedish-NumbersWithUnit.yaml
+++ b/Patterns/Swedish/Swedish-NumbersWithUnit.yaml
@@ -842,6 +842,7 @@ CurrencyPrefixList: !dictionary
 AmbiguousCurrencyUnitList: !list
   types: [ string ]
   entries:
+    - att
     - din.
     - kiwi
     - kina

--- a/Specs/NumberWithUnit/Swedish/CurrencyModel.json
+++ b/Specs/NumberWithUnit/Swedish/CurrencyModel.json
@@ -600,5 +600,26 @@
         "End": 5
       }
     ]
+  },
+  {
+    "Input": "Se till att rymma västkustens tidszon",
+    "NotSupported": "javascript,python,java",
+    "Results": []
+  },
+  {
+    "Input": "vi har 100 Att",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "100 att",
+        "TypeName": "currency",
+        "Resolution": {
+          "value": "100",
+          "unit": "Att"
+        },
+        "Start": 7,
+        "End": 13
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2891.

Test cases added to CurrencyModel.