### PR TITLE
[EN DateTime V2] Added support for cases like "April ninth through 15th" (#2905)

### DIFF
--- a/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/English/DateTimeDefinitions.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string WrittenElevenToNineteenRegex = @"(?:eleven|twelve|(?:thir|four|fif|six|seven|eigh|nine)teen)";
       public const string WrittenTensRegex = @"(?:ten|twenty|thirty|fou?rty|fifty|sixty|seventy|eighty|ninety)";
       public static readonly string WrittenNumRegex = $@"(?:{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)";
+      public const string WrittenOneToNineOrdinalRegex = @"(?:first|second|third|fourth|fifth|sixth|seventh|eighth|nine?th)";
+      public const string WrittenTensOrdinalRegex = @"(?:tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth)";
+      public static readonly string WrittenOrdinalRegex = $@"(?:{WrittenOneToNineOrdinalRegex}|{WrittenTensOrdinalRegex}|{WrittenTensRegex}\s+{WrittenOneToNineOrdinalRegex})";
+      public static readonly string WrittenOrdinalDayRegex = $@"\b(the\s+)?(?<day>(?<ordinal>{WrittenOneToNineOrdinalRegex}|(?:tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth)|(?:ten|twenty)\s+{WrittenOneToNineOrdinalRegex}|thirty\s+first))\b";
       public static readonly string WrittenCenturyFullYearRegex = $@"(?:(one|two)\s+thousand((\s+and)?\s+{WrittenOneToNineRegex}\s+hundred)?)";
       public const string WrittenCenturyOrdinalYearRegex = @"(?:twenty(\s+(one|two))?|ten|eleven|twelve|thirteen|fifteen|eighteen|(?:four|six|seven|nine)(teen)?|one|two|three|five|eight)";
       public static readonly string CenturyRegex = $@"\b(?<century>{WrittenCenturyFullYearRegex}|{WrittenCenturyOrdinalYearRegex}(\s+hundred)?)\b";
@@ -78,10 +82,10 @@ namespace Microsoft.Recognizers.Definitions.English
       public const string ToTokenRegex = @"\b(to)$";
       public const string FromRegex = @"\b(from(\s+the)?)$";
       public const string BetweenTokenRegex = @"\b(between(\s+the)?)$";
-      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}\s+{MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((from)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b";
-      public static readonly string BetweenRegex = $@"\b(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string SimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?({DayRegex}|{WrittenOrdinalDayRegex})\s*{TillRegex}\s*(({DayRegex}|{WrittenOrdinalDayRegex})\s+{MonthSuffixRegex}|{MonthSuffixRegex}\s+({DayRegex}|{WrittenOrdinalDayRegex}))((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string MonthFrontSimpleCasesRegex = $@"\b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((from)\s+)?({DayRegex}|{WrittenOrdinalDayRegex})\s*{TillRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string MonthFrontBetweenRegex = $@"\b{MonthSuffixRegex}\s+(between\s+)({DayRegex}|{WrittenOrdinalDayRegex})\s*{RangeConnectorRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})((\s+|\s*,\s*){YearRegex})?\b";
+      public static readonly string BetweenRegex = $@"\b(between\s+)({DayRegex}|{WrittenOrdinalDayRegex})\s*{RangeConnectorRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b";
       public static readonly string MonthWithYear = $@"\b((({WrittenMonthRegex}[\.]?|((the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|sixth|6th|seventh|7th|eighth|8th|ninth|9th|tenth|10th|eleventh|11th|twelfth|12th|last)\s+month(?=\s+(of|in))))((\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year)|\s+(of|in)\s+{TwoDigitYearRegex}))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b";
       public const string SpecialYearPrefixes = @"(calendar|(?<special>fiscal|school))";
       public static readonly string OneWordPeriodRegex = $@"\b((((the\s+)?month of\s+)?({StrictRelativeRegex}\s+)?{MonthRegex})|(month|year) to date|(?<toDate>((un)?till?|to)\s+date)|({RelativeRegex}\s+)?(my\s+)?((?<business>working\s+week|workweek)|week(end)?|month|fortnight|(({SpecialYearPrefixes}\s+)?year))(?!((\s+of)?\s+\d+(?!({BaseDateTime.BaseAmDescRegex}|{BaseDateTime.BasePmDescRegex}))|\s+to\s+date))(\s+{AfterNextSuffixRegex})?)\b";

--- a/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/NumbersDefinitions.cs
+++ b/.NET/Microsoft.Recognizers.Definitions.Common/Hindi/NumbersDefinitions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Recognizers.Definitions.Hindi
       public const string DecimalUnitsRegex = @"(?:डेढ़|डेढ़|डेढ|ढाई|सवा|सावा)";
       public static readonly string DecimalUnitsWithRoundNumberRegex = $@"({DecimalUnitsRegex}\s+({{AllNumericalIntRegex}}\s+)?{RoundNumberIntegerRegex}|{DecimalUnitsRegex})";
       public const string RoundNumberOrdinalRegex = @"(?:(सौ|हजार|हज़ार|लाख|करोड़|अरब|खरब)(वां|वीं|वें|वाँ))";
-      public const string OneToNineOrdinalRegex = @"(?:पहला|पहले|पहली|तीसरे|प्रथम|दूसरा|दूसरी|दूसरे|तिहाई|चौथाई|((पांच|पाँच|छठ|सात|आठ|नौ)(वां|वीं|वें|वाँ|वा)))";
+      public const string OneToNineOrdinalRegex = @"(?:पहला|(?<!से\s*)पहले|पहली|तीसरे|प्रथम|दूसरा|दूसरी|दूसरे|तिहाई|चौथाई|((पांच|पाँच|छठ|सात|आठ|नौ)(वां|वीं|वें|वाँ|वा)))";
       public const string TenToNineteenOrdinalRegex = @"(?:(दस|ग्यारह|बारह|तेरह|चौदह|पंद्रह|सोलह|सत्रह|अठारह|उन्नीस)(वां|वीं|वें|वाँ))";
       public const string TwentyToTwentyNineOrdinalRegex = @"(?:(बीस|इक्कीस|बाईस|बाइस|तेईस|तेइस|चौबीस|पच्चीस|छब्बीस|सत्ताईस|सत्ताइस|अट्ठाईस|अट्ठाइस|उनतीस)(वां|वीं|वें|वाँ))";
       public const string ThirtyToThirtyNineOrdinalRegex = @"(?:(तीस|इकतीस|इकत्तीस|बत्तीस|तैंतीस|चौंतीस|पैंतीस|छ्त्तीस|सैंतीस|अड़तीस|उनतालीस)(वां|वीं|वें|वाँ))";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const int MaxWeekOfMonth = 5;
         public const int MaxMonth = 12;
         public const int MinMonth = 1;
+        public const int MaxDayMonth = 31;
 
         // Day start hour
         public const int DayHourStart = 0;

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Constants.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Recognizers.Text.DateTime
         // SourceEntity Types
         public const string SYS_DATETIME_DATETIMEPOINT = "datetimepoint";
 
+        // Number Types
+        public const string SYS_NUMBER_ORDINAL = "builtin.num.ordinal";
+
         // Model Name
         public const string MODEL_DATETIME = "datetime";
 
@@ -238,6 +241,7 @@ namespace Microsoft.Recognizers.Text.DateTime
         public const string EndGroupName = "end";
         public const string WithinGroupName = "within";
         public const string NumberGroupName = "number";
+        public const string OrdinalGroupName = "ordinal";
         public const string OrderGroupName = "order";
         public const string AgoGroupName = "ago";
         public const string YesterdayGroupName = "yesterday";

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -346,12 +346,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             var simpleCasesResults = Token.MergeAllTokens(tokens, text, ExtractorName);
             var ordinalExtractions = config.OrdinalExtractor.Extract(text);
 
-            tokens.AddRange(MergeTwoTimePoints(text, new List<ExtractResult>(ordinalExtractions), reference));
+            tokens.AddRange(MergeTwoTimePoints(text, reference));
             tokens.AddRange(MatchDuration(text, reference));
-            tokens.AddRange(SingleTimePointWithPatterns(text, new List<ExtractResult>(ordinalExtractions), reference));
+            tokens.AddRange(SingleTimePointWithPatterns(text, ordinalExtractions, reference));
             tokens.AddRange(MatchComplexCases(text, simpleCasesResults, reference));
             tokens.AddRange(MatchYearPeriod(text, reference));
-            tokens.AddRange(MatchOrdinalNumberWithCenturySuffix(text, new List<ExtractResult>(ordinalExtractions)));
+            tokens.AddRange(MatchOrdinalNumberWithCenturySuffix(text, ordinalExtractions));
 
             return Token.MergeAllTokens(tokens, text, ExtractorName);
         }
@@ -559,19 +559,12 @@ namespace Microsoft.Recognizers.Text.DateTime
             return MergeMultipleExtractions(text, er);
         }
 
-        private List<Token> MergeTwoTimePoints(string text, List<ExtractResult> ordinalExtractions, DateObject reference)
+        private List<Token> MergeTwoTimePoints(string text, DateObject reference)
         {
             var er = this.config.DatePointExtractor.Extract(text, reference);
 
             // Handle "now"
             er = MatchNow(text, er);
-
-            // Handle cases like "april 9th through seventeenth"
-            if (er.Count > 0)
-            {
-                er.AddRange(ordinalExtractions.Where(o => !er.Any(er => er.IsOverlap(o)) && !o.Metadata.IsOrdinalRelative));
-                er = er.OrderBy(o => o.Start).ToList();
-            }
 
             return MergeMultipleExtractions(text, er);
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Extractors/BaseDatePeriodExtractor.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Recognizers.Text.DateTime
             var simpleCasesResults = Token.MergeAllTokens(tokens, text, ExtractorName);
             var ordinalExtractions = config.OrdinalExtractor.Extract(text);
 
-            tokens.AddRange(MergeTwoTimePoints(text, reference));
+            tokens.AddRange(MergeTwoTimePoints(text, new List<ExtractResult>(ordinalExtractions), reference));
             tokens.AddRange(MatchDuration(text, reference));
             tokens.AddRange(SingleTimePointWithPatterns(text, new List<ExtractResult>(ordinalExtractions), reference));
             tokens.AddRange(MatchComplexCases(text, simpleCasesResults, reference));
@@ -559,12 +559,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             return MergeMultipleExtractions(text, er);
         }
 
-        private List<Token> MergeTwoTimePoints(string text, DateObject reference)
+        private List<Token> MergeTwoTimePoints(string text, List<ExtractResult> ordinalExtractions, DateObject reference)
         {
             var er = this.config.DatePointExtractor.Extract(text, reference);
 
             // Handle "now"
             er = MatchNow(text, er);
+
+            // Handle cases like "april 9th through seventeenth"
+            if (er.Count > 0)
+            {
+                er.AddRange(ordinalExtractions.Where(o => !er.Any(er => er.IsOverlap(o)) && !o.Metadata.IsOrdinalRelative));
+                er = er.OrderBy(o => o.Start).ToList();
+            }
 
             return MergeMultipleExtractions(text, er);
         }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Parsers/BaseDatePeriodParser.cs
@@ -1365,15 +1365,36 @@ namespace Microsoft.Recognizers.Text.DateTime
             var er = this.config.DateExtractor.Extract(text, referenceDate);
             DateTimeParseResult pr1 = null;
             DateTimeParseResult pr2 = null;
+            var isOrdinal = false;
             if (er.Count < 2)
             {
                 er = this.config.DateExtractor.Extract(this.config.TokenBeforeDate + text, referenceDate);
-                if (er.Count >= 2)
+                er.ForEach(o => o.Start -= this.config.TokenBeforeDate.Length);
+                if (er.Count == 1)
                 {
-                    er[0].Start -= this.config.TokenBeforeDate.Length;
-                    er[1].Start -= this.config.TokenBeforeDate.Length;
+                    var ordinalExtractions = this.config.OrdinalExtractor.Extract(text);
+                    ordinalExtractions = ordinalExtractions.Where(o => !er.Any(er => er.IsOverlap(o)) && !o.Metadata.IsOrdinalRelative).ToList();
+                    foreach (var ordinal in ordinalExtractions)
+                    {
+                        if (ordinal.Metadata != null && int.TryParse(((Metadata)ordinal.Metadata).Offset, out int num) && num <= Constants.MaxDayMonth)
+                        {
+                            var ordinalEr = new ExtractResult
+                            {
+                                Start = ordinal.Start,
+                                Length = ordinal.Length,
+                                Text = ordinal.Text,
+                                Type = Constants.SYS_DATETIME_DATE,
+                            };
+
+                            er.Add(ordinalEr);
+                            isOrdinal = true;
+                        }
+                    }
+
+                    er = er.OrderBy(o => o.Start).ToList();
                 }
-                else
+
+                if (er.Count < 2)
                 {
                     var nowPr = ParseNowAsDate(text, referenceDate);
                     if (nowPr.Value == null || er.Count < 1)
@@ -1437,6 +1458,11 @@ namespace Microsoft.Recognizers.Text.DateTime
                     (pr1, pr2) = dateContext.SyncYear(pr1, pr2);
                 }
 
+                if (isOrdinal)
+                {
+                    (pr1, pr2) = dateContext.SyncMonth(pr1, pr2);
+                }
+
                 // Expressions like "today", "tomorrow",... should keep their original year
                 if (!this.config.SpecialDayRegex.IsMatch(pr1.Text))
                 {
@@ -1469,9 +1495,9 @@ namespace Microsoft.Recognizers.Text.DateTime
 
             ret.Timex = TimexUtility.GenerateDatePeriodTimex(futureBegin, futureEnd, DatePeriodTimexType.ByDay, pr1.TimexStr, pr2.TimexStr);
 
-            if (pr1.TimexStr.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal) &&
+            if ((pr1.TimexStr.StartsWith(Constants.TimexFuzzyYear, StringComparison.Ordinal) &&
                 futureBegin.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 2, 28)) <= 0 &&
-                futureEnd.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 3, 1)) >= 0)
+                futureEnd.CompareTo(DateObject.MinValue.SafeCreateFromValue(futureBegin.Year, 3, 1)) >= 0) || isOrdinal)
             {
                 // Handle cases like "Feb 28th - March 1st".
                 // There may be different timexes for FutureValue and PastValue due to the different validity of Feb 29th.

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -109,19 +109,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             return firstWeekday.AddDays(7 * (cardinal - 1));
         }
 
-        // This method is to ensure the month of end date is same with the begin date in patterns like "april 9th through seventeenth".
-        public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncMonth(DateTimeParseResult pr1, DateTimeParseResult pr2)
-        {
-            var pr1Value = (DateTimeResolutionResult)pr1.Value;
-            var pr2Value = (DateTimeResolutionResult)pr2.Value;
-            var timexList1 = pr1.TimexStr.Split(Constants.DateTimexConnector[0]);
-            var timexList2 = pr2.TimexStr.Split(Constants.DateTimexConnector[0]);
-            (pr1.TimexStr, pr1.Value) = SyncDateEntityResolutionMonth(pr1Value, pr2Value, timexList1, timexList2);
-            (pr2.TimexStr, pr2.Value) = SyncDateEntityResolutionMonth(pr2Value, pr1Value, timexList2, timexList1, false);
-
-            return (pr1, pr2);
-        }
-
         // This method is to ensure the year of begin date is same with the end date in no year situation.
         public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncYear(DateTimeParseResult pr1, DateTimeParseResult pr2)
         {
@@ -210,30 +197,6 @@ namespace Microsoft.Recognizers.Text.DateTime
             var endDate = SetDateWithContext(originalDateRange.Item2);
 
             return new Tuple<DateObject, DateObject>(startDate, endDate);
-        }
-
-        private (string, DateTimeResolutionResult) SyncDateEntityResolutionMonth(DateTimeResolutionResult value1, DateTimeResolutionResult value2, string[] timexList1, string[] timexList2, bool isFirstDate = true)
-        {
-            if (timexList1[1].Equals(Constants.TimexFuzzyMonth, StringComparison.Ordinal) && !timexList2[1].Equals(Constants.TimexFuzzyMonth, StringComparison.Ordinal))
-            {
-                var futureValue1 = (DateObject)value1.FutureValue;
-                var futureValue2 = (DateObject)value2.FutureValue;
-                var pastValue1 = (DateObject)value1.PastValue;
-                var pastValue2 = (DateObject)value2.PastValue;
-
-                // If the ordinal number is the first date and it represents a day larger than the second date (e.g. "from the twenty-seventh to the fourth of april"),
-                // it is resolved according to the reference date, otherwise it is resolved to the month of the other date.
-                if (!(isFirstDate && futureValue2.Day <= futureValue1.Day))
-                {
-                    int swift = isFirstDate || futureValue1.Day > futureValue2.Day ? 0 : 1;
-                    value1.FutureValue = DateObject.MinValue.SafeCreateFromValue(futureValue2.Year, futureValue2.Month, futureValue1.Day).AddMonths(swift);
-                    value1.PastValue = DateObject.MinValue.SafeCreateFromValue(pastValue2.Year, pastValue2.Month, pastValue1.Day).AddMonths(swift);
-                    timexList1[1] = ((DateObject)value1.FutureValue).Month.ToString("D2");
-                }
-            }
-
-            var timexStr = string.Join(Constants.DateTimexConnector, timexList1);
-            return (timexStr, value1);
         }
     }
 }

--- a/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
+++ b/.NET/Microsoft.Recognizers.Text.DateTime/Utilities/DateContext.cs
@@ -109,6 +109,19 @@ namespace Microsoft.Recognizers.Text.DateTime
             return firstWeekday.AddDays(7 * (cardinal - 1));
         }
 
+        // This method is to ensure the month of end date is same with the begin date in patterns like "april 9th through seventeenth".
+        public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncMonth(DateTimeParseResult pr1, DateTimeParseResult pr2)
+        {
+            var pr1Value = (DateTimeResolutionResult)pr1.Value;
+            var pr2Value = (DateTimeResolutionResult)pr2.Value;
+            var timexList1 = pr1.TimexStr.Split(Constants.DateTimexConnector[0]);
+            var timexList2 = pr2.TimexStr.Split(Constants.DateTimexConnector[0]);
+            (pr1.TimexStr, pr1.Value) = SyncDateEntityResolutionMonth(pr1Value, pr2Value, timexList1, timexList2);
+            (pr2.TimexStr, pr2.Value) = SyncDateEntityResolutionMonth(pr2Value, pr1Value, timexList2, timexList1, false);
+
+            return (pr1, pr2);
+        }
+
         // This method is to ensure the year of begin date is same with the end date in no year situation.
         public (DateTimeParseResult pr1, DateTimeParseResult pr2) SyncYear(DateTimeParseResult pr1, DateTimeParseResult pr2)
         {
@@ -197,6 +210,30 @@ namespace Microsoft.Recognizers.Text.DateTime
             var endDate = SetDateWithContext(originalDateRange.Item2);
 
             return new Tuple<DateObject, DateObject>(startDate, endDate);
+        }
+
+        private (string, DateTimeResolutionResult) SyncDateEntityResolutionMonth(DateTimeResolutionResult value1, DateTimeResolutionResult value2, string[] timexList1, string[] timexList2, bool isFirstDate = true)
+        {
+            if (timexList1[1].Equals(Constants.TimexFuzzyMonth, StringComparison.Ordinal) && !timexList2[1].Equals(Constants.TimexFuzzyMonth, StringComparison.Ordinal))
+            {
+                var futureValue1 = (DateObject)value1.FutureValue;
+                var futureValue2 = (DateObject)value2.FutureValue;
+                var pastValue1 = (DateObject)value1.PastValue;
+                var pastValue2 = (DateObject)value2.PastValue;
+
+                // If the ordinal number is the first date and it represents a day larger than the second date (e.g. "from the twenty-seventh to the fourth of april"),
+                // it is resolved according to the reference date, otherwise it is resolved to the month of the other date.
+                if (!(isFirstDate && futureValue2.Day <= futureValue1.Day))
+                {
+                    int swift = isFirstDate || futureValue1.Day > futureValue2.Day ? 0 : 1;
+                    value1.FutureValue = DateObject.MinValue.SafeCreateFromValue(futureValue2.Year, futureValue2.Month, futureValue1.Day).AddMonths(swift);
+                    value1.PastValue = DateObject.MinValue.SafeCreateFromValue(pastValue2.Year, pastValue2.Month, pastValue1.Day).AddMonths(swift);
+                    timexList1[1] = ((DateObject)value1.FutureValue).Month.ToString("D2");
+                }
+            }
+
+            var timexStr = string.Join(Constants.DateTimexConnector, timexList1);
+            return (timexStr, value1);
         }
     }
 }

--- a/Patterns/English/English-DateTime.yaml
+++ b/Patterns/English/English-DateTime.yaml
@@ -60,6 +60,16 @@ WrittenTensRegex: !simpleRegex
 WrittenNumRegex: !nestedRegex
   def: (?:{WrittenOneToNineRegex}|{WrittenElevenToNineteenRegex}|{WrittenTensRegex}(\s+{WrittenOneToNineRegex})?)
   references: [ WrittenOneToNineRegex, WrittenElevenToNineteenRegex, WrittenTensRegex ]
+WrittenOneToNineOrdinalRegex: !simpleRegex
+  def: (?:first|second|third|fourth|fifth|sixth|seventh|eighth|nine?th)
+WrittenTensOrdinalRegex: !simpleRegex
+  def: (?:tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth|fortieth|fiftieth|sixtieth|seventieth|eightieth|ninetieth)
+WrittenOrdinalRegex: !nestedRegex
+  def: (?:{WrittenOneToNineOrdinalRegex}|{WrittenTensOrdinalRegex}|{WrittenTensRegex}\s+{WrittenOneToNineOrdinalRegex})
+  references: [ WrittenOneToNineOrdinalRegex, WrittenTensOrdinalRegex, WrittenTensRegex ]
+WrittenOrdinalDayRegex: !nestedRegex
+  def: \b(the\s+)?(?<day>(?<ordinal>{WrittenOneToNineOrdinalRegex}|(?:tenth|eleventh|twelfth|thirteenth|fourteenth|fifteenth|sixteenth|seventeenth|eighteenth|nineteenth|twentieth|thirtieth)|(?:ten|twenty)\s+{WrittenOneToNineOrdinalRegex}|thirty\s+first))\b
+  references: [ WrittenOneToNineOrdinalRegex ]
 WrittenCenturyFullYearRegex: !nestedRegex
   def: (?:(one|two)\s+thousand((\s+and)?\s+{WrittenOneToNineRegex}\s+hundred)?)
   references: [ WrittenOneToNineRegex]
@@ -137,17 +147,17 @@ FromRegex: !simpleRegex
 BetweenTokenRegex: !simpleRegex
   def: \b(between(\s+the)?)$
 SimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex}\s+{MonthSuffixRegex}|{MonthSuffixRegex}\s+{DayRegex})((\s+|\s*,\s*){YearRegex})?\b
-  references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex ]
+  def: \b({RangePrefixRegex}\s+)?({DayRegex}|{WrittenOrdinalDayRegex})\s*{TillRegex}\s*(({DayRegex}|{WrittenOrdinalDayRegex})\s+{MonthSuffixRegex}|{MonthSuffixRegex}\s+({DayRegex}|{WrittenOrdinalDayRegex}))((\s+|\s*,\s*){YearRegex})?\b
+  references: [ DayRegex, TillRegex, MonthSuffixRegex, YearRegex, RangePrefixRegex, WrittenOrdinalDayRegex ]
 MonthFrontSimpleCasesRegex: !nestedRegex
-  def: \b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((from)\s+)?({DayRegex})\s*{TillRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
-  references: [ MonthSuffixRegex, DayRegex, TillRegex, YearRegex, RangePrefixRegex ]
+  def: \b({RangePrefixRegex}\s+)?{MonthSuffixRegex}\s+((from)\s+)?({DayRegex}|{WrittenOrdinalDayRegex})\s*{TillRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})((\s+|\s*,\s*){YearRegex})?\b
+  references: [ MonthSuffixRegex, DayRegex, TillRegex, YearRegex, RangePrefixRegex, WrittenOrdinalDayRegex ]
 MonthFrontBetweenRegex: !nestedRegex
-  def: \b{MonthSuffixRegex}\s+(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})((\s+|\s*,\s*){YearRegex})?\b
-  references: [ MonthSuffixRegex, DayRegex, RangeConnectorRegex , YearRegex ]
+  def: \b{MonthSuffixRegex}\s+(between\s+)({DayRegex}|{WrittenOrdinalDayRegex})\s*{RangeConnectorRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})((\s+|\s*,\s*){YearRegex})?\b
+  references: [ MonthSuffixRegex, DayRegex, RangeConnectorRegex , YearRegex, WrittenOrdinalDayRegex ]
 BetweenRegex: !nestedRegex
-  def: \b(between\s+)({DayRegex})\s*{RangeConnectorRegex}\s*({DayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
-  references: [ DayRegex, RangeConnectorRegex , MonthSuffixRegex, YearRegex ]
+  def: \b(between\s+)({DayRegex}|{WrittenOrdinalDayRegex})\s*{RangeConnectorRegex}\s*({DayRegex}|{WrittenOrdinalDayRegex})\s+{MonthSuffixRegex}((\s+|\s*,\s*){YearRegex})?\b
+  references: [ DayRegex, RangeConnectorRegex , MonthSuffixRegex, YearRegex, WrittenOrdinalDayRegex ]
 MonthWithYear: !nestedRegex
   def: \b((({WrittenMonthRegex}[\.]?|((the\s+)?(?<cardinal>first|1st|second|2nd|third|3rd|fourth|4th|fifth|5th|sixth|6th|seventh|7th|eighth|8th|ninth|9th|tenth|10th|eleventh|11th|twelfth|12th|last)\s+month(?=\s+(of|in))))((\s*)[/\\\-\.,]?(\s+(of|in))?(\s*)({YearRegex}|(?<order>following|next|last|this)\s+year)|\s+(of|in)\s+{TwoDigitYearRegex}))|(({YearRegex}|(?<order>following|next|last|this)\s+year)(\s*),?(\s*){WrittenMonthRegex}))\b
   references: [ WrittenMonthRegex, YearRegex, TwoDigitYearRegex ]

--- a/Patterns/Hindi/Hindi-Numbers.yaml
+++ b/Patterns/Hindi/Hindi-Numbers.yaml
@@ -125,7 +125,7 @@ DecimalUnitsWithRoundNumberRegex: !nestedRegex
 RoundNumberOrdinalRegex: !simpleRegex
   def: (?:(सौ|हजार|हज़ार|लाख|करोड़|अरब|खरब)(वां|वीं|वें|वाँ))
 OneToNineOrdinalRegex: !simpleRegex
-  def: (?:पहला|पहले|पहली|तीसरे|प्रथम|दूसरा|दूसरी|दूसरे|तिहाई|चौथाई|((पांच|पाँच|छठ|सात|आठ|नौ)(वां|वीं|वें|वाँ|वा)))
+  def: (?:पहला|(?<!से\s*)पहले|पहली|तीसरे|प्रथम|दूसरा|दूसरी|दूसरे|तिहाई|चौथाई|((पांच|पाँच|छठ|सात|आठ|नौ)(वां|वीं|वें|वाँ|वा)))
 TenToNineteenOrdinalRegex: !simpleRegex
   def: (?:(दस|ग्यारह|बारह|तेरह|चौदह|पंद्रह|सोलह|सत्रह|अठारह|उन्नीस)(वां|वीं|वें|वाँ))
 TwentyToTwentyNineOrdinalRegex: !simpleRegex

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -24216,7 +24216,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "dotnet, java, javascript, python",
     "Results": [
       {
         "Text": "from april twenty-seventh to the third",
@@ -24247,7 +24247,7 @@
     "Context": {
       "ReferenceDateTime": "2016-11-07T00:00:00"
     },
-    "NotSupported": "java, javascript, python",
+    "NotSupported": "dotnet, java, javascript, python",
     "Results": [
       {
         "Text": "from the twenty-seventh to the third of april",

--- a/Specs/DateTime/English/DateTimeModel.json
+++ b/Specs/DateTime/English/DateTimeModel.json
@@ -23962,5 +23962,315 @@
         }
       }
     ]
+  },
+  {
+    "Input": "i am off april 9th through 17th",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "april 9th through 17th",
+        "Start": 9,
+        "End": 30,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off april ninth through seventeenth",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "april ninth through seventeenth",
+        "Start": 9,
+        "End": 39,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off april ninth through 17th",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "april ninth through 17th",
+        "Start": 9,
+        "End": 32,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off april 9th through seventeenth",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "april 9th through seventeenth",
+        "Start": 9,
+        "End": 37,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off from ninth till seventeenth of april",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from ninth till seventeenth of april",
+        "Start": 9,
+        "End": 44,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off between ninth and seventeenth of april",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between ninth and seventeenth of april",
+        "Start": 9,
+        "End": 46,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off between the ninth and the seventeenth of april",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "between the ninth and the seventeenth of april",
+        "Start": 9,
+        "End": 54,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off from april the ninth till the seventeenth",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from april the ninth till the seventeenth",
+        "Start": 9,
+        "End": 49,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2016-04-09",
+              "end": "2016-04-17"
+            },
+            {
+              "timex": "(XXXX-04-09,XXXX-04-17,P8D)",
+              "type": "daterange",
+              "start": "2017-04-09",
+              "end": "2017-04-17"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off from april twenty-seventh to the third",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from april twenty-seventh to the third",
+        "Start": 9,
+        "End": 46,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-04-27,XXXX-05-03,P6D)",
+              "type": "daterange",
+              "start": "2016-04-27",
+              "end": "2016-05-03"
+            },
+            {
+              "timex": "(XXXX-04-27,XXXX-05-03,P6D)",
+              "type": "daterange",
+              "start": "2017-04-27",
+              "end": "2017-05-03"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Input": "i am off from the twenty-seventh to the third of april",
+    "Context": {
+      "ReferenceDateTime": "2016-11-07T00:00:00"
+    },
+    "NotSupported": "java, javascript, python",
+    "Results": [
+      {
+        "Text": "from the twenty-seventh to the third of april",
+        "Start": 9,
+        "End": 53,
+        "TypeName": "datetimeV2.daterange",
+        "Resolution": {
+          "values": [
+            {
+              "timex": "(XXXX-XX-27,XXXX-04-03,P158D)",
+              "type": "daterange",
+              "start": "2016-10-27",
+              "end": "2017-04-03"
+            },
+            {
+              "timex": "(XXXX-XX-27,XXXX-04-03,P127D)",
+              "type": "daterange",
+              "start": "2016-11-27",
+              "end": "2017-04-03"
+            }
+          ]
+        }
+      }
+    ]
   }
 ]

--- a/Specs/Number/Hindi/OrdinalModelSuppressExtendedTypes.json
+++ b/Specs/Number/Hindi/OrdinalModelSuppressExtendedTypes.json
@@ -29,19 +29,7 @@
   {
     "Input": "मुझे आखिरी से पहले का दिखाएं।",
     "NotSupportedByDesign": "javascript,python,java",
-    "Results": [
-      {
-        "Text": "पहले",
-        "Start": 14,
-        "End": 17,
-        "TypeName": "ordinal",
-        "Resolution": {
-          "offset": "1",
-          "relativeTo": "start",
-          "value": "1"
-        }
-      }
-    ]
+    "Results": []
   },
   {
     "Input": "मुझे आखिरी का दूसरा दिखाएं",


### PR DESCRIPTION
Fix to issue #2905.

Modified methods MergeTwoTimePoints in Base DatePeriod Extractor/Parser to support cases where one of the date points is an ordinal number.
Fixed issue in Hindi where "पहले" (first) was wrongly extracted from "से पहले" (before).

Test cases added to EN DateTimeModel.