### PR TITLE
[Javascript] Refinements from issue #2557

### DIFF
--- a/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/baseMerged.ts
@@ -223,7 +223,7 @@ export class BaseMergedExtractor implements IDateTimeExtractor {
         });
     }
 
-    private tryMergeModifierToken(er:ExtractResult, regex: RegExp, source: string, potentialAmbiguity:boolean = false): boolean {
+    protected tryMergeModifierToken(er:ExtractResult, regex: RegExp, source: string, potentialAmbiguity:boolean = false): boolean {
         let beforeStr = source.substr(0, er.start).toLowerCase();
 
         // Avoid adding mod for ambiguity cases, such as "from" in "from ... to ..." should not add mod
@@ -250,7 +250,7 @@ export class BaseMergedExtractor implements IDateTimeExtractor {
         return false;
     }
 
-    private assignModMetadata(metadata: MetaData): MetaData {
+    protected assignModMetadata(metadata: MetaData): MetaData {
 
         if (metadata === undefined || metadata === null) {
             metadata = new MetaData();
@@ -262,7 +262,7 @@ export class BaseMergedExtractor implements IDateTimeExtractor {
         return metadata
     }
 
-    private hasTokenIndex(source: string, regex: RegExp): { matched: boolean, index: number } {
+    protected hasTokenIndex(source: string, regex: RegExp): { matched: boolean, index: number } {
         // This part is different from C# because no Regex RightToLeft option in JS
         let result = { matched: false, index: -1 };
         let matchResult = RegExpUtility.getMatches(regex, source);

--- a/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
+++ b/JavaScript/packages/recognizers-date-time/src/dateTime/chinese/dateTimeConfiguration.ts
@@ -246,11 +246,16 @@ class ChineseDateTimeParserConfiguration implements IDateTimeParserConfiguration
 export class ChineseDateTimeParser extends BaseDateTimeParser {
     private readonly durationExtractor: ChineseDurationExtractor;
     private readonly integerExtractor: BaseNumberExtractor
+    private readonly lunarRegex: RegExp;
+    private readonly lunarHolidayRegex: RegExp;
+
     constructor(dmyDateFormat: boolean) {
         let config = new ChineseDateTimeParserConfiguration(dmyDateFormat);
         super(config);
         this.durationExtractor = new ChineseDurationExtractor();
         this.integerExtractor = new ChineseIntegerExtractor();
+        this.lunarRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.LunarRegex);
+        this.lunarHolidayRegex = RegExpUtility.getSafeRegExp(ChineseDateTime.LunarHolidayRegex);
     }
 
     parse(er: ExtractResult, refTime?: Date): DateTimeParseResult {
@@ -276,6 +281,7 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
                 innerResult.futureResolution[TimeTypeConstants.DATETIME] = DateTimeFormatUtil.formatDateTime(innerResult.futureValue);
                 innerResult.pastResolution = {};
                 innerResult.pastResolution[TimeTypeConstants.DATETIME] = DateTimeFormatUtil.formatDateTime(innerResult.pastValue);
+                innerResult.isLunar = this.isLunarCalendar(er.text);
                 value = innerResult;
             }
         }
@@ -287,6 +293,17 @@ export class ChineseDateTimeParser extends BaseDateTimeParser {
         };
 
         return ret;
+    }
+
+    // parse if lunar contains
+    private isLunarCalendar(text: string): boolean {
+        let trimmedText = text.trim();
+        if (RegExpUtility.getMatches(this.lunarRegex, text).length || RegExpUtility.getMatches(this.lunarHolidayRegex, text).length)
+        {
+            return true;
+        }
+
+        return false;
     }
 
     // merge a Date entity and a Time entity

--- a/Specs/DateTime/Chinese/DateTimeModel.json
+++ b/Specs/DateTime/Chinese/DateTimeModel.json
@@ -225,7 +225,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "农历2015年十月初一",
@@ -250,7 +249,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "正月三十",
@@ -651,7 +649,6 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T14:07:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "2015年十月初一早上九点二十",
@@ -1655,7 +1652,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "2018年以前",
@@ -1681,7 +1678,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "2018年之后",
@@ -1759,7 +1756,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "自2018年以来",
@@ -1785,7 +1782,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "2018年开始",
@@ -1811,7 +1808,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "07年以后",
@@ -1837,7 +1834,7 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript, python",
+    "NotSupported": "python",
     "Results": [
       {
         "Text": "07 年以前",
@@ -2193,7 +2190,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "2015年前",
@@ -3144,7 +3141,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "今天晚上八点之前",
@@ -3170,7 +3167,7 @@
     "Context": {
       "ReferenceDateTime": "2019-07-01T00:00:00"
     },
-    "NotSupported": "javascript, python, java",
+    "NotSupported": "python, java",
     "Results": [
       {
         "Text": "下午三点之前",
@@ -3850,7 +3847,7 @@
     "Context": {
       "ReferenceDateTime": "2018-08-30T14:16:03"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, python",
     "Results": [
       {
         "Text": "从2016年3月1日开始",
@@ -4565,7 +4562,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, python",
     "Results": [
       {
         "Text": "自2016年9月1日起",
@@ -4821,7 +4818,7 @@
     "Context": {
       "ReferenceDateTime": "2019-01-06T12:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "java, python",
     "Results": [
       {
         "Text": "2015年1月1日",
@@ -5883,7 +5880,6 @@
     "Context": {
       "ReferenceDateTime": "2017-03-22T00:00:00"
     },
-    "NotSupported": "javascript",
     "Results": [
       {
         "Text": "神龙二年正月初一",


### PR DESCRIPTION
Addressing comments from PR #2593.

Added support for 'isLunar' tag in Javascript (ZH).
Added support for mods 'before', 'after', 'since' in Javascript (ZH) (mod 'until' is not supported in JS standard implementation).

Test cases enabled in Chinese DateTimeModel.
