### PR TITLE
[ES DateTimeV2] Fix misc bugs generated from Speech (#2890)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string PrefixDayRegex = @"\b((?<EarlyPrefix>earl(y|ier))|(?<MidPrefix>mid(dle)?)|(?<LatePrefix>later?))(\s+in)?(\s+the\s+day)?$";
       public const string SeasonDescRegex = @"(?<seas>spring|summer|fall|autumn|winter)";
       public static readonly string SeasonRegex = $@"\b(?<season>({PrefixPeriodRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+of|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+year))?)\b";
-      public const string WhichWeekRegex = @"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
+      public static readonly string WhichWeekRegex = $@"\b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+of\s+({YearRegex}|{RelativeRegex}\s+year))?\b";
       public const string WeekOfRegex = @"(the\s+)?((week)(\s+(of|(commencing|starting|beginning)(\s+on)?))|w/c)(\s+the)?";
       public const string MonthOfRegex = @"(month)(\s*)(of)";
       public static readonly string DateYearRegex = $@"(?<year>{BaseDateTime.FourDigitYearRegex}|(?<!,\s?){TwoDigitYearRegex}|{TwoDigitYearRegex}(?=(\.(?!\d)|[?!;]|$)))";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -699,7 +699,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string MonthTypeRegex = @"(mensal(mente)?)$";
       public const string BiMonthTypeRegex = @"(bimestral(mente)?)$";
       public const string QuarterTypeRegex = @"(trimestral(mente)?)$";
-      public const string BiAnnualTypeRegex = @"(semestral(mente)?)$";
+      public const string SemiAnnualTypeRegex = @"(semestral(mente)?)$";
       public const string YearTypeRegex = @"(anual(mente)?)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Portuguese/DateTimeDefinitions.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string AfterNextSuffixRegex = @"\b(que\s+vem|passad[oa])\b";
       public const string RangePrefixRegex = @"((de(sde)?|das?|entre)\s+(a(s)?\s+)?)";
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b";
-      public const string RelativeRegex = @"(?<order>((est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b";
-      public const string StrictRelativeRegex = @"(?<order>((est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b";
+      public const string RelativeRegex = @"(?<order>((n?est[ae]s?|pr[oó]xim[oa]s?|([uú]ltim[ao]s?))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b";
+      public const string StrictRelativeRegex = @"(?<order>((n?est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b";
       public const string WrittenOneToNineRegex = @"(uma?|dois|duas|tr[eê]s|quatro|cinco|seis|sete|oito|nove)";
       public const string WrittenOneHundredToNineHundredRegex = @"(duzent[oa]s|trezent[oa]s|[cq]uatrocent[ao]s|quinhent[ao]s|seiscent[ao]s|setecent[ao]s|oitocent[ao]s|novecent[ao]s|cem|(?<!por\s+)(cento))";
       public static readonly string WrittenOneToNinetyNineRegex = $@"(((vinte|trinta|[cq]uarenta|cinquenta|sessenta|setenta|oitenta|noventa)(\s+e\s+{WrittenOneToNineRegex})?)|d[eé]z|onze|doze|treze|(c|qu)atorze|quinze|dez[ea]sseis|dez[ea]ssete|dez[ea]nove|dezoito|uma?|d(oi|ua)s|tr[eê]s|quatro|cinco|seis|sete|oito|nove)";
@@ -54,7 +54,8 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public static readonly string MonthFrontSimpleCasesRegex = $@"\b{MonthSuffixRegex}\s+((desde\s+[oa]|desde|d[oa])\s+)?(dia\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre|entre\s+[oa]s?)\s+)(dias?\s+)?({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string DayBetweenRegex = $@"\b((entre|entre\s+[oa]s?)\s+)(dia\s+)?({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
-      public const string OneWordPeriodRegex = @"\b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\s+)?(?<month>abr(il)?|ago(sto)?|dez(embro)?|fev(ereiro)?|jan(eiro)?|ju[ln](ho)?|mar([çc]o)?|maio?|nov(embro)?|out(ubro)?|sep?t(embro)?)|(?<=\b(de|do|da|o|a)\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\b";
+      public const string SpecialYearPrefixes = @"((do\s+)?calend[aá]rio|civil|(?<special>fiscal|escolar|letivo))";
+      public static readonly string OneWordPeriodRegex = $@"\b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\s+)?(?<month>abr(il)?|ago(sto)?|dez(embro)?|fev(ereiro)?|jan(eiro)?|ju[ln](ho)?|mar([çc]o)?|maio?|nov(embro)?|out(ubro)?|sep?t(embro)?)|({RelativeRegex}\s+)?(ano\s+{SpecialYearPrefixes}|{SpecialYearPrefixes}\s+ano)|(?<=\b(de|do|da|o|a)\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\b";
       public static readonly string MonthWithYearRegex = $@"\b((((pr[oó]xim[oa](s)?|[nd]?es[st]e|aquele|[uú]ltim[oa]?|em)\s+)?{MonthRegex}|((n?o\s+)?(?<cardinal>primeiro|1o|segundo|2o|terceiro|3o|[cq]uarto|4o|quinto|5o|sexto|6o|s[eé]timo|7o|oitavo|8o|nono|9o|d[eé]cimo(\s+(primeiro|segundo))?|10o|11o|12o|[uú]ltimo)\s+m[eê]s(?=\s+(d[aeo]|[ao]))))\s+((d[aeo]|[ao])\s+)?({YearRegex}|{TwoDigitYearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|[nd]?es[st]e)\s+ano))\b";
       public static readonly string MonthNumWithYearRegex = $@"({YearRegex}(\s*?)[/\-\.](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-](\s*?){YearRegex})";
       public static readonly string WeekOfMonthRegex = $@"(?<wom>(a|na\s+)?(?<cardinal>primeira?|1a|segunda|2a|terceira|3a|[qc]uarta|4a|quinta|5a|[uú]ltima)\s+semana\s+{MonthSuffixRegex})";
@@ -68,7 +69,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string AllHalfYearRegex = @"^[.]";
       public const string PrefixDayRegex = @"^[.]";
       public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|[nd]?es[st][ea]|n?[oa]|(pr[oó]xim[oa]s?|seguinte))\s+)?(?<seas>primavera|ver[ãa]o|outono|inverno)((\s+)?(seguinte|((de\s+|,)?\s*{YearRegex})|((do\s+)?(?<order>pr[oó]ximo|[uú]ltimo|[nd]?es[st]e)\s+ano)))?)\b";
-      public const string WhichWeekRegex = @"\b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
+      public static readonly string WhichWeekRegex = $@"\b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+(de|do)\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|[nd]?es[st]e)\s+ano|ano\s+(?<order>passado)))?\b";
       public const string WeekOfRegex = @"(semana)(\s*)((do|da|de))";
       public const string MonthOfRegex = @"(mes)(\s*)((do|da|de))";
       public const string RangeUnitRegex = @"\b(?<unit>anos?|meses|m[êe]s|semanas?)\b";
@@ -102,7 +103,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public static readonly string OfMonthRegex = $@"^(\s*de)?\s*{MonthSuffixRegex}";
       public static readonly string MonthEndRegex = $@"({MonthRegex}\s*(o)?\s*$)";
       public static readonly string WeekDayEnd = $@"{WeekDayRegex}\s*,?\s*$";
-      public const string WeekDayStart = @"^[\.]";
+      public const string WeekDayStart = @"^\b$";
       public static readonly string DateYearRegex = $@"(?<year>{YearRegex}|{TwoDigitYearRegex})";
       public static readonly string DateExtractor1 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?{DayRegex}((\s*(de)|[/\\\.\- ])\s*)?{MonthRegex}\b";
       public static readonly string DateExtractor2 = $@"\b({WeekDayRegex}(\s+|\s*,\s*))?({DayRegex}(\s*([/\.\-]|de)?\s*{MonthRegex}|\s+de\s+{MonthNumRegex})(\s*([,./-]|de|\s+)\s*){DateYearRegex}|{BaseDateTime.FourDigitYearRegex}\s*[/\.\- ]\s*{DayRegex}\s*[/\.\- ]\s*{MonthRegex})\b";
@@ -192,7 +193,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string AfterRegex = @"((depois|ap[óo]s|a\s+partir)(\s*(de|d?[oa]s?)?)?)";
       public const string SinceRegex = @"(desde(\s+(as?|o))?)";
       public const string AroundRegex = @"(?:\b(?:cerca|perto|ao\s+redor|por\s+volta)\s*?\b)(\s+(de|das))?";
-      public const string PeriodicRegex = @"\b(?<periodic>di[áa]ri[ao]|(diaria|mensal|semanal|quinzenal|anual)mente)\b";
+      public const string PeriodicRegex = @"\b(?<periodic>di[áa]ri[ao]|(diaria|mensal|semanal|quinzenal|(bi|tri|se)mestral|anual)(mente)?)\b";
       public const string EachExpression = @"cada|tod[oa]s?\s*([oa]s)?";
       public static readonly string EachUnitRegex = $@"(?<each>({EachExpression})\s*{UnitRegex})";
       public static readonly string EachPrefixRegex = $@"(?<each>({EachExpression})\s*$)";
@@ -205,13 +206,14 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string MiddlePauseRegex = @"^[.]";
       public const string PrefixArticleRegex = @"^[\.]";
       public const string OrRegex = @"^[.]";
-      public const string YearPlusNumberRegex = @"^[.]";
+      public static readonly string SpecialYearTermsRegex = $@"\b(({SpecialYearPrefixes}\s+anos?\s+|anos?\s+({SpecialYearPrefixes}\s+)?)(d[oe]\s+)?)";
+      public static readonly string YearPlusNumberRegex = $@"\b({SpecialYearTermsRegex}((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
       public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|({TimeHourNumRegex}|{BaseDateTime.HourRegex})(?<desc>\s*horas)?)\b";
       public const string TimeBeforeAfterRegex = @"^[.]";
       public const string DateNumberConnectorRegex = @"^[.]";
       public const string ComplexDatePeriodRegex = @"^[.]";
-      public const string AgoRegex = @"\b(antes|atr[áa]s|no passado)\b";
-      public const string LaterRegex = @"\b(depois d[eoa]s?|ap[óo]s (as)?|desde( (as|o))?|no futuro|mais tarde)\b";
+      public const string AgoRegex = @"\b(antes(\s+d[eoa]s?\s+(?<day>hoje|ontem|manhã))?|atr[áa]s|no passado)\b";
+      public const string LaterRegex = @"\b(depois(\s+d[eoa]s?\s+(agora|(?<day>hoje|ontem|manhã)))?|ap[óo]s (as)?|desde( (as|o))?|no futuro|mais tarde)\b";
       public const string Tomorrow = @"amanh[ãa]";
       public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
         {
@@ -265,7 +267,9 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
         };
       public static readonly Dictionary<string, string> SpecialYearPrefixesMap = new Dictionary<string, string>
         {
-            { @"", @"" }
+            { @"fiscal", @"FY" },
+            { @"escolar", @"SY" },
+            { @"letivo", @"SY" }
         };
       public static readonly Dictionary<string, string> SeasonMap = new Dictionary<string, string>
         {
@@ -540,7 +544,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string TokenBeforeDate = @"o ";
       public const string TokenBeforeTime = @"as ";
       public const string PastPrefixRegex = @".^";
-      public static readonly string PreviousPrefixRegex = $@"([uú]ltim[oa]s?|{PastPrefixRegex})\b";
+      public static readonly string PreviousPrefixRegex = $@"([uú]ltim[oa]s?|passad[oa]s?|{PastPrefixRegex})\b";
       public const string ThisPrefixRegex = @"([nd]?es[st][ea])\b";
       public const string RelativeDayRegex = @"^[\.]";
       public const string RestOfDateRegex = @"^[\.]";
@@ -559,7 +563,7 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
       public const string CenturyRegex = @"^[.]";
       public const string DecadeRegex = @"^[.]";
       public const string DecadeWithCenturyRegex = @"^[.]";
-      public const string RelativeDecadeRegex = @"^[.]";
+      public static readonly string RelativeDecadeRegex = $@"\b((n?as?\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?(d[eé]cada)s?)\b";
       public static readonly string YearSuffix = $@"((,|\sde)?\s*({YearRegex}|{FullTextYearRegex}))";
       public const string SuffixAfterRegex = @"^\b$";
       public const string YearPeriodRegex = @"^[.]";
@@ -689,5 +693,13 @@ namespace Microsoft.Recognizers.Definitions.Portuguese
             { 'õ', 'o' },
             { 'ç', 'c' }
         };
+      public const string DayTypeRegex = @"(diari([ao]|amente))$";
+      public const string WeekTypeRegex = @"(semanal(mente)?)$";
+      public const string BiWeekTypeRegex = @"(quinzenal(mente)?)$";
+      public const string MonthTypeRegex = @"(mensal(mente)?)$";
+      public const string BiMonthTypeRegex = @"(bimestral(mente)?)$";
+      public const string QuarterTypeRegex = @"(trimestral(mente)?)$";
+      public const string BiAnnualTypeRegex = @"(semestral(mente)?)$";
+      public const string YearTypeRegex = @"(anual(mente)?)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -767,7 +767,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string WeekendTypeRegex = @"(fin(es)?\s+de\s+semana|finde)$";
       public const string MonthTypeRegex = @"(mes(es)?|mensual(es|mente)?)$";
       public const string QuarterTypeRegex = @"(trimestral(es|mente)?)$";
-      public const string BiAnnualTypeRegex = @"(semestral(es|mente)?)$";
-      public const string YearTypeRegex = @"(años?|anualmente)$";
+      public const string SemiAnnualTypeRegex = @"(semestral(es|mente)?)$";
+      public const string YearTypeRegex = @"(años?|anual(mente)?)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/DateTimeDefinitions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string RelativeSuffixRegex = $@"({AfterNextSuffixRegex}|{NextSuffixRegex}|{PreviousSuffixRegex})";
       public const string RangePrefixRegex = @"((de(l|sde)?|entre)(\s+la(s)?)?)";
       public static readonly string TwoDigitYearRegex = $@"\b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d))|\.?[º°ª])\b";
-      public const string RelativeRegex = @"(?<order>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b";
+      public const string RelativeRegex = @"(?<order>est[ae]s?|pr[oó]xim[oa]s?|siguiente|(([uú]ltim|pasad)[ao]s?))\b";
       public const string StrictRelativeRegex = @"(?<order>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b";
       public const string WrittenOneToNineRegex = @"(un[ao]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve)";
       public const string WrittenOneHundredToNineHundredRegex = @"(doscient[oa]s|trescient[oa]s|cuatrocient[ao]s|quinient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s|cien(to)?)";
@@ -59,7 +59,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+((entre(\s+el)?)\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*)((en|del?)\s+)?{YearRegex})?\b";
       public static readonly string DayBetweenRegex = $@"\b((entre(\s+el)?)\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*)((en|del?)\s+)?{YearRegex})?\b";
       public const string SpecialYearPrefixes = @"((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))";
-      public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)";
+      public static readonly string OneWordPeriodRegex = $@"\b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((el\s+)?{RelativeRegex}\s+)?(({SpecialYearPrefixes}\s+)año|año\s+{SpecialYearPrefixes})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)(\s+(a|hasta)\s+la\s+fecha)?|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)";
       public static readonly string MonthWithYearRegex = $@"\b((((pr[oó]xim[oa](s)?|est?[ae]|[uú]ltim[oa]?)\s+)?{MonthRegex}|((el\s+)?(?<cardinal>primero?|1(er|ro)|segundo|2do|tercero?|3(er|ro)|uarto|4to|quinto|5to|sexto|6to|s[eé]ptimo|7mo|octavo|8vo|noveno|9no|d[eé]cimo|10mo|und[eé]cimo|11mo|duod[eé]cimo|12mo|[uú]ltimo)\s+mes(?=\s+(del?|en))))((\s+|(\s*[,-]\s*))((de(l|\s+la)?|en)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año)|\s+(del?|en)\s+{TwoDigitYearRegex}))\b";
       public static readonly string MonthNumWithYearRegex = $@"\b(({YearRegex}(\s*?)[/\-\.~](\s*?){MonthNumRegex})|({MonthNumRegex}(\s*?)[/\-\.~](\s*?){YearRegex}))\b";
       public static readonly string WeekOfMonthRegex = $@"(?<wom>(la\s+)?(?<cardinal>primera?|1ra|segunda|2da|tercera?|3ra|cuarta|4ta|quinta|5ta|([12345](\.)?ª)|[uú]ltima)\s+semana\s+{MonthSuffixRegex}((\s+de)?\s+({BaseDateTime.FourDigitYearRegex}|{RelativeRegex}\s+año))?)\b";
@@ -80,7 +80,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string PrefixDayRegex = $@"\b((?<EarlyPrefix>(comienzos?|inicios?|principios?|temprano))|(?<MidPrefix>mediados)|(?<LatePrefix>(fin((al)?es)?|m[aá]s\s+tarde)))(\s+(en|{OfPrepositionRegex}))?(\s+([ae]l)(\s+d[ií]a)?)?$";
       public const string CenturySuffixRegex = @"(^siglo)\b";
       public static readonly string SeasonRegex = $@"\b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente)|{PrefixPeriodRegex})\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+(del?|en)|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b";
-      public const string WhichWeekRegex = @"\b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b";
+      public static readonly string WhichWeekRegex = $@"\b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+del?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año|año\s+(?<order>pasado)))?\b";
       public static readonly string WeekOfRegex = $@"((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex}|que\s+(inicia|comienza)\s+el|(que\s+va|a\s+partir)\s+del)";
       public static readonly string MonthOfRegex = $@"(mes)(\s+)({OfPrepositionRegex})";
       public const string RangeUnitRegex = @"\b(?<unit>años?|mes(es)?|semanas?)\b";
@@ -92,7 +92,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string WeekDayRegex = @"\b(?<weekday>(domingos?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?)\b|(lun|mar|mi[eé]|jue|vie|s[aá]b|dom|lu|ma|mi|ju|vi|s[aá]|do)(\.|\b))(?!ñ)";
       public static readonly string OnRegex = $@"((?<=\b(e[ln])\s+)|(\be[ln]\s+d[ií]a\s+))({DayRegex}s?)(?![.,]\d)\b";
       public const string RelaxedOnRegex = @"(?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)(?![.,]\d)\b";
-      public const string SpecialDayRegex = @"\b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+d)|ayer|mañana|hoy)\b";
+      public const string SpecialDayRegex = @"\b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+(de|internacional))|ayer|mañana|hoy)\b";
       public const string SpecialDayWithNumRegex = @"^[.]";
       public static readonly string FlexibleDayRegex = $@"(?<DayOfMonth>([a-z]+\s)?({WrittenDayRegex}|{DayRegex}))";
       public static readonly string ForTheRegex = $@"\b((((?<=para\s+el\s+){FlexibleDayRegex})|((?<!(\b{MonthRegex},?|\bpara)\s+(el\s+)|{WeekDayRegex}\s+(el\s+)?)((?<=(e[ln]\s+))|(\be[ln]\s+d[ií]a\s+)){FlexibleDayRegex}))(?<end>\s*(,|\.(?![º°ª])|!|\?|-|$))(?!\d))";
@@ -126,6 +126,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string DateExtractor8 = $@"(?<=\b(en|el)\s+){DayRegex}[\\\-]{MonthNumRegex}{BaseDateTime.CheckDecimalRegex}\b(?!\s*[/\\\.]\s*\d+)";
       public static readonly string DateExtractor9 = $@"\b({WeekDayRegex}\s+)?(?<!\d[.,]){DayRegex}\s*/\s*{MonthNumRegex}((\s+|\s*,\s*|\s+d[eo]\s+){DateYearRegex})?\b{BaseDateTime.CheckDecimalRegex}(?!\s*[/\\\.]\s*\d+)";
       public static readonly string DateExtractor10 = $@"\b(?<!\d[.,])(({YearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+))|({MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{DayRegex})|({DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex}))";
+      public const string HourRegex = @"\b(?<!\d[,.])(?<hour>2[0-4]|[0-1]?\d)";
       public const string HourNumRegex = @"\b(?<hournum>cero|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce)\b";
       public const string MinuteNumRegex = @"(?<minnum>uno?|d[óo]s|tr[eé]s|cuatro|cinco|s[eé]is|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|diecis[eé]is|diecisiete|dieciocho|diecinueve|veinte|treinta|cuarenta|cincuenta)";
       public const string DeltaMinuteNumRegex = @"(?<deltaminnum>uno?|d[óo]s|tr[eé]s|cuatro|cinco|s[eé]is|siete|ocho|nueve|diez|once|doce|trece|catorce|quince|diecis[eé]is|diecisiete|dieciocho|diecinueve|veinte|treinta|cuarenta|cincuenta)";
@@ -150,12 +151,12 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string ConnectNumRegex = $@"({BaseDateTime.HourRegex}(?<min>[0-5][0-9])\s*{DescRegex})";
       public static readonly string TimeRegexWithDotConnector = $@"({BaseDateTime.HourRegex}\.{BaseDateTime.MinuteRegex})";
       public static readonly string TimeRegex1 = $@"(\b{TimePrefix}\s+)?({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex})\s*({DescRegex}|\s*\bh\b)";
-      public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex2 = $@"(\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*({DescRegex}|\bh\b)|\b)";
       public static readonly string TimeRegex3 = $@"\b(({TimePrefix}\s+)?{TimeRegexWithDotConnector}(\s*({DescRegex}|{TimeSuffix}|\bh\b))|((las\s+{TimeRegexWithDotConnector})(?!\s*(por\s+cien(to)?|%))(\s*({DescRegex}|{TimeSuffix}|\bh\b)|\b)))";
-      public static readonly string TimeRegex4 = $@"\b(({DescRegex}?)|({BasicTime}\s*)?({GeneralDescRegex}?)){TimePrefix}(\s*({HourNumRegex}|{BaseDateTime.HourRegex}))?(\s+{TensTimeRegex}(\s*(y\s+)?{MinuteNumRegex})?)?(\s*({OclockRegex}|{DescRegex})|\b)";
+      public static readonly string TimeRegex4 = $@"\b(({DescRegex}?)|({BasicTime}\s*)?({GeneralDescRegex}?)){TimePrefix}(\s*({HourNumRegex}|{BaseDateTime.HourRegex}))?(\s+{TensTimeRegex}(\s*(y\s+)?{MinuteNumRegex})?)?(\s*({OclockRegex}|{DescRegex}|\bh\b)|\b)";
       public static readonly string TimeRegex5 = $@"\b({TimePrefix}|{BasicTime}{TimePrefix})\s+(\s*{DescRegex})?{BasicTime}?\s*{TimeSuffix}\b";
       public static readonly string TimeRegex6 = $@"({BasicTime}(\s*{DescRegex})?\s+{TimeSuffix}\b)";
-      public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+a\s+las\s+{BasicTime}((\s*{DescRegex})|\b)";
+      public static readonly string TimeRegex7 = $@"\b{TimeSuffix}\s+a\s+las\s+{BasicTime}((\s*{DescRegex}|\bh\b)|\b)";
       public static readonly string TimeRegex8 = $@"\b{TimeSuffix}\s+{BasicTime}((\s*{DescRegex})|\b)";
       public static readonly string TimeRegex9 = $@"\b(?<writtentime>{HourNumRegex}\s+({TensTimeRegex}\s*)(y\s+)?{MinuteNumRegex}?)\b";
       public static readonly string TimeRegex11 = $@"\b({WrittenTimeRegex})(\s+{DescRegex})?\b";
@@ -202,15 +203,15 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string ConjunctionRegex = @"^[.]";
       public const string InexactNumberRegex = @"\b(pocos?|algo|vari[ao]s|algun[ao]s|un[ao]s)\b";
       public static readonly string InexactNumberUnitRegex = $@"({InexactNumberRegex})\s+{UnitRegex}";
-      public static readonly string HolidayRegex1 = $@"\b(?<holiday>viernes santo|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
-      public static readonly string HolidayRegex2 = $@"\b(?<holiday>(d[ií]a( del?( la)?)? )?(martin luther king|todos los santos|blanco|san patricio|san valent[ií]n|san jorge|cinco de mayo|independencia|raza|trabajador))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
+      public static readonly string HolidayRegex1 = $@"\b(?<holiday>viernes\s+(santo|negro)|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
+      public static readonly string HolidayRegex2 = $@"\b(?<holiday>(d[ií]a( del?( la)?)? )?(martin luther king|todos los santos|tierra|blanco|san patricio|san valent[ií]n|san jorge|cinco de mayo|independencia|raza|trabajador))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public static readonly string HolidayRegex3 = $@"\b(?<holiday>(d[ií]a( internacional)?( del?( l[ao]s?)?)? )(trabajador(es)?|madres?|padres?|[aá]rbol|mujer(es)?|solteros?|niños?|marmota|san valent[ií]n|maestro))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b";
       public const string BeforeRegex = @"(\b((ante(s|rior)|m[aá]s\s+temprano|no\s+m[aá]s\s+tard(e|ar)|hasta|(?<include>tan\s+tarde\s+como))(\s+(del?|a|que)(\s+(el|las?|los?))?)?)|(?<!\w|>)((?<include><\s*=)|<))";
       public const string AfterRegex = @"((\b(despu[eé]s|(año\s+)?posterior|m[aá]s\s+tarde|a\s+primeros)(\s*(del?|en|a)(\s+(el|las?|los?))?)?|(empi?en?zando|comenzando)(\s+(el|las?|los?))?)\b|(?<!\w|<)((?<include>>\s*=)|>))";
       public const string SinceRegex = @"\b(((cualquier\s+tiempo\s+)?(desde|a\s+partir\s+del?)|tan\s+(temprano|pronto)\s+como(\s+(de|a))?)(\s+(el|las?|los?))?)\b";
       public static readonly string SinceRegexExp = $@"({SinceRegex}|\bde\b)";
       public const string AroundRegex = @"(?:\b(?:cerca|alrededor|aproximadamente)(\s+(de\s+(las?|el)|del?))?\s*\b)";
-      public const string PeriodicRegex = @"\b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|semestral|anual)(es|mente)?)\b";
+      public const string PeriodicRegex = @"\b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|(se|tri)mestral|anual)(es|mente)?)\b";
       public const string EachExpression = @"\b(cada|tod[oa]s\s*(l[oa]s)?)\b\s*(?!\s*l[oa]\b)";
       public static readonly string EachUnitRegex = $@"(?<each>({EachExpression})\s*({UnitRegex}|(?<specialUnit>fin(es)?\s+de\s+semana|finde)\b))";
       public static readonly string EachPrefixRegex = $@"(?<each>({EachExpression})\s*$)";
@@ -224,21 +225,21 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string MiddlePauseRegex = @"^[.]";
       public const string PrefixArticleRegex = @"\b(e[ln]\s+(d[ií]a\s+)?)";
       public const string OrRegex = @"^[.]";
-      public static readonly string SpecialYearTermsRegex = $@"\b(años?\s+({SpecialYearPrefixes}\s+)?(de\s+)?)";
+      public static readonly string SpecialYearTermsRegex = $@"\b(({SpecialYearPrefixes}\s+años?\s+|años?\s+({SpecialYearPrefixes}\s+)?)(de\s+)?)";
       public static readonly string YearPlusNumberRegex = $@"\b({SpecialYearTermsRegex}((?<year>(\d{{2,4}}))|{FullTextYearRegex}))\b";
-      public const string NumberAsTimeRegex = @"^[.]";
+      public static readonly string NumberAsTimeRegex = $@"\b({WrittenTimeRegex}|{HourRegex}(?<desc>\s*h(oras)?)?)\b";
       public static readonly string TimeBeforeAfterRegex = $@"\b((?<=\b(antes|no\s+m[aá]s\s+tard(e|ar)\s+(de|a\s+las?)|por| después)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))\b";
-      public const string DateNumberConnectorRegex = @"^[.]";
+      public const string DateNumberConnectorRegex = @"^\s*(?<connector>a\s+las)\s*$";
       public const string CenturyRegex = @"^[.]";
       public const string DecadeRegex = @"(?<decade>diez|veinte|treinta|cuarenta|cincuenta|se[st]enta|ochenta|noventa)";
       public static readonly string DecadeWithCenturyRegex = $@"(los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))";
-      public static readonly string RelativeDecadeRegex = $@"\b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b";
+      public static readonly string RelativeDecadeRegex = $@"\b(((el|las?)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?(d[eé]cada|decenio)s?)\b";
       public static readonly string ComplexDatePeriodRegex = $@"(?:((de(sde)?)\s+)?(?<start>.+)\s*({StrictTillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))";
       public const string AmbiguousPointRangeRegex = @"^(mar\.?)$";
       public static readonly string YearSuffix = $@"((,|\sdel?)?\s*({YearRegex}|{FullTextYearRegex}))";
       public static readonly string SinceYearSuffixRegex = $@"(^\s*{SinceRegex}(\s*(el\s+)?año\s*)?{YearSuffix})";
       public const string AgoRegex = @"\b(antes\s+de\s+(?<day>hoy|ayer|mañana)|antes|hace)\b";
-      public const string LaterRegex = @"\b(despu[eé]s(?!\s+de\b)|desde\s+ahora|a\s+partir\s+de\s+(ahora|(?<day>hoy|ayer|mañana)))\b";
+      public const string LaterRegex = @"\b(despu[eé]s(?!\s+de\b)|desde\s+ahora|(a\s+partir|despu[eé]s)\s+de\s+(ahora|(?<day>hoy|ayer|mañana)))\b";
       public const string Tomorrow = @"mañana";
       public static readonly Dictionary<string, string> UnitMap = new Dictionary<string, string>
         {
@@ -572,7 +573,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"padres", new string[] { @"diadelpadre" } },
             { @"madres", new string[] { @"diadelamadre" } },
             { @"acciondegracias", new string[] { @"diadegracias", @"diadeacciondegracias", @"acciondegracias" } },
-            { @"trabajador", new string[] { @"diadeltrabajador", @"diainternacionaldelostrabajadores" } },
+            { @"trabajador", new string[] { @"diadeltrabajador", @"diadelostrabajadores", @"diainternacionaldeltrabajador", @"diainternacionaldelostrabajadores" } },
             { @"delaraza", new string[] { @"diadelaraza", @"diadeladiversidadcultural" } },
             { @"memoria", new string[] { @"diadelamemoria" } },
             { @"pascuas", new string[] { @"diadepascuas", @"pascuas" } },
@@ -586,7 +587,11 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"todoslossantos", new string[] { @"todoslossantos" } },
             { @"niño", new string[] { @"diadelniño" } },
             { @"mujer", new string[] { @"diadelamujer" } },
-            { @"independencia", new string[] { @"diadelaindependencia", @"diadeindependencia", @"independencia" } }
+            { @"independencia", new string[] { @"diadelaindependencia", @"diadeindependencia", @"independencia" } },
+            { @"blackfriday", new string[] { @"viernesnegro" } },
+            { @"goodfriday", new string[] { @"viernessanto" } },
+            { @"stpatrickday", new string[] { @"sanpatricio", @"diadesanpatricio" } },
+            { @"valentinesday", new string[] { @"sanvalentin", @"diadesanvalentin" } }
         };
       public static readonly Dictionary<string, string> VariableHolidaysTimexDictionary = new Dictionary<string, string>
         {
@@ -720,7 +725,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly IList<string> MonthToDateTerms = new List<string>
         {
             @"mes a la fecha",
-            @"meses a la fecha"
+            @"mes hasta la fecha"
         };
       public static readonly IList<string> WeekendTerms = new List<string>
         {
@@ -745,7 +750,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly IList<string> YearToDateTerms = new List<string>
         {
             @"año a la fecha",
-            @"años a la fecha"
+            @"año hasta la fecha"
         };
       public static readonly Dictionary<char, char> SpecialCharactersEquivalent = new Dictionary<char, char>
         {
@@ -761,6 +766,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string BiWeekTypeRegex = @"(quincenalmente)$";
       public const string WeekendTypeRegex = @"(fin(es)?\s+de\s+semana|finde)$";
       public const string MonthTypeRegex = @"(mes(es)?|mensual(es|mente)?)$";
+      public const string QuarterTypeRegex = @"(trimestral(es|mente)?)$";
+      public const string BiAnnualTypeRegex = @"(semestral(es|mente)?)$";
       public const string YearTypeRegex = @"(años?|anualmente)$";
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -2100,16 +2100,17 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             if (match.Success)
             {
-                var num = int.Parse(match.Groups["number"].ToString(), CultureInfo.InvariantCulture);
+                var num = int.Parse(match.Groups[Constants.NumberGroupName].ToString(), CultureInfo.InvariantCulture);
                 if (num == 0)
                 {
                     return ret;
                 }
 
+                // cases like "week 23 of 2019", "week 12 of last year"
                 var year = config.DateExtractor.GetYearFromText(match.Match);
                 if (year == Constants.InvalidYear)
                 {
-                    var orderStr = match.Groups["order"].Value;
+                    var orderStr = match.Groups[Constants.OrderGroupName].Value;
                     var swift = this.config.GetSwiftYear(orderStr);
                     if (swift < -1)
                     {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -2106,7 +2106,19 @@ namespace Microsoft.Recognizers.Text.DateTime
                     return ret;
                 }
 
-                var year = referenceDate.Year;
+                var year = config.DateExtractor.GetYearFromText(match.Match);
+                if (year == Constants.InvalidYear)
+                {
+                    var orderStr = match.Groups["order"].Value;
+                    var swift = this.config.GetSwiftYear(orderStr);
+                    if (swift < -1)
+                    {
+                        swift = 0;
+                    }
+
+                    year = referenceDate.Year + swift;
+                }
+
                 ret.Timex = year.ToString("D4", CultureInfo.InvariantCulture) + "-W" + num.ToString("D2", CultureInfo.InvariantCulture);
 
                 var firstDay = DateObject.MinValue.SafeCreateFromValue(year, 1, 1);

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Extractors/PortugueseDatePeriodExtractorConfiguration.cs
@@ -198,6 +198,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
             QuarterRegex,
             QuarterRegexYearFront,
             SeasonRegex,
+            WhichWeekRegex,
             RestOfDateRegex,
             LaterEarlyPeriodRegex,
             WeekWithWeekDayRangeRegex,

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseDatePeriodParserConfiguration.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public static readonly Regex UnspecificEndOfRangeRegex =
             new Regex(DateTimeDefinitions.UnspecificEndOfRangeRegex, RegexFlags);
 
+        public static readonly Regex SpecialYearPrefixes =
+            new Regex(DateTimeDefinitions.SpecialYearPrefixes, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public PortugueseDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
@@ -319,7 +322,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         public bool IsYearOnly(string text)
         {
             var trimmedText = text.Trim();
-            return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal));
+            return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
+                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && SpecialYearPrefixes.IsMatch(trimmedText));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         private static readonly Regex QuarterTypeRegex =
             new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
 
-        private static readonly Regex BiAnnualTypeRegex =
-            new Regex(DateTimeDefinitions.BiAnnualTypeRegex, RegexFlags);
+        private static readonly Regex SemiAnnualTypeRegex =
+            new Regex(DateTimeDefinitions.SemiAnnualTypeRegex, RegexFlags);
 
         private static readonly Regex YearTypeRegex =
             new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
@@ -143,10 +143,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
                 durationType = "M";
                 multiplier = 3;
             }
-            else if (BiAnnualTypeRegex.IsMatch(trimmedText))
+            else if (SemiAnnualTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "M";
-                multiplier = 6;
+                durationType = "Y";
+                multiplier = 0.5f;
             }
             else if (YearTypeRegex.IsMatch(trimmedText))
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -118,39 +118,39 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 
             if (DayTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "D";
+                durationType = Constants.TimexDay;
             }
             else if (WeekTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "W";
+                durationType = Constants.TimexWeek;
             }
             else if (BiWeekTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "W";
+                durationType = Constants.TimexWeek;
                 multiplier = 2;
             }
             else if (MonthTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "M";
+                durationType = Constants.TimexMonth;
             }
             else if (BiMonthTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "M";
+                durationType = Constants.TimexMonth;
                 multiplier = 2;
             }
             else if (QuarterTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "M";
+                durationType = Constants.TimexMonth;
                 multiplier = 3;
             }
             else if (SemiAnnualTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "Y";
+                durationType = Constants.TimexYear;
                 multiplier = 0.5f;
             }
             else if (YearTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "Y";
+                durationType = Constants.TimexYear;
             }
             else
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Portuguese/Parsers/PortugueseSetParserConfiguration.cs
@@ -12,6 +12,32 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
 {
     public class PortugueseSetParserConfiguration : BaseDateTimeOptionsConfiguration, ISetParserConfiguration
     {
+        private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
+
+        private static readonly Regex DayTypeRegex =
+            new Regex(DateTimeDefinitions.DayTypeRegex, RegexFlags);
+
+        private static readonly Regex WeekTypeRegex =
+            new Regex(DateTimeDefinitions.WeekTypeRegex, RegexFlags);
+
+        private static readonly Regex BiWeekTypeRegex =
+            new Regex(DateTimeDefinitions.BiWeekTypeRegex, RegexFlags);
+
+        private static readonly Regex MonthTypeRegex =
+            new Regex(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
+
+        private static readonly Regex BiMonthTypeRegex =
+            new Regex(DateTimeDefinitions.BiMonthTypeRegex, RegexFlags);
+
+        private static readonly Regex QuarterTypeRegex =
+            new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
+
+        private static readonly Regex BiAnnualTypeRegex =
+            new Regex(DateTimeDefinitions.BiAnnualTypeRegex, RegexFlags);
+
+        private static readonly Regex YearTypeRegex =
+            new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
+
         public PortugueseSetParserConfiguration(ICommonDateTimeParserConfiguration config)
             : base(config)
         {
@@ -86,33 +112,53 @@ namespace Microsoft.Recognizers.Text.DateTime.Portuguese
         {
             var trimmedText = text.Trim().Normalized(DateTimeDefinitions.SpecialCharactersEquivalent);
 
-            // @TODO move hardcoded values to resources file
-            if (trimmedText.EndsWith("diario", StringComparison.Ordinal) || trimmedText.EndsWith("diaria", StringComparison.Ordinal) ||
-                trimmedText.EndsWith("diariamente", StringComparison.Ordinal))
+            float durationLength = 1; // Default value
+            float multiplier = 1;
+            string durationType;
+
+            if (DayTypeRegex.IsMatch(trimmedText))
             {
-                timex = "P1D";
+                durationType = "D";
             }
-            else if (trimmedText.Equals("semanalmente", StringComparison.Ordinal))
+            else if (WeekTypeRegex.IsMatch(trimmedText))
             {
-                timex = "P1W";
+                durationType = "W";
             }
-            else if (trimmedText.Equals("quinzenalmente", StringComparison.Ordinal))
+            else if (BiWeekTypeRegex.IsMatch(trimmedText))
             {
-                timex = "P2W";
+                durationType = "W";
+                multiplier = 2;
             }
-            else if (trimmedText.Equals("mensalmente", StringComparison.Ordinal))
+            else if (MonthTypeRegex.IsMatch(trimmedText))
             {
-                timex = "P1M";
+                durationType = "M";
             }
-            else if (trimmedText.Equals("anualmente", StringComparison.Ordinal))
+            else if (BiMonthTypeRegex.IsMatch(trimmedText))
             {
-                timex = "P1Y";
+                durationType = "M";
+                multiplier = 2;
+            }
+            else if (QuarterTypeRegex.IsMatch(trimmedText))
+            {
+                durationType = "M";
+                multiplier = 3;
+            }
+            else if (BiAnnualTypeRegex.IsMatch(trimmedText))
+            {
+                durationType = "M";
+                multiplier = 6;
+            }
+            else if (YearTypeRegex.IsMatch(trimmedText))
+            {
+                durationType = "Y";
             }
             else
             {
                 timex = null;
                 return false;
             }
+
+            timex = TimexUtility.GenerateSetTimex(durationType, durationLength, multiplier);
 
             return true;
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishDatePeriodParserConfiguration.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         public static readonly Regex AmbiguousPointRangeRegex =
             new Regex(DateTimeDefinitions.AmbiguousPointRangeRegex, RegexFlags);
 
+        public static readonly Regex SpecialYearPrefixes =
+            new Regex(DateTimeDefinitions.SpecialYearPrefixes, RegexFlags);
+
         private const RegexOptions RegexFlags = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
 
         public SpanishDatePeriodParserConfiguration(ICommonDateTimeParserConfiguration config)
@@ -345,7 +348,7 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         {
             var trimmedText = text.Trim();
             return DateTimeDefinitions.YearTerms.Any(o => trimmedText.EndsWith(o, StringComparison.Ordinal)) ||
-                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && RelativeSuffixRegex.IsMatch(trimmedText));
+                   (DateTimeDefinitions.YearTerms.Any(o => trimmedText.Contains(o)) && (RelativeSuffixRegex.IsMatch(trimmedText) || SpecialYearPrefixes.IsMatch(trimmedText)));
         }
 
         public bool IsYearToDate(string text)

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishHolidayParserConfiguration.cs
@@ -71,6 +71,11 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 { "todoslossantos", HalloweenDay },
                 { "niño", ChildrenDay },
                 { "mujer", FemaleDay },
+                { "independencia", UsaIndependenceDay },
+                { "earthday", EarthDay },
+                { "stpatrickday", StPatrickDay },
+                { "valentinesday", ValentinesDay },
+                { "goodfriday", GoodFriday },
             };
         }
 
@@ -91,5 +96,15 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static DateObject TeacherDay(int year) => new DateObject(year, 9, 11);
 
         private static DateObject Pascuas(int year) => HolidayFunctions.CalculateHolidayByEaster(year);
+
+        private static DateObject GoodFriday(int year) => Pascuas(year).AddDays(-2);
+
+        private static DateObject UsaIndependenceDay(int year) => new DateObject(year, 7, 4);
+
+        private static DateObject EarthDay(int year) => new DateObject(year, 4, 22);
+
+        private static DateObject ValentinesDay(int year) => new DateObject(year, 2, 14);
+
+        private static DateObject StPatrickDay(int year) => new DateObject(year, 3, 17);
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -125,38 +125,38 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
 
             if (DayTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "D";
+                durationType = Constants.TimexDay;
             }
             else if (WeekTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "W";
+                durationType = Constants.TimexWeek;
             }
             else if (BiWeekTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "W";
+                durationType = Constants.TimexWeek;
                 multiplier = 2;
             }
             else if (WeekendTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "WE";
+                durationType = Constants.TimexWeekend;
             }
             else if (MonthTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "M";
+                durationType = Constants.TimexMonth;
             }
             else if (QuarterTypeRegex.IsMatch(trimmedText))
             {
                 multiplier = 3;
-                durationType = "M";
+                durationType = Constants.TimexMonth;
             }
             else if (SemiAnnualTypeRegex.IsMatch(trimmedText))
             {
                 multiplier = 0.5f;
-                durationType = "Y";
+                durationType = Constants.TimexYear;
             }
             else if (YearTypeRegex.IsMatch(trimmedText))
             {
-                durationType = "Y";
+                durationType = Constants.TimexYear;
             }
             else
             {

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex MonthTypeRegex =
             new Regex(DateTimeDefinitions.MonthTypeRegex, RegexFlags);
 
+        private static readonly Regex QuarterTypeRegex =
+            new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
+
+        private static readonly Regex BiAnnualTypeRegex =
+            new Regex(DateTimeDefinitions.BiAnnualTypeRegex, RegexFlags);
+
         private static readonly Regex YearTypeRegex =
             new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
 
@@ -136,6 +142,16 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
             }
             else if (MonthTypeRegex.IsMatch(trimmedText))
             {
+                durationType = "M";
+            }
+            else if (QuarterTypeRegex.IsMatch(trimmedText))
+            {
+                multiplier = 3;
+                durationType = "M";
+            }
+            else if (BiAnnualTypeRegex.IsMatch(trimmedText))
+            {
+                multiplier = 6;
                 durationType = "M";
             }
             else if (YearTypeRegex.IsMatch(trimmedText))

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Spanish/Parsers/SpanishSetParserConfiguration.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
         private static readonly Regex QuarterTypeRegex =
             new Regex(DateTimeDefinitions.QuarterTypeRegex, RegexFlags);
 
-        private static readonly Regex BiAnnualTypeRegex =
-            new Regex(DateTimeDefinitions.BiAnnualTypeRegex, RegexFlags);
+        private static readonly Regex SemiAnnualTypeRegex =
+            new Regex(DateTimeDefinitions.SemiAnnualTypeRegex, RegexFlags);
 
         private static readonly Regex YearTypeRegex =
             new Regex(DateTimeDefinitions.YearTypeRegex, RegexFlags);
@@ -149,10 +149,10 @@ namespace Microsoft.Recognizers.Text.DateTime.Spanish
                 multiplier = 3;
                 durationType = "M";
             }
-            else if (BiAnnualTypeRegex.IsMatch(trimmedText))
+            else if (SemiAnnualTypeRegex.IsMatch(trimmedText))
             {
-                multiplier = 6;
-                durationType = "M";
+                multiplier = 0.5f;
+                durationType = "Y";
             }
             else if (YearTypeRegex.IsMatch(trimmedText))
             {

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -213,8 +213,9 @@ SeasonDescRegex: !simpleRegex
 SeasonRegex: !nestedRegex
   def: \b(?<season>({PrefixPeriodRegex}\s+)?({RelativeRegex}\s+)?{SeasonDescRegex}((\s+of|\s*,\s*)?\s+({YearRegex}|{RelativeRegex}\s+year))?)\b
   references: [ YearRegex, RelativeRegex, SeasonDescRegex, PrefixPeriodRegex ]
-WhichWeekRegex: !simpleRegex
-  def: \b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b
+WhichWeekRegex: !nestedRegex
+  def: \b(week)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+of\s+({YearRegex}|{RelativeRegex}\s+year))?\b
+  references: [ YearRegex, RelativeRegex ]
 WeekOfRegex: !simpleRegex
   def: (the\s+)?((week)(\s+(of|(commencing|starting|beginning)(\s+on)?))|w/c)(\s+the)?
 MonthOfRegex: !simpleRegex

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -38,9 +38,9 @@ TwoDigitYearRegex: !nestedRegex
   def: \b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d)))\b
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
-  def: (?<order>((est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b
+  def: (?<order>((n?est[ae]s?|pr[oó]xim[oa]s?|([uú]ltim[ao]s?))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b
 StrictRelativeRegex: !simpleRegex
-  def: (?<order>((est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b
+  def: (?<order>((n?est[ae]|pr[oó]xim[oa]|([uú]ltim(o|as|os)))(\s+fina(l|is)\s+d[eao])?)|(fina(l|is)\s+d[eao]))\b
 WrittenOneToNineRegex: !simpleRegex
   def: (uma?|dois|duas|tr[eê]s|quatro|cinco|seis|sete|oito|nove)
 WrittenOneHundredToNineHundredRegex: !simpleRegex
@@ -79,8 +79,11 @@ MonthFrontBetweenRegex: !nestedRegex
 DayBetweenRegex: !nestedRegex
   def: \b((entre|entre\s+[oa]s?)\s+)(dia\s+)?({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
   references: [ DayRegex, RangeConnectorRegex, MonthSuffixRegex, YearRegex ]
-OneWordPeriodRegex: !simpleRegex
-  def: \b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\s+)?(?<month>abr(il)?|ago(sto)?|dez(embro)?|fev(ereiro)?|jan(eiro)?|ju[ln](ho)?|mar([çc]o)?|maio?|nov(embro)?|out(ubro)?|sep?t(embro)?)|(?<=\b(de|do|da|o|a)\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\b
+SpecialYearPrefixes: !simpleRegex
+  def: ((do\s+)?calend[aá]rio|civil|(?<special>fiscal|escolar|letivo))
+OneWordPeriodRegex: !nestedRegex
+  def: \b(((pr[oó]xim[oa]?|[nd]?es[st]e|aquel[ea]|[uú]ltim[oa]?|em)\s+)?(?<month>abr(il)?|ago(sto)?|dez(embro)?|fev(ereiro)?|jan(eiro)?|ju[ln](ho)?|mar([çc]o)?|maio?|nov(embro)?|out(ubro)?|sep?t(embro)?)|({RelativeRegex}\s+)?(ano\s+{SpecialYearPrefixes}|{SpecialYearPrefixes}\s+ano)|(?<=\b(de|do|da|o|a)\s+)?(pr[oó]xim[oa](s)?|[uú]ltim[oa]s?|est(e|a))\s+(fim de semana|fins de semana|semana|m[êe]s|ano)|fim de semana|fins de semana|(m[êe]s|anos)? [àa] data)\b
+  references: [RelativeRegex, SpecialYearPrefixes]
 MonthWithYearRegex: !nestedRegex
   def: \b((((pr[oó]xim[oa](s)?|[nd]?es[st]e|aquele|[uú]ltim[oa]?|em)\s+)?{MonthRegex}|((n?o\s+)?(?<cardinal>primeiro|1o|segundo|2o|terceiro|3o|[cq]uarto|4o|quinto|5o|sexto|6o|s[eé]timo|7o|oitavo|8o|nono|9o|d[eé]cimo(\s+(primeiro|segundo))?|10o|11o|12o|[uú]ltimo)\s+m[eê]s(?=\s+(d[aeo]|[ao]))))\s+((d[aeo]|[ao])\s+)?({YearRegex}|{TwoDigitYearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|[nd]?es[st]e)\s+ano))\b
   references: [ MonthRegex, YearRegex, TwoDigitYearRegex ]
@@ -119,8 +122,9 @@ PrefixDayRegex: !simpleRegex
 SeasonRegex: !nestedRegex
   def: \b(?<season>(([uú]ltim[oa]|[nd]?es[st][ea]|n?[oa]|(pr[oó]xim[oa]s?|seguinte))\s+)?(?<seas>primavera|ver[ãa]o|outono|inverno)((\s+)?(seguinte|((de\s+|,)?\s*{YearRegex})|((do\s+)?(?<order>pr[oó]ximo|[uú]ltimo|[nd]?es[st]e)\s+ano)))?)\b
   references: [ YearRegex ]
-WhichWeekRegex: !simpleRegex
-  def: \b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b
+WhichWeekRegex: !nestedRegex
+  def: \b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+(de|do)\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|[nd]?es[st]e)\s+ano|ano\s+(?<order>passado)))?\b
+  references: [ YearRegex ]
 WeekOfRegex: !simpleRegex
   def: (semana)(\s*)((do|da|de))
 MonthOfRegex: !simpleRegex
@@ -211,7 +215,7 @@ WeekDayEnd: !nestedRegex
   def: '{WeekDayRegex}\s*,?\s*$'
   references: [ WeekDayRegex ]
 WeekDayStart: !simpleRegex
-  def: ^[\.]
+  def: ^\b$
 DateYearRegex: !nestedRegex
   def: (?<year>{YearRegex}|{TwoDigitYearRegex})
   references: [ YearRegex, TwoDigitYearRegex ]
@@ -485,7 +489,7 @@ AroundRegex: !simpleRegex
   def: (?:\b(?:cerca|perto|ao\s+redor|por\s+volta)\s*?\b)(\s+(de|das))?
 # PortugueseSetExtractorConfiguration
 PeriodicRegex: !simpleRegex
-  def: \b(?<periodic>di[áa]ri[ao]|(diaria|mensal|semanal|quinzenal|anual)mente)\b
+  def: \b(?<periodic>di[áa]ri[ao]|(diaria|mensal|semanal|quinzenal|(bi|tri|se)mestral|anual)(mente)?)\b
 EachExpression: !simpleRegex
   def: cada|tod[oa]s?\s*([oa]s)?
 EachUnitRegex: !nestedRegex
@@ -521,7 +525,13 @@ PrefixArticleRegex: !simpleRegex
 OrRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
-YearPlusNumberRegex: !simpleRegex
+SpecialYearTermsRegex: !nestedRegex
+  def: \b(({SpecialYearPrefixes}\s+anos?\s+|anos?\s+({SpecialYearPrefixes}\s+)?)(d[oe]\s+)?)
+  references: [ SpecialYearPrefixes ]
+YearPlusNumberRegex: !nestedRegex
+  def: \b({SpecialYearTermsRegex}((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
+  references: [ FullTextYearRegex, SpecialYearTermsRegex ]
+NumberAsTimeRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 NumberAsTimeRegex: !nestedRegex
@@ -538,9 +548,9 @@ ComplexDatePeriodRegex: !simpleRegex
   def: ^[.]
 # PortugueseDatetimeUtilityConfiguration
 AgoRegex: !simpleRegex
-  def: \b(antes|atr[áa]s|no passado)\b
+  def: \b(antes(\s+d[eoa]s?\s+(?<day>hoje|ontem|manhã))?|atr[áa]s|no passado)\b
 LaterRegex: !simpleRegex
-  def: \b(depois d[eoa]s?|ap[óo]s (as)?|desde( (as|o))?|no futuro|mais tarde)\b
+  def: \b(depois(\s+d[eoa]s?\s+(agora|(?<day>hoje|ontem|manhã)))?|ap[óo]s (as)?|desde( (as|o))?|no futuro|mais tarde)\b
 # DateTimePeriodParser
 Tomorrow: amanh[ãa]
 # PortugueseCommonDateTimeParserConfiguration
@@ -594,11 +604,12 @@ UnitValueMap: !dictionary
     segundo: 1
     segs: 1
     seg: 1
-# TODO: modify below regex according to the counterpart in English
 SpecialYearPrefixesMap: !dictionary
   types: [ string, string ]
   entries:
-    '': ''
+    fiscal: FY
+    escolar: SY
+    letivo: SY
 SeasonMap: !dictionary
   types: [ string, string ]
   entries:
@@ -877,7 +888,7 @@ PastPrefixRegex: !simpleRegex
   def: .^
 # TODO: modify below regex according to the counterpart in English
 PreviousPrefixRegex: !nestedRegex
-  def: ([uú]ltim[oa]s?|{PastPrefixRegex})\b
+  def: ([uú]ltim[oa]s?|passad[oa]s?|{PastPrefixRegex})\b
   references: [PastPrefixRegex]
 ThisPrefixRegex: !simpleRegex
   def: ([nd]?es[st][ea])\b
@@ -930,9 +941,9 @@ DecadeRegex: !simpleRegex
 DecadeWithCenturyRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
-RelativeDecadeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+RelativeDecadeRegex: !nestedRegex
+  def: \b((n?as?\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?(d[eé]cada)s?)\b
+  references: [ RelativeRegex,WrittenOneToNineRegex ]
 YearSuffix: !nestedRegex
   def: ((,|\sde)?\s*({YearRegex}|{FullTextYearRegex}))
   references: [ YearRegex, FullTextYearRegex ]
@@ -1079,4 +1090,21 @@ SpecialCharactersEquivalent: !dictionary
     ã: a
     õ: o
     ç: c
+# For SetParserConfiguration
+DayTypeRegex: !simpleRegex
+  def: (diari([ao]|amente))$
+WeekTypeRegex: !simpleRegex
+  def: (semanal(mente)?)$
+BiWeekTypeRegex: !simpleRegex
+  def: (quinzenal(mente)?)$
+MonthTypeRegex: !simpleRegex
+  def: (mensal(mente)?)$
+BiMonthTypeRegex: !simpleRegex
+  def: (bimestral(mente)?)$
+QuarterTypeRegex: !simpleRegex
+  def: (trimestral(mente)?)$
+BiAnnualTypeRegex: !simpleRegex
+  def: (semestral(mente)?)$
+YearTypeRegex: !simpleRegex
+  def: (anual(mente)?)$
 ...

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -531,9 +531,6 @@ SpecialYearTermsRegex: !nestedRegex
 YearPlusNumberRegex: !nestedRegex
   def: \b({SpecialYearTermsRegex}((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
   references: [ FullTextYearRegex, SpecialYearTermsRegex ]
-NumberAsTimeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
 NumberAsTimeRegex: !nestedRegex
   def: \b({WrittenTimeRegex}|({TimeHourNumRegex}|{BaseDateTime.HourRegex})(?<desc>\s*horas)?)\b
   references: [ WrittenTimeRegex, TimeHourNumRegex, BaseDateTime.HourRegex ]

--- a/Patterns/Portuguese/Portuguese-DateTime.yaml
+++ b/Patterns/Portuguese/Portuguese-DateTime.yaml
@@ -1103,7 +1103,7 @@ BiMonthTypeRegex: !simpleRegex
   def: (bimestral(mente)?)$
 QuarterTypeRegex: !simpleRegex
   def: (trimestral(mente)?)$
-BiAnnualTypeRegex: !simpleRegex
+SemiAnnualTypeRegex: !simpleRegex
   def: (semestral(mente)?)$
 YearTypeRegex: !simpleRegex
   def: (anual(mente)?)$

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -1193,8 +1193,8 @@ MonthTypeRegex: !simpleRegex
   def: (mes(es)?|mensual(es|mente)?)$
 QuarterTypeRegex: !simpleRegex
   def: (trimestral(es|mente)?)$
-BiAnnualTypeRegex: !simpleRegex
+SemiAnnualTypeRegex: !simpleRegex
   def: (semestral(es|mente)?)$
 YearTypeRegex: !simpleRegex
-  def: (años?|anualmente)$
+  def: (años?|anual(mente)?)$
 ...

--- a/Patterns/Spanish/Spanish-DateTime.yaml
+++ b/Patterns/Spanish/Spanish-DateTime.yaml
@@ -49,7 +49,7 @@ TwoDigitYearRegex: !nestedRegex
   def: \b(?<![$])(?<year>([0-9]\d))(?!(\s*((\:\d)|{AmDescRegex}|{PmDescRegex}|\.\d))|\.?[º°ª])\b
   references: [ AmDescRegex, PmDescRegex]
 RelativeRegex: !simpleRegex
-  def: (?<order>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b
+  def: (?<order>est[ae]s?|pr[oó]xim[oa]s?|siguiente|(([uú]ltim|pasad)[ao]s?))\b
 StrictRelativeRegex: !simpleRegex
   def: (?<order>est[ae]|pr[oó]xim[oa]|siguiente|(([uú]ltim|pasad)(o|as|os)))\b
 WrittenOneToNineRegex: !simpleRegex
@@ -93,8 +93,8 @@ DayBetweenRegex: !nestedRegex
 SpecialYearPrefixes: !simpleRegex
   def: ((del\s+)?calend[aá]rio|(?<special>fiscal|escolar))
 OneWordPeriodRegex: !nestedRegex
-  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)
-  references: [MonthRegex, RelativeRegex, OfPrepositionRegex, RelativeSuffixRegex, DateUnitRegex]
+  def: \b(((((la|el)\s+)?mes\s+(({OfPrepositionRegex})\s+)?)|((pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?)\s+))?({MonthRegex})|((el\s+)?{RelativeRegex}\s+)?(({SpecialYearPrefixes}\s+)año|año\s+{SpecialYearPrefixes})|(((la|el)\s+)?((({RelativeRegex}\s+)({DateUnitRegex}|(fin\s+de\s+)?semana|finde)(\s+{RelativeSuffixRegex})?)|{DateUnitRegex}(\s+{RelativeSuffixRegex}))|va\s+de\s+{DateUnitRegex}|((año|mes)(\s+(a|hasta)\s+la\s+fecha)?|((el\s+)?fin\s+de\s+)?semana|(el\s+)?finde))\b)
+  references: [MonthRegex, RelativeRegex, OfPrepositionRegex, RelativeSuffixRegex, DateUnitRegex, SpecialYearPrefixes]
 MonthWithYearRegex: !nestedRegex
   def: \b((((pr[oó]xim[oa](s)?|est?[ae]|[uú]ltim[oa]?)\s+)?{MonthRegex}|((el\s+)?(?<cardinal>primero?|1(er|ro)|segundo|2do|tercero?|3(er|ro)|uarto|4to|quinto|5to|sexto|6to|s[eé]ptimo|7mo|octavo|8vo|noveno|9no|d[eé]cimo|10mo|und[eé]cimo|11mo|duod[eé]cimo|12mo|[uú]ltimo)\s+mes(?=\s+(del?|en))))((\s+|(\s*[,-]\s*))((de(l|\s+la)?|en)\s+)?({YearRegex}|(?<order>pr[oó]ximo(s)?|[uú]ltimo?|este)\s+año)|\s+(del?|en)\s+{TwoDigitYearRegex}))\b
   references: [ MonthRegex, YearRegex, TwoDigitYearRegex ]
@@ -152,8 +152,9 @@ CenturySuffixRegex: !simpleRegex
 SeasonRegex: !nestedRegex
   def: \b(?<season>(([uú]ltim[oa]|est[ea]|el|la|(pr[oó]xim[oa]s?|siguiente)|{PrefixPeriodRegex})\s+)?(?<seas>primavera|verano|otoño|invierno)((\s+(del?|en)|\s*,\s*)?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año))?)\b
   references: [ YearRegex, PrefixPeriodRegex ]
-WhichWeekRegex: !simpleRegex
-  def: \b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])\b
+WhichWeekRegex: !nestedRegex
+  def: \b(semana)(\s*)(?<number>5[0-3]|[1-4]\d|0?[1-9])(\s+del?\s+({YearRegex}|(?<order>pr[oó]ximo|[uú]ltimo|este)\s+año|año\s+(?<order>pasado)))?\b
+  references: [ YearRegex ]
 WeekOfRegex: !nestedRegex
   def: ((del?|el|la)\s+)?(semana)(\s*)({OfPrepositionRegex}|que\s+(inicia|comienza)\s+el|(que\s+va|a\s+partir)\s+del)
   references: [ OfPrepositionRegex ]
@@ -181,7 +182,7 @@ OnRegex: !nestedRegex
 RelaxedOnRegex: !simpleRegex
   def: (?<=\b(en|d?el)\s+)((?<day>10|11|12|13|14|15|16|17|18|19|1st|20|21|22|23|24|25|26|27|28|29|2|30|31|3|4|5|6|7|8|9)s?)(?![.,]\d)\b
 SpecialDayRegex: !simpleRegex
-  def: \b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+d)|ayer|mañana|hoy)\b
+  def: \b((el\s+)?(d[ií]a\s+antes\s+de\s+ayer|anteayer)|((el\s+)?d[ií]a\s+(despu[eé]s\s+)?de\s+mañana|pasado\s+mañana)|(el\s)?d[ií]a\s+(siguiente|anterior)|(el\s)?pr[oó]ximo\s+d[ií]a|(el\s+)?[uú]ltimo\s+d[ií]a|(d)?el\s+d[ií]a(?!\s+(de|internacional))|ayer|mañana|hoy)\b
 SpecialDayWithNumRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -280,6 +281,8 @@ DateExtractor10: !nestedRegex
   def: \b(?<!\d[.,])(({YearRegex}\s*[/\\\-\.]\s*({MonthNumRegex}|{MonthRegex})\s*[/\\\-\.]\s*{DayRegex}(?!\s*[/\\\-\.]\s*\d+))|({MonthRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{DayRegex})|({DayRegex}\s*[/\\\-\.]\s*{BaseDateTime.FourDigitYearRegex}\s*[/\\\-\.]\s*{MonthRegex}))
   references: [ YearRegex, MonthNumRegex, DayRegex, MonthRegex, BaseDateTime.FourDigitYearRegex ]
 # SpanishTimeExtractorConfiguration
+HourRegex: !simpleRegex
+  def: \b(?<!\d[,.])(?<hour>2[0-4]|[0-1]?\d)
 HourNumRegex: !simpleRegex
   def: \b(?<hournum>cero|una|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez|once|doce)\b
 MinuteNumRegex: !simpleRegex
@@ -347,7 +350,7 @@ TimeRegex1: !nestedRegex
   references: [ TimePrefix, WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, DescRegex ]
 TimeRegex2: !nestedRegex
   # (tres min pasadas las)? 3:00(:00)? (pm)?
-  def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?((\s*{DescRegex})|\b)
+  def: (\b{TimePrefix}\s+)?(t)?{BaseDateTime.HourRegex}(\s*)?:(\s*)?{BaseDateTime.MinuteRegex}((\s*)?:(\s*)?{BaseDateTime.SecondRegex})?(\s*({DescRegex}|\bh\b)|\b)
   references: [ TimePrefix, BaseDateTime.HourRegex, BaseDateTime.MinuteRegex, BaseDateTime.SecondRegex, DescRegex ]
 TimeRegex3: !nestedRegex
   # (tres min pasadas las)? 3.00 (pm|h) | a las 2.40
@@ -355,7 +358,7 @@ TimeRegex3: !nestedRegex
   references: [ TimePrefix, TimeRegexWithDotConnector, DescRegex, TimeTokenPrefix, TimeSuffix ]
 TimeRegex4: !nestedRegex
   # (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)?
-  def: \b(({DescRegex}?)|({BasicTime}\s*)?({GeneralDescRegex}?)){TimePrefix}(\s*({HourNumRegex}|{BaseDateTime.HourRegex}))?(\s+{TensTimeRegex}(\s*(y\s+)?{MinuteNumRegex})?)?(\s*({OclockRegex}|{DescRegex})|\b)
+  def: \b(({DescRegex}?)|({BasicTime}\s*)?({GeneralDescRegex}?)){TimePrefix}(\s*({HourNumRegex}|{BaseDateTime.HourRegex}))?(\s+{TensTimeRegex}(\s*(y\s+)?{MinuteNumRegex})?)?(\s*({OclockRegex}|{DescRegex}|\bh\b)|\b)
   references: [ DescRegex, GeneralDescRegex, BasicTime, TimePrefix, HourNumRegex, BaseDateTime.HourRegex, TensTimeRegex, MinuteNumRegex, OclockRegex ]
 TimeRegex5: !nestedRegex
   # (tres min pasadas las) (cinco treinta|siete|7|7:00(:00)?) (pm)? (de la noche)
@@ -367,7 +370,7 @@ TimeRegex6: !nestedRegex
   references: [ BasicTime, DescRegex, TimeSuffix ]
 TimeRegex7: !nestedRegex
   # (En la noche) a las (cinco treinta|siete|7|7:00(:00)?) (pm)?
-  def: \b{TimeSuffix}\s+a\s+las\s+{BasicTime}((\s*{DescRegex})|\b)
+  def: \b{TimeSuffix}\s+a\s+las\s+{BasicTime}((\s*{DescRegex}|\bh\b)|\b)
   references: [ TimeSuffix, BasicTime, DescRegex ]
 TimeRegex8: !nestedRegex
   # (En la noche) (cinco treinta|siete|7|7:00(:00)?) (pm)?
@@ -499,10 +502,10 @@ InexactNumberUnitRegex: !nestedRegex
   references: [ InexactNumberRegex, UnitRegex ]
 # SpanishHolidayExtractorConfiguration
 HolidayRegex1: !nestedRegex
-  def: \b(?<holiday>viernes santo|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
+  def: \b(?<holiday>viernes\s+(santo|negro)|mi[eé]rcoles de ceniza|martes de carnaval|d[ií]a (de|de los) presidentes?|clebraci[oó]n de mao|año nuevo chino|año nuevo|noche vieja|(festividad de )?los mayos|d[ií]a de los inocentes|navidad|noche buena|d[ií]a de acci[oó]n de gracias|acci[oó]n de gracias|yuandan|halloween|noches de brujas|pascuas)(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
   references: [ YearRegex ]
 HolidayRegex2: !nestedRegex
-  def: \b(?<holiday>(d[ií]a( del?( la)?)? )?(martin luther king|todos los santos|blanco|san patricio|san valent[ií]n|san jorge|cinco de mayo|independencia|raza|trabajador))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
+  def: \b(?<holiday>(d[ií]a( del?( la)?)? )?(martin luther king|todos los santos|tierra|blanco|san patricio|san valent[ií]n|san jorge|cinco de mayo|independencia|raza|trabajador))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
   references: [ YearRegex ]
 HolidayRegex3: !nestedRegex
   def: \b(?<holiday>(d[ií]a( internacional)?( del?( l[ao]s?)?)? )(trabajador(es)?|madres?|padres?|[aá]rbol|mujer(es)?|solteros?|niños?|marmota|san valent[ií]n|maestro))(\s+(del?\s+)?({YearRegex}|(?<order>(pr[oó]xim[oa]?|est[ea]|[uú]ltim[oa]?|en))\s+año))?\b
@@ -521,7 +524,7 @@ AroundRegex: !simpleRegex
   def: (?:\b(?:cerca|alrededor|aproximadamente)(\s+(de\s+(las?|el)|del?))?\s*\b)
 # SpanishSetExtractorConfiguration
 PeriodicRegex: !simpleRegex
-  def: \b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|semestral|anual)(es|mente)?)\b
+  def: \b(?<periodic>a\s*diario|diaria(s|mente)|(bi|tri)?(semanal|quincenal|mensual|(se|tri)mestral|anual)(es|mente)?)\b
 EachExpression: !simpleRegex
   def: \b(cada|tod[oa]s\s*(l[oa]s)?)\b\s*(?!\s*l[oa]\b)
 EachUnitRegex: !nestedRegex
@@ -558,20 +561,19 @@ OrRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
 SpecialYearTermsRegex: !nestedRegex
-  def: \b(años?\s+({SpecialYearPrefixes}\s+)?(de\s+)?)
+  def: \b(({SpecialYearPrefixes}\s+años?\s+|años?\s+({SpecialYearPrefixes}\s+)?)(de\s+)?)
   references: [ SpecialYearPrefixes ]
 YearPlusNumberRegex: !nestedRegex
   def: \b({SpecialYearTermsRegex}((?<year>(\d{2,4}))|{FullTextYearRegex}))\b
   references: [ FullTextYearRegex, SpecialYearTermsRegex ]
-NumberAsTimeRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+NumberAsTimeRegex: !nestedRegex
+  def: \b({WrittenTimeRegex}|{HourRegex}(?<desc>\s*h(oras)?)?)\b
+  references: [ WrittenTimeRegex, HourRegex ]
 TimeBeforeAfterRegex: !nestedRegex
   def: \b((?<=\b(antes|no\s+m[aá]s\s+tard(e|ar)\s+(de|a\s+las?)|por| después)\s+)({WrittenTimeRegex}|{HourNumRegex}|{BaseDateTime.HourRegex}|{MidTimeRegex}))\b
   references: [ WrittenTimeRegex, HourNumRegex, BaseDateTime.HourRegex, MidTimeRegex ]
 DateNumberConnectorRegex: !simpleRegex
-  # TODO: modify below regex according to the counterpart in English
-  def: ^[.]
+  def: ^\s*(?<connector>a\s+las)\s*$
 CenturyRegex: !simpleRegex
   # TODO: modify below regex according to the counterpart in English
   def: ^[.]
@@ -581,7 +583,7 @@ DecadeWithCenturyRegex: !nestedRegex
   def: (los\s+)?((((d[ée]cada(\s+de)?)\s+)(((?<century>\d|1\d|2\d)?(?<decade>\d0))))|a[ñn]os\s+((((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex})|((dos\s+)?mil\s+)?({WrittenOneHundredToNineHundredRegex})(\s+{DecadeRegex}?)|((dos\s+)?mil)(\s+{WrittenOneHundredToNineHundredRegex}\s+)?{DecadeRegex}?))
   references: [ WrittenOneHundredToNineHundredRegex, DecadeRegex ]
 RelativeDecadeRegex: !nestedRegex
-  def: \b(((el|las?)\s+)?{RelativeRegex}\s+(((?<number>[\d]+)|{WrittenOneToNineRegex})\s+)?d[eé]cadas?)\b
+  def: \b(((el|las?)\s+)?{RelativeRegex}\s+((?<number>[\w,]+)\s+)?(d[eé]cada|decenio)s?)\b
   references: [ RelativeRegex,WrittenOneToNineRegex ]
 ComplexDatePeriodRegex: !nestedRegex
   def: (?:((de(sde)?)\s+)?(?<start>.+)\s*({StrictTillRegex})\s*(?<end>.+)|((entre)\s+)(?<start>.+)\s*({RangeConnectorRegex})\s*(?<end>.+))
@@ -598,7 +600,7 @@ SinceYearSuffixRegex: !nestedRegex
 AgoRegex: !simpleRegex
   def: \b(antes\s+de\s+(?<day>hoy|ayer|mañana)|antes|hace)\b
 LaterRegex: !simpleRegex
-  def: \b(despu[eé]s(?!\s+de\b)|desde\s+ahora|a\s+partir\s+de\s+(ahora|(?<day>hoy|ayer|mañana)))\b
+  def: \b(despu[eé]s(?!\s+de\b)|desde\s+ahora|(a\s+partir|despu[eé]s)\s+de\s+(ahora|(?<day>hoy|ayer|mañana)))\b
 # DateTimePeriodParser
 Tomorrow: mañana
 # SpanishCommonDateTimeParserConfiguration
@@ -935,7 +937,7 @@ HolidayNames: !dictionary
     padres: [ diadelpadre ]
     madres: [ diadelamadre ]
     acciondegracias: [ diadegracias, diadeacciondegracias, acciondegracias ]
-    trabajador: [ diadeltrabajador, diainternacionaldelostrabajadores ]
+    trabajador: [ diadeltrabajador, diadelostrabajadores, diainternacionaldeltrabajador, diainternacionaldelostrabajadores ]
     delaraza: [ diadelaraza, diadeladiversidadcultural ]
     memoria: [ diadelamemoria ]
     pascuas: [ diadepascuas, pascuas ]
@@ -950,6 +952,10 @@ HolidayNames: !dictionary
     niño: [ diadelniño ]
     mujer: [ diadelamujer ]
     independencia: [diadelaindependencia, diadeindependencia, independencia]
+    blackfriday: [viernesnegro]
+    goodfriday: [viernessanto]
+    stpatrickday: [ sanpatricio, diadesanpatricio ]
+    valentinesday: [ sanvalentin, diadesanvalentin ]
 VariableHolidaysTimexDictionary: !dictionary
   types: [ string, string ]
   entries:
@@ -1138,7 +1144,7 @@ MonthToDateTerms: !list
   types: [ string ]
   entries:
     - mes a la fecha
-    - meses a la fecha
+    - mes hasta la fecha
 WeekendTerms: !list
   types: [ string ]
   entries:
@@ -1163,7 +1169,7 @@ YearToDateTerms: !list
   types: [ string ]
   entries:
     - año a la fecha
-    - años a la fecha
+    - año hasta la fecha
 SpecialCharactersEquivalent: !dictionary
   types: [ char, char ]
   entries:
@@ -1185,6 +1191,10 @@ WeekendTypeRegex: !simpleRegex
   def: (fin(es)?\s+de\s+semana|finde)$
 MonthTypeRegex: !simpleRegex
   def: (mes(es)?|mensual(es|mente)?)$
+QuarterTypeRegex: !simpleRegex
+  def: (trimestral(es|mente)?)$
+BiAnnualTypeRegex: !simpleRegex
+  def: (semestral(es|mente)?)$
 YearTypeRegex: !simpleRegex
   def: (años?|anualmente)$
 ...

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -23005,5 +23005,105 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Show sales in the week 3 of 2027",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "week 3 of 2027",
+        "Start": 18,
+        "End": 31,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2027-W03",
+              "type": "daterange",
+              "start": "2027-01-18",
+              "end": "2027-01-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Show sales in the week 27 of last year",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "week 27 of last year",
+        "Start": 18,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-W27",
+              "type": "daterange",
+              "start": "2017-07-03",
+              "end": "2017-07-10"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The project should start in the next decade",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "the next decade",
+        "Start": 28,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2030-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2030-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "The project should be completed in the next two decades.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "the next two decades",
+        "Start": 35,
+        "End": 54,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2040-01-01,P20Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2040-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -23105,5 +23105,50 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Let's meet on Thursday, week 23",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "thursday",
+        "Start": 14,
+        "End": 21,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-4",
+              "type": "date",
+              "value": "2018-06-28"
+            },
+            {
+              "timex": "XXXX-WXX-4",
+              "type": "date",
+              "value": "2018-07-05"
+            }
+          ]
+        }
+      },
+      {
+        "Text": "week 23",
+        "Start": 24,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-W23",
+              "type": "daterange",
+              "start": "2018-06-04",
+              "end": "2018-06-11"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Italian/DateTimeModel.json
+++ b/Specs/DateTime/Italian/DateTimeModel.json
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "Input": "Tornerò il Ott/2",
     "Context": {
@@ -2985,7 +2985,7 @@
     "Context": {
       "ReferenceDateTime": "2022-11-07T16:12:00"
     },
-    "NotSupportedByDesign": "javascript,python,java",
+    "NotSupportedByDesign": "javascript,java,python",
     "Results": [
       {
         "Text": "da gennaio ad aprile",

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -3751,5 +3751,347 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Estarei fora na semana 3 de dois mil e vinte e sete",
+    "Context": {
+      "ReferenceDateTime": "2021-11-29T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semana 3 de dois mil e vinte e sete",
+        "Start": 16,
+        "End": 50,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2027-W03",
+              "type": "daterange",
+              "start": "2027-01-18",
+              "end": "2027-01-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar vendas na semana 27 do ano passado",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semana 27 do ano passado",
+        "Start": 18,
+        "End": 41,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-W27",
+              "type": "daterange",
+              "start": "2017-07-03",
+              "end": "2017-07-10"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "O projeto deve começar na próxima década.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "na próxima década",
+        "Start": 23,
+        "End": 39,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2030-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2030-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "O projeto deve ser concluído nas próximas duas décadas.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "nas próximas duas décadas",
+        "Start": 29,
+        "End": 53,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2040-01-01,P20Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2040-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Tais acordos proliferaram na última década.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "na última década",
+        "Start": 26,
+        "End": 41,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-01-01,2010-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2000-01-01",
+              "end": "2010-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Vamos ter uma reunião trimestral.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "trimestral",
+        "Start": 22,
+        "End": 31,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3M",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "O Conselho será informado semestralmente sobre o andamento do pedido",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semestralmente",
+        "Start": 26,
+        "End": 39,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P6M",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu tenho muitos ganhos neste ano letivo.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "neste ano letivo",
+        "Start": 23,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "SY2019",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu tenho muitos ganhos neste letivo ano.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "neste letivo ano",
+        "Start": 23,
+        "End": 38,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "SY2019",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu tenho muitos ganhos no último ano fiscal.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "último ano fiscal",
+        "Start": 26,
+        "End": 42,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "FY2018",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu tenho muitos ganhos neste ano civil.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "neste ano civil",
+        "Start": 23,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar vendas no ano fiscal de 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "ano fiscal de 2008",
+        "Start": 18,
+        "End": 35,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "FY2008",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Você está disponível dois dias depois de hoje?",
+    "Context": {
+      "ReferenceDateTime": "2018-05-31T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "dois dias depois de hoje",
+        "Start": 21,
+        "End": 44,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-06-02",
+              "type": "date",
+              "value": "2018-06-02"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Eu já terminei todos os meus trabalhos 2 semanas antes de hoje.",
+    "Context": {
+      "ReferenceDateTime": "2018-06-12T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "2 semanas antes de hoje",
+        "Start": 39,
+        "End": 61,
+        "TypeName": "datetimeV2.date",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-29",
+              "type": "date",
+              "value": "2018-05-29"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Portuguese/DateTimeModel.json
+++ b/Specs/DateTime/Portuguese/DateTimeModel.json
@@ -3916,7 +3916,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "P6M",
+              "timex": "P0.5Y",
               "type": "set",
               "value": "not resolved"
             }

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -5294,8 +5294,7 @@
     "Context": {
       "ReferenceDateTime": "2018-05-31T00:00:00"
     },
-    "Comment": "MERGE Merge sub-entities for consistency with English.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "dos días después de hoy",
@@ -7547,7 +7546,7 @@
       "ReferenceDateTime": "2018-07-17T13:00:00"
     },
     "Comment": "HOLIDAY",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "día de independencia de este año",
@@ -13692,7 +13691,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "Comment": "HOLIDAY",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "viernes negro 2010",
@@ -13717,7 +13716,7 @@
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
     "Comment": "HOLIDAY",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "día de la tierra 2010",
@@ -14137,7 +14136,7 @@
       "ReferenceDateTime": "2019-06-18T00:00:00"
     },
     "Comment": "SPTERM Special terms",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "este año escolar",
@@ -14162,11 +14161,11 @@
       "ReferenceDateTime": "2019-06-18T00:00:00"
     },
     "Comment": "SPTERM Special terms",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
-        "Text": "último año fiscal",
-        "Start": 27,
+        "Text": "el último año fiscal",
+        "Start": 24,
         "End": 43,
         "TypeName": "datetimeV2.daterange",
         "Resolution": {
@@ -14187,7 +14186,7 @@
       "ReferenceDateTime": "2019-06-18T00:00:00"
     },
     "Comment": "SPTERM Special terms",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "este año calendario",
@@ -14311,7 +14310,7 @@
       "ReferenceDateTime": "2019-06-18T00:00:00"
     },
     "Comment": "SPTERM Special terms",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "año fiscal",
@@ -14385,7 +14384,7 @@
       "ReferenceDateTime": "2019-06-28T00:00:00"
     },
     "Comment": "HOLIDAY",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "día de san patricio 2020",
@@ -17720,7 +17719,7 @@
       "ReferenceDateTime": "2020-05-14T12:00:00"
     },
     "Comment": "HOLIDAY",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "día internacional de los trabajadores",
@@ -22252,6 +22251,402 @@
               "type": "daterange",
               "start": "2020-01-01",
               "end": "2020-01-11"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Estaré afuera en semana 3 de dos mil veintisiete",
+    "Context": {
+      "ReferenceDateTime": "2021-11-29T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semana 3 de dos mil veintisiete",
+        "Start": 17,
+        "End": 47,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2027-W03",
+              "type": "daterange",
+              "start": "2027-01-18",
+              "end": "2027-01-25"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar ventas en la semana 27 del año pasado",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semana 27 del año pasado",
+        "Start": 21,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2017-W27",
+              "type": "daterange",
+              "start": "2017-07-03",
+              "end": "2017-07-10"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "programarme una reunión a las 3:00 h",
+    "Context": {
+      "ReferenceDateTime": "2017-12-04T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "3:00 h",
+        "Start": 30,
+        "End": 35,
+        "TypeName": "datetimeV2.time",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "T03:00",
+              "type": "time",
+              "value": "03:00:00"
+            },
+            {
+              "timex": "T15:00",
+              "type": "time",
+              "value": "15:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "La acción de este banco ha bajado un 20% en el año hasta la fecha.",
+    "Context": {
+      "ReferenceDateTime": "2018-09-07T12:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "año hasta la fecha",
+        "Start": 47,
+        "End": 64,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018",
+              "type": "daterange",
+              "start": "2018-01-01",
+              "end": "2018-09-07"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "El proyecto debería comenzar en la próxima década.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "la próxima década",
+        "Start": 32,
+        "End": 48,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2030-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2030-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "El proyecto debería estar terminado en las próximas dos décadas.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "las próximas dos décadas",
+        "Start": 39,
+        "End": 62,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2020-01-01,2040-01-01,P20Y)",
+              "type": "daterange",
+              "start": "2020-01-01",
+              "end": "2040-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Esos acuerdos han proliferado en el último decenio.",
+    "Context": {
+      "ReferenceDateTime": "2018-07-02T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "el último decenio",
+        "Start": 33,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(2000-01-01,2010-01-01,P10Y)",
+              "type": "daterange",
+              "start": "2000-01-01",
+              "end": "2010-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Tengamos una reunión trimestral.",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "trimestral",
+        "Start": 21,
+        "End": 30,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P3M",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Se informará a la Junta semestralmente de los avances en la aplicación",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "semestralmente",
+        "Start": 24,
+        "End": 37,
+        "TypeName": "datetimeV2.set",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "P6M",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Tengo muchas ganancias en este escolar año.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "este escolar año",
+        "Start": 26,
+        "End": 41,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "SY2019",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Tengo muchas ganancias en el último fiscal año.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "el último fiscal año",
+        "Start": 26,
+        "End": 45,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "FY2018",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Tengo muchas ganancias en este calendario año.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "este calendario año",
+        "Start": 26,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Mostrar ventas en el fiscal año 2008",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "fiscal año 2008",
+        "Start": 21,
+        "End": 35,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "FY2008",
+              "type": "daterange",
+              "value": "not resolved"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Voy a volver a las 7 del próximo domingo a la tarde",
+    "Context": {
+      "ReferenceDateTime": "2018-05-01T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7 del próximo domingo a la tarde",
+        "Start": 19,
+        "End": 50,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-13T19",
+              "type": "datetime",
+              "value": "2018-05-13 19:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Voy a volver 7h del próximo domingo a la tarde",
+    "Context": {
+      "ReferenceDateTime": "2018-05-01T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7h del próximo domingo a la tarde",
+        "Start": 13,
+        "End": 45,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-13T19",
+              "type": "datetime",
+              "value": "2018-05-13 19:00:00"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "Voy a volver 7 horas del próximo domingo a la tarde",
+    "Context": {
+      "ReferenceDateTime": "2018-05-01T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "7 horas del próximo domingo a la tarde",
+        "Start": 13,
+        "End": 50,
+        "TypeName": "datetimeV2.datetime",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2018-05-13T19",
+              "type": "datetime",
+              "value": "2018-05-13 19:00:00"
             }
           ]
         }

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -22624,5 +22624,31 @@
         }
       }
     ]
+  },
+  {
+    "Input": "Se espera que la transacción se cierre este año calendario.",
+    "Context": {
+      "ReferenceDateTime": "2019-06-18T00:00:00"
+    },
+    "Comment": "SPTERM Special terms",
+    "NotSupported": "javascript, python, java",
+    "Results": [
+      {
+        "Text": "este año calendario",
+        "Start": 39,
+        "End": 57,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "2019",
+              "type": "daterange",
+              "start": "2019-01-01",
+              "end": "2020-01-01"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/DateTime/Spanish/DateTimeModel.json
+++ b/Specs/DateTime/Spanish/DateTimeModel.json
@@ -16687,8 +16687,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "Comment": "SETREF. Set implementation to be refined.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "trimestral",
@@ -18242,8 +18241,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "SETREF. Set implementation to be refined.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "semestralmente",
@@ -18267,8 +18265,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "SETREF. Set implementation to be refined.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "semestral",
@@ -18367,8 +18364,7 @@
     "Context": {
       "ReferenceDateTime": "2020-06-12T00:00:00"
     },
-    "Comment": "SETREF. Set implementation to be refined.",
-    "NotSupported": "dotnet, javascript, python, java",
+    "NotSupported": "javascript, python, java",
     "Results": [
       {
         "Text": "anual",
@@ -22437,30 +22433,6 @@
     ]
   },
   {
-    "Input": "Tengamos una reunión trimestral.",
-    "Context": {
-      "ReferenceDateTime": "2016-11-07T00:00:00"
-    },
-    "NotSupported": "java, javascript, python",
-    "Results": [
-      {
-        "Text": "trimestral",
-        "Start": 21,
-        "End": 30,
-        "TypeName": "datetimeV2.set",
-        "Resolution": {
-          "values": [
-            {
-              "timex": "P3M",
-              "type": "set",
-              "value": "not resolved"
-            }
-          ]
-        }
-      }
-    ]
-  },
-  {
     "Input": "Se informará a la Junta semestralmente de los avances en la aplicación",
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
@@ -22475,7 +22447,7 @@
         "Resolution": {
           "values": [
             {
-              "timex": "P6M",
+              "timex": "P0.5Y",
               "type": "set",
               "value": "not resolved"
             }


### PR DESCRIPTION
Fix to issue #2890.

Test cases added to EN, PT, ES DateTimeModels.

Did not add support for pattern "7 del próximo domingo a la tarde" because it is ambiguous ("Jornada 7 del próximo domingo", "Torneo de Fútbol 7 del próximo domingo", "Las máximas se mantendrán entre los 13 grados de este jueves y los 7 del próximo domingo"...). 
Added support for the less ambiguous patterns "a las 7 del...", "7h del...", "7 horas del..."