### PR TITLE
[ES Number] Missing support for a few units and abbreviations (#2888)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string IndianNumberingSystemRegex = @"(?<=\b)((?:\d{1,2},(?:\d{2},)*\d{3})(?=\b))";
       public static readonly string NumbersWithSuffix = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)\d+\s+{RoundNumberIntegerRegex}(?=\b)";
-      public static readonly string NumbersWithDozenSuffix = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s+dozen(s)?(?=\b)";
+      public static readonly string NumbersWithDozenSuffix = $@"(((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s+(doz(en)?|dz)s?(?=\b)";
       public static readonly string AllIntRegexWithLocks = $@"((?<=\b){AllIntRegex}(?=\b))";
-      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((half\s+)?a\s+dozen)|({AllIntRegex}\s+dozen(s)?))(?=\b)";
+      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((half\s+)?a\s+dozen)|({AllIntRegex}\s+(doz(en)?|dz)s?))(?=\b)";
       public const string RoundNumberOrdinalRegex = @"(?:hundredth|thousandth|millionth|billionth|trillionth)";
       public const string NumberOrdinalRegex = @"(?:first|second|third|fourth|fifth|sixth|seventh|eighth|nine?th|tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth)";
       public const string RelativeOrdinalRegex = @"(?<relativeOrdinal>(next|previous|current)\s+one|(the\s+second|next)\s+to\s+last|the\s+one\s+before\s+the\s+last(\s+one)?|the\s+last\s+but\s+one|(ante)?penultimate|last|next|previous|current)";
@@ -123,7 +123,7 @@ namespace Microsoft.Recognizers.Definitions.English
       public static readonly string[] WrittenIntegerSeparatorTexts = { @"and" };
       public static readonly string[] WrittenFractionSeparatorTexts = { @"and" };
       public const string HalfADozenRegex = @"half\s+a\s+dozen";
-      public static readonly string DigitalNumberRegex = $@"((?<=\b)(hundred|thousand|[mb]illion|trillion|[mbt]ln|lakh|crore|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
+      public static readonly string DigitalNumberRegex = $@"((?<=\b)(hundred|thousand|[mb]illion|trillion|[mbt]ln|lakh|crore|(doz(en)?|dz)s?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
       public static readonly Dictionary<string, long> CardinalNumberMap = new Dictionary<string, long>
         {
             { @"a", 1 },
@@ -143,6 +143,10 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"twelve", 12 },
             { @"dozen", 12 },
             { @"dozens", 12 },
+            { @"dz", 12 },
+            { @"doz", 12 },
+            { @"dzs", 12 },
+            { @"dozs", 12 },
             { @"thirteen", 13 },
             { @"fourteen", 14 },
             { @"fifteen", 15 },
@@ -280,6 +284,10 @@ namespace Microsoft.Recognizers.Definitions.English
             { @"trillionths", 1000000000000 },
             { @"dozen", 12 },
             { @"dozens", 12 },
+            { @"dz", 12 },
+            { @"doz", 12 },
+            { @"dzs", 12 },
+            { @"dozs", 12 },
             { @"k", 1000 },
             { @"m", 1000000 },
             { @"mm", 1000000 },

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             @"es-pr"
         };
       public const string HundredsNumberIntegerRegex = @"(cuatrocient[ao]s|trescient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s|doscient[ao]s|quinient[ao]s|(?<!por\s+)(cien(to)?))";
-      public const string RoundNumberIntegerRegex = @"(mil\s+millones|mill[oó]n(es)?|mil|bill[oó]n(es)?|trill[oó]n(es)?|cuatrill[oó]n(es)?|quintill[oó]n(es)?|sextill[oó]n(es)?|septill[oó]n(es)?)";
+      public const string RoundNumberIntegerSingRegex = @"(((mil\s+)?mi|bi|cuatri|quinti|sexti|septi)ll[oó]n|mil)";
+      public static readonly string RoundNumberIntegerRegex = $@"({RoundNumberIntegerSingRegex}(es)?)";
       public const string ZeroToNineIntegerRegex = @"(cuatro|cinco|siete|nueve|cero|tres|seis|ocho|dos|un[ao]?)";
       public const string TwoToNineIntegerRegex = @"(cuatro|cinco|siete|nueve|tres|seis|ocho|dos)";
       public const string TenToNineteenIntegerRegex = @"(diecisiete|diecinueve|diecis[eé]is|dieciocho|catorce|quince|trece|diez|once|doce)";
@@ -47,9 +48,9 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string DigitsNumberRegex = @"\d|\d{1,3}(\.\d{3})";
       public static readonly string BelowHundredsRegex = $@"(({TenToNineteenIntegerRegex}|{TwentiesIntegerRegex}|({TensNumberIntegerRegex}(\s+y\s+{ZeroToNineIntegerRegex})?))|{ZeroToNineIntegerRegex})";
       public static readonly string BelowThousandsRegex = $@"({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex})";
-      public static readonly string SupportThousandsRegex = $@"((({BelowThousandsRegex}|{BelowHundredsRegex})\s+)?{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)";
+      public static readonly string SupportThousandsRegex = $@"(({BelowThousandsRegex}|{BelowHundredsRegex})\s+{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)";
       public static readonly string SeparaIntRegex = $@"({SupportThousandsRegex}(\s+{SupportThousandsRegex})*(\s+{BelowThousandsRegex})?|{BelowThousandsRegex})";
-      public static readonly string AllIntRegex = $@"({SeparaIntRegex}|mil(\s+{BelowThousandsRegex})?)";
+      public static readonly string AllIntRegex = $@"({SeparaIntRegex}|mil(\s+{BelowThousandsRegex})?|{RoundNumberIntegerSingRegex})";
       public const string PlaceHolderPureNumber = @"\b";
       public const string PlaceHolderDefault = @"\D|\b";
       public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Spanish/NumbersDefinitions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public const string DigitsNumberRegex = @"\d|\d{1,3}(\.\d{3})";
       public static readonly string BelowHundredsRegex = $@"(({TenToNineteenIntegerRegex}|{TwentiesIntegerRegex}|({TensNumberIntegerRegex}(\s+y\s+{ZeroToNineIntegerRegex})?))|{ZeroToNineIntegerRegex})";
       public static readonly string BelowThousandsRegex = $@"({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex})";
-      public static readonly string SupportThousandsRegex = $@"(({BelowThousandsRegex}|{BelowHundredsRegex})\s+{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)";
+      public static readonly string SupportThousandsRegex = $@"((({BelowThousandsRegex}|{BelowHundredsRegex})\s+)?{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)";
       public static readonly string SeparaIntRegex = $@"({SupportThousandsRegex}(\s+{SupportThousandsRegex})*(\s+{BelowThousandsRegex})?|{BelowThousandsRegex})";
       public static readonly string AllIntRegex = $@"({SeparaIntRegex}|mil(\s+{BelowThousandsRegex})?)";
       public const string PlaceHolderPureNumber = @"\b";
@@ -55,9 +55,9 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly Func<string, string> NumbersWithPlaceHolder = (placeholder) => $@"(((?<!\d+\s*)-\s*)|(?<=\b))\d+(?!([\.,]\d+[a-zA-Z]))(?={placeholder})";
       public static readonly string NumbersWithSuffix = $@"(((?<=\W|^)-\s*)|(?<=\b))\d+\s*{BaseNumbers.NumberMultiplierRegex}(?=\b)";
       public static readonly string RoundNumberIntegerRegexWithLocks = $@"(?<=\b)({DigitsNumberRegex})+\s+{RoundNumberIntegerRegex}(?=\b)";
-      public const string NumbersWithDozenSuffix = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+docenas?(?=\b)";
+      public const string NumbersWithDozenSuffix = @"(((?<=\W|^)-\s*)|(?<=\b))\d+\s+(docena|dz|doz)s?(?=\b)";
       public static readonly string AllIntRegexWithLocks = $@"((?<=\b){AllIntRegex}(?=\b))";
-      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((media\s+)?\s+docena)|({AllIntRegex}\s+(y|con)\s+)?({AllIntRegex}\s+docenas?))(?=\b)";
+      public static readonly string AllIntRegexWithDozenSuffixLocks = $@"(?<=\b)(((media\s+)?\s+docena)|({AllIntRegex}\s+(y|con)\s+)?({AllIntRegex}\s+(docena|dz|doz)s?))(?=\b)";
       public const string SimpleRoundOrdinalRegex = @"(mil[eé]simo|millon[eé]sim[oa]|billon[eé]sim[oa]|trillon[eé]sim[oa]|cuatrillon[eé]sim[oa]|quintillon[eé]sim[oa]|sextillon[eé]sim[oa]|septillon[eé]sim[oa])";
       public const string OneToNineOrdinalRegex = @"(primer[oa]?|segund[oa]|tercer[oa]?|cuart[oa]|quint[oa]|sext[oa]|s[eé]ptim[oa]|octav[oa]|noven[oa])";
       public const string TensOrdinalRegex = @"(nonag[eé]sim[oa]|octog[eé]sim[oa]|septuag[eé]sim[oa]|sexag[eé]sim[oa]|quincuag[eé]sim[oa]|cuadrag[eé]sim[oa]|trig[eé]sim[oa]|vig[eé]sim[oa]|d[eé]cim[oa])";
@@ -71,7 +71,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string SufixRoundOrdinalRegex = $@"(({AllIntRegex})({SimpleRoundOrdinalRegex}))";
       public static readonly string ComplexRoundOrdinalRegex = $@"((({SufixRoundOrdinalRegex}(\s)?)?{ComplexOrdinalRegex})|{SufixRoundOrdinalRegex})";
       public static readonly string AllOrdinalNumberRegex = $@"{ComplexOrdinalRegex}|{SimpleRoundOrdinalRegex}|{ComplexRoundOrdinalRegex}";
-      public static readonly string AllOrdinalRegex = $@"(?:{AllOrdinalNumberRegex}|{RelativeOrdinalRegex})";
+      public static readonly string AllOrdinalRegex = $@"(?:{AllOrdinalNumberRegex}s?|{RelativeOrdinalRegex})";
       public const string OrdinalSuffixRegex = @"(?<=\b)(\d*((1(er|r[oa])|2d[oa]|3r[oa]|4t[oa]|5t[oa]|6t[oa]|7m[oa]|8v[oa]|9n[oa]|0m[oa]|11[vm][oa]|12[vm][oa])|\d\.?[ºª]))(?=\b)";
       public static readonly string OrdinalNounRegex = $@"(?<=\b){AllOrdinalRegex}(?=\b)";
       public static readonly string SpecialFractionInteger = $@"((({AllIntRegex})i?({ZeroToNineIntegerRegex})|({AllIntRegex}))a?v[oa]s?)";
@@ -80,8 +80,8 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string FractionMultiplierRegex = $@"(?<fracMultiplier>\s+(y|con)\s+(medio|(un|{TwoToNineIntegerRegex})\s+(medio|terci[oa]?|cuart[oa]|quint[oa]|sext[oa]|s[eé]ptim[oa]|octav[oa]|noven[oa]|d[eé]cim[oa])s?))";
       public static readonly string RoundMultiplierWithFraction = $@"(?<multiplier>(?:(mil\s+millones|mill[oó]n(es)?|bill[oó]n(es)?|trill[oó]n(es)?|cuatrill[oó]n(es)?|quintill[oó]n(es)?|sextill[oó]n(es)?|septill[oó]n(es)?)))(?={FractionMultiplierRegex}?$)";
       public static readonly string RoundMultiplierRegex = $@"\b\s*({RoundMultiplierWithFraction}|(?<multiplier>(mil))$)";
-      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?(({AllIntRegex})(\s+((y|con)\s)?)((({AllOrdinalNumberRegex})s?|({SpecialFractionInteger})|({SufixRoundOrdinalRegex})s?)|medi[oa]s?|tercios?)|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)";
-      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(y\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?)(?=\b)";
+      public static readonly string FractionNounRegex = $@"(?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?({AllIntRegex}\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\s+)?(medi[oa]s?|tercios?))|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)";
+      public static readonly string FractionNounWithArticleRegex = $@"(?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+((y|con)\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?|mitad)(?=\b)";
       public static readonly string FractionPrepositionRegex = $@"(?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+sobre\s+(?<denominator>({AllIntRegex})|((\d+)(?!\.)))(?=\b)";
       public static readonly string AllPointRegex = $@"((\s+{ZeroToNineIntegerRegex})+|(\s+{AllIntRegex}))";
       public static readonly string AllFloatRegex = $@"{AllIntRegex}(\s+(coma|con)){AllPointRegex}";
@@ -132,7 +132,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
       public static readonly string[] WrittenFractionSeparatorTexts = { @"con" };
       public static readonly string[] OneHalfTokens = { @"un", @"medio" };
       public const string HalfADozenRegex = @"media\s+docena";
-      public static readonly string DigitalNumberRegex = $@"((?<=\b)(mil(l[oó]n(es)?)?|bill[oó]n(es)?|trill[oó]n(es)?|docenas?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
+      public static readonly string DigitalNumberRegex = $@"((?<=\b)(mil(l[oó]n(es)?)?|bill[oó]n(es)?|trill[oó]n(es)?|(docena|dz|doz)s?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))";
       public static readonly Dictionary<string, long> CardinalNumberMap = new Dictionary<string, long>
         {
             { @"cero", 0 },
@@ -152,6 +152,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"doce", 12 },
             { @"docena", 12 },
             { @"docenas", 12 },
+            { @"dz", 12 },
+            { @"doz", 12 },
+            { @"dzs", 12 },
+            { @"dozs", 12 },
             { @"trece", 13 },
             { @"catorce", 14 },
             { @"quince", 15 },
@@ -223,6 +227,7 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"segunda", 2 },
             { @"medio", 2 },
             { @"media", 2 },
+            { @"mitad", 2 },
             { @"tercero", 3 },
             { @"tercera", 3 },
             { @"tercer", 3 },
@@ -346,7 +351,134 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"billonesimo", 1000000000000 },
             { @"billonesima", 1000000000000 },
             { @"billonésimo", 1000000000000 },
-            { @"billonésima", 1000000000000 }
+            { @"billonésima", 1000000000000 },
+            { @"primeros", 1 },
+            { @"primeras", 1 },
+            { @"segundos", 2 },
+            { @"segundas", 2 },
+            { @"terceros", 3 },
+            { @"terceras", 3 },
+            { @"tercios", 3 },
+            { @"cuartos", 4 },
+            { @"cuartas", 4 },
+            { @"quintos", 5 },
+            { @"quintas", 5 },
+            { @"sextos", 6 },
+            { @"sextas", 6 },
+            { @"septimos", 7 },
+            { @"septimas", 7 },
+            { @"séptimos", 7 },
+            { @"séptimas", 7 },
+            { @"octavos", 8 },
+            { @"octavas", 8 },
+            { @"novenos", 9 },
+            { @"novenas", 9 },
+            { @"decimos", 10 },
+            { @"décimos", 10 },
+            { @"decimas", 10 },
+            { @"décimas", 10 },
+            { @"undecimos", 11 },
+            { @"undecimas", 11 },
+            { @"undécimos", 11 },
+            { @"undécimas", 11 },
+            { @"duodecimos", 12 },
+            { @"duodecimas", 12 },
+            { @"duodécimos", 12 },
+            { @"duodécimas", 12 },
+            { @"decimoterceros", 13 },
+            { @"decimoterceras", 13 },
+            { @"decimocuartos", 14 },
+            { @"decimocuartas", 14 },
+            { @"decimoquintos", 15 },
+            { @"decimoquintas", 15 },
+            { @"decimosextos", 16 },
+            { @"decimosextas", 16 },
+            { @"decimoseptimos", 17 },
+            { @"decimoseptimas", 17 },
+            { @"decimoctavos", 18 },
+            { @"decimoctavas", 18 },
+            { @"decimonovenos", 19 },
+            { @"decimonovenas", 19 },
+            { @"vigesimos", 20 },
+            { @"vigesimas", 20 },
+            { @"vigésimos", 20 },
+            { @"vigésimas", 20 },
+            { @"trigesimos", 30 },
+            { @"trigesimas", 30 },
+            { @"trigésimos", 30 },
+            { @"trigésimas", 30 },
+            { @"cuadragesimos", 40 },
+            { @"cuadragesimas", 40 },
+            { @"cuadragésimos", 40 },
+            { @"cuadragésimas", 40 },
+            { @"quincuagesimos", 50 },
+            { @"quincuagesimas", 50 },
+            { @"quincuagésimos", 50 },
+            { @"quincuagésimas", 50 },
+            { @"sexagesimos", 60 },
+            { @"sexagesimas", 60 },
+            { @"sexagésimos", 60 },
+            { @"sexagésimas", 60 },
+            { @"septuagesimos", 70 },
+            { @"septuagesimas", 70 },
+            { @"septuagésimos", 70 },
+            { @"septuagésimas", 70 },
+            { @"octogesimos", 80 },
+            { @"octogesimas", 80 },
+            { @"octogésimos", 80 },
+            { @"octogésimas", 80 },
+            { @"nonagesimos", 90 },
+            { @"nonagesimas", 90 },
+            { @"nonagésimos", 90 },
+            { @"nonagésimas", 90 },
+            { @"centesimos", 100 },
+            { @"centesimas", 100 },
+            { @"centésimos", 100 },
+            { @"centésimas", 100 },
+            { @"ducentesimos", 200 },
+            { @"ducentesimas", 200 },
+            { @"ducentésimos", 200 },
+            { @"ducentésimas", 200 },
+            { @"tricentesimos", 300 },
+            { @"tricentesimas", 300 },
+            { @"tricentésimos", 300 },
+            { @"tricentésimas", 300 },
+            { @"cuadringentesimos", 400 },
+            { @"cuadringentesimas", 400 },
+            { @"cuadringentésimos", 400 },
+            { @"cuadringentésimas", 400 },
+            { @"quingentesimos", 500 },
+            { @"quingentesimas", 500 },
+            { @"quingentésimos", 500 },
+            { @"quingentésimas", 500 },
+            { @"sexcentesimos", 600 },
+            { @"sexcentesimas", 600 },
+            { @"sexcentésimos", 600 },
+            { @"sexcentésimas", 600 },
+            { @"septingentesimos", 700 },
+            { @"septingentesimas", 700 },
+            { @"septingentésimos", 700 },
+            { @"septingentésimas", 700 },
+            { @"octingentesimos", 800 },
+            { @"octingentesimas", 800 },
+            { @"octingentésimos", 800 },
+            { @"octingentésimas", 800 },
+            { @"noningentesimos", 900 },
+            { @"noningentesimas", 900 },
+            { @"noningentésimos", 900 },
+            { @"noningentésimas", 900 },
+            { @"milesimos", 1000 },
+            { @"milesimas", 1000 },
+            { @"milésimos", 1000 },
+            { @"milésimas", 1000 },
+            { @"millonesimos", 1000000 },
+            { @"millonesimas", 1000000 },
+            { @"millonésimos", 1000000 },
+            { @"millonésimas", 1000000 },
+            { @"billonesimos", 1000000000000 },
+            { @"billonesimas", 1000000000000 },
+            { @"billonésimos", 1000000000000 },
+            { @"billonésimas", 1000000000000 }
         };
       public static readonly Dictionary<string, long> PrefixCardinalMap = new Dictionary<string, long>
         {
@@ -422,6 +554,10 @@ namespace Microsoft.Recognizers.Definitions.Spanish
             { @"trillonesimo", 1000000000000000000 },
             { @"docena", 12 },
             { @"docenas", 12 },
+            { @"dz", 12 },
+            { @"doz", 12 },
+            { @"dzs", 12 },
+            { @"dozs", 12 },
             { @"k", 1000 },
             { @"m", 1000000 },
             { @"g", 1000000000 },

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -55,13 +55,13 @@ RoundNumberIntegerRegexWithLocks: !nestedRegex
   def: (?<=\b)\d+\s+{RoundNumberIntegerRegex}(?=\b)
   references: [ RoundNumberIntegerRegex ]
 NumbersWithDozenSuffix: !nestedRegex
-  def: (((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s+dozen(s)?(?=\b)
+  def: (((?<!\d+(\s*{BaseNumbers.NumberMultiplierRegex})?\s*)-\s*)|(?<=\b))\d+\s+(doz(en)?|dz)s?(?=\b)
   references: [ BaseNumbers.NumberMultiplierRegex ]
 AllIntRegexWithLocks: !nestedRegex
   def: ((?<=\b){AllIntRegex}(?=\b))
   references: [ AllIntRegex ]
 AllIntRegexWithDozenSuffixLocks: !nestedRegex
-  def: (?<=\b)(((half\s+)?a\s+dozen)|({AllIntRegex}\s+dozen(s)?))(?=\b)
+  def: (?<=\b)(((half\s+)?a\s+dozen)|({AllIntRegex}\s+(doz(en)?|dz)s?))(?=\b)
   references: [ AllIntRegex ]
 #Ordinal Regex
 RoundNumberOrdinalRegex: !simpleRegex
@@ -254,7 +254,7 @@ WrittenFractionSeparatorTexts: [and]
 HalfADozenRegex: !simpleRegex
   def: half\s+a\s+dozen
 DigitalNumberRegex: !nestedRegex
-  def: ((?<=\b)(hundred|thousand|[mb]illion|trillion|[mbt]ln|lakh|crore|dozen(s)?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
+  def: ((?<=\b)(hundred|thousand|[mb]illion|trillion|[mbt]ln|lakh|crore|(doz(en)?|dz)s?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
   references: [ BaseNumbers.MultiplierLookupRegex ]
 CardinalNumberMap: !dictionary
   types: [ string, long ]
@@ -276,6 +276,10 @@ CardinalNumberMap: !dictionary
     twelve: 12
     dozen: 12
     dozens: 12
+    dz: 12
+    doz: 12
+    dzs: 12
+    dozs: 12
     thirteen: 13
     fourteen: 14
     fifteen: 15
@@ -413,6 +417,10 @@ RoundNumberMap: !dictionary
     trillionths: 1000000000000
     dozen: 12
     dozens: 12
+    dz: 12
+    doz: 12
+    dzs: 12
+    dozs: 12
     k: 1000
     m: 1000000
     mm: 1000000

--- a/Patterns/Spanish/Spanish-Numbers.yaml
+++ b/Patterns/Spanish/Spanish-Numbers.yaml
@@ -20,8 +20,11 @@ NonStandardSeparatorVariants: !list
 #Integer Regex
 HundredsNumberIntegerRegex: !simpleRegex
   def: (cuatrocient[ao]s|trescient[ao]s|seiscient[ao]s|setecient[ao]s|ochocient[ao]s|novecient[ao]s|doscient[ao]s|quinient[ao]s|(?<!por\s+)(cien(to)?))
-RoundNumberIntegerRegex: !simpleRegex
-  def: (mil\s+millones|mill[oó]n(es)?|mil|bill[oó]n(es)?|trill[oó]n(es)?|cuatrill[oó]n(es)?|quintill[oó]n(es)?|sextill[oó]n(es)?|septill[oó]n(es)?)
+RoundNumberIntegerSingRegex: !simpleRegex
+  def: (((mil\s+)?mi|bi|cuatri|quinti|sexti|septi)ll[oó]n|mil)
+RoundNumberIntegerRegex: !nestedRegex
+  def: ({RoundNumberIntegerSingRegex}(es)?)
+  references: [ RoundNumberIntegerSingRegex ]
 ZeroToNineIntegerRegex: !simpleRegex
   def: (cuatro|cinco|siete|nueve|cero|tres|seis|ocho|dos|un[ao]?)
 TwoToNineIntegerRegex: !simpleRegex
@@ -46,14 +49,14 @@ BelowThousandsRegex: !nestedRegex
   def: ({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex})
   references: [ HundredsNumberIntegerRegex, BelowHundredsRegex ]
 SupportThousandsRegex: !nestedRegex
-  def: ((({BelowThousandsRegex}|{BelowHundredsRegex})\s+)?{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)
+  def: (({BelowThousandsRegex}|{BelowHundredsRegex})\s+{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)
   references: [ BelowThousandsRegex, BelowHundredsRegex, RoundNumberIntegerRegex ]
 SeparaIntRegex: !nestedRegex
   def: ({SupportThousandsRegex}(\s+{SupportThousandsRegex})*(\s+{BelowThousandsRegex})?|{BelowThousandsRegex})
   references: [ SupportThousandsRegex, BelowThousandsRegex ]
 AllIntRegex: !nestedRegex
-  def: ({SeparaIntRegex}|mil(\s+{BelowThousandsRegex})?)
-  references: [ SeparaIntRegex, BelowThousandsRegex ]
+  def: ({SeparaIntRegex}|mil(\s+{BelowThousandsRegex})?|{RoundNumberIntegerSingRegex})
+  references: [ SeparaIntRegex, BelowThousandsRegex, RoundNumberIntegerSingRegex ]
 PlaceHolderPureNumber: !simpleRegex
   def: \b
 PlaceHolderDefault: !simpleRegex

--- a/Patterns/Spanish/Spanish-Numbers.yaml
+++ b/Patterns/Spanish/Spanish-Numbers.yaml
@@ -46,7 +46,7 @@ BelowThousandsRegex: !nestedRegex
   def: ({HundredsNumberIntegerRegex}(\s+{BelowHundredsRegex})?|{BelowHundredsRegex})
   references: [ HundredsNumberIntegerRegex, BelowHundredsRegex ]
 SupportThousandsRegex: !nestedRegex
-  def: (({BelowThousandsRegex}|{BelowHundredsRegex})\s+{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)
+  def: ((({BelowThousandsRegex}|{BelowHundredsRegex})\s+)?{RoundNumberIntegerRegex}(\s+{RoundNumberIntegerRegex})?)
   references: [ BelowThousandsRegex, BelowHundredsRegex, RoundNumberIntegerRegex ]
 SeparaIntRegex: !nestedRegex
   def: ({SupportThousandsRegex}(\s+{SupportThousandsRegex})*(\s+{BelowThousandsRegex})?|{BelowThousandsRegex})
@@ -68,12 +68,12 @@ RoundNumberIntegerRegexWithLocks: !nestedRegex
   def: (?<=\b)({DigitsNumberRegex})+\s+{RoundNumberIntegerRegex}(?=\b)
   references: [ DigitsNumberRegex, RoundNumberIntegerRegex ]
 NumbersWithDozenSuffix: !simpleRegex
-  def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+docenas?(?=\b)
+  def: (((?<=\W|^)-\s*)|(?<=\b))\d+\s+(docena|dz|doz)s?(?=\b)
 AllIntRegexWithLocks: !nestedRegex
   def: ((?<=\b){AllIntRegex}(?=\b))
   references: [ AllIntRegex ]
 AllIntRegexWithDozenSuffixLocks: !nestedRegex
-  def: (?<=\b)(((media\s+)?\s+docena)|({AllIntRegex}\s+(y|con)\s+)?({AllIntRegex}\s+docenas?))(?=\b)
+  def: (?<=\b)(((media\s+)?\s+docena)|({AllIntRegex}\s+(y|con)\s+)?({AllIntRegex}\s+(docena|dz|doz)s?))(?=\b)
   references: [ AllIntRegex ]
 #Ordinal Regex
 SimpleRoundOrdinalRegex: !simpleRegex
@@ -110,7 +110,7 @@ AllOrdinalNumberRegex: !nestedRegex
   def: '{ComplexOrdinalRegex}|{SimpleRoundOrdinalRegex}|{ComplexRoundOrdinalRegex}'
   references: [ ComplexOrdinalRegex, SimpleRoundOrdinalRegex, ComplexRoundOrdinalRegex ]
 AllOrdinalRegex: !nestedRegex
-  def: (?:{AllOrdinalNumberRegex}|{RelativeOrdinalRegex})
+  def: (?:{AllOrdinalNumberRegex}s?|{RelativeOrdinalRegex})
   references: [ AllOrdinalNumberRegex, RelativeOrdinalRegex ]
 OrdinalSuffixRegex: !simpleRegex
   def: (?<=\b)(\d*((1(er|r[oa])|2d[oa]|3r[oa]|4t[oa]|5t[oa]|6t[oa]|7m[oa]|8v[oa]|9n[oa]|0m[oa]|11[vm][oa]|12[vm][oa])|\d\.?[ºª]))(?=\b)
@@ -136,10 +136,10 @@ RoundMultiplierRegex: !nestedRegex
   def: \b\s*({RoundMultiplierWithFraction}|(?<multiplier>(mil))$)
   references: [ RoundMultiplierWithFraction ]
 FractionNounRegex: !nestedRegex
-  def: (?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?(({AllIntRegex})(\s+((y|con)\s)?)((({AllOrdinalNumberRegex})s?|({SpecialFractionInteger})|({SufixRoundOrdinalRegex})s?)|medi[oa]s?|tercios?)|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)
+  def: (?<=\b)({AllIntRegex}\s+((y|con)\s+)?)?({AllIntRegex}\s+((({AllOrdinalNumberRegex}|{SufixRoundOrdinalRegex})s|{SpecialFractionInteger})|((y|con)\s+)?(medi[oa]s?|tercios?))|(medio|un\s+cuarto\s+de)\s+{RoundNumberIntegerRegex})(?=\b)
   references: [ AllIntRegex, AllOrdinalNumberRegex, SpecialFractionInteger, SufixRoundOrdinalRegex, RoundNumberIntegerRegex ]
 FractionNounWithArticleRegex: !nestedRegex
-  def: (?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+(y\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?)(?=\b)
+  def: (?<=\b)(({AllIntRegex}|{RoundNumberIntegerRegexWithLocks})\s+((y|con)\s+)?)?((un|un[oa])(\s+)(({AllOrdinalNumberRegex})|({SufixRoundOrdinalRegex}))|(un[ao]?\s+)?medi[oa]s?|mitad)(?=\b)
   references: [ AllIntRegex, AllOrdinalNumberRegex, SufixRoundOrdinalRegex, RoundNumberIntegerRegexWithLocks ]
 FractionPrepositionRegex: !nestedRegex
   def: (?<!{BaseNumbers.CommonCurrencySymbol}\s*)(?<=\b)(?<numerator>({AllIntRegex})|((?<!\.)\d+))\s+sobre\s+(?<denominator>({AllIntRegex})|((\d+)(?!\.)))(?=\b)
@@ -263,7 +263,7 @@ OneHalfTokens: [un, medio]
 HalfADozenRegex: !simpleRegex
   def: media\s+docena
 DigitalNumberRegex: !nestedRegex
-  def: ((?<=\b)(mil(l[oó]n(es)?)?|bill[oó]n(es)?|trill[oó]n(es)?|docenas?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
+  def: ((?<=\b)(mil(l[oó]n(es)?)?|bill[oó]n(es)?|trill[oó]n(es)?|(docena|dz|doz)s?)(?=\b))|((?<=(\d|\b)){BaseNumbers.MultiplierLookupRegex}(?=\b))
   references: [ BaseNumbers.MultiplierLookupRegex ]
 CardinalNumberMap: !dictionary
   types: [ string, long ]
@@ -285,6 +285,10 @@ CardinalNumberMap: !dictionary
     doce: 12
     docena: 12
     docenas: 12
+    dz: 12
+    doz: 12
+    dzs: 12
+    dozs: 12
     trece: 13
     catorce: 14
     quince: 15
@@ -356,6 +360,7 @@ OrdinalNumberMap: !dictionary
     segunda: 2
     medio: 2
     media: 2
+    mitad: 2
     tercero: 3
     tercera: 3
     tercer: 3
@@ -480,6 +485,133 @@ OrdinalNumberMap: !dictionary
     billonesima: 1000000000000
     billonésimo: 1000000000000
     billonésima: 1000000000000
+    primeros: 1
+    primeras: 1
+    segundos: 2
+    segundas: 2
+    terceros: 3
+    terceras: 3
+    tercios: 3
+    cuartos: 4
+    cuartas: 4
+    quintos: 5
+    quintas: 5
+    sextos: 6
+    sextas: 6
+    septimos: 7
+    septimas: 7
+    séptimos: 7
+    séptimas: 7
+    octavos: 8
+    octavas: 8
+    novenos: 9
+    novenas: 9
+    decimos: 10
+    décimos: 10
+    decimas: 10
+    décimas: 10
+    undecimos: 11
+    undecimas: 11
+    undécimos: 11
+    undécimas: 11
+    duodecimos: 12
+    duodecimas: 12
+    duodécimos: 12
+    duodécimas: 12
+    decimoterceros: 13
+    decimoterceras: 13
+    decimocuartos: 14
+    decimocuartas: 14
+    decimoquintos: 15
+    decimoquintas: 15
+    decimosextos: 16
+    decimosextas: 16
+    decimoseptimos: 17
+    decimoseptimas: 17
+    decimoctavos: 18
+    decimoctavas: 18
+    decimonovenos: 19
+    decimonovenas: 19
+    vigesimos: 20
+    vigesimas: 20
+    vigésimos: 20
+    vigésimas: 20
+    trigesimos: 30
+    trigesimas: 30
+    trigésimos: 30
+    trigésimas: 30
+    cuadragesimos: 40
+    cuadragesimas: 40
+    cuadragésimos: 40
+    cuadragésimas: 40
+    quincuagesimos: 50
+    quincuagesimas: 50
+    quincuagésimos: 50
+    quincuagésimas: 50
+    sexagesimos: 60
+    sexagesimas: 60
+    sexagésimos: 60
+    sexagésimas: 60
+    septuagesimos: 70
+    septuagesimas: 70
+    septuagésimos: 70
+    septuagésimas: 70
+    octogesimos: 80
+    octogesimas: 80
+    octogésimos: 80
+    octogésimas: 80
+    nonagesimos: 90
+    nonagesimas: 90
+    nonagésimos: 90
+    nonagésimas: 90
+    centesimos: 100
+    centesimas: 100
+    centésimos: 100
+    centésimas: 100
+    ducentesimos: 200
+    ducentesimas: 200
+    ducentésimos: 200
+    ducentésimas: 200
+    tricentesimos: 300
+    tricentesimas: 300
+    tricentésimos: 300
+    tricentésimas: 300
+    cuadringentesimos: 400
+    cuadringentesimas: 400
+    cuadringentésimos: 400
+    cuadringentésimas: 400
+    quingentesimos: 500
+    quingentesimas: 500
+    quingentésimos: 500
+    quingentésimas: 500
+    sexcentesimos: 600
+    sexcentesimas: 600
+    sexcentésimos: 600
+    sexcentésimas: 600
+    septingentesimos: 700
+    septingentesimas: 700
+    septingentésimos: 700
+    septingentésimas: 700
+    octingentesimos: 800
+    octingentesimas: 800
+    octingentésimos: 800
+    octingentésimas: 800
+    noningentesimos: 900
+    noningentesimas: 900
+    noningentésimos: 900
+    noningentésimas: 900
+    milesimos: 1000
+    milesimas: 1000
+    milésimos: 1000
+    milésimas: 1000
+    millonesimos: 1000000
+    millonesimas: 1000000
+    millonésimos: 1000000
+    millonésimas: 1000000
+    billonesimos: 1000000000000
+    billonesimas: 1000000000000
+    billonésimos: 1000000000000
+    billonésimas: 1000000000000
 PrefixCardinalMap: !dictionary
   types: [ string, long ]
   entries:
@@ -555,6 +687,10 @@ RoundNumberMap: !dictionary
     trillonesimo: 1000000000000000000
     docena: 12
     docenas: 12
+    dz: 12
+    doz: 12
+    dzs: 12
+    dozs: 12
     k: 1000
     m: 1000000
     g: 1000000000

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -3562,5 +3562,65 @@
         "End": 42
       }
     ]
+  },
+  {
+    "Input": " 3 dzs",
+    "Results": [
+      {
+        "Text": "3 dzs",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "36"
+        },
+        "Start": 1,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": " five dozs",
+    "Results": [
+      {
+        "Text": "five dozs",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "60"
+        },
+        "Start": 1,
+        "End": 9
+      }
+    ]
+  },
+  {
+    "Input": " two millionth",
+    "Results": [
+      {
+        "Text": "two",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 1,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": " 100 millionths",
+    "Results": [
+      {
+        "Text": "100",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "100"
+        },
+        "Start": 1,
+        "End": 3
+      }
+    ]
   }
 ]

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -2010,17 +2010,17 @@
     ]
   },
   {
-    "Input": "cien mil billonesima",
+    "Input": "cien mil billonesimas",
     "Results": [
       {
-        "Text": "cien mil billonesima",
+        "Text": "cien mil billonesimas",
         "TypeName": "number",
         "Resolution": {
           "subtype": "fraction",
           "value": "1E-07"
         },
         "Start": 0,
-        "End": 19
+        "End": 20
       }
     ]
   },
@@ -3104,6 +3104,171 @@
         },
         "Start": 6,
         "End": 34
+      }
+    ]
+  },
+  {
+    "Input": "3 dz",
+    "Results": [
+      {
+        "Text": "3 dz",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "36"
+        },
+        "Start": 0,
+        "End": 3
+      }
+    ]
+  },
+  {
+    "Input": " cinco dozs",
+    "Results": [
+      {
+        "Text": "cinco dozs",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "60"
+        },
+        "Start": 1,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "La mitad de la clase no vino esta mañana.",
+    "Results": [
+      {
+        "Text": "mitad",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,5"
+        },
+        "Start": 3,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "100 billonesimo",
+    "Results": [
+      {
+        "Text": "100",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "100"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "100 millonesimo",
+    "Results": [
+      {
+        "Text": "100",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "100"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "100 millonesimas",
+    "Results": [
+      {
+        "Text": "100",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "100"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "cien millonesimas",
+    "Results": [
+      {
+        "Text": "cien millonesimas",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "0,0001"
+        },
+        "Start": 0,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "dos millonesimo",
+    "Results": [
+      {
+        "Text": "dos",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "2"
+        },
+        "Start": 0,
+        "End": 2
+      }
+    ]
+  },
+  {
+    "Input": "dos millonésimas",
+    "Results": [
+      {
+        "Text": "dos millonésimas",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "fraction",
+          "value": "2E-06"
+        },
+        "Start": 0,
+        "End": 15
+      }
+    ]
+  },
+  {
+    "Input": "millon",
+    "Results": [
+      {
+        "Text": "millon",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "1000000"
+        },
+        "Start": 0,
+        "End": 5
+      }
+    ]
+  },
+  {
+    "Input": "billon",
+    "Results": [
+      {
+        "Text": "billon",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "1000000000000"
+        },
+        "Start": 0,
+        "End": 5
       }
     ]
   }

--- a/Specs/Number/Spanish/NumberModel.json
+++ b/Specs/Number/Spanish/NumberModel.json
@@ -3271,5 +3271,9 @@
         "End": 5
       }
     ]
+  },
+  {
+    "Input": "billons",
+    "Results": []
   }
 ]

--- a/Specs/Number/Spanish/OrdinalModel.json
+++ b/Specs/Number/Spanish/OrdinalModel.json
@@ -1238,5 +1238,101 @@
         }
       }
     ]
+  },
+  {
+    "Input": "dos millonesimo",
+    "Results": [
+      {
+        "Text": "dos millonesimo",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "2000000",
+          "offset":"2000000",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 14
+      }
+    ]
+  },
+  {
+    "Input": "terceros",
+    "Results": [
+      {
+        "Text": "terceros",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "3",
+          "offset":"3",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 7
+      }
+    ]
+  },
+  {
+    "Input": "millonesimos",
+    "Results": [
+      {
+        "Text": "millonesimos",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "1000000",
+          "offset":"1000000",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 11
+      }
+    ]
+  },
+  {
+    "Input": "billonesimos",
+    "Results": [
+      {
+        "Text": "billonesimos",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "1000000000000",
+          "offset":"1000000000000",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 11
+      }
+    ]
+  },
+  {
+    "Input": "tres millonesimos",
+    "Results": [
+      {
+        "Text": "tres millonesimos",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "3000000",
+          "offset":"3000000",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 16
+      }
+    ]
+  },
+  {
+    "Input": "cien millonesimos",
+    "Results": [
+      {
+        "Text": "cien millonesimos",
+        "TypeName": "ordinal",
+        "Resolution": {
+          "value": "100000000",
+          "offset":"100000000",
+          "relativeTo":"start"
+        },
+        "Start": 0,
+        "End": 16
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2888.

Test cases added to EN NumberModel and ES NumberModel and OrdinalModel.