### PR TITLE
[EN Number] Added support for "nought" as 0 (#2968)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/NumbersDefinitions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Recognizers.Definitions.English
             @"en-zw"
         };
       public const string RoundNumberIntegerRegex = @"(?:hundred|thousand|million|mln|billion|bln|trillion|tln|lakh|crore)s?";
-      public const string ZeroToNineIntegerRegex = @"(?:three|seven|eight|four|five|zero|nine|one|two|six)";
+      public const string ZeroToNineIntegerRegex = @"(?:three|seven|eight|four|five|zero|nought|nine|one|two|six)";
       public const string TwoToNineIntegerRegex = @"(?:three|seven|eight|four|five|nine|two|six)";
       public const string NegativeNumberTermsRegex = @"(?<negTerm>(minus|negative)\s+)";
       public static readonly string NegativeNumberSignRegex = $@"^{NegativeNumberTermsRegex}.*";
@@ -128,6 +128,7 @@ namespace Microsoft.Recognizers.Definitions.English
         {
             { @"a", 1 },
             { @"zero", 0 },
+            { @"nought", 0 },
             { @"an", 1 },
             { @"one", 1 },
             { @"two", 2 },

--- a/Patterns/English/English-Numbers.yaml
+++ b/Patterns/English/English-Numbers.yaml
@@ -16,7 +16,7 @@ NonStandardSeparatorVariants: !list
 RoundNumberIntegerRegex: !simpleRegex
   def: (?:hundred|thousand|million|mln|billion|bln|trillion|tln|lakh|crore)s?
 ZeroToNineIntegerRegex: !simpleRegex
-  def: (?:three|seven|eight|four|five|zero|nine|one|two|six)
+  def: (?:three|seven|eight|four|five|zero|nought|nine|one|two|six)
 TwoToNineIntegerRegex: !simpleRegex
   def: (?:three|seven|eight|four|five|nine|two|six)
 NegativeNumberTermsRegex: !simpleRegex
@@ -261,6 +261,7 @@ CardinalNumberMap: !dictionary
   entries:
     a: 1
     zero: 0
+    nought: 0
     an: 1
     one: 1
     two: 2

--- a/Specs/Number/English/NumberModel.json
+++ b/Specs/Number/English/NumberModel.json
@@ -3622,5 +3622,115 @@
         "End": 3
       }
     ]
+  },
+  {
+    "Input": "nought is 0",
+    "Results": [
+      {
+        "Text": "nought",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        },
+        "Start": 0,
+        "End": 5
+      },
+      {
+        "Text": "0",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        },
+        "Start": 10,
+        "End": 10
+      }
+    ]
+  },
+  {
+    "Input": "nine point nought four",
+    "Results": [
+      {
+        "Text": "nine point nought four",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "9.04"
+        },
+        "Start": 0,
+        "End": 21
+      }
+    ]
+  },
+  {
+    "Input": "nought point nought three plus zero point zero eight equals nought point eleven",
+    "Results": [
+      {
+        "Text": "nought point nought three",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "0.03"
+        },
+        "Start": 0,
+        "End": 24
+      },
+      {
+        "Text": "zero point zero eight",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "0.08"
+        },
+        "Start": 31,
+        "End": 51
+      },
+      {
+        "Text": "nought point eleven",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "decimal",
+          "value": "0.11"
+        },
+        "Start": 60,
+        "End": 78
+      }
+    ]
+  },
+  {
+    "Input": "they were playing three-nought-four",
+    "Results": [
+      {
+        "Text": "three",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "3"
+        },
+        "Start": 18,
+        "End": 22
+      },
+      {
+        "Text": "nought",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "0"
+        },
+        "Start": 24,
+        "End": 29
+      },
+      {
+        "Text": "four",
+        "TypeName": "number",
+        "Resolution": {
+          "subtype": "integer",
+          "value": "4"
+        },
+        "Start": 31,
+        "End": 34
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix to issue #2968.

Test cases added to NumberModel.