### PR TITLE
[SAMPLE] Update Azure Function to v4 and NET 6 (LTS)

### DIFF
--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-	<AzureFunctionsVersion>v4</AzureFunctionsVersion>
-	<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <TargetFramework>net6.0</TargetFramework>
+	<AzureFunctionsVersion>v4</AzureFunctionsVersion>
+	<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +18,7 @@
     <ProjectReference Include="..\..\Microsoft.Recognizers.Text.Sequence\Microsoft.Recognizers.Text.Sequence.csproj" />
     <ProjectReference Include="..\..\Microsoft.Recognizers.Text\Microsoft.Recognizers.Text.csproj" />
   </ItemGroup>
-
+	
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
+++ b/.NET/Samples/RecognizerFunction/RecognizerFunction.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\Microsoft.Recognizers.Text.Sequence\Microsoft.Recognizers.Text.Sequence.csproj" />
     <ProjectReference Include="..\..\Microsoft.Recognizers.Text\Microsoft.Recognizers.Text.csproj" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/.NET/Samples/RecognizerFunction/host.json
+++ b/.NET/Samples/RecognizerFunction/host.json
@@ -1,2 +1,11 @@
 {
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
 }

--- a/.NET/Samples/RecognizerFunction/local.settings.json
+++ b/.NET/Samples/RecognizerFunction/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    }
+}


### PR DESCRIPTION
- Updated the Azure Function sample to .NET 6 (LTS) and thus Az Func v4
- Remove FxCopAnalyzers for this csproj, since .NET5+ has this in by default and FxCopAnalyzers is deprecated
- Update host.json and local.settings.json with the default Azure Functions values